### PR TITLE
Fix template catalog member paths

### DIFF
--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -105,7 +105,9 @@ $i = 0
 foreach ($f in $files) {
     $ext = $f.Extension.TrimStart('.').ToLower()
     $label = "${ext}_${i}_" + ($f.Name -replace '[^\w\.-]', '_')
-    $cdfContent += "<hash>$label=`"$($f.FullName)`""
+    # CDF values extend to the end of the line, so quotes become part of the member path.
+    # See https://learn.microsoft.com/windows/win32/seccrypto/makecat
+    $cdfContent += "<hash>$label=$($f.FullName)"
     $i++
 }
 


### PR DESCRIPTION
## Description

Fixes the Windows internal build failure introduced by catalog signing for JavaScript files in `Aspire.ProjectTemplates`.

`makecat.exe` treats quotes in Catalog Definition File member values as literal path characters. The generated CDF therefore referenced filenames that began and ended with `"`, causing `makecat.exe` to report that existing template files did not exist. This change emits the member paths unquoted, as required by the CDF format; paths containing spaces remain supported because values extend to the end of the line.

Validation: internal Azure DevOps build 3047697 passed the previous `makecat.exe` failure point and continued without build errors.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
