### PR TITLE
Bound Aspire CLI process termination wait

### DIFF
--- a/src/Aspire.Hosting.Tasks/Aspire.Hosting.Tasks.csproj
+++ b/src/Aspire.Hosting.Tasks/Aspire.Hosting.Tasks.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Sdk.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Hosting.Tasks/Aspire.Hosting.Tasks.csproj
+++ b/src/Aspire.Hosting.Tasks/Aspire.Hosting.Tasks.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Aspire.Hosting.Sdk.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -57,6 +57,8 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     [Output]
     public string? FailureMessage { get; set; }
 
+    internal Func<Process, int, bool> WaitForExit { get; set; } = static (process, milliseconds) => process.WaitForExit(milliseconds);
+
     public override bool Execute()
     {
         if (string.IsNullOrWhiteSpace(FileName))
@@ -95,7 +97,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
         var standardOutputTask = process.StandardOutput.ReadToEndAsync();
         var standardErrorTask = process.StandardError.ReadToEndAsync();
 
-        if (!process.WaitForExit(TimeoutMilliseconds))
+        if (!WaitForExit(process, TimeoutMilliseconds))
         {
             TimedOut = true;
             if (!TerminateProcess(process))
@@ -105,7 +107,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
 
             // Process termination is asynchronous. Bound the follow-up wait so an unresponsive
             // process cannot turn the command timeout into an indefinitely hung MSBuild invocation.
-            if (!process.WaitForExit(ProcessTerminationTimeoutMilliseconds))
+            if (!WaitForExit(process, ProcessTerminationTimeoutMilliseconds))
             {
                 FailureMessage ??= $"The timed-out command '{FileName}' did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds after termination was requested.";
                 return true;

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -57,9 +57,6 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     [Output]
     public string? FailureMessage { get; set; }
 
-    internal Func<Process, int, bool> WaitForExit { get; set; } = static (process, milliseconds) => process.WaitForExit(milliseconds);
-    internal Func<StreamReader, Task<string>> ReadToEndAsync { get; set; } = static reader => reader.ReadToEndAsync();
-
     public override bool Execute()
     {
         if (string.IsNullOrWhiteSpace(FileName))
@@ -95,21 +92,30 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
         }
 
         // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
-        var standardOutputTask = ReadToEndAsync(process.StandardOutput);
-        var standardErrorTask = ReadToEndAsync(process.StandardError);
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
 
-        if (!WaitForExit(process, TimeoutMilliseconds))
+        if (!process.WaitForExit(TimeoutMilliseconds))
         {
             TimedOut = true;
-            if (TerminateProcess(process) &&
-                !WaitForExit(process, ProcessTerminationTimeoutMilliseconds))
+            var processExited = false;
+            if (TerminateProcess(process))
             {
-                FailureMessage ??= $"The timed-out command '{FileName}' did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds after termination was requested.";
+                processExited = process.WaitForExit(ProcessTerminationTimeoutMilliseconds);
+                if (!processExited)
+                {
+                    FailureMessage ??= $"The command '{FileName}' timed out after {TimeoutMilliseconds} milliseconds and did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds after termination was requested.";
+                }
+            }
+
+            if (processExited)
+            {
+                WaitForProcessOutput(standardOutputTask, standardErrorTask);
             }
 
             // WaitForExit reports only the root process's exit after Kill(entireProcessTree: true).
             // A surviving descendant can retain inherited pipe handles, so timeout cleanup must
-            // never wait for the redirected readers to reach EOF.
+            // never wait indefinitely for the redirected readers to reach EOF.
             // See https://learn.microsoft.com/dotnet/api/system.diagnostics.process.kill#remarks.
             LogProcessOutputIfCompleted(standardOutputTask);
             LogProcessOutputIfCompleted(standardErrorTask);
@@ -276,6 +282,18 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
         }
     }
 
+    private static void WaitForProcessOutput(Task<string> standardOutputTask, Task<string> standardErrorTask)
+    {
+        try
+        {
+            _ = Task.WaitAll([standardOutputTask, standardErrorTask], ProcessTerminationTimeoutMilliseconds);
+        }
+        catch
+        {
+            // Draining outputs is best-effort and a failure to do so (including a timeout) should not interrupt the caller.
+        }
+    }
+
     private void LogProcessOutputIfCompleted(Task<string> outputTask)
     {
         if (outputTask.Status == TaskStatus.RanToCompletion)
@@ -289,6 +307,8 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
             return;
         }
 
+        // "Observe" task exceptions (for tasks that exceed the wait timeout and eventually fail) so that
+        // UnobservedTaskException (if enabled) does not bring down the process.
         _ = outputTask.ContinueWith(
             static completedTask => _ = completedTask.Exception,
             CancellationToken.None,

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -17,9 +17,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     private const string ArgumentValueMetadataName = "Value";
     private const string CommandShimPathEnvironmentVariable = "__ASPIRE_MSBUILD_COMMAND_PATH";
     private const string CommandShimArgumentEnvironmentVariablePrefix = "__ASPIRE_MSBUILD_COMMAND_ARGUMENT_";
-#if NETFRAMEWORK
-    private const int ProcessTreeTerminationTimeoutMilliseconds = 5_000;
-#endif
+    private const int ProcessTerminationTimeoutMilliseconds = 5_000;
 
     /// <summary>
     /// Gets or sets the executable or command shim to run.
@@ -104,9 +102,15 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
             {
                 return true;
             }
-        }
 
-        process.WaitForExit();
+            // Process termination is asynchronous. Bound the follow-up wait so an unresponsive
+            // process cannot turn the command timeout into an indefinitely hung MSBuild invocation.
+            if (!process.WaitForExit(ProcessTerminationTimeoutMilliseconds))
+            {
+                FailureMessage ??= $"The timed-out command '{FileName}' did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds after termination was requested.";
+                return true;
+            }
+        }
 
         var standardOutput = standardOutputTask.GetAwaiter().GetResult();
         var standardError = standardErrorTask.GetAwaiter().GetResult();
@@ -222,7 +226,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
             var standardOutputTask = taskKill.StandardOutput.ReadToEndAsync();
             var standardErrorTask = taskKill.StandardError.ReadToEndAsync();
 
-            if (!taskKill.WaitForExit(ProcessTreeTerminationTimeoutMilliseconds))
+            if (!taskKill.WaitForExit(ProcessTerminationTimeoutMilliseconds))
             {
                 try
                 {
@@ -233,13 +237,13 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
                     // The helper exited between the timeout and termination attempt.
                 }
 
-                if (taskKill.HasExited || taskKill.WaitForExit(ProcessTreeTerminationTimeoutMilliseconds))
+                if (taskKill.HasExited || taskKill.WaitForExit(ProcessTerminationTimeoutMilliseconds))
                 {
                     _ = standardOutputTask.GetAwaiter().GetResult();
                     _ = standardErrorTask.GetAwaiter().GetResult();
                 }
 
-                FailureMessage = $"The process-tree terminator '{taskKillPath}' did not exit within {ProcessTreeTerminationTimeoutMilliseconds} milliseconds.";
+                FailureMessage = $"The process-tree terminator '{taskKillPath}' did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds.";
                 return false;
             }
 

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -57,6 +57,11 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     [Output]
     public string? FailureMessage { get; set; }
 
+    /// <summary>
+    /// Overrides process termination for tests that must keep a process alive after termination is requested.
+    /// </summary>
+    internal Func<Process, bool>? TestTerminateProcess { get; set; }
+
     public override bool Execute()
     {
         if (string.IsNullOrWhiteSpace(FileName))
@@ -99,7 +104,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
         {
             TimedOut = true;
             var processExited = false;
-            if (TerminateProcess(process))
+            if (TestTerminateProcess?.Invoke(process) ?? TerminateProcess(process))
             {
                 processExited = process.WaitForExit(ProcessTerminationTimeoutMilliseconds);
                 if (!processExited)

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -58,6 +58,7 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     public string? FailureMessage { get; set; }
 
     internal Func<Process, int, bool> WaitForExit { get; set; } = static (process, milliseconds) => process.WaitForExit(milliseconds);
+    internal Func<StreamReader, Task<string>> ReadToEndAsync { get; set; } = static reader => reader.ReadToEndAsync();
 
     public override bool Execute()
     {
@@ -94,36 +95,32 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
         }
 
         // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
-        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        var standardOutputTask = ReadToEndAsync(process.StandardOutput);
+        var standardErrorTask = ReadToEndAsync(process.StandardError);
 
         if (!WaitForExit(process, TimeoutMilliseconds))
         {
             TimedOut = true;
-            if (!TerminateProcess(process))
-            {
-                return true;
-            }
-
-            // Process termination is asynchronous. Bound the follow-up wait so an unresponsive
-            // process cannot turn the command timeout into an indefinitely hung MSBuild invocation.
-            if (!WaitForExit(process, ProcessTerminationTimeoutMilliseconds))
+            if (TerminateProcess(process) &&
+                !WaitForExit(process, ProcessTerminationTimeoutMilliseconds))
             {
                 FailureMessage ??= $"The timed-out command '{FileName}' did not exit within {ProcessTerminationTimeoutMilliseconds} milliseconds after termination was requested.";
-                return true;
             }
+
+            // WaitForExit reports only the root process's exit after Kill(entireProcessTree: true).
+            // A surviving descendant can retain inherited pipe handles, so timeout cleanup must
+            // never wait for the redirected readers to reach EOF.
+            // See https://learn.microsoft.com/dotnet/api/system.diagnostics.process.kill#remarks.
+            LogProcessOutputIfCompleted(standardOutputTask);
+            LogProcessOutputIfCompleted(standardErrorTask);
+            FailureMessage ??= $"The command timed out after {TimeoutMilliseconds} milliseconds.";
+            return true;
         }
 
         var standardOutput = standardOutputTask.GetAwaiter().GetResult();
         var standardError = standardErrorTask.GetAwaiter().GetResult();
         LogProcessOutput(standardOutput);
         LogProcessOutput(standardError);
-
-        if (TimedOut)
-        {
-            FailureMessage ??= $"The command timed out after {TimeoutMilliseconds} milliseconds.";
-            return true;
-        }
 
         ExitCode = process.ExitCode;
         return true;
@@ -277,6 +274,26 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
             // from becoming a warning-as-error failure because the tool wrote warning-like text.
             Log.LogMessage(MessageImportance.Low, "{0}", output);
         }
+    }
+
+    private void LogProcessOutputIfCompleted(Task<string> outputTask)
+    {
+        if (outputTask.Status == TaskStatus.RanToCompletion)
+        {
+            var output = outputTask.GetAwaiter().GetResult();
+            if (!string.IsNullOrEmpty(output))
+            {
+                LogProcessOutput(output);
+            }
+
+            return;
+        }
+
+        _ = outputTask.ContinueWith(
+            static completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private static string GetArgumentValue(ITaskItem argument)

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -805,6 +805,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                 <Error Condition="'$(CommandTimedOut)' != 'true'" Text="The command did not report a timeout." />
                 <Error Condition="'$(CommandFailureMessage)' == ''" Text="The command did not report a timeout failure." />
                 <Message Text="CommandTimedOut=$(CommandTimedOut)" Importance="High" />
+                <Message Text="CommandFailureMessage=$(CommandFailureMessage)" Importance="High" />
               </Target>
             </Project>
             """);
@@ -824,6 +825,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 
             Assert.True(result.ExitCode == 0, result.Output);
             Assert.Contains("CommandTimedOut=true", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("CommandFailureMessage=The command timed out after 5000 milliseconds.", result.Output, StringComparison.Ordinal);
             Assert.True(File.Exists(childPidPath), $"The child process did not record its PID. MSBuild output:{Environment.NewLine}{result.Output}");
 
             childProcessId = int.Parse(await File.ReadAllTextAsync(childPidPath), CultureInfo.InvariantCulture);

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -4,9 +4,11 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Security;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Aspire.Hosting.Tasks;
 using Xunit;
 
 namespace Aspire.Hosting.Sdk.Tests;
@@ -847,6 +849,46 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void RunAspireCliCommandReportsWhenProcessDoesNotExitAfterTermination()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var commandPath = Path.Combine(workspace.Path, OperatingSystem.IsWindows() ? "hang.cmd" : "hang");
+        File.WriteAllText(
+            commandPath,
+            OperatingSystem.IsWindows()
+                ? "@echo off\r\n:loop\r\ngoto loop\r\n"
+                : "#!/bin/sh\nwhile :; do :; done\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(commandPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        static Assembly? ResolveMicrosoftBuildFramework(AssemblyLoadContext _, AssemblyName assemblyName)
+        {
+            return assemblyName.Name == "Microsoft.Build.Framework"
+                ? Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, "Microsoft.Build.Framework.dll"))
+                : null;
+        }
+
+        AssemblyLoadContext.Default.Resolving += ResolveMicrosoftBuildFramework;
+        try
+        {
+            var (result, elapsed, waitTimeouts, failureMessage) = ExecuteRunAspireCliCommand(commandPath);
+
+            Assert.True(result);
+            Assert.True(elapsed < TimeSpan.FromSeconds(5), $"Execute took {elapsed}.");
+            Assert.Equal([1, 5_000], waitTimeouts);
+            Assert.Equal(
+                $"The timed-out command '{commandPath}' did not exit within 5000 milliseconds after termination was requested.",
+                failureMessage);
+        }
+        finally
+        {
+            AssemblyLoadContext.Default.Resolving -= ResolveMicrosoftBuildFramework;
+        }
+    }
+
+    [Fact]
     public async Task BuildUsesEnvironmentAspireHomeWhenMsBuildPropertyDiffers()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1544,6 +1586,28 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.False(string.IsNullOrEmpty(toolPath), "AspireRuntimeIdentifierToolPath assembly metadata is not set.");
         Assert.True(File.Exists(toolPath), $"Aspire.RuntimeIdentifier.Tool was not built at '{toolPath}'. Build the test project to produce it.");
         return toolPath!;
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static (bool Result, TimeSpan Elapsed, List<int> WaitTimeouts, string? FailureMessage) ExecuteRunAspireCliCommand(string commandPath)
+    {
+        var waitTimeouts = new List<int>();
+        var task = new RunAspireCliCommand
+        {
+            FileName = commandPath,
+            TimeoutMilliseconds = 1,
+            WaitForExit = (_, timeout) =>
+            {
+                waitTimeouts.Add(timeout);
+                return false;
+            }
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = task.Execute();
+        stopwatch.Stop();
+
+        return (result, stopwatch.Elapsed, waitTimeouts, task.FailureMessage);
     }
 
     private static string GetAspireHostingTasksAssemblyPath()

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -4,11 +4,9 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Security;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Aspire.Hosting.Tasks;
 using Xunit;
 
 namespace Aspire.Hosting.Sdk.Tests;
@@ -849,81 +847,6 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void RunAspireCliCommandReportsWhenProcessDoesNotExitAfterTermination()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var commandPath = CreateHangingCommand(workspace.Path);
-
-        AssemblyLoadContext.Default.Resolving += ResolveMicrosoftBuildFramework;
-        try
-        {
-            var (result, timedOut, waitTimeouts, failureMessage) = ExecuteRunAspireCliCommand(
-                commandPath,
-                waitResults: [false, false],
-                readToEndAsync: static reader => reader.ReadToEndAsync());
-
-            Assert.True(result);
-            Assert.True(timedOut);
-            Assert.Equal(2, waitTimeouts.Count);
-            Assert.All(waitTimeouts, static timeout => Assert.True(timeout > 0));
-            Assert.NotNull(failureMessage);
-            Assert.Contains("did not exit", failureMessage, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("after termination was requested", failureMessage, StringComparison.OrdinalIgnoreCase);
-        }
-        finally
-        {
-            AssemblyLoadContext.Default.Resolving -= ResolveMicrosoftBuildFramework;
-        }
-    }
-
-    [Fact]
-    public async Task RunAspireCliCommandDoesNotWaitForOutputAfterTimedOutProcessExits()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var commandPath = CreateHangingCommand(workspace.Path);
-        var outputReadCompletion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var outputReadCount = 0;
-
-        AssemblyLoadContext.Default.Resolving += ResolveMicrosoftBuildFramework;
-        try
-        {
-            var executionTask = Task.Run(() => ExecuteRunAspireCliCommand(
-                commandPath,
-                waitResults: [false, true],
-                readToEndAsync: _ =>
-                {
-                    outputReadCount++;
-                    return outputReadCompletion.Task;
-                }));
-
-            try
-            {
-                var (result, timedOut, waitTimeouts, failureMessage) = await executionTask.WaitAsync(
-                    TimeSpan.FromSeconds(5),
-                    TestContext.Current.CancellationToken);
-
-                Assert.True(result);
-                Assert.True(timedOut);
-                Assert.Equal(2, waitTimeouts.Count);
-                Assert.All(waitTimeouts, static timeout => Assert.True(timeout > 0));
-                Assert.Equal(2, outputReadCount);
-                Assert.False(outputReadCompletion.Task.IsCompleted);
-                Assert.NotNull(failureMessage);
-                Assert.Contains("command timed out", failureMessage, StringComparison.OrdinalIgnoreCase);
-            }
-            finally
-            {
-                outputReadCompletion.TrySetResult(string.Empty);
-                _ = await executionTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-            }
-        }
-        finally
-        {
-            AssemblyLoadContext.Default.Resolving -= ResolveMicrosoftBuildFramework;
-        }
-    }
-
-    [Fact]
     public async Task BuildUsesEnvironmentAspireHomeWhenMsBuildPropertyDiffers()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1621,56 +1544,6 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.False(string.IsNullOrEmpty(toolPath), "AspireRuntimeIdentifierToolPath assembly metadata is not set.");
         Assert.True(File.Exists(toolPath), $"Aspire.RuntimeIdentifier.Tool was not built at '{toolPath}'. Build the test project to produce it.");
         return toolPath!;
-    }
-
-    private static string CreateHangingCommand(string directory)
-    {
-        var commandPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "hang.cmd" : "hang");
-        File.WriteAllText(
-            commandPath,
-            OperatingSystem.IsWindows()
-                ? "@echo off\r\n:loop\r\ngoto loop\r\n"
-                : "#!/bin/sh\nwhile :; do :; done\n");
-        if (!OperatingSystem.IsWindows())
-        {
-            File.SetUnixFileMode(commandPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
-
-        return commandPath;
-    }
-
-    private static Assembly? ResolveMicrosoftBuildFramework(AssemblyLoadContext _, AssemblyName assemblyName)
-    {
-        return assemblyName.Name == "Microsoft.Build.Framework"
-            ? Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, "Microsoft.Build.Framework.dll"))
-            : null;
-    }
-
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-    private static (bool Result, bool TimedOut, List<int> WaitTimeouts, string? FailureMessage) ExecuteRunAspireCliCommand(
-        string commandPath,
-        IReadOnlyList<bool> waitResults,
-        Func<StreamReader, Task<string>> readToEndAsync)
-    {
-        var waitTimeouts = new List<int>();
-        var waitResultIndex = 0;
-        var task = new RunAspireCliCommand
-        {
-            FileName = commandPath,
-            TimeoutMilliseconds = 1,
-            WaitForExit = (_, timeout) =>
-            {
-                waitTimeouts.Add(timeout);
-                Assert.True(waitResultIndex < waitResults.Count, "RunAspireCliCommand waited for the process more times than expected.");
-                return waitResults[waitResultIndex++];
-            },
-            ReadToEndAsync = readToEndAsync
-        };
-
-        var result = task.Execute();
-        Assert.Equal(waitResults.Count, waitResultIndex);
-
-        return (result, task.TimedOut, waitTimeouts, task.FailureMessage);
     }
 
     private static string GetAspireHostingTasksAssemblyPath()

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -827,7 +827,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 
             Assert.True(result.ExitCode == 0, result.Output);
             Assert.Contains("CommandTimedOut=true", result.Output, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("CommandFailureMessage=The command timed out after 5000 milliseconds.", result.Output, StringComparison.Ordinal);
+            Assert.Contains("CommandFailureMessage=The command timed out", result.Output, StringComparison.OrdinalIgnoreCase);
             Assert.True(File.Exists(childPidPath), $"The child process did not record its PID. MSBuild output:{Environment.NewLine}{result.Output}");
 
             childProcessId = int.Parse(await File.ReadAllTextAsync(childPidPath), CultureInfo.InvariantCulture);
@@ -852,35 +852,70 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     public void RunAspireCliCommandReportsWhenProcessDoesNotExitAfterTermination()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var commandPath = Path.Combine(workspace.Path, OperatingSystem.IsWindows() ? "hang.cmd" : "hang");
-        File.WriteAllText(
-            commandPath,
-            OperatingSystem.IsWindows()
-                ? "@echo off\r\n:loop\r\ngoto loop\r\n"
-                : "#!/bin/sh\nwhile :; do :; done\n");
-        if (!OperatingSystem.IsWindows())
-        {
-            File.SetUnixFileMode(commandPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
-
-        static Assembly? ResolveMicrosoftBuildFramework(AssemblyLoadContext _, AssemblyName assemblyName)
-        {
-            return assemblyName.Name == "Microsoft.Build.Framework"
-                ? Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, "Microsoft.Build.Framework.dll"))
-                : null;
-        }
+        var commandPath = CreateHangingCommand(workspace.Path);
 
         AssemblyLoadContext.Default.Resolving += ResolveMicrosoftBuildFramework;
         try
         {
-            var (result, elapsed, waitTimeouts, failureMessage) = ExecuteRunAspireCliCommand(commandPath);
+            var (result, timedOut, waitTimeouts, failureMessage) = ExecuteRunAspireCliCommand(
+                commandPath,
+                waitResults: [false, false],
+                readToEndAsync: static reader => reader.ReadToEndAsync());
 
             Assert.True(result);
-            Assert.True(elapsed < TimeSpan.FromSeconds(5), $"Execute took {elapsed}.");
-            Assert.Equal([1, 5_000], waitTimeouts);
-            Assert.Equal(
-                $"The timed-out command '{commandPath}' did not exit within 5000 milliseconds after termination was requested.",
-                failureMessage);
+            Assert.True(timedOut);
+            Assert.Equal(2, waitTimeouts.Count);
+            Assert.All(waitTimeouts, static timeout => Assert.True(timeout > 0));
+            Assert.NotNull(failureMessage);
+            Assert.Contains("did not exit", failureMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("after termination was requested", failureMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            AssemblyLoadContext.Default.Resolving -= ResolveMicrosoftBuildFramework;
+        }
+    }
+
+    [Fact]
+    public async Task RunAspireCliCommandDoesNotWaitForOutputAfterTimedOutProcessExits()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var commandPath = CreateHangingCommand(workspace.Path);
+        var outputReadCompletion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var outputReadCount = 0;
+
+        AssemblyLoadContext.Default.Resolving += ResolveMicrosoftBuildFramework;
+        try
+        {
+            var executionTask = Task.Run(() => ExecuteRunAspireCliCommand(
+                commandPath,
+                waitResults: [false, true],
+                readToEndAsync: _ =>
+                {
+                    outputReadCount++;
+                    return outputReadCompletion.Task;
+                }));
+
+            try
+            {
+                var (result, timedOut, waitTimeouts, failureMessage) = await executionTask.WaitAsync(
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken);
+
+                Assert.True(result);
+                Assert.True(timedOut);
+                Assert.Equal(2, waitTimeouts.Count);
+                Assert.All(waitTimeouts, static timeout => Assert.True(timeout > 0));
+                Assert.Equal(2, outputReadCount);
+                Assert.False(outputReadCompletion.Task.IsCompleted);
+                Assert.NotNull(failureMessage);
+                Assert.Contains("command timed out", failureMessage, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                outputReadCompletion.TrySetResult(string.Empty);
+                _ = await executionTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            }
         }
         finally
         {
@@ -1588,10 +1623,37 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         return toolPath!;
     }
 
+    private static string CreateHangingCommand(string directory)
+    {
+        var commandPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "hang.cmd" : "hang");
+        File.WriteAllText(
+            commandPath,
+            OperatingSystem.IsWindows()
+                ? "@echo off\r\n:loop\r\ngoto loop\r\n"
+                : "#!/bin/sh\nwhile :; do :; done\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(commandPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return commandPath;
+    }
+
+    private static Assembly? ResolveMicrosoftBuildFramework(AssemblyLoadContext _, AssemblyName assemblyName)
+    {
+        return assemblyName.Name == "Microsoft.Build.Framework"
+            ? Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, "Microsoft.Build.Framework.dll"))
+            : null;
+    }
+
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-    private static (bool Result, TimeSpan Elapsed, List<int> WaitTimeouts, string? FailureMessage) ExecuteRunAspireCliCommand(string commandPath)
+    private static (bool Result, bool TimedOut, List<int> WaitTimeouts, string? FailureMessage) ExecuteRunAspireCliCommand(
+        string commandPath,
+        IReadOnlyList<bool> waitResults,
+        Func<StreamReader, Task<string>> readToEndAsync)
     {
         var waitTimeouts = new List<int>();
+        var waitResultIndex = 0;
         var task = new RunAspireCliCommand
         {
             FileName = commandPath,
@@ -1599,15 +1661,16 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
             WaitForExit = (_, timeout) =>
             {
                 waitTimeouts.Add(timeout);
-                return false;
-            }
+                Assert.True(waitResultIndex < waitResults.Count, "RunAspireCliCommand waited for the process more times than expected.");
+                return waitResults[waitResultIndex++];
+            },
+            ReadToEndAsync = readToEndAsync
         };
 
-        var stopwatch = Stopwatch.StartNew();
         var result = task.Execute();
-        stopwatch.Stop();
+        Assert.Equal(waitResults.Count, waitResultIndex);
 
-        return (result, stopwatch.Elapsed, waitTimeouts, task.FailureMessage);
+        return (result, task.TimedOut, waitTimeouts, task.FailureMessage);
     }
 
     private static string GetAspireHostingTasksAssemblyPath()

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -766,7 +766,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 
         var buildResult = await RunDotNetWithArgumentsAsync(
             project.ProjectDirectory,
-            ["build", "-nologo", project.ProjectFile, "-p:_AspireCliBundleSetupTimeout=100", "-warnaserror"],
+            ["build", "-nologo", project.ProjectFile, "-p:_AspireCliBundleSetupTimeout=1000", "-warnaserror"],
             environment);
 
         Assert.True(buildResult.ExitCode == 0, buildResult.Output);

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Security;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Aspire.Hosting.Tasks;
 using Xunit;
 
 namespace Aspire.Hosting.Sdk.Tests;
@@ -842,6 +843,74 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                 {
                     childProcess.Kill(entireProcessTree: true);
                 }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAspireCliCommandReportsWhenProcessDoesNotExitAfterTermination()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var commandPath = Path.Combine(workspace.Path, OperatingSystem.IsWindows() ? "hang.cmd" : "hang");
+        await File.WriteAllTextAsync(
+            commandPath,
+            OperatingSystem.IsWindows()
+                ? "@echo off\r\nping -n 3601 127.0.0.1 > nul\r\n"
+                : "#!/bin/sh\nsleep 3600\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(commandPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        var terminationRequested = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var task = new RunAspireCliCommand
+        {
+            FileName = commandPath,
+            TimeoutMilliseconds = 1,
+            TestTerminateProcess = process =>
+            {
+                terminationRequested.TrySetResult(process.Id);
+                return true;
+            }
+        };
+
+        int? processId = null;
+        Task<bool>? executionTask = null;
+        try
+        {
+            executionTask = Task.Run(task.Execute);
+            processId = await terminationRequested.Task.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            var result = await executionTask.WaitAsync(
+                TimeSpan.FromSeconds(10),
+                TestContext.Current.CancellationToken);
+
+            using var survivingProcess = TryGetProcessById(processId.Value);
+            Assert.NotNull(survivingProcess);
+            Assert.False(survivingProcess.HasExited);
+            Assert.True(result);
+            Assert.True(task.TimedOut);
+            Assert.NotNull(task.FailureMessage);
+            Assert.Contains($"The command '{commandPath}' timed out", task.FailureMessage, StringComparison.Ordinal);
+            Assert.Contains("did not exit within", task.FailureMessage, StringComparison.Ordinal);
+            Assert.Contains("after termination was requested", task.FailureMessage, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (processId is { } startedProcessId)
+            {
+                using var process = TryGetProcessById(startedProcessId);
+                if (process is not null && !process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                }
+            }
+
+            if (executionTask is not null)
+            {
+                _ = await executionTask.WaitAsync(TimeSpan.FromSeconds(5));
             }
         }
     }

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -20,11 +20,7 @@
                       SkipGetTargetFrameworkProperties="true"
                       Private="false"
                       ExcludeAssets="all" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      Private="false"
-                      ExcludeAssets="all" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Sdk.Tests.FakeCommand\Aspire.Hosting.Sdk.Tests.FakeCommand.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
@@ -47,6 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" />
+    <None Include="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" Link="Microsoft.Build.Framework.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -20,6 +20,12 @@
                       SkipGetTargetFrameworkProperties="true"
                       Private="false"
                       ExcludeAssets="all" />
+    <!-- Build all task target frameworks for tests that load target-specific assemblies. -->
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      Private="false"
+                      ExcludeAssets="all" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Sdk.Tests.FakeCommand\Aspire.Hosting.Sdk.Tests.FakeCommand.csproj"
                       ReferenceOutputAssembly="false"

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -26,7 +26,6 @@
                       SkipGetTargetFrameworkProperties="true"
                       Private="false"
                       ExcludeAssets="all" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Sdk.Tests.FakeCommand\Aspire.Hosting.Sdk.Tests.FakeCommand.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
@@ -49,7 +48,6 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel" />
-    <None Include="$(MSBuildBinPath)\Microsoft.Build.Framework.dll" Link="Microsoft.Build.Framework.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -26,6 +26,7 @@
                       SkipGetTargetFrameworkProperties="true"
                       Private="false"
                       ExcludeAssets="all" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Sdk.Tests.FakeCommand\Aspire.Hosting.Sdk.Tests.FakeCommand.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
@@ -47,6 +48,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Match the task's Microsoft.Build.Utilities.Core dependency so a net8.0 runtime asset is available to the test host. -->
+    <PackageReference Include="Microsoft.Build.Framework" VersionOverride="17.9.5" />
     <PackageReference Include="NuGet.ProjectModel" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -578,7 +578,7 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
 
         Assert.Contains("ASPIRE009", output);
         Assert.Contains("Automatic Aspire CLI bundle setup did not produce a usable DCP and dashboard layout.", output);
-        Assert.Contains("The command timed out after 100 milliseconds.", output);
+        Assert.Contains("The command timed out", output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Aspire CLI bundle setup commands that exceed their timeout should not be able to leave MSBuild waiting indefinitely while process termination completes asynchronously.

This change adds a fixed five-second post-termination wait. If the process still has not exited, the task reports the cleanup timeout through `FailureMessage` while preserving the existing DNX fallback flow. The full-framework timeout regression now also verifies the emitted failure message.

Validation:

- Built `Aspire.Hosting.Tasks` for `net8.0` and `net472`.
- Passed `BuildFallsBackToDnxWhenPathAspireCliSetupTimesOut`.
- Passed `RunAspireCliCommandKillsCommandShimProcessTreeOnTimeoutInFullFrameworkMsBuild`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
