### PR TITLE
Update gRPC packages to 2.83.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,9 +109,9 @@
     <PackageVersion Include="Deque.AxeCore.Playwright" Version="4.11.3" />
     <PackageVersion Include="DnsClient" Version="1.8.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
     <PackageVersion Include="Hex1b" Version="0.163.0" />
     <PackageVersion Include="Hex1b.McpServer" Version="0.163.0" />
     <PackageVersion Include="Hex1b.Tool" Version="0.163.0" />

--- a/playground/Stress/Stress.TelemetryService/Stress.TelemetryService.csproj
+++ b/playground/Stress/Stress.TelemetryService/Stress.TelemetryService.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.ClientFactory" />
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="all" />
     <PackageReference Include="Google.Protobuf" />
   </ItemGroup>
 

--- a/playground/TestShop/BasketService/BasketService.csproj
+++ b/playground/TestShop/BasketService/BasketService.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" />
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/TestShop/MyFrontend/MyFrontend.csproj
+++ b/playground/TestShop/MyFrontend/MyFrontend.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Yarp.ReverseProxy" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Net.ClientFactory" />
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -51,7 +51,6 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" />
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
     <PackageReference Include="Hex1b" />
     <PackageReference Include="Humanizer.Core" />
     <PackageReference Include="Markdig" />

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -69,7 +69,6 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" />
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
     <PackageReference Include="KubernetesClient" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="ModelContextProtocol" />

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <!-- axe-core accessibility scanning for the Playwright integration tests (AccessibilityTests). -->


### PR DESCRIPTION
## Description

Updates `Grpc.AspNetCore`, `Grpc.Net.ClientFactory`, and `Grpc.Tools` from 2.80.0 to 2.83.0. `Grpc.Tools` 2.83.0 fixes the Linux ARM64 `protoc` crash tracked by https://github.com/grpc/grpc/issues/38538, so the project-level 2.68.1 version overrides are no longer needed.

This also removes redundant direct `Grpc.Tools` references from projects that receive the build tooling through `Grpc.AspNetCore`, and from the Dashboard test project, which does not compile protobuf files. Client-only projects that compile protobuf files retain direct `Grpc.Tools` references and now use the centrally managed 2.83.0 version.

Validation:

- `dotnet build .\playground\TestShop\BasketService\BasketService.csproj /p:SkipNativeBuild=true`
- `dotnet build .\src\Aspire.Hosting\Aspire.Hosting.csproj /p:SkipNativeBuild=true`
- `dotnet build .\tests\Aspire.Dashboard.Tests\Aspire.Dashboard.Tests.csproj /p:SkipNativeBuild=true`
- `dotnet build .\playground\Stress\Stress.TelemetryService\Stress.TelemetryService.csproj /p:SkipNativeBuild=true`
- `dotnet build .\playground\TestShop\MyFrontend\MyFrontend.csproj /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No