### PR TITLE
Color statuses in aspire ps output

### DIFF
--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -441,7 +441,7 @@ internal sealed partial class PsCommand
             var columns = new List<string>
             {
                 Markup.Escape(shortPath),
-                Markup.Escape(appHost.Status),
+                GetStatusMarkup(appHost.Status),
                 Markup.Escape(appHost.SdkVersion ?? "-"),
                 appHost.AppHostPid.ToString(CultureInfo.InvariantCulture),
                 cliPid,
@@ -453,6 +453,16 @@ internal sealed partial class PsCommand
         }
 
         InteractionService.DisplayRenderable(table);
+    }
+
+    internal static string GetStatusMarkup(string status)
+    {
+        return status switch
+        {
+            AppHostDisplayStatus.Running => $"[green]{AppHostDisplayStatus.Running}[/]",
+            AppHostDisplayStatus.Stopped => $"[red]{AppHostDisplayStatus.Stopped}[/]",
+            _ => Markup.Escape(status)
+        };
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -20,6 +20,15 @@ namespace Aspire.Cli.Tests.Commands;
 
 public class PsCommandTests(ITestOutputHelper outputHelper)
 {
+    [Theory]
+    [InlineData(AppHostDisplayStatus.Running, "[green]running[/]")]
+    [InlineData(AppHostDisplayStatus.Stopped, "[red]stopped[/]")]
+    [InlineData("unknown[status]", "unknown[[status]]")]
+    public void GetStatusMarkup_ReturnsExpectedMarkup(string status, string expectedMarkup)
+    {
+        Assert.Equal(expectedMarkup, PsCommand.GetStatusMarkup(status));
+    }
+
     [Fact]
     public async Task PsCommand_Help_Works()
     {


### PR DESCRIPTION
## Description

`aspire ps` currently renders AppHost statuses as unstyled text, making the running state harder to scan than comparable CLI status tables. This change renders `running` in green and `stopped` in red in table output, while preserving escaped plain text for unknown statuses and leaving JSON output unchanged.

### User-facing usage

Run:

```console
aspire ps
```

Known statuses in the result table are now color-coded: `running` is green and `stopped` is red.

### Screenshots / Recordings

Before:
<img width="1457" height="139" alt="image" src="https://github.com/user-attachments/assets/19aefe58-bdc8-42ae-9db1-7f2599806b39" />

After:
<img width="1449" height="138" alt="image" src="https://github.com/user-attachments/assets/886b15e0-31d7-48fa-bfb1-f494b3c9eb45" />

### Validation

```console
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.PsCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

All 31 tests passed.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
