### PR TITLE
Set a default fsGroup for Kubernetes persistent volumes

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
@@ -239,8 +239,9 @@ public static class KubernetesPersistentVolumeExtensions
     /// <c>mountPath</c> instead. The generated pod uses an Aspire-managed
     /// <c>fsGroup</c> of <c>2000</c> with an <c>OnRootMismatch</c> change policy so
     /// non-root containers can access supported volumes without matching the image's
-    /// primary group. Use <c>PublishAsKubernetesService</c> to customize the pod
-    /// security context when a different group or policy is required.
+    /// primary group. Use
+    /// <see cref="KubernetesServiceExtensions.PublishAsKubernetesService{T}(IResourceBuilder{T}, Action{KubernetesResource})"/>
+    /// to customize the pod security context when a different group or policy is required.
     /// </remarks>
     /// <example>
     /// <code>
@@ -286,8 +287,8 @@ public static class KubernetesPersistentVolumeExtensions
     /// The generated pod uses an Aspire-managed <c>fsGroup</c> of <c>2000</c> with
     /// an <c>OnRootMismatch</c> change policy so non-root containers can access
     /// supported volumes without matching the image's primary group. Use
-    /// <c>PublishAsKubernetesService</c> to customize the pod security context when
-    /// a different group or policy is required.
+    /// <see cref="KubernetesServiceExtensions.PublishAsKubernetesService{T}(IResourceBuilder{T}, Action{KubernetesResource})"/>
+    /// to customize the pod security context when a different group or policy is required.
     /// </remarks>
     /// <example>
     /// <code>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
@@ -236,7 +236,11 @@ public static class KubernetesPersistentVolumeExtensions
     /// <remarks>
     /// To bind a workload that does not already have a matching named mount (for
     /// example a <c>ProjectResource</c>), use the overload that accepts a
-    /// <c>mountPath</c> instead.
+    /// <c>mountPath</c> instead. The generated pod uses an Aspire-managed
+    /// <c>fsGroup</c> of <c>2000</c> with an <c>OnRootMismatch</c> change policy so
+    /// non-root containers can access supported volumes without matching the image's
+    /// primary group. Use <c>PublishAsKubernetesService</c> to customize the pod
+    /// security context when a different group or policy is required.
     /// </remarks>
     /// <example>
     /// <code>
@@ -278,6 +282,13 @@ public static class KubernetesPersistentVolumeExtensions
     /// <param name="isReadOnly">When <see langword="true"/>, mounts the volume
     /// read-only.</param>
     /// <returns>The same builder for chaining.</returns>
+    /// <remarks>
+    /// The generated pod uses an Aspire-managed <c>fsGroup</c> of <c>2000</c> with
+    /// an <c>OnRootMismatch</c> change policy so non-root containers can access
+    /// supported volumes without matching the image's primary group. Use
+    /// <c>PublishAsKubernetesService</c> to customize the pod security context when
+    /// a different group or policy is required.
+    /// </remarks>
     /// <example>
     /// <code>
     /// var media = k8s.AddPersistentVolume("media")

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -21,6 +21,9 @@ namespace Aspire.Hosting.Kubernetes;
 [AspireExport(ExposeProperties = true)]
 public partial class KubernetesResource(string name, IResource resource, KubernetesEnvironmentResource kubernetesEnvironmentResource) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>
 {
+    private const long DefaultPersistentVolumeFsGroup = 2000;
+    private const string DefaultPersistentVolumeFsGroupChangePolicy = "OnRootMismatch";
+
     /// <inheritdoc/>
     public KubernetesEnvironmentResource Parent => kubernetesEnvironmentResource;
 
@@ -164,18 +167,31 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
 
     private void CreateApplication()
     {
+        var hasPersistentVolumeBinding = resource.HasAnnotationOfType<KubernetesPersistentVolumeBindingAnnotation>();
+
         // Promote to a StatefulSet when the workload is bound to a first-class persistent
         // volume — Kubernetes requires stable identity and ordered rollout for pods that
         // share named PVCs. The historical IResourceWithConnectionString rule remains so
         // existing integrations that imply state continue to render as StatefulSets.
-        if (resource is IResourceWithConnectionString ||
-            resource.HasAnnotationOfType<KubernetesPersistentVolumeBindingAnnotation>())
+        if (resource is IResourceWithConnectionString || hasPersistentVolumeBinding)
         {
             Workload = resource.ToStatefulSet(this);
-            return;
+        }
+        else
+        {
+            Workload = resource.ToDeployment(this);
         }
 
-        Workload = resource.ToDeployment(this);
+        if (hasPersistentVolumeBinding)
+        {
+            // fsGroup is a supplemental group, not the image's primary GID. A stable
+            // publisher-owned value lets non-root images access supported volumes without
+            // coupling the manifest to image-specific identities. Kubernetes customization
+            // callbacks run after this default is applied and can replace or remove it.
+            var securityContext = Workload.PodTemplate.Spec.SecurityContext ??= new();
+            securityContext.FsGroup ??= DefaultPersistentVolumeFsGroup;
+            securityContext.FsGroupChangePolicy ??= DefaultPersistentVolumeFsGroupChangePolicy;
+        }
     }
 
     internal string GetContainerImageName(IResource resourceInstance)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
@@ -355,7 +355,18 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
         await auto.RunCommandAsync(
             $"FS_GROUP=$(kubectl get statefulset apiservice-statefulset --namespace \"$NS\" -o jsonpath='{{.spec.template.spec.securityContext.fsGroup}}') && " +
             $"test \"$FS_GROUP\" = \"{expectedFsGroup}\" && " +
-            $"echo \"StatefulSet uses fsGroup {expectedFsGroup}\"",
+            // Verify the Linux identity and mount ownership reported as:
+            //   id -u: 1654
+            //   id -G: 1654 2000
+            //   stat -c %g /srv/data: 2000
+            // This proves the write succeeds through group access rather than root privileges.
+            "PROCESS_UID=$(kubectl exec pod/apiservice-statefulset-0 --namespace \"$NS\" -- id -u) && " +
+            "PROCESS_GROUPS=$(kubectl exec pod/apiservice-statefulset-0 --namespace \"$NS\" -- id -G) && " +
+            "VOLUME_GROUP=$(kubectl exec pod/apiservice-statefulset-0 --namespace \"$NS\" -- stat -c %g /srv/data) && " +
+            "test \"$PROCESS_UID\" != \"0\" && " +
+            $"printf ' %s ' \"$PROCESS_GROUPS\" | grep --fixed-strings --quiet ' {expectedFsGroup} ' && " +
+            $"test \"$VOLUME_GROUP\" = \"{expectedFsGroup}\" && " +
+            $"echo \"StatefulSet uses fsGroup {expectedFsGroup}; pod UID is $PROCESS_UID with groups $PROCESS_GROUPS; /srv/data group is $VOLUME_GROUP\"",
             counter);
     }
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
@@ -121,6 +121,8 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
 
             await WaitForStatefulSetAndManagedDiskAsync(auto, counter);
 
+            await VerifyFileSystemGroupAsync(auto, counter, expectedFsGroup: 2000);
+
             await auto.RunCommandAsync(
                 "PVC_UID_BEFORE=$(kubectl get persistentvolumeclaim data --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
                 "POD_UID_BEFORE=$(kubectl get pod apiservice-statefulset-0 --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
@@ -150,6 +152,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 "kubectl wait --for=condition=Ready pod/apiservice-statefulset-0 --namespace \"$NS\" --timeout=5m",
                 counter,
                 TimeSpan.FromMinutes(6));
+            await VerifyFileSystemGroupAsync(auto, counter, expectedFsGroup: 3000);
             await auto.RunCommandAsync(
                 "PVC_UID_AFTER=$(kubectl get persistentvolumeclaim data --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
                 "POD_UID_AFTER=$(kubectl get pod apiservice-statefulset-0 --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
@@ -166,6 +169,12 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 apiPort,
                 "?action=read",
                 "PASSED: read aks-pv-marker-42 revision second");
+            await VerifyApiResponseAsync(
+                auto,
+                counter,
+                apiPort,
+                "?action=write-new",
+                "PASSED: wrote new aks-pv-marker-42 revision second");
             await StopPortForwardAsync(auto, counter);
 
             await auto.AspireDestroyAsync(counter);
@@ -231,17 +240,6 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             builder.AddProject<Projects.AksPersistentVolume_ApiService>("apiservice")
                 .WithPersistentVolume(data, "/srv/data")
                 .WithEnvironment("DEPLOYMENT_REVISION", "first")
-                .PublishAsKubernetesService(resource =>
-                {
-                    // .NET containers run as the non-root app user. Apply its group to the
-                    // managed disk so the API can write to the filesystem mounted by kubelet.
-                    var workload = resource.Workload
-                        ?? throw new InvalidOperationException("The API Kubernetes workload was not generated.");
-                    workload.PodTemplate.Spec.SecurityContext = new()
-                    {
-                        FsGroup = 1654
-                    };
-                })
             """,
             appHostPath);
 
@@ -254,7 +252,16 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
         content = ReplaceRequired(
             content,
             """.WithEnvironment("DEPLOYMENT_REVISION", "first")""",
-            """.WithEnvironment("DEPLOYMENT_REVISION", "second")""",
+            """
+            .WithEnvironment("DEPLOYMENT_REVISION", "second")
+                .PublishAsKubernetesService(resource =>
+                {
+                    var podSpec = resource.Workload?.PodTemplate.Spec
+                        ?? throw new InvalidOperationException("The API Kubernetes workload was not generated.");
+                    podSpec.SecurityContext ??= new();
+                    podSpec.SecurityContext.FsGroup = 3000;
+                })
+            """,
             appHostPath);
         File.WriteAllText(appHostPath, content);
     }
@@ -271,6 +278,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             var app = builder.Build();
 
             const string markerPath = "/srv/data/marker.txt";
+            const string newMarkerPath = "/srv/data/new-marker.txt";
             const string markerToken = "aks-pv-marker-42";
             var deploymentRevision = app.Configuration["DEPLOYMENT_REVISION"]
                 ?? throw new InvalidOperationException("DEPLOYMENT_REVISION is not configured.");
@@ -300,7 +308,13 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                     return Results.Ok($"PASSED: read {persistedValue} revision {deploymentRevision}");
                 }
 
-                return Results.BadRequest("FAILED: action must be write or read");
+                if (action == "write-new")
+                {
+                    await File.WriteAllTextAsync(newMarkerPath, markerToken);
+                    return Results.Ok($"PASSED: wrote new {markerToken} revision {deploymentRevision}");
+                }
+
+                return Results.BadRequest("FAILED: action must be write, read, or write-new");
             });
 
             app.MapDefaultEndpoints();
@@ -331,6 +345,18 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             "kubectl wait --for=condition=Ready pod/apiservice-statefulset-0 --namespace \"$NS\" --timeout=5m",
             counter,
             TimeSpan.FromMinutes(6));
+    }
+
+    private static async Task VerifyFileSystemGroupAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        long expectedFsGroup)
+    {
+        await auto.RunCommandAsync(
+            $"FS_GROUP=$(kubectl get statefulset apiservice-statefulset --namespace \"$NS\" -o jsonpath='{{.spec.template.spec.securityContext.fsGroup}}') && " +
+            $"test \"$FS_GROUP\" = \"{expectedFsGroup}\" && " +
+            $"echo \"StatefulSet uses fsGroup {expectedFsGroup}\"",
+            counter);
     }
 
     private static async Task DeployAsync(

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -1290,6 +1290,71 @@ public class KubernetesPublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationOverridesDefaultFsGroup()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var data = k8s.AddPersistentVolume("data");
+
+        builder.AddProject<TestProject>("api", launchProfileName: null)
+            .WithPersistentVolume(data, "/srv/data")
+            .PublishAsKubernetesService(resource =>
+            {
+                var podSpec = resource.Workload?.PodTemplate.Spec
+                    ?? throw new InvalidOperationException("The Kubernetes workload was not generated.");
+                podSpec.SecurityContext ??= new();
+                podSpec.SecurityContext.FsGroup = 3000;
+            });
+
+        var app = builder.Build();
+        app.Run();
+
+        var statefulSetPath = Path.Combine(workspace.Path, "templates", "api", "statefulset.yaml");
+        var content = await File.ReadAllTextAsync(statefulSetPath);
+
+        await Verify(content, "yaml");
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationCanRemoveDefaultSecurityContext()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var data = k8s.AddPersistentVolume("data");
+
+        builder.AddProject<TestProject>("api", launchProfileName: null)
+            .WithPersistentVolume(data, "/srv/data")
+            .PublishAsKubernetesService(resource =>
+            {
+                var podSpec = resource.Workload?.PodTemplate.Spec
+                    ?? throw new InvalidOperationException("The Kubernetes workload was not generated.");
+                podSpec.SecurityContext = null;
+            });
+
+        var app = builder.Build();
+        app.Run();
+
+        var statefulSetPath = Path.Combine(workspace.Path, "templates", "api", "statefulset.yaml");
+        var content = await File.ReadAllTextAsync(statefulSetPath);
+
+        var yaml = new YamlStream();
+        using (var reader = new StringReader(content))
+        {
+            yaml.Load(reader);
+        }
+
+        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
+        var podSpec = (YamlMappingNode)root["spec"]["template"]["spec"];
+        Assert.False(podSpec.Children.ContainsKey(new YamlScalarNode("securityContext")));
+
+        await Verify(content, "yaml");
+    }
+
+    [Fact]
     public async Task PublishAsync_WithFirstClassPersistentVolume_FallsThroughForUnboundVolumes()
     {
         // A workload may declare both a bound and an unbound volume. The bound one
@@ -1399,6 +1464,10 @@ public class KubernetesPublisherTests(ITestOutputHelper outputHelper)
 
         var root = (YamlMappingNode)yaml.Documents[0].RootNode;
         var podSpec = (YamlMappingNode)root["spec"]["template"]["spec"];
+
+        var securityContext = (YamlMappingNode)podSpec["securityContext"];
+        Assert.Equal("2000", ((YamlScalarNode)securityContext["fsGroup"]).Value);
+        Assert.Equal("OnRootMismatch", ((YamlScalarNode)securityContext["fsGroupChangePolicy"]).Value);
 
         // Container mount side: containers[0].volumeMounts[?(@.name == "media")].readOnly == true
         var container = (YamlMappingNode)((YamlSequenceNode)podSpec["containers"])[0];

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_BindsByName_PromotesToStatefulSet#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_BindsByName_PromotesToStatefulSet#00.verified.yaml
@@ -26,6 +26,9 @@ spec:
         - name: "data"
           persistentVolumeClaim:
             claimName: "data"
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Chart.Name }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationCanRemoveDefaultSecurityContext.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationCanRemoveDefaultSecurityContext.verified.yaml
@@ -2,40 +2,36 @@
 apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
-  name: "service-statefulset"
+  name: "api-statefulset"
   labels:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
-    app.kubernetes.io/component: "service"
+    app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ .Chart.Name }}"
-        app.kubernetes.io/component: "service"
+        app.kubernetes.io/component: "api"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "nginx:latest"
-          name: "service"
+        - image: "{{ .Values.parameters.api.api_image }}"
+          name: "api"
+          envFrom:
+            - configMapRef:
+                name: "api-config"
           volumeMounts:
             - name: "data"
-              mountPath: "/var/lib/data"
-            - name: "scratch"
-              mountPath: "/srv/scratch"
+              mountPath: "/srv/data"
           imagePullPolicy: "IfNotPresent"
       volumes:
         - name: "data"
           persistentVolumeClaim:
             claimName: "data"
-        - name: "scratch"
-          emptyDir: {}
-      securityContext:
-        fsGroup: 2000
-        fsGroupChangePolicy: "OnRootMismatch"
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Chart.Name }}"
-      app.kubernetes.io/component: "service"
+      app.kubernetes.io/component: "api"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationOverridesDefaultFsGroup.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_KubernetesCustomizationOverridesDefaultFsGroup.verified.yaml
@@ -2,40 +2,39 @@
 apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
-  name: "service-statefulset"
+  name: "api-statefulset"
   labels:
     app.kubernetes.io/name: "{{ .Chart.Name }}"
-    app.kubernetes.io/component: "service"
+    app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/name: "{{ .Chart.Name }}"
-        app.kubernetes.io/component: "service"
+        app.kubernetes.io/component: "api"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "nginx:latest"
-          name: "service"
+        - image: "{{ .Values.parameters.api.api_image }}"
+          name: "api"
+          envFrom:
+            - configMapRef:
+                name: "api-config"
           volumeMounts:
             - name: "data"
-              mountPath: "/var/lib/data"
-            - name: "scratch"
-              mountPath: "/srv/scratch"
+              mountPath: "/srv/data"
           imagePullPolicy: "IfNotPresent"
       volumes:
         - name: "data"
           persistentVolumeClaim:
             claimName: "data"
-        - name: "scratch"
-          emptyDir: {}
       securityContext:
-        fsGroup: 2000
+        fsGroup: 3000
         fsGroupChangePolicy: "OnRootMismatch"
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Chart.Name }}"
-      app.kubernetes.io/component: "service"
+      app.kubernetes.io/component: "api"
       app.kubernetes.io/instance: "{{ .Release.Name }}"
   replicas: 1

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_OnProject_BindsViaMountPathOverload#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithFirstClassPersistentVolume_OnProject_BindsViaMountPathOverload#00.verified.yaml
@@ -29,6 +29,9 @@ spec:
         - name: "media"
           persistentVolumeClaim:
             claimName: "media"
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ .Chart.Name }}"


### PR DESCRIPTION
## Description

This is a usability fix targeted for **Aspire 13.5**.

### The problem

A Kubernetes volume access mode such as `ReadWriteOnce` controls how the volume can be attached and mounted; it does not grant the container's Linux process permission to write to the mounted filesystem.

That distinction produces a confusing experience with first-class Aspire persistent volumes. The PVC can be `Bound`, the pod can be `Running`, and the volume can be mounted successfully, while the application still fails on its first write because the filesystem is owned by `root:root` and the container runs as a non-root user. From the application's perspective this surfaces as an I/O permission error even though the deployment otherwise appears healthy.

### The workaround before this change

Today, users must understand the underlying Kubernetes ownership model and customize every affected workload themselves:

```csharp
builder.AddProject<Projects.WebFrontend>("webfrontend")
    .WithPersistentVolume(data, "/data")
    .PublishAsKubernetesService(resource =>
    {
        var podSpec = resource.Workload?.PodTemplate.Spec
            ?? throw new InvalidOperationException("The Kubernetes workload was not generated.");

        podSpec.SecurityContext ??= new();
        podSpec.SecurityContext.FsGroup = 2000;
        podSpec.SecurityContext.FsGroupChangePolicy = "OnRootMismatch";
    });
```

The alternatives are similarly low-level, such as adding a privileged init container to run `chown`, changing the image to use a known UID/GID, or configuring storage-driver-specific mount options. Requiring one of these workarounds makes a newly provisioned persistent volume look broken by default and leaks Kubernetes filesystem details into otherwise straightforward AppHost code.

### How this change fixes it

Workloads bound through either `WithPersistentVolume(...)` overload now receive this pod security context automatically:

```yaml
securityContext:
  fsGroup: 2000
  fsGroupChangePolicy: OnRootMismatch
```

`fsGroup` adds a supplemental group to the processes in the pod and, for supported volume types, instructs Kubernetes or the CSI driver to make the mounted volume accessible to that group. It does not change the image-defined UID or primary GID, so Aspire does not need to know which identity the image uses.

Aspire uses a stable group ID rather than selecting a new value on each deployment because numeric ownership is persisted on the volume. `OnRootMismatch` avoids unnecessary recursive ownership changes when the volume already has the expected group.

Existing AppHost code therefore requires no extra configuration:

```csharp
var data = k8s.AddPersistentVolume("data")
    .WithCapacity("10Gi");

builder.AddProject<Projects.WebFrontend>("webfrontend")
    .WithPersistentVolume(data, "/data");
```

This behavior is limited to first-class `WithPersistentVolume(...)` bindings. Ordinary workloads and legacy PVC generation through the Kubernetes environment's default storage type are unchanged. Read-only mounts remain read-only.

### Using a different fsGroup

The default is applied before existing `PublishAsKubernetesService` callbacks run, so a workload or cluster that requires a specific group can replace it:

```csharp
builder.AddProject<Projects.WebFrontend>("webfrontend")
    .WithPersistentVolume(data, "/data")
    .PublishAsKubernetesService(resource =>
    {
        var podSpec = resource.Workload?.PodTemplate.Spec
            ?? throw new InvalidOperationException("The Kubernetes workload was not generated.");

        podSpec.SecurityContext ??= new();
        podSpec.SecurityContext.FsGroup = 3000;
    });
```

The generated `OnRootMismatch` policy is retained unless the callback also replaces it.

### Opting out

A workload can remove the generated pod security context through the same customization mechanism:

```csharp
builder.AddProject<Projects.WebFrontend>("webfrontend")
    .WithPersistentVolume(data, "/data")
    .PublishAsKubernetesService(resource =>
    {
        var podSpec = resource.Workload?.PodTemplate.Spec
            ?? throw new InvalidOperationException("The Kubernetes workload was not generated.");

        podSpec.SecurityContext = null;
    });
```

This is useful when ownership is managed by the image, an admission controller, or storage-specific configuration. Workloads that need other pod security-context settings can instead clear or replace only `FsGroup` and `FsGroupChangePolicy`.

### Security and compatibility considerations

The group ID `2000` is an Aspire-managed default, not a Kubernetes-reserved value. Some storage drivers do not support `fsGroup`, CSI drivers may apply the group at mount time themselves, and cluster admission policies can restrict allowed group ranges. The existing customization callback remains the escape hatch for those environments.

This change intentionally grants processes in the pod supplemental group access to supported mounted volumes and can update persisted POSIX group ownership. It does not change the image-defined UID or primary GID, and it does not make a read-only mount writable.

### Validation

- Publisher tests verify the generated defaults for first-class persistent-volume bindings, including read-only mounts.
- Publisher tests verify that Kubernetes customization can override the group to `3000` or remove the generated security context entirely.
- The live AKS deployment test [`DeployAksPersistentVolumeSurvivesRedeploy`](https://github.com/microsoft/aspire/actions/runs/31772264851/job/94681733158) passed against commit `7b565f163e`. It verifies that the application runs as non-root UID `1654`, receives supplemental group `2000`, sees `/srv/data` owned by group `2000`, and can write. It then redeploys with `fsGroup: 3000`, confirms the same PVC is reused, verifies UID `1654` now has supplemental group `3000` and `/srv/data` is owned by group `3000`, reads the persisted data, and creates a new file.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
