### PR TITLE
[release/13.5] Ensure the typescript app host trusts the dev cert

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateCacheWriter.cs
+++ b/src/Aspire.Cli/Certificates/CertificateCacheWriter.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Certificates;
+
+internal static class CertificateCacheWriter
+{
+    private const UnixFileMode DirectoryPermissions =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+    private const UnixFileMode FilePermissions =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    public static void WriteFile(string outputPath, ReadOnlySpan<byte> contents, ILogger logger)
+    {
+        EnsureDirectory(Path.GetDirectoryName(outputPath)!);
+
+        // Publish a fully flushed file atomically so readers never observe a partial certificate bundle.
+        var temporaryPath = Path.Combine(
+            Path.GetDirectoryName(outputPath)!,
+            $".{Path.GetFileName(outputPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            var options = new FileStreamOptions
+            {
+                Access = FileAccess.Write,
+                Mode = FileMode.CreateNew,
+                Share = FileShare.None
+            };
+
+            if (!OperatingSystem.IsWindows())
+            {
+#pragma warning disable CA1416 // Validate platform compatibility
+                options.UnixCreateMode = FilePermissions;
+#pragma warning restore CA1416 // Validate platform compatibility
+            }
+
+            using (var stream = new FileStream(temporaryPath, options))
+            {
+                stream.Write(contents);
+                stream.Flush(flushToDisk: true);
+            }
+
+            try
+            {
+                File.Move(temporaryPath, outputPath);
+            }
+            catch (IOException) when (File.Exists(outputPath))
+            {
+                // Another process published the same content-addressed file first.
+            }
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogDebug(ex, "Failed to delete temporary certificate cache file {TemporaryPath}", temporaryPath);
+            }
+        }
+    }
+
+    private static void EnsureDirectory(string directory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.CreateDirectory(directory);
+            return;
+        }
+
+#pragma warning disable CA1416 // Validate platform compatibility
+        Directory.CreateDirectory(directory, DirectoryPermissions);
+        File.SetUnixFileMode(directory, DirectoryPermissions);
+#pragma warning restore CA1416 // Validate platform compatibility
+    }
+}

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Certificates;
 
@@ -42,6 +43,8 @@ internal sealed class EnsureCertificatesTrustedResult
 internal interface ICertificateService
 {
     Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken);
+
+    string? ExportDevCertificatePem(CancellationToken cancellationToken);
 }
 
 internal sealed class CertificateService(
@@ -49,9 +52,13 @@ internal sealed class CertificateService(
     IInteractionService interactionService,
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
-    IEnvironment environment) : ICertificateService
+    IEnvironment environment,
+    CliExecutionContext executionContext,
+    ILogger<CertificateService> logger) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
+    internal string DevCertDirectory => Path.Combine(
+        executionContext.AspireHomeDirectory.FullName, "dev-certs");
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {
@@ -195,6 +202,33 @@ internal sealed class CertificateService(
             systemCertDirs.Add(devCertsTrustPath);
 
             environmentVariables[SslCertDirEnvVar] = string.Join(Path.PathSeparator, systemCertDirs);
+        }
+    }
+
+    public string? ExportDevCertificatePem(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = certificateToolRunner.ExportDevCertificatePublicPem(DevCertDirectory, cancellationToken);
+            if (result is not null)
+            {
+                logger.LogDebug("Exported dev certificate public PEM to {Path}", result);
+            }
+            else
+            {
+                logger.LogDebug("No valid dev certificate found to export as PEM");
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to export dev certificate as PEM");
+            return null;
         }
     }
 }

--- a/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
@@ -30,4 +30,13 @@ internal interface ICertificateToolRunner
     /// Removes all HTTPS development certificates.
     /// </summary>
     CertificateCleanResult CleanHttpCertificate();
+
+    /// <summary>
+    /// Exports the highest-versioned trusted ASP.NET Core HTTPS development certificate
+    /// as a content-addressed PEM file in the specified directory.
+    /// </summary>
+    /// <param name="outputDirectory">The directory where the PEM certificate should be cached.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>The output path if a certificate was exported; <see langword="null"/> if no valid certificate was found.</returns>
+    string? ExportDevCertificatePublicPem(string outputDirectory, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -1,18 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Certificates;
 
 /// <summary>
 /// Certificate tool runner that uses the native CertificateManager directly (no subprocess needed).
 /// </summary>
-internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, IEnvironment environment) : ICertificateToolRunner
+internal sealed class NativeCertificateToolRunner(
+    CertificateManager certificateManager,
+    IEnvironment environment,
+    ILogger<NativeCertificateToolRunner> logger) : ICertificateToolRunner
 {
-
     public CertificateTrustResult CheckHttpCertificate(CancellationToken cancellationToken = default)
     {
         var availableCertificates = certificateManager.ListCertificates(
@@ -30,13 +36,11 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
                 {
                     trustLevel = CertificateManager.TrustLevel.None;
                 }
-                else if (certificateManager is UnixCertificateManager unixCertificateManager)
-                {
-                    trustLevel = unixCertificateManager.GetTrustLevel(cert, cancellationToken);
-                }
                 else
                 {
-                    trustLevel = certificateManager.GetTrustLevel(cert);
+                    trustLevel = certificateManager is UnixCertificateManager unixCertificateManager
+                        ? unixCertificateManager.GetTrustLevel(cert, cancellationToken)
+                        : certificateManager.GetTrustLevel(cert);
                 }
 
                 return new DevCertInfo
@@ -190,6 +194,67 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
         {
             return new CertificateCleanResult { Success = false, ErrorMessage = ex.Message };
         }
+    }
+
+    public string? ExportDevCertificatePublicPem(string outputDirectory, CancellationToken cancellationToken = default)
+    {
+        logger.LogDebug("Searching for a trusted ASP.NET Core development certificate to export");
+
+        var availableCertificates = certificateManager.ListCertificates(
+            StoreName.My, StoreLocation.CurrentUser, isValid: false, requireExportable: false);
+
+        try
+        {
+            var now = DateTimeOffset.Now;
+            var validCertificates = availableCertificates
+                .Where(c => c.HasPrivateKey && c.NotBefore <= now && now <= c.NotAfter)
+                .ToList();
+
+            if (validCertificates.Any(c => c.HasSubjectKeyIdentifier()))
+            {
+                validCertificates = validCertificates.Where(c => c.HasSubjectKeyIdentifier()).ToList();
+            }
+
+            var certificate = validCertificates
+                .GroupBy(c => c.Extensions.OfType<X509SubjectKeyIdentifierExtension>().FirstOrDefault()?.SubjectKeyIdentifier)
+                .SelectMany(group => group.OrderByVersion().Take(1))
+                .OrderByVersion()
+                .GetTrustedCertificates(cancellationToken)
+                .FirstOrDefault();
+
+            if (certificate is null)
+            {
+                logger.LogDebug("No trusted ASP.NET Core development certificate was available to export");
+                return null;
+            }
+
+            logger.LogDebug(
+                "Selected ASP.NET Core development certificate {Thumbprint} for public PEM export",
+                certificate.Thumbprint);
+
+            return GetOrCreateCertificateCacheFile(certificate, outputDirectory);
+        }
+        finally
+        {
+            CertificateManager.DisposeCertificates(availableCertificates);
+        }
+    }
+
+    internal string GetOrCreateCertificateCacheFile(X509Certificate2 certificate, string outputDirectory)
+    {
+        var pemContents = Encoding.UTF8.GetBytes(certificate.ExportCertificatePem());
+        var hash = Convert.ToHexString(XxHash128.Hash(pemContents)).ToLowerInvariant();
+        var outputPath = Path.Combine(outputDirectory, $"aspire-dev-cert-{hash}.pem");
+
+        if (File.Exists(outputPath))
+        {
+            logger.LogDebug("Reusing cached development certificate PEM at {Path}", outputPath);
+            return outputPath;
+        }
+
+        logger.LogDebug("Writing development certificate PEM to cache at {Path}", outputPath);
+        CertificateCacheWriter.WriteFile(outputPath, pemContents, logger);
+        return outputPath;
     }
 
     private static string[]? GetSanExtension(X509Certificate2 cert)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.IO.Hashing;
 using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
@@ -30,6 +31,9 @@ namespace Aspire.Cli.Projects;
 /// </summary>
 internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGenerator
 {
+    private const string DevCertificateCacheDirectoryName = "dev-certs";
+    private const string CertificateBundleCacheDirectoryName = "bundles";
+
     private readonly IInteractionService _interactionService;
     private readonly IAppHostCliBackchannel _backchannel;
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
@@ -595,6 +599,24 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;
                 environmentVariables[KnownConfigNames.RemoteAppHostToken] = authenticationToken;
 
+                if (_guestRuntime is null)
+                {
+                    _interactionService.DisplayError("GuestRuntime not initialized.");
+                    return CliExitCodes.FailedToDotnetRunAppHost;
+                }
+
+                if (_guestRuntime.CertificateBundleEnvironmentVariable is { } certificateBundleEnvironmentVariable)
+                {
+                    var devCertPemPath = _certificateService.ExportDevCertificatePem(cancellationToken);
+                    await ConfigureCertificateBundleEnvironmentAsync(
+                        environmentVariables,
+                        directory,
+                        devCertPemPath,
+                        certificateBundleEnvironmentVariable,
+                        _guestRuntime.Language.Replace('/', '-'),
+                        cancellationToken);
+                }
+
                 // Pass debug flag to the guest process
                 if (context.Debug)
                 {
@@ -605,12 +627,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 // This mirrors the pattern in DotNetCliRunner.ExecuteAsync for .NET app hosts.
                 // The RuntimeSpec declares the required extension capability (e.g., "node" for TypeScript);
                 // only use the extension launcher when the runtime requests it and the extension supports it.
-                if (_guestRuntime is null)
-                {
-                    _interactionService.DisplayError("GuestRuntime not initialized.");
-                    return CliExitCodes.FailedToDotnetRunAppHost;
-                }
-
                 if (_guestRuntime.ExtensionLaunchCapability is { } requiredCapability
                     && ExtensionHelper.IsExtensionHost(_interactionService, out var extensionInteractionService, out var extensionBackchannel)
                     && await extensionBackchannel.HasCapabilityAsync(requiredCapability, cancellationToken))
@@ -1981,4 +1997,109 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         var id = UserSecretsPathHelper.ComputeSyntheticUserSecretsId(appHostFile.FullName);
         return Task.FromResult<string?>(id);
     }
+
+    /// <summary>
+    /// Configures a language runtime's certificate bundle to trust the ASP.NET Core development certificate.
+    /// </summary>
+    internal async Task ConfigureCertificateBundleEnvironmentAsync(
+        IDictionary<string, string> environmentVariables,
+        DirectoryInfo workingDirectory,
+        string? devCertPemPath,
+        string environmentVariableName,
+        string cacheFilePrefix,
+        CancellationToken cancellationToken)
+    {
+        if (devCertPemPath is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(environmentVariableName))
+        {
+            throw new InvalidOperationException("The certificate bundle environment variable name cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(cacheFilePrefix) ||
+            cacheFilePrefix.Any(character => !char.IsAsciiLetterOrDigit(character) && character is not '-' and not '_'))
+        {
+            throw new InvalidOperationException("The certificate bundle cache file prefix contains invalid characters.");
+        }
+
+        // Explicit AppHost configuration takes precedence over the inherited environment.
+        // Environment variable names are case-insensitive on Windows.
+        var configuredKeys = _environment.IsWindows()
+            ? environmentVariables.Keys
+                .Where(key => string.Equals(key, environmentVariableName, StringComparison.OrdinalIgnoreCase))
+                .ToArray()
+            : environmentVariables.ContainsKey(environmentVariableName)
+                ? [environmentVariableName]
+                : [];
+        var existingCertificateBundle = configuredKeys.LastOrDefault() is { } configuredKey
+            ? environmentVariables[configuredKey]
+            : _environment.GetEnvironmentVariable(environmentVariableName);
+        var certificateBundlePath = devCertPemPath;
+
+        if (!string.IsNullOrWhiteSpace(existingCertificateBundle))
+        {
+            try
+            {
+                var existingBundlePath = Path.GetFullPath(existingCertificateBundle, workingDirectory.FullName);
+                var pathComparison = _environment.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+
+                if (!string.Equals(existingBundlePath, devCertPemPath, pathComparison))
+                {
+                    var devCertificateContents = await File.ReadAllBytesAsync(devCertPemPath, cancellationToken);
+                    var existingBundleContents = await File.ReadAllBytesAsync(existingBundlePath, cancellationToken);
+
+                    // Place the Aspire certificate first because OpenSSL may select the first matching self-signed certificate.
+                    byte[] bundleContents = [.. devCertificateContents, (byte)'\n', .. existingBundleContents];
+
+                    // Cache by the final contents so unchanged inputs reuse the same immutable bundle.
+                    var bundleHash = Convert.ToHexString(XxHash128.Hash(bundleContents)).ToLowerInvariant();
+                    var bundleDirectory = Path.Combine(
+                        _executionContext.AspireHomeDirectory.FullName,
+                        DevCertificateCacheDirectoryName,
+                        CertificateBundleCacheDirectoryName);
+                    var bundlePath = Path.Combine(bundleDirectory, $"{cacheFilePrefix}-{bundleHash}.pem");
+
+                    if (!File.Exists(bundlePath))
+                    {
+                        CertificateCacheWriter.WriteFile(bundlePath, bundleContents, _logger);
+                    }
+
+                    certificateBundlePath = bundlePath;
+                }
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                _logger.LogWarning(ex, "Failed to combine {EnvironmentVariableName} bundle {ExistingBundlePath} with the Aspire development certificate", environmentVariableName, existingCertificateBundle);
+                _interactionService.DisplayMessage(
+                    KnownEmojis.Warning,
+                    $"Unable to add the Aspire development certificate to {environmentVariableName} '{existingCertificateBundle}'. The existing certificate bundle will be used unchanged.");
+                certificateBundlePath = existingCertificateBundle;
+            }
+        }
+
+        SetCertificateBundleEnvironmentVariable(environmentVariables, configuredKeys, environmentVariableName, certificateBundlePath);
+    }
+
+    private static void SetCertificateBundleEnvironmentVariable(
+        IDictionary<string, string> environmentVariables,
+        IEnumerable<string> configuredKeys,
+        string environmentVariableName,
+        string value)
+    {
+        foreach (var configuredKey in configuredKeys)
+        {
+            if (!string.Equals(configuredKey, environmentVariableName, StringComparison.Ordinal))
+            {
+                environmentVariables.Remove(configuredKey);
+            }
+        }
+
+        environmentVariables[environmentVariableName] = value;
+    }
+
 }

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -64,6 +64,11 @@ internal sealed class GuestRuntime
     public string? ExtensionLaunchCapability => _spec.ExtensionLaunchCapability;
 
     /// <summary>
+    /// Gets the environment variable used by the runtime for an additional certificate bundle in run mode.
+    /// </summary>
+    public string? CertificateBundleEnvironmentVariable => _spec.CertificateBundleEnvironmentVariable;
+
+    /// <summary>
     /// Initializes the project environment (e.g., creates a virtual environment and installs dependencies).
     /// Runs each command in <see cref="RuntimeSpec.Initialize"/> sequentially.
     /// </summary>

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -156,6 +156,7 @@ internal static class TypeScriptAppHostToolchainResolver
             WatchExecute = CreateWatchCommand(toolchain, tsConfigFileName),
             PublishExecute = baseRuntimeSpec.PublishExecute,
             ExtensionLaunchCapability = baseRuntimeSpec.ExtensionLaunchCapability,
+            CertificateBundleEnvironmentVariable = baseRuntimeSpec.CertificateBundleEnvironmentVariable,
             MigrationFiles = baseRuntimeSpec.MigrationFiles
         };
     }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -57,6 +57,9 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
     public string Language => LanguageId;
 
     /// <inheritdoc />
+    public string CertificateBundleEnvironmentVariable => "NODE_EXTRA_CA_CERTS";
+
+    /// <inheritdoc />
     public Dictionary<string, string> Scaffold(ScaffoldRequest request)
     {
         var files = new Dictionary<string, string>();
@@ -252,6 +255,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             CodeGenLanguage = CodeGenTarget,
             DetectionPatterns = s_detectionPatterns,
             ExtensionLaunchCapability = "node",
+            CertificateBundleEnvironmentVariable = CertificateBundleEnvironmentVariable,
             InstallDependencies = new CommandSpec
             {
                 Command = "npm",

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -57,56 +57,7 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
                     .OrderByVersion()
                     .ToList();
 
-                // Partition into trusted and untrusted using a single X509Chain instance.
-                // RevocationMode is set to NoCheck since revocation doesn't apply to self-signed dev certs.
-                using var chain = new X509Chain();
-                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-
-                // On Windows, chain.Build() can succeed even when the certificate isn't in the
-                // trusted root store. Open the CurrentUser Root store so we can verify membership.
-                X509Certificate2Collection? rootCerts = null;
-                if (OperatingSystem.IsWindows())
-                {
-                    using var rootStore = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
-                    rootStore.Open(OpenFlags.ReadOnly);
-                    rootCerts = rootStore.Certificates;
-                }
-
-                // Find the dev certs that are trusted
-                var trustedCerts = new List<X509Certificate2>();
-                foreach (var cert in bestCerts)
-                {
-                    try
-                    {
-                        if (!chain.Build(cert))
-                        {
-                            continue;
-                        }
-
-                        // On Windows, also verify the certificate exists in the root store
-                        if (rootCerts is not null &&
-                            !rootCerts.Any(rc => rc.RawDataMemory.Span.SequenceEqual(cert.RawDataMemory.Span)))
-                        {
-                            continue;
-                        }
-
-                        trustedCerts.Add(cert);
-                    }
-                    finally
-                    {
-                        // Reset the chain for the next certificate regardless of branch taken.
-                        chain.Reset();
-                    }
-                }
-
-                // Dispose root store certificates after use
-                if (rootCerts is not null)
-                {
-                    foreach (var rc in rootCerts)
-                    {
-                        rc.Dispose();
-                    }
-                }
+                var trustedCerts = bestCerts.GetTrustedCertificates();
 
                 // Flag if the newest/highest-version cert is not trusted
                 if (bestCerts.Count > 0 &&

--- a/src/Aspire.TypeSystem/ILanguageSupport.cs
+++ b/src/Aspire.TypeSystem/ILanguageSupport.cs
@@ -15,6 +15,22 @@ public interface ILanguageSupport
     string Language { get; }
 
     /// <summary>
+    /// Gets the environment variable that accepts an additional PEM certificate bundle when running an AppHost for this language.
+    /// </summary>
+    /// <remarks>
+    /// The CLI sets this environment variable only when running the AppHost, not when publishing it.
+    /// Return the name of the runtime-specific environment variable, rather than a certificate path.
+    /// The runtime uses the certificate bundle as additional trusted roots for the entire AppHost process,
+    /// affecting all outbound TLS connections, including connections unrelated to Aspire-managed resources.
+    /// Implementations should opt in only when this process-wide trust scope is appropriate.
+    /// For example:
+    /// <code>
+    /// public string? CertificateBundleEnvironmentVariable => "NODE_EXTRA_CA_CERTS";
+    /// </code>
+    /// </remarks>
+    string? CertificateBundleEnvironmentVariable => null;
+
+    /// <summary>
     /// Generates scaffold files for a new project.
     /// </summary>
     /// <param name="request">The scaffold request containing project details.</param>

--- a/src/Aspire.TypeSystem/RuntimeSpec.cs
+++ b/src/Aspire.TypeSystem/RuntimeSpec.cs
@@ -68,6 +68,21 @@ public sealed class RuntimeSpec
     public string? ExtensionLaunchCapability { get; init; }
 
     /// <summary>
+    /// Gets the environment variable that accepts an additional PEM certificate bundle when running an AppHost for this language.
+    /// </summary>
+    /// <remarks>
+    /// When set, the CLI assigns this environment variable a certificate bundle containing the
+    /// ASP.NET Core development certificate before launching the AppHost in run mode. The variable
+    /// is not set when publishing the AppHost. The runtime uses the bundle as additional trusted roots
+    /// for the entire AppHost process, affecting all outbound TLS connections, including connections
+    /// unrelated to Aspire-managed resources. For example:
+    /// <code>
+    /// CertificateBundleEnvironmentVariable = "NODE_EXTRA_CA_CERTS";
+    /// </code>
+    /// </remarks>
+    public string? CertificateBundleEnvironmentVariable { get; init; }
+
+    /// <summary>
     /// Gets files that must exist in the project directory before execution.
     /// If a file in this dictionary is missing, the CLI will create it with the provided content.
     /// This supports upgrade scenarios where new runtime requirements are introduced.

--- a/src/Shared/X509Certificate2Extensions.cs
+++ b/src/Shared/X509Certificate2Extensions.cs
@@ -129,4 +129,69 @@ internal static class X509Certificate2Extensions
             .OrderByDescending(c => c.GetCertificateVersion())
             .ThenByDescending(c => c.NotAfter);
     }
+
+    /// <summary>
+    /// Gets the certificates trusted by the current user's platform trust store.
+    /// </summary>
+    /// <param name="certificates">The certificates to check.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>The trusted certificates in their original order.</returns>
+    public static List<X509Certificate2> GetTrustedCertificates(
+        this IEnumerable<X509Certificate2> certificates,
+        CancellationToken cancellationToken = default)
+    {
+        using var chain = new X509Chain();
+        // Revocation does not apply to self-signed development certificates.
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        X509Certificate2Collection? rootCertificates = null;
+        if (OperatingSystem.IsWindows())
+        {
+            // On Windows, chain.Build() can succeed even when the certificate is not in the trusted root store.
+            using var rootStore = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+            rootStore.Open(OpenFlags.ReadOnly);
+            rootCertificates = rootStore.Certificates;
+        }
+
+        try
+        {
+            var trustedCertificates = new List<X509Certificate2>();
+            foreach (var certificate in certificates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    if (!chain.Build(certificate))
+                    {
+                        continue;
+                    }
+
+                    if (rootCertificates is not null &&
+                        !rootCertificates.Any(rootCertificate => rootCertificate.RawDataMemory.Span.SequenceEqual(certificate.RawDataMemory.Span)))
+                    {
+                        continue;
+                    }
+
+                    trustedCertificates.Add(certificate);
+                }
+                finally
+                {
+                    chain.Reset();
+                }
+            }
+
+            return trustedCertificates;
+        }
+        finally
+        {
+            if (rootCertificates is not null)
+            {
+                foreach (var rootCertificate in rootCertificates)
+                {
+                    rootCertificate.Dispose();
+                }
+            }
+        }
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -18,7 +18,7 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
-    public async Task CreateAndRunTypeScriptEmptyAppHostProject()
+    public async Task CreateAndRunTypeScriptEmptyAppHostProjectWithDevelopmentCertificate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -34,9 +34,28 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
 
         await auto.AspireNewAsync("TsEmptyApp", counter, template: AspireTemplate.TypeScriptEmptyAppHost);
 
-        GitIgnoreAssertions.AssertContainsEntry(
-            Path.Combine(workspace.WorkspaceRoot.FullName, "TsEmptyApp"),
-            ".aspire/");
+        var appDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "TsEmptyApp");
+        GitIgnoreAssertions.AssertContainsEntry(appDirectory, ".aspire/");
+
+        var appHostPath = Path.Combine(appDirectory, "apphost.mts");
+        var appHostContents = await File.ReadAllTextAsync(appHostPath, TestContext.Current.CancellationToken);
+        appHostContents = appHostContents
+            .Replace(
+                "import { createBuilder } from './.aspire/modules/aspire.mjs';",
+                """
+                import { writeFileSync } from 'node:fs';
+                import { createBuilder } from './.aspire/modules/aspire.mjs';
+                """,
+                StringComparison.Ordinal)
+            .Replace(
+                "const builder = await createBuilder();",
+                """
+                writeFileSync('node-extra-ca-certs.txt', process.env.NODE_EXTRA_CA_CERTS ?? '');
+
+                const builder = await createBuilder();
+                """,
+                StringComparison.Ordinal);
+        await File.WriteAllTextAsync(appHostPath, appHostContents, TestContext.Current.CancellationToken);
 
         // Start the empty TypeScript AppHost to verify the scaffolded project works
         await auto.TypeAsync("cd TsEmptyApp");
@@ -46,6 +65,9 @@ public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output
         await auto.RunCommandAsync("npm run build", counter, TimeSpan.FromMinutes(2));
 
         await auto.AspireStartAsync(counter);
+        await auto.RunCommandAsync(
+            "CERT_PATH=$(cat node-extra-ca-certs.txt) && test -s \"$CERT_PATH\" && grep -q -- '-----BEGIN CERTIFICATE-----' \"$CERT_PATH\"",
+            counter);
         await auto.AspireStopAsync(counter);
     }
 

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Tests.Certificates;
 
@@ -216,6 +217,118 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task CertificatePemExport_IsExplicitAndUsesAspireHomeDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var aspireHomeDirectory = workspace.CreateDirectory("custom-aspire-home");
+        var exportCalled = false;
+        string? exportDirectory = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => TestExecutionContextHelper.CreateExecutionContext(
+                workspace.WorkspaceRoot,
+                aspireHomeDirectory: aspireHomeDirectory);
+            options.CertificateToolRunnerFactory = sp =>
+            {
+                return new TestCertificateToolRunner
+                {
+                    CheckHttpCertificateCallback = () =>
+                    {
+                        return new CertificateTrustResult
+                        {
+                            HasCertificates = true,
+                            TrustLevel = CertificateManager.TrustLevel.Full,
+                            Certificates = [new DevCertInfo { Version = 5, TrustLevel = CertificateManager.TrustLevel.Full, IsHttpsDevelopmentCertificate = true, ValidityNotBefore = DateTimeOffset.Now.AddDays(-1), ValidityNotAfter = DateTimeOffset.Now.AddDays(365) }]
+                        };
+                    },
+                    ExportDevCertificatePublicPemCallback = directory =>
+                    {
+                        exportCalled = true;
+                        exportDirectory = directory;
+                        return Path.Combine(directory, "aspire-dev-cert-test.pem");
+                    }
+                };
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.False(exportCalled);
+
+        var result = cs.ExportDevCertificatePem(TestContext.Current.CancellationToken);
+
+        Assert.True(exportCalled);
+        Assert.Equal(Path.Combine(aspireHomeDirectory.FullName, "dev-certs"), exportDirectory);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void ExportDevCertificatePem_Failure_DoesNotThrow()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = sp =>
+            {
+                return new TestCertificateToolRunner
+                {
+                    CheckHttpCertificateCallback = () =>
+                    {
+                        return new CertificateTrustResult
+                        {
+                            HasCertificates = true,
+                            TrustLevel = CertificateManager.TrustLevel.Full,
+                            Certificates = [new DevCertInfo { Version = 5, TrustLevel = CertificateManager.TrustLevel.Full, IsHttpsDevelopmentCertificate = true, ValidityNotBefore = DateTimeOffset.Now.AddDays(-1), ValidityNotAfter = DateTimeOffset.Now.AddDays(365) }]
+                        };
+                    },
+                    ExportDevCertificatePublicPemCallback = (_) => throw new IOException("Disk full")
+                };
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = cs.ExportDevCertificatePem(TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ExportDevCertificatePem_Cancellation_Throws()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = sp =>
+            {
+                return new TestCertificateToolRunner
+                {
+                    CheckHttpCertificateCallback = () => CreateTrustResult(CertificateManager.TrustLevel.Full),
+                    ExportDevCertificatePublicPemCallback = _ =>
+                    {
+                        cancellationTokenSource.Cancel();
+                        throw new OperationCanceledException(cancellationTokenSource.Token);
+                    }
+                };
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var certificateService = sp.GetRequiredService<ICertificateService>();
+
+        Assert.ThrowsAny<OperationCanceledException>(
+            () => certificateService.ExportDevCertificatePem(cancellationTokenSource.Token));
+    }
+
+    [Fact]
     public async Task EnsureCertificatesTrustedAsync_NonInteractive_WarnsWhenUntrustedOnNonLinux()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -326,7 +439,9 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, TestEnvironment.CreateLinux());
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                var logger = sp.GetRequiredService<ILogger<CertificateService>>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, TestEnvironment.CreateLinux(), executionContext, logger);
             };
         });
 
@@ -519,7 +634,9 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 var interactiveService = sp.GetRequiredService<IInteractionService>();
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, environment ?? sp.GetRequiredService<IEnvironment>());
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                var logger = sp.GetRequiredService<ILogger<CertificateService>>();
+                return new CertificateService(toolRunner, interactiveService, telemetry, hostEnvironment, environment ?? sp.GetRequiredService<IEnvironment>(), executionContext, logger);
             };
         });
 

--- a/tests/Aspire.Cli.Tests/Certificates/NativeCertificateToolRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/NativeCertificateToolRunnerTests.cs
@@ -1,21 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.Certificates;
 
-public class NativeCertificateToolRunnerTests
+public class NativeCertificateToolRunnerTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public void TrustHttpCertificateOnLinux_WithNoCurrentCertificate_CreatesAndTrustsCertificate()
     {
         var certificateManager = new TestCertificateManager();
-        var runner = new NativeCertificateToolRunner(certificateManager, TestEnvironment.CreateLinux());
+        var runner = CreateRunner(certificateManager);
 
         var result = runner.TrustHttpCertificateOnLinux([], DateTimeOffset.UtcNow);
 
@@ -31,7 +34,7 @@ public class NativeCertificateToolRunnerTests
         using var certificate = certificateManager.CreateAspNetCoreHttpsDevelopmentCertificate(
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(365));
-        var runner = new NativeCertificateToolRunner(certificateManager, TestEnvironment.CreateLinux());
+        var runner = CreateRunner(certificateManager);
 
         var result = runner.TrustHttpCertificateOnLinux([certificate], DateTimeOffset.UtcNow);
 
@@ -48,7 +51,7 @@ public class NativeCertificateToolRunnerTests
         using var olderCertificate = olderVersionManager.CreateAspNetCoreHttpsDevelopmentCertificate(
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(365));
-        var runner = new NativeCertificateToolRunner(currentVersionManager, TestEnvironment.CreateLinux());
+        var runner = CreateRunner(currentVersionManager);
 
         var result = runner.TrustHttpCertificateOnLinux([olderCertificate], DateTimeOffset.UtcNow);
 
@@ -57,11 +60,98 @@ public class NativeCertificateToolRunnerTests
         Assert.True(currentVersionManager.TrustCalled);
     }
 
+    [Fact]
+    public void ExportDevCertificatePublicPem_WithUntrustedCertificate_ReturnsNull()
+    {
+        var certificateManager = new TestCertificateManager();
+        using var certificate = certificateManager.CreateAspNetCoreHttpsDevelopmentCertificate(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(365));
+        certificateManager.Certificates.Add(certificate.Export(X509ContentType.Pfx));
+        var logger = new FakeLogger<NativeCertificateToolRunner>();
+        var runner = CreateRunner(certificateManager, logger);
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var result = runner.ExportDevCertificatePublicPem(
+            workspace.WorkspaceRoot.FullName,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Contains(
+            logger.Collector.GetSnapshot(),
+            record => record.Message.Contains("No trusted ASP.NET Core development certificate", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetOrCreateCertificateCacheFile_CachesPublicPemWithRestrictedPermissions()
+    {
+        var certificateManager = new TestCertificateManager();
+        using var certificate = certificateManager.CreateAspNetCoreHttpsDevelopmentCertificate(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(365));
+        var logger = new FakeLogger<NativeCertificateToolRunner>();
+        var runner = CreateRunner(certificateManager, logger);
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "dev-certs");
+        var pemContents = certificate.ExportCertificatePem();
+        var pemBytes = Encoding.UTF8.GetBytes(pemContents);
+        var hash = Convert.ToHexString(XxHash128.Hash(pemBytes)).ToLowerInvariant();
+        var expectedPath = Path.Combine(outputDirectory, $"aspire-dev-cert-{hash}.pem");
+
+        var firstResult = runner.GetOrCreateCertificateCacheFile(certificate, outputDirectory);
+        var lastWriteTime = DateTime.UtcNow.AddHours(-1);
+        File.SetLastWriteTimeUtc(firstResult, lastWriteTime);
+        lastWriteTime = File.GetLastWriteTimeUtc(firstResult);
+        var secondResult = runner.GetOrCreateCertificateCacheFile(certificate, outputDirectory);
+
+        Assert.Equal(expectedPath, firstResult);
+        Assert.Equal(firstResult, secondResult);
+        Assert.Equal(pemContents, File.ReadAllText(firstResult));
+        Assert.Equal(lastWriteTime, File.GetLastWriteTimeUtc(secondResult));
+        Assert.Contains(
+            logger.Collector.GetSnapshot(),
+            record => record.Message.Contains("Writing development certificate PEM to cache", StringComparison.Ordinal));
+        Assert.Contains(
+            logger.Collector.GetSnapshot(),
+            record => record.Message.Contains("Reusing cached development certificate PEM", StringComparison.Ordinal));
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(outputDirectory));
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(firstResult));
+        }
+    }
+
+    private static NativeCertificateToolRunner CreateRunner(
+        CertificateManager certificateManager,
+        FakeLogger<NativeCertificateToolRunner>? logger = null) =>
+        new(
+            certificateManager,
+            TestEnvironment.CreateLinux(),
+            logger ?? new FakeLogger<NativeCertificateToolRunner>());
+
     private sealed class TestCertificateManager(int version = CertificateManager.CurrentAspNetCoreCertificateVersion)
         : CertificateManager(NullLogger.Instance, CertificateManager.LocalhostHttpsDistinguishedName, version, version)
     {
+        public List<byte[]> Certificates { get; } = [];
         public bool SaveCalled { get; private set; }
         public bool TrustCalled { get; private set; }
+
+        protected override void PopulateCertificatesFromStore(
+            X509Store store,
+            List<X509Certificate2> certificates,
+            bool requireExportable)
+        {
+            certificates.AddRange(
+                Certificates.Select(certificate => X509CertificateLoader.LoadPkcs12(
+                    certificate,
+                    password: null,
+                    X509KeyStorageFlags.Exportable)));
+        }
 
         protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
         {

--- a/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CertificatesCommandTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -99,7 +100,9 @@ public class CertificatesCommandTests(ITestOutputHelper outputHelper)
             {
                 var telemetry = sp.GetRequiredService<AspireCliTelemetry>();
                 var hostEnvironment = sp.GetRequiredService<ICliHostEnvironment>();
-                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, TestEnvironment.CreateLinux());
+                var executionContext = sp.GetRequiredService<CliExecutionContext>();
+                var logger = sp.GetRequiredService<ILogger<CertificateService>>();
+                return new CertificateService(toolRunner, interactionService, telemetry, hostEnvironment, TestEnvironment.CreateLinux(), executionContext, logger);
             };
         });
         using var provider = services.BuildServiceProvider();

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -749,6 +749,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         {
             throw new CertificateServiceException("Failed to trust certificates");
         }
+
+        public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1479,6 +1479,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             throw new Aspire.Cli.Certificates.CertificateServiceException("Failed to trust certificates");
         }
+
+        public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
     }
 
     private sealed class NoProjectFileProjectLocator : IProjectLocator

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
 using System.Net.Sockets;
+using System.Text;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Diagnostics;
@@ -1238,10 +1240,13 @@ public class GuestAppHostProjectTests : IDisposable
         TestAppHostBackchannel? backchannel = null,
         TestAppHostServerProjectFactory? appHostServerProjectFactory = null,
         IAppHostServerSessionFactory? serverSessionFactory = null,
-        bool identityOverridden = false)
+        bool identityOverridden = false,
+        string languageId = "typescript/nodejs",
+        IEnvironment? environment = null,
+        DirectoryInfo? homeDirectory = null)
     {
         var language = new LanguageInfo(
-            LanguageId: "typescript/nodejs",
+            LanguageId: languageId,
             DisplayName: "TypeScript (Node.js)",
             PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
             DetectionPatterns: ["apphost.ts"],
@@ -1253,7 +1258,8 @@ public class GuestAppHostProjectTests : IDisposable
             new DirectoryInfo(AppContext.BaseDirectory),
             identityChannel: identityChannel,
             logFilePath: logFilePath,
-            identityOverridden: identityOverridden);
+            identityOverridden: identityOverridden,
+            homeDirectory: homeDirectory);
 
         // Construct a real graceful-shutdown window so the contract matches production:
         // GuestAppHostProject requires it even when a test exits the Run path early
@@ -1274,7 +1280,7 @@ public class GuestAppHostProjectTests : IDisposable
             features: new Features(_configuration, NullLogger<Features>.Instance),
             languageDiscovery: new TestLanguageDiscovery(),
             executionContext: executionContext,
-            environment: new TestEnvironment(),
+            environment: environment ?? new TestEnvironment(),
             logger: NullLogger<GuestAppHostProject>.Instance,
             fileLoggerProvider: new FileLoggerProvider(logFilePath, new TestStartupErrorWriter()),
             profilingTelemetry: _profilingTelemetry,
@@ -1282,6 +1288,225 @@ public class GuestAppHostProjectTests : IDisposable
             shutdownService: shutdownWindow,
             serverSessionFactory: serverSessionFactory ?? new FakeAppHostServerSessionFactory(),
             timeProvider: TimeProvider.System);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_SetsEnvironmentVariable_WhenExistingValueIsNotUsable(string? existingValue)
+    {
+        var project = CreateGuestAppHostProject();
+        var envVars = new Dictionary<string, string>();
+        if (existingValue is not null)
+        {
+            envVars["NODE_EXTRA_CA_CERTS"] = existingValue;
+        }
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            "/path/to/cert.pem",
+            "NODE_EXTRA_CA_CERTS",
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("/path/to/cert.pem", envVars["NODE_EXTRA_CA_CERTS"]);
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_ReusesDevCertificate_WhenAlreadyConfigured()
+    {
+        var devCertificatePath = Path.Combine(_workspace.WorkspaceRoot.FullName, "aspire-dev-cert.pem");
+        var project = CreateGuestAppHostProject();
+        var envVars = new Dictionary<string, string>
+        {
+            ["NODE_EXTRA_CA_CERTS"] = Path.GetFileName(devCertificatePath)
+        };
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            "NODE_EXTRA_CA_CERTS",
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(devCertificatePath, envVars["NODE_EXTRA_CA_CERTS"]);
+        Assert.False(Directory.Exists(Path.Combine(_workspace.WorkspaceRoot.FullName, "bundles")));
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_UsesCaseInsensitivePathComparisonOnWindows()
+    {
+        var devCertificatePath = Path.Combine(_workspace.WorkspaceRoot.FullName, "aspire-dev-cert.pem");
+        var project = CreateGuestAppHostProject(environment: TestEnvironment.CreateWindows());
+        var envVars = new Dictionary<string, string>
+        {
+            ["NODE_EXTRA_CA_CERTS"] = devCertificatePath.ToUpperInvariant()
+        };
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            "NODE_EXTRA_CA_CERTS",
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(devCertificatePath, envVars["NODE_EXTRA_CA_CERTS"]);
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_DoesNotAssumeMacOSPathsAreCaseInsensitive()
+    {
+        var lowerCaseDirectory = Path.Combine(_workspace.WorkspaceRoot.FullName, "certificates");
+        var upperCaseDirectory = Path.Combine(_workspace.WorkspaceRoot.FullName, "CERTIFICATES");
+        Directory.CreateDirectory(lowerCaseDirectory);
+        Directory.CreateDirectory(upperCaseDirectory);
+        var devCertificatePath = Path.Combine(lowerCaseDirectory, "aspire.pem");
+        var existingBundlePath = Path.Combine(upperCaseDirectory, "ASPIRE.PEM");
+        await File.WriteAllTextAsync(existingBundlePath, "existing certificate", TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(devCertificatePath, "development certificate", TestContext.Current.CancellationToken);
+        var expectedDevCertificateContents = await File.ReadAllBytesAsync(devCertificatePath, TestContext.Current.CancellationToken);
+        var expectedExistingBundleContents = await File.ReadAllBytesAsync(existingBundlePath, TestContext.Current.CancellationToken);
+        byte[] expectedBundleContents = [.. expectedDevCertificateContents, (byte)'\n', .. expectedExistingBundleContents];
+        var project = CreateGuestAppHostProject(environment: TestEnvironment.CreateMacOS());
+        var envVars = new Dictionary<string, string>
+        {
+            ["NODE_EXTRA_CA_CERTS"] = existingBundlePath
+        };
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            "NODE_EXTRA_CA_CERTS",
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(devCertificatePath, envVars["NODE_EXTRA_CA_CERTS"]);
+        Assert.Equal(
+            expectedBundleContents,
+            await File.ReadAllBytesAsync(envVars["NODE_EXTRA_CA_CERTS"], TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_DoesNotSet_WhenPemPathIsNull()
+    {
+        var project = CreateGuestAppHostProject();
+        var envVars = new Dictionary<string, string>();
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertPemPath: null,
+            environmentVariableName: "NODE_EXTRA_CA_CERTS",
+            cacheFilePrefix: "typescript-nodejs",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(envVars.ContainsKey("NODE_EXTRA_CA_CERTS"));
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_CreatesAndReusesCombinedBundle_WhenAlreadySet()
+    {
+        const string certificateBundleEnvironmentVariable = "NODE_EXTRA_CA_CERTS";
+        const string configuredNodeExtraCaCertsKey = "Node_Extra_Ca_Certs";
+        var homeDirectory = _workspace.CreateDirectory("bundle-home");
+        var existingBundlePath = Path.Combine(_workspace.WorkspaceRoot.FullName, "existing-ca-certs.pem");
+        var inheritedBundlePath = Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-ca-certs.pem");
+        var devCertificateDirectory = Path.Combine(homeDirectory.FullName, ".aspire", "dev-certs");
+        var devCertificatePath = Path.Combine(devCertificateDirectory, "aspire-dev-cert.pem");
+        const string existingBundleContents = "-----BEGIN CERTIFICATE-----\nexisting\n-----END CERTIFICATE-----\n";
+        const string inheritedBundleContents = "-----BEGIN CERTIFICATE-----\ninherited\n-----END CERTIFICATE-----\n";
+        const string devCertificateContents = "-----BEGIN CERTIFICATE-----\ndev\n-----END CERTIFICATE-----";
+        Directory.CreateDirectory(devCertificateDirectory);
+        await File.WriteAllTextAsync(existingBundlePath, existingBundleContents, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(inheritedBundlePath, inheritedBundleContents, TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(devCertificatePath, devCertificateContents, TestContext.Current.CancellationToken);
+
+        var environment = TestEnvironment.CreateWindows(new Dictionary<string, string?>
+        {
+            [certificateBundleEnvironmentVariable] = inheritedBundlePath
+        });
+        var project = CreateGuestAppHostProject(environment: environment, homeDirectory: homeDirectory);
+        var envVars = new Dictionary<string, string>
+        {
+            [certificateBundleEnvironmentVariable] = inheritedBundlePath,
+            [configuredNodeExtraCaCertsKey] = Path.GetFileName(existingBundlePath)
+        };
+        var expectedBundleContents = Encoding.UTF8.GetBytes($"{devCertificateContents}\n{existingBundleContents}");
+        var expectedHash = Convert.ToHexString(XxHash128.Hash(expectedBundleContents)).ToLowerInvariant();
+        var expectedBundlePath = Path.Combine(
+            homeDirectory.FullName,
+            ".aspire",
+            "dev-certs",
+            "bundles",
+            $"typescript-nodejs-{expectedHash}.pem");
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            certificateBundleEnvironmentVariable,
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedBundlePath, envVars[certificateBundleEnvironmentVariable]);
+        Assert.DoesNotContain(configuredNodeExtraCaCertsKey, envVars.Keys);
+        Assert.Equal(expectedBundleContents, await File.ReadAllBytesAsync(expectedBundlePath, TestContext.Current.CancellationToken));
+
+        var cachedWriteTime = DateTime.UtcNow.AddDays(-1);
+        File.SetLastWriteTimeUtc(expectedBundlePath, cachedWriteTime);
+        cachedWriteTime = File.GetLastWriteTimeUtc(expectedBundlePath);
+        envVars.Remove(certificateBundleEnvironmentVariable);
+        envVars[configuredNodeExtraCaCertsKey] = Path.GetFileName(existingBundlePath);
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            certificateBundleEnvironmentVariable,
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(cachedWriteTime, File.GetLastWriteTimeUtc(expectedBundlePath));
+        Assert.DoesNotContain(configuredNodeExtraCaCertsKey, envVars.Keys);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(Path.GetDirectoryName(expectedBundlePath)!));
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(expectedBundlePath));
+        }
+    }
+
+    [Fact]
+    public async Task ConfigureCertificateBundleEnvironmentAsync_PreservesExistingBundle_WhenCombinationFails()
+    {
+        var interactionService = new TestInteractionService();
+        var project = CreateGuestAppHostProject(interactionService: interactionService);
+        var devCertificatePath = Path.Combine(_workspace.WorkspaceRoot.FullName, "aspire-dev-cert.pem");
+        await File.WriteAllTextAsync(devCertificatePath, "dev certificate", TestContext.Current.CancellationToken);
+        var envVars = new Dictionary<string, string>
+        {
+            ["NODE_EXTRA_CA_CERTS"] = "missing-ca-certs.pem"
+        };
+
+        await project.ConfigureCertificateBundleEnvironmentAsync(
+            envVars,
+            _workspace.WorkspaceRoot,
+            devCertificatePath,
+            "NODE_EXTRA_CA_CERTS",
+            "typescript-nodejs",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("missing-ca-certs.pem", envVars["NODE_EXTRA_CA_CERTS"]);
+        Assert.Single(interactionService.DisplayedMessages);
+        Assert.Contains("existing certificate bundle will be used unchanged", interactionService.DisplayedMessages[0].Message);
     }
 
     private static async Task InvokeStartBackchannelConnectionAsync(
@@ -1310,5 +1535,4 @@ public class GuestAppHostProjectTests : IDisposable
         public Task<bool> RequestProcessTreeGracefulShutdownAsync(int pid, DateTimeOffset? startTime, bool includeStartTimeForDcp, CancellationToken cancellationToken)
             => Task.FromResult(true);
     }
-
 }

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -309,6 +309,7 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
             ],
             runtimeSpec.WatchExecute!.Args);
         Assert.Equal("node", runtimeSpec.ExtensionLaunchCapability);
+        Assert.Equal("NODE_EXTRA_CA_CERTS", runtimeSpec.CertificateBundleEnvironmentVariable);
     }
 
     [Fact]
@@ -377,7 +378,8 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
                 Command = "npx",
                 Args = ["--no-install", "nodemon", "--exec", "npx --no-install tsx --tsconfig tsconfig.apphost.json {appHostFile}"]
             },
-            ExtensionLaunchCapability = "node"
+            ExtensionLaunchCapability = "node",
+            CertificateBundleEnvironmentVariable = "NODE_EXTRA_CA_CERTS"
         };
     }
 

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -474,6 +474,8 @@ public class DotNetTemplateFactoryTests
                 EnvironmentVariables = new Dictionary<string, string>(),
                 Success = true
             });
+
+        public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
     }
 
     private sealed class TestNewCommandPrompter : INewCommandPrompter, ITemplateVersionPrompter

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateService.cs
@@ -15,4 +15,6 @@ internal sealed class TestCertificateService : ICertificateService
             Success = true
         });
     }
+
+    public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
@@ -16,6 +16,7 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
     public Func<EnsureCertificateResult>? EnsureHttpCertificateExistsCallback { get; set; }
     public Func<EnsureCertificateResult>? TrustHttpCertificateCallback { get; set; }
     public Func<CertificateCleanResult>? CleanHttpCertificateCallback { get; set; }
+    public Func<string, string?>? ExportDevCertificatePublicPemCallback { get; set; }
 
     public CertificateTrustResult CheckHttpCertificate(CancellationToken cancellationToken = default)
     {
@@ -53,5 +54,13 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
         return CleanHttpCertificateCallback is not null
             ? CleanHttpCertificateCallback()
             : new CertificateCleanResult { Success = true };
+    }
+
+    public string? ExportDevCertificatePublicPem(string outputDirectory, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ExportDevCertificatePublicPemCallback is not null
+            ? ExportDevCertificatePublicPemCallback(outputDirectory)
+            : null;
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -509,7 +509,10 @@ internal sealed class CliServiceCollectionTestOptions
         var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, serviceProvider.GetRequiredService<IEnvironment>());
+        var environment = serviceProvider.GetRequiredService<IEnvironment>();
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        var logger = serviceProvider.GetRequiredService<ILogger<CertificateService>>();
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment, environment, executionContext, logger);
     };
 
     public Func<IServiceProvider, IScaffoldingService> ScaffoldingServiceFactory { get; set; } = (IServiceProvider serviceProvider) =>

--- a/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/TestExecutionContextHelper.cs
@@ -22,7 +22,8 @@ internal static class TestExecutionContextHelper
         string? logFilePath = null,
         string? identityVersion = null,
         string? identityCommit = null,
-        bool identityOverridden = false)
+        bool identityOverridden = false,
+        DirectoryInfo? aspireHomeDirectory = null)
     {
         return CreateExecutionContext(
             workspace.WorkspaceRoot,
@@ -30,7 +31,8 @@ internal static class TestExecutionContextHelper
             logFilePath: logFilePath,
             identityVersion: identityVersion,
             identityCommit: identityCommit,
-            identityOverridden: identityOverridden);
+            identityOverridden: identityOverridden,
+            aspireHomeDirectory: aspireHomeDirectory);
     }
 
     /// <summary>
@@ -49,7 +51,8 @@ internal static class TestExecutionContextHelper
         string? identityVersion = null,
         string? identityCommit = null,
         bool identityOverridden = false,
-        DirectoryInfo? identityPackagesDirectory = null)
+        DirectoryInfo? identityPackagesDirectory = null,
+        DirectoryInfo? aspireHomeDirectory = null)
     {
         var root = rootDirectory.FullName;
         hivesDirectory ??= new DirectoryInfo(Path.Combine(root, ".aspire", "hives"));
@@ -74,6 +77,7 @@ internal static class TestExecutionContextHelper
             identityPackagesDirectory: identityPackagesDirectory,
             debugMode: debugMode,
             homeDirectory: homeDirectory,
-            packagesDirectory: packagesDirectory);
+            packagesDirectory: packagesDirectory,
+            aspireHomeDirectory: aspireHomeDirectory);
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -256,6 +256,8 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
         var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         var watchExecute = Assert.IsType<CommandSpec>(runtimeSpec.WatchExecute);
 
+        Assert.Equal("NODE_EXTRA_CA_CERTS", _languageSupport.CertificateBundleEnvironmentVariable);
+        Assert.Equal(_languageSupport.CertificateBundleEnvironmentVariable, runtimeSpec.CertificateBundleEnvironmentVariable);
         Assert.Equal("npx", preExecute.Command);
         Assert.Equal(new[] { "--no-install", "tsc", "--noEmit", "-p", "tsconfig.apphost.json" }, preExecute.Args);
         Assert.Equal(new[] { "--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);


### PR DESCRIPTION
Backport of #15634 to release/13.5

/cc @danegsta

## Customer Impact

TypeScript AppHosts cannot validate Aspire-managed development certificates when custom AppHost code connects to TLS-enabled resources, forcing customers to disable certificate validation as a workaround.

## Testing

Validated real Node TLS connections on macOS and Linux, existing CA preservation, secure cache permissions and reuse, missing-bundle fallback, and the publish-mode boundary. On release/13.5, 105 focused unit tests passed and the CLI E2E test project built successfully.

## Risk

Medium — this changes cross-platform certificate export, caching, and TypeScript AppHost process environment setup, but is scoped to run mode and has extensive platform and regression coverage.

## Regression?

No — this fixes an existing gap.
