### PR TITLE
Fix MAUI OTLP dev tunnel resolution

### DIFF
--- a/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
@@ -32,6 +32,11 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
     public IResourceBuilder<DevTunnelResource> DevTunnel { get; }
 
     /// <summary>
+    /// The public dev tunnel endpoint used by MAUI platform environment variables.
+    /// </summary>
+    public EndpointReference TunnelEndpoint { get; }
+
+    /// <summary>
     /// Gets a value indicating whether the dashboard OTLP listener has been resolved.
     /// </summary>
     public bool IsOtlpEndpointResolved => Volatile.Read(ref _isOtlpEndpointResolved) != 0;
@@ -45,11 +50,13 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
         OtlpLoopbackResource otlpStub,
         IResourceBuilder<OtlpLoopbackResource> otlpStubBuilder,
         IResourceBuilder<DevTunnelResource> devTunnel,
+        EndpointReference tunnelEndpoint,
         bool isOtlpEndpointResolved)
     {
         OtlpStub = otlpStub;
         OtlpStubBuilder = otlpStubBuilder;
         DevTunnel = devTunnel;
+        TunnelEndpoint = tunnelEndpoint;
         _isOtlpEndpointResolved = isOtlpEndpointResolved ? 1 : 0;
     }
 
@@ -69,6 +76,29 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
             endpoint.Transport = transport;
             endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", port);
             Volatile.Write(ref _isOtlpEndpointResolved, 1);
+
+            return true;
+        }
+    }
+
+    internal bool TryFailOtlpEndpointResolution(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        lock (_otlpEndpointLock)
+        {
+            if (_isOtlpEndpointResolved != 0)
+            {
+                return false;
+            }
+
+            // DCP can resolve MAUI environment variables while the tunnel startup callback is
+            // still waiting for the dashboard listener. Fault the synthetic target so the
+            // failure-aware endpoint and protocol providers stop waiting. Do not fault the public
+            // DevTunnel endpoint because its lifecycle reads the snapshot before replacing it on retry.
+#pragma warning disable CS0618 // Type or member is obsolete
+            OtlpStub.OtlpEndpoint.AllocatedEndpointSnapshot.SetException(exception);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return true;
         }

--- a/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
@@ -13,6 +13,9 @@ namespace Aspire.Hosting.Maui.Annotations;
 /// </summary>
 internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
 {
+    private readonly object _otlpEndpointLock = new();
+    private int _isOtlpEndpointResolved;
+
     /// <summary>
     /// The OTLP loopback stub resource that acts as the service discovery target.
     /// </summary>
@@ -28,13 +31,46 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
     /// </summary>
     public IResourceBuilder<DevTunnelResource> DevTunnel { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the dashboard OTLP listener has been resolved.
+    /// </summary>
+    public bool IsOtlpEndpointResolved => Volatile.Read(ref _isOtlpEndpointResolved) != 0;
+
+    /// <summary>
+    /// Gets or sets the maximum time to wait for DCP to publish the dashboard's concrete OTLP listener.
+    /// </summary>
+    internal TimeSpan RuntimeSnapshotResolutionTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
     public OtlpDevTunnelConfigurationAnnotation(
         OtlpLoopbackResource otlpStub,
         IResourceBuilder<OtlpLoopbackResource> otlpStubBuilder,
-        IResourceBuilder<DevTunnelResource> devTunnel)
+        IResourceBuilder<DevTunnelResource> devTunnel,
+        bool isOtlpEndpointResolved)
     {
         OtlpStub = otlpStub;
         OtlpStubBuilder = otlpStubBuilder;
         DevTunnel = devTunnel;
+        _isOtlpEndpointResolved = isOtlpEndpointResolved ? 1 : 0;
+    }
+
+    internal bool UpdateOtlpEndpoint(string scheme, int port, string transport)
+    {
+        lock (_otlpEndpointLock)
+        {
+            if (_isOtlpEndpointResolved != 0)
+            {
+                return false;
+            }
+
+            var endpoint = OtlpStub.OtlpEndpoint;
+            endpoint.UriScheme = scheme;
+            endpoint.Port = port;
+            endpoint.TargetPort = port;
+            endpoint.Transport = transport;
+            endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", port);
+            Volatile.Write(ref _isOtlpEndpointResolved, 1);
+
+            return true;
+        }
     }
 }

--- a/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/OtlpDevTunnelConfigurationAnnotation.cs
@@ -14,6 +14,7 @@ namespace Aspire.Hosting.Maui.Annotations;
 internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
 {
     private readonly object _otlpEndpointLock = new();
+    private readonly DevTunnelPortOptions _tunnelPortOptions;
     private int _isOtlpEndpointResolved;
 
     /// <summary>
@@ -50,12 +51,14 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
         OtlpLoopbackResource otlpStub,
         IResourceBuilder<OtlpLoopbackResource> otlpStubBuilder,
         IResourceBuilder<DevTunnelResource> devTunnel,
+        DevTunnelPortOptions tunnelPortOptions,
         EndpointReference tunnelEndpoint,
         bool isOtlpEndpointResolved)
     {
         OtlpStub = otlpStub;
         OtlpStubBuilder = otlpStubBuilder;
         DevTunnel = devTunnel;
+        _tunnelPortOptions = tunnelPortOptions;
         TunnelEndpoint = tunnelEndpoint;
         _isOtlpEndpointResolved = isOtlpEndpointResolved ? 1 : 0;
     }
@@ -70,6 +73,7 @@ internal sealed class OtlpDevTunnelConfigurationAnnotation : IResourceAnnotation
             }
 
             var endpoint = OtlpStub.OtlpEndpoint;
+            _tunnelPortOptions.Protocol = scheme;
             endpoint.UriScheme = scheme;
             endpoint.Port = port;
             endpoint.TargetPort = port;

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -211,15 +211,17 @@ public static class MauiOtlpExtensions
 
         // Create dev tunnel with anonymous access for OTLP. The dynamic unresolved-endpoint guard above
         // must be registered first so it can fail fast before the dev tunnel waits on the target endpoint.
+        var tunnelPortOptions = new DevTunnelPortOptions { Protocol = initialOtlpScheme };
         var devTunnel = appBuilder.AddDevTunnel(tunnelName)
             .WithAnonymousAccess()
-            .WithReference(stubBuilder, new DevTunnelPortOptions { Protocol = "https" });
+            .WithReference(stubBuilder, tunnelPortOptions);
         var tunnelEndpoint = devTunnel.GetEndpoint(stubResource, "otlp");
 
         tunnelConfig = new OtlpDevTunnelConfigurationAnnotation(
             stubResource,
             stubBuilder,
             devTunnel,
+            tunnelPortOptions,
             tunnelEndpoint,
             isOtlpEndpointResolved: configuredOtlpEndpoint is not null);
         return tunnelConfig;

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -139,7 +139,13 @@ public static class MauiOtlpExtensions
                         string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
                     if (dashboardResource is null)
                     {
-                        throw new DistributedApplicationException($"The MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' requires the Aspire dashboard to be enabled or an explicit OTLP endpoint URL to be configured.");
+                        var exception = new DistributedApplicationException($"The MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' requires the Aspire dashboard to be enabled or an explicit OTLP endpoint URL to be configured.");
+                        if (currentTunnelConfig.TryFailOtlpEndpointResolution(exception))
+                        {
+                            throw exception;
+                        }
+
+                        return;
                     }
 
                     evt.Services.GetRequiredService<ResourceLoggerService>()
@@ -148,18 +154,38 @@ public static class MauiOtlpExtensions
                             "Waiting up to {Timeout} for the Aspire dashboard to publish a concrete OTLP listener.",
                             currentTunnelConfig.RuntimeSnapshotResolutionTimeout);
 
-                    if (await TryResolveDashboardOtlpEndpointAsync(
-                        dashboardResource,
-                        evt.Services,
-                        waitForRuntimeSnapshot: true,
-                        currentTunnelConfig.RuntimeSnapshotResolutionTimeout,
-                        ct).ConfigureAwait(false) is { } dashboardOtlpEndpoint)
+                    OtlpEndpointTarget? dashboardOtlpEndpoint;
+                    try
                     {
-                        await AllocateOtlpStubEndpointAsync(currentTunnelConfig, dashboardOtlpEndpoint, evt.Services, appBuilder.Eventing, ct).ConfigureAwait(false);
+                        dashboardOtlpEndpoint = await TryResolveDashboardOtlpEndpointAsync(
+                            dashboardResource,
+                            evt.Services,
+                            waitForRuntimeSnapshot: true,
+                            currentTunnelConfig.RuntimeSnapshotResolutionTimeout,
+                            ct).ConfigureAwait(false);
+                    }
+                    catch (DistributedApplicationException exception)
+                    {
+                        if (currentTunnelConfig.TryFailOtlpEndpointResolution(exception))
+                        {
+                            throw;
+                        }
+
                         return;
                     }
 
-                    throw new DistributedApplicationException($"The Aspire dashboard resource '{KnownResourceNames.AspireDashboard}' terminated or does not have a concrete OTLP endpoint named '{KnownEndpointNames.OtlpHttpEndpointName}' or '{KnownEndpointNames.OtlpGrpcEndpointName}', so the MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' cannot start. Ensure dashboard OTLP ingestion is enabled, or configure an explicit OTLP endpoint URL.");
+                    if (dashboardOtlpEndpoint is null)
+                    {
+                        var exception = new DistributedApplicationException($"The Aspire dashboard resource '{KnownResourceNames.AspireDashboard}' terminated or does not have a concrete OTLP endpoint named '{KnownEndpointNames.OtlpHttpEndpointName}' or '{KnownEndpointNames.OtlpGrpcEndpointName}', so the MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' cannot start. Ensure dashboard OTLP ingestion is enabled, or configure an explicit OTLP endpoint URL.");
+                        if (currentTunnelConfig.TryFailOtlpEndpointResolution(exception))
+                        {
+                            throw exception;
+                        }
+
+                        return;
+                    }
+
+                    await AllocateOtlpStubEndpointAsync(currentTunnelConfig, dashboardOtlpEndpoint.Value, evt.Services, appBuilder.Eventing, ct).ConfigureAwait(false);
                 }
             });
 
@@ -188,11 +214,13 @@ public static class MauiOtlpExtensions
         var devTunnel = appBuilder.AddDevTunnel(tunnelName)
             .WithAnonymousAccess()
             .WithReference(stubBuilder, new DevTunnelPortOptions { Protocol = "https" });
+        var tunnelEndpoint = devTunnel.GetEndpoint(stubResource, "otlp");
 
         tunnelConfig = new OtlpDevTunnelConfigurationAnnotation(
             stubResource,
             stubBuilder,
             devTunnel,
+            tunnelEndpoint,
             isOtlpEndpointResolved: configuredOtlpEndpoint is not null);
         return tunnelConfig;
     }
@@ -508,16 +536,16 @@ public static class MauiOtlpExtensions
             return;
         }
 
-        // Get the tunnel endpoint for the OTLP stub directly, bypassing service discovery injection
-        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
-
         // Ensure the platform resource waits for the tunnel to be ready
         platformBuilder.WithReferenceRelationship(tunnelConfig.DevTunnel);
 
-        // Set OTEL_EXPORTER_OTLP_ENDPOINT directly to the tunnel endpoint URL
-        platformBuilder.WithEnvironment(KnownOtelConfigNames.ExporterOtlpEndpoint, tunnelEndpoint);
         platformBuilder.WithEnvironment(context =>
         {
+            context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpEndpoint] =
+                new OtlpEndpointValueProvider(
+                    tunnelConfig.TunnelEndpoint,
+                    tunnelConfig.OtlpStub.OtlpEndpoint,
+                    tunnelConfig.RuntimeSnapshotResolutionTimeout);
             context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol] =
                 new OtlpProtocolValueProvider(
                     tunnelConfig.OtlpStub.OtlpEndpoint,
@@ -533,6 +561,37 @@ public static class MauiOtlpExtensions
 
     private readonly record struct OtlpEndpointTarget(string Scheme, int Port, string Protocol);
     private readonly record struct EndpointPortResolution(int? Port, bool HasUnresolvedExpression);
+
+    private sealed class OtlpEndpointValueProvider(
+        EndpointReference tunnelEndpoint,
+        EndpointAnnotation targetEndpoint,
+        TimeSpan resolutionTimeout) : IValueProvider
+    {
+        public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(resolutionTimeout);
+
+            try
+            {
+                // Wait for target resolution first so its failure is propagated immediately instead
+                // of leaving the public tunnel endpoint pending until application cancellation.
+#pragma warning disable CS0618 // Type or member is obsolete
+                await targetEndpoint.AllocatedEndpointSnapshot
+                    .GetValueAsync(timeoutCts.Token)
+                    .ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                return await tunnelEndpoint.GetValueAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new DistributedApplicationException(
+                    $"The MAUI OTLP endpoint could not be determined within {resolutionTimeout:c}.",
+                    ex);
+            }
+        }
+    }
 
     private sealed class OtlpProtocolValueProvider(
         EndpointAnnotation endpoint,

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -20,6 +20,7 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class MauiOtlpExtensions
 {
+    private const string DcpExecutableTerminatedState = "Terminated";
     private const string OtlpGrpcProtocol = "grpc";
     private const string OtlpHttpProtobufProtocol = "http/protobuf";
 
@@ -453,6 +454,9 @@ public static class MauiOtlpExtensions
     private static bool IsUnavailableState(string? state) =>
         state is not null &&
         (KnownResourceStates.TerminalStates.Contains(state, StringComparers.ResourceState) ||
+         // Resource notifications can expose the raw DCP executable state before it is normalized.
+         // DCP emits "Terminated" when the controller kills the dashboard executable.
+         string.Equals(state, DcpExecutableTerminatedState, StringComparisons.ResourceState) ||
          string.Equals(state, KnownResourceStates.RuntimeUnhealthy, StringComparisons.ResourceState));
 
     private static bool IsLocalDashboardBinding(Uri uri) =>

--- a/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiOtlpExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Net;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DevTunnels;
 using Aspire.Hosting.Eventing;
@@ -8,6 +10,8 @@ using Aspire.Hosting.Maui;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Otlp;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -16,6 +20,9 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class MauiOtlpExtensions
 {
+    private const string OtlpGrpcProtocol = "grpc";
+    private const string OtlpHttpProtobufProtocol = "http/protobuf";
+
     /// <summary>
     /// Configures the MAUI platform resource to send OpenTelemetry data through an automatically created dev tunnel.
     /// This is the easiest option for most scenarios, as it handles tunnel creation, configuration, and endpoint
@@ -101,6 +108,8 @@ public static class MauiOtlpExtensions
 
         // Create OtlpLoopbackResource - a synthetic IResourceWithEndpoints for service discovery
         var stubResource = new OtlpLoopbackResource(stubName, configuredOtlpEndpoint?.Port, initialOtlpScheme);
+        stubResource.OtlpEndpoint.Transport = GetEndpointTransport(configuredOtlpEndpoint?.Protocol);
+        OtlpDevTunnelConfigurationAnnotation? tunnelConfig = null;
 
         var stubBuilder = appBuilder.AddResource(stubResource)
             .ExcludeFromManifest();
@@ -114,32 +123,57 @@ public static class MauiOtlpExtensions
 
         if (configuredOtlpEndpoint is null)
         {
-            appBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>((evt, _) =>
+            appBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(async (evt, ct) =>
             {
                 if (evt.Resource is DevTunnelResource devTunnelResource &&
-                    string.Equals(devTunnelResource.Name, tunnelName, StringComparisons.ResourceName) &&
-                    stubResource.OtlpEndpoint.AllocatedEndpoint is null)
+                    string.Equals(devTunnelResource.Name, tunnelName, StringComparisons.ResourceName))
                 {
-                    var hasDashboardResource = appBuilder.Resources.Any(resource => string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
-                    if (!hasDashboardResource)
+                    var currentTunnelConfig = tunnelConfig ?? throw new InvalidOperationException("The MAUI OTLP dev tunnel configuration was not initialized before tunnel startup.");
+                    if (currentTunnelConfig.IsOtlpEndpointResolved)
+                    {
+                        return;
+                    }
+
+                    var dashboardResource = appBuilder.Resources.FirstOrDefault(resource =>
+                        string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+                    if (dashboardResource is null)
                     {
                         throw new DistributedApplicationException($"The MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' requires the Aspire dashboard to be enabled or an explicit OTLP endpoint URL to be configured.");
                     }
 
-                    throw new DistributedApplicationException($"The Aspire dashboard resource '{KnownResourceNames.AspireDashboard}' does not have an allocated OTLP endpoint named '{KnownEndpointNames.OtlpGrpcEndpointName}' or '{KnownEndpointNames.OtlpHttpEndpointName}', so the MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' cannot start. Ensure dashboard OTLP ingestion is enabled, or configure an explicit OTLP endpoint URL.");
-                }
+                    evt.Services.GetRequiredService<ResourceLoggerService>()
+                        .GetLogger(devTunnelResource)
+                        .LogInformation(
+                            "Waiting up to {Timeout} for the Aspire dashboard to publish a concrete OTLP listener.",
+                            currentTunnelConfig.RuntimeSnapshotResolutionTimeout);
 
-                return Task.CompletedTask;
+                    if (await TryResolveDashboardOtlpEndpointAsync(
+                        dashboardResource,
+                        evt.Services,
+                        waitForRuntimeSnapshot: true,
+                        currentTunnelConfig.RuntimeSnapshotResolutionTimeout,
+                        ct).ConfigureAwait(false) is { } dashboardOtlpEndpoint)
+                    {
+                        await AllocateOtlpStubEndpointAsync(currentTunnelConfig, dashboardOtlpEndpoint, evt.Services, appBuilder.Eventing, ct).ConfigureAwait(false);
+                        return;
+                    }
+
+                    throw new DistributedApplicationException($"The Aspire dashboard resource '{KnownResourceNames.AspireDashboard}' terminated or does not have a concrete OTLP endpoint named '{KnownEndpointNames.OtlpHttpEndpointName}' or '{KnownEndpointNames.OtlpGrpcEndpointName}', so the MAUI OTLP dev tunnel for resource '{parentBuilder.Resource.Name}' cannot start. Ensure dashboard OTLP ingestion is enabled, or configure an explicit OTLP endpoint URL.");
+                }
             });
 
-            appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>((evt, ct) =>
+            appBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(async (evt, ct) =>
             {
-                if (TryResolveDashboardOtlpEndpoint(evt.Resource, out var dashboardOtlpEndpoint))
+                var currentTunnelConfig = tunnelConfig ?? throw new InvalidOperationException("The MAUI OTLP dev tunnel configuration was not initialized before endpoint allocation.");
+                if (await TryResolveDashboardOtlpEndpointAsync(
+                    evt.Resource,
+                    evt.Services,
+                    waitForRuntimeSnapshot: false,
+                    currentTunnelConfig.RuntimeSnapshotResolutionTimeout,
+                    ct).ConfigureAwait(false) is { } dashboardOtlpEndpoint)
                 {
-                    return AllocateOtlpStubEndpointAsync(stubResource, dashboardOtlpEndpoint, evt.Services, appBuilder.Eventing, ct);
+                    await AllocateOtlpStubEndpointAsync(currentTunnelConfig, dashboardOtlpEndpoint, evt.Services, appBuilder.Eventing, ct).ConfigureAwait(false);
                 }
-
-                return Task.CompletedTask;
             });
         }
         else
@@ -154,7 +188,12 @@ public static class MauiOtlpExtensions
             .WithAnonymousAccess()
             .WithReference(stubBuilder, new DevTunnelPortOptions { Protocol = "https" });
 
-        return new OtlpDevTunnelConfigurationAnnotation(stubResource, stubBuilder, devTunnel);
+        tunnelConfig = new OtlpDevTunnelConfigurationAnnotation(
+            stubResource,
+            stubBuilder,
+            devTunnel,
+            isOtlpEndpointResolved: configuredOtlpEndpoint is not null);
+        return tunnelConfig;
     }
 
     private static OtlpEndpointTarget? ResolveConfiguredOtlpEndpoint(IConfiguration configuration)
@@ -167,78 +206,288 @@ public static class MauiOtlpExtensions
             return null;
         }
 
-        return !string.IsNullOrWhiteSpace(configuredGrpcUrl)
-            ? CreateConfiguredOtlpEndpointTarget(configuredGrpcUrl, KnownConfigNames.DashboardOtlpGrpcEndpointUrl)
-            : CreateConfiguredOtlpEndpointTarget(configuredHttpUrl!, KnownConfigNames.DashboardOtlpHttpEndpointUrl);
+        return !string.IsNullOrWhiteSpace(configuredHttpUrl)
+            ? CreateConfiguredOtlpEndpointTarget(configuredHttpUrl, KnownConfigNames.DashboardOtlpHttpEndpointUrl, OtlpHttpProtobufProtocol)
+            : CreateConfiguredOtlpEndpointTarget(configuredGrpcUrl!, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, OtlpGrpcProtocol);
     }
 
-    private static OtlpEndpointTarget CreateConfiguredOtlpEndpointTarget(string url, string configKey)
+    private static OtlpEndpointTarget CreateConfiguredOtlpEndpointTarget(string url, string configKey, string protocol)
     {
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
-            uri.Scheme is not ("http" or "https"))
+            uri.Scheme is not ("http" or "https") ||
+            !IsLocalDashboardBinding(uri) ||
+            uri.Port is < 1 or > 65535)
         {
-            throw new DistributedApplicationException($"The configured OTLP endpoint URL '{url}' from '{configKey}' must be an absolute HTTP or HTTPS URL.");
+            throw new DistributedApplicationException($"The configured OTLP endpoint URL '{url}' from '{configKey}' must be an absolute locally reachable HTTP or HTTPS URL with a port between 1 and 65535.");
         }
 
-        return new OtlpEndpointTarget(uri.Scheme, uri.Port);
+        return new OtlpEndpointTarget(uri.Scheme, uri.Port, protocol);
     }
 
     private static string ResolveDynamicDashboardOtlpScheme(IConfiguration configuration)
         => configuration.GetBool(KnownConfigNames.AllowUnsecuredTransport) is true ? "http" : "https";
 
-    private static bool TryResolveDashboardOtlpEndpoint(IResource resource, out OtlpEndpointTarget target)
+    private static async ValueTask<OtlpEndpointTarget?> TryResolveDashboardOtlpEndpointAsync(
+        IResource resource,
+        IServiceProvider services,
+        bool waitForRuntimeSnapshot,
+        TimeSpan runtimeSnapshotResolutionTimeout,
+        CancellationToken cancellationToken)
     {
-        target = default;
-
         if (!string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName) || resource is not IResourceWithEndpoints dashboardResource)
+        {
+            return null;
+        }
+
+        // Mobile runtimes use the dev tunnel's HTTPS forwarding path most reliably with OTLP/HTTP.
+        // An existing but unresolved HTTP endpoint is not a reason to fall back to gRPC.
+        var httpEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpHttpEndpointName);
+        if (httpEndpoint.Exists)
+        {
+            if (await TryResolveEndpointAsync(httpEndpoint, OtlpHttpProtobufProtocol, cancellationToken).ConfigureAwait(false) is { } httpTarget)
+            {
+                return httpTarget;
+            }
+
+            if (await HasUnresolvedTargetPortExpressionAsync(httpEndpoint, cancellationToken).ConfigureAwait(false))
+            {
+                return await TryResolveDashboardOtlpEndpointFromRuntimeSnapshotAsync(
+                    httpEndpoint,
+                    services,
+                    waitForRuntimeSnapshot,
+                    runtimeSnapshotResolutionTimeout,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return null;
+        }
+
+        var grpcEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpGrpcEndpointName);
+        if (await TryResolveEndpointAsync(grpcEndpoint, OtlpGrpcProtocol, cancellationToken).ConfigureAwait(false) is { } grpcTarget)
+        {
+            return grpcTarget;
+        }
+
+        if (!await HasUnresolvedTargetPortExpressionAsync(grpcEndpoint, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return await TryResolveDashboardOtlpEndpointFromRuntimeSnapshotAsync(
+            grpcEndpoint,
+            services,
+            waitForRuntimeSnapshot,
+            runtimeSnapshotResolutionTimeout,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<OtlpEndpointTarget?> TryResolveEndpointAsync(
+        EndpointReference endpointReference,
+        string protocol,
+        CancellationToken cancellationToken)
+    {
+        if (!endpointReference.Exists || endpointReference.EndpointAnnotation.AllocatedEndpoint is not { } allocatedEndpoint)
+        {
+            return null;
+        }
+
+        var port = allocatedEndpoint.Port;
+        if (endpointReference.Resource.IsContainer())
+        {
+            var allocatedPort = await TryGetEndpointPortAsync(endpointReference, EndpointProperty.Port, cancellationToken).ConfigureAwait(false);
+            if (allocatedPort.Port is { } resolvedAllocatedPort)
+            {
+                port = resolvedAllocatedPort;
+            }
+        }
+        else
+        {
+            // DCP-proxied executable endpoints expose the proxy as Port. Dev tunnels run on the host
+            // and must forward to the dashboard's concrete target listener instead.
+            var targetPort = await TryGetEndpointPortAsync(endpointReference, EndpointProperty.TargetPort, cancellationToken).ConfigureAwait(false);
+            if (IsLocalTunnelTargetHost(endpointReference.EndpointAnnotation.TargetHost) &&
+                targetPort.Port is { } resolvedTargetPort)
+            {
+                port = resolvedTargetPort;
+            }
+            else if (IsLocalTunnelTargetHost(endpointReference.EndpointAnnotation.TargetHost) &&
+                     targetPort.HasUnresolvedExpression)
+            {
+                return null;
+            }
+        }
+
+        return new OtlpEndpointTarget(allocatedEndpoint.UriScheme, port, protocol);
+    }
+
+    private static async ValueTask<bool> HasUnresolvedTargetPortExpressionAsync(
+        EndpointReference endpointReference,
+        CancellationToken cancellationToken)
+    {
+        if (!endpointReference.Exists ||
+            endpointReference.EndpointAnnotation.AllocatedEndpoint is null ||
+            endpointReference.Resource.IsContainer())
         {
             return false;
         }
 
-        var grpcEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpGrpcEndpointName);
-        if (TryResolveEndpoint(grpcEndpoint, out target))
+        var targetPort = await TryGetEndpointPortAsync(endpointReference, EndpointProperty.TargetPort, cancellationToken).ConfigureAwait(false);
+        return targetPort.HasUnresolvedExpression;
+    }
+
+    private static async ValueTask<EndpointPortResolution> TryGetEndpointPortAsync(
+        EndpointReference endpointReference,
+        EndpointProperty property,
+        CancellationToken cancellationToken)
+    {
+        string? portValue;
+        try
+        {
+            portValue = await endpointReference.Property(property).GetValueAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException) when (property == EndpointProperty.TargetPort && endpointReference.IsAllocated)
+        {
+            return default;
+        }
+
+        if (int.TryParse(portValue, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+        {
+            return new(port, HasUnresolvedExpression: false);
+        }
+
+        // DCP reports dynamically assigned target listener ports as expressions such as:
+        //   {{- portForServing "dashboard-otlp-http" -}}
+        return string.IsNullOrWhiteSpace(portValue)
+            ? default
+            : new(null, HasUnresolvedExpression: true);
+    }
+
+    private static async ValueTask<OtlpEndpointTarget?> TryResolveDashboardOtlpEndpointFromRuntimeSnapshotAsync(
+        EndpointReference endpointReference,
+        IServiceProvider services,
+        bool waitForRuntimeSnapshot,
+        TimeSpan runtimeSnapshotResolutionTimeout,
+        CancellationToken cancellationToken)
+    {
+        var notificationService = services.GetService<ResourceNotificationService>();
+        if (notificationService is null)
+        {
+            return null;
+        }
+
+        var resourceName = endpointReference.Resource.Name;
+        if (notificationService.TryGetCurrentState(resourceName, out var currentState) &&
+            TryResolveDashboardOtlpEndpointFromSnapshot(endpointReference, currentState) is { } currentTarget)
+        {
+            return currentTarget;
+        }
+
+        if (!waitForRuntimeSnapshot)
+        {
+            return null;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(runtimeSnapshotResolutionTimeout);
+
+        ResourceEvent resourceEvent;
+        try
+        {
+            resourceEvent = await notificationService.WaitForResourceAsync(
+                resourceName,
+                resourceEvent => TryResolveDashboardOtlpEndpointFromSnapshot(endpointReference, resourceEvent) is not null ||
+                    IsUnavailableState(resourceEvent.Snapshot.State?.Text),
+                timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new DistributedApplicationException(
+                $"The Aspire dashboard resource '{resourceName}' did not publish a concrete OTLP listener within {runtimeSnapshotResolutionTimeout:c}.",
+                ex);
+        }
+
+        return TryResolveDashboardOtlpEndpointFromSnapshot(endpointReference, resourceEvent);
+    }
+
+    private static OtlpEndpointTarget? TryResolveDashboardOtlpEndpointFromSnapshot(
+        EndpointReference endpointReference,
+        ResourceEvent resourceEvent)
+    {
+        if (IsUnavailableState(resourceEvent.Snapshot.State?.Text) ||
+            !endpointReference.Exists ||
+            endpointReference.EndpointAnnotation.AllocatedEndpoint is null)
+        {
+            return null;
+        }
+
+        if (endpointReference.Resource.IsContainer())
+        {
+            var allocatedEndpoint = endpointReference.EndpointAnnotation.AllocatedEndpoint;
+            return new OtlpEndpointTarget(
+                allocatedEndpoint.UriScheme,
+                allocatedEndpoint.Port,
+                GetOtlpProtocol(endpointReference.EndpointAnnotation));
+        }
+
+        string[]? environmentVariableNames =
+            string.Equals(endpointReference.EndpointName, KnownEndpointNames.OtlpHttpEndpointName, StringComparisons.EndpointAnnotationName)
+                ? [KnownConfigNames.DashboardOtlpHttpEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpHttpEndpointUrl]
+                : string.Equals(endpointReference.EndpointName, KnownEndpointNames.OtlpGrpcEndpointName, StringComparisons.EndpointAnnotationName)
+                    ? [KnownConfigNames.DashboardOtlpGrpcEndpointUrl, KnownConfigNames.Legacy.DashboardOtlpGrpcEndpointUrl]
+                    : null;
+
+        var endpointUrl = resourceEvent.Snapshot.EnvironmentVariables
+            .FirstOrDefault(environmentVariable => environmentVariableNames?.Contains(
+                environmentVariable.Name,
+                StringComparers.EnvironmentVariableName) is true)
+            ?.Value;
+
+        return Uri.TryCreate(endpointUrl, UriKind.Absolute, out var uri) &&
+            IsLocalDashboardBinding(uri) &&
+            uri.Port is >= 1 and <= 65535 &&
+            uri.Scheme is "http" or "https"
+                ? new OtlpEndpointTarget(uri.Scheme, uri.Port, GetOtlpProtocol(endpointReference.EndpointAnnotation))
+                : null;
+    }
+
+    private static bool IsUnavailableState(string? state) =>
+        state is not null &&
+        (KnownResourceStates.TerminalStates.Contains(state, StringComparers.ResourceState) ||
+         string.Equals(state, KnownResourceStates.RuntimeUnhealthy, StringComparisons.ResourceState));
+
+    private static bool IsLocalDashboardBinding(Uri uri) =>
+        IsLocalTunnelTargetHost(uri.Host);
+
+    private static bool IsLocalTunnelTargetHost(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host) ||
+            host is "*" or "+" ||
+            EndpointHostHelpers.IsLocalhostOrLocalhostTld(host))
         {
             return true;
         }
 
-        var httpEndpoint = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpHttpEndpointName);
-        return TryResolveEndpoint(httpEndpoint, out target);
+        return IPAddress.TryParse(host.Trim('[', ']'), out var address) &&
+            (IPAddress.IsLoopback(address) ||
+             address.Equals(IPAddress.Any) ||
+             address.Equals(IPAddress.IPv6Any));
     }
 
-    private static bool TryResolveEndpoint(EndpointReference endpointReference, out OtlpEndpointTarget target)
-    {
-        target = default;
-
-        if (!endpointReference.Exists || endpointReference.EndpointAnnotation.AllocatedEndpoint is not { } allocatedEndpoint)
-        {
-            return false;
-        }
-
-        target = new OtlpEndpointTarget(allocatedEndpoint.UriScheme, allocatedEndpoint.Port);
-        return true;
-    }
-
-    private static Task AllocateOtlpStubEndpointAsync(
-        OtlpLoopbackResource stubResource,
+    private static async Task AllocateOtlpStubEndpointAsync(
+        OtlpDevTunnelConfigurationAnnotation tunnelConfig,
         OtlpEndpointTarget target,
         IServiceProvider services,
         IDistributedApplicationEventing eventing,
         CancellationToken cancellationToken)
     {
-        var endpoint = stubResource.OtlpEndpoint;
-        if (endpoint.AllocatedEndpoint is not null)
+        if (!tunnelConfig.UpdateOtlpEndpoint(target.Scheme, target.Port, GetEndpointTransport(target.Protocol)))
         {
-            return Task.CompletedTask;
+            return;
         }
-
-        endpoint.UriScheme = target.Scheme;
-        endpoint.Port = target.Port;
-        endpoint.TargetPort = target.Port;
-        endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", target.Port);
 
         // The stub endpoint is synthetic and not allocated by DCP. Publishing the event keeps
         // endpoint consumers such as dev tunnel ports on the normal endpoint-allocation path.
-        return eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(stubResource, services), cancellationToken);
+        await eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(tunnelConfig.OtlpStub, services), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -250,6 +499,11 @@ public static class MauiOtlpExtensions
         OtlpDevTunnelConfigurationAnnotation tunnelConfig)
         where T : IMauiPlatformResource, IResourceWithEnvironment
     {
+        if (platformBuilder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            return;
+        }
+
         // Get the tunnel endpoint for the OTLP stub directly, bypassing service discovery injection
         var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
 
@@ -258,7 +512,47 @@ public static class MauiOtlpExtensions
 
         // Set OTEL_EXPORTER_OTLP_ENDPOINT directly to the tunnel endpoint URL
         platformBuilder.WithEnvironment(KnownOtelConfigNames.ExporterOtlpEndpoint, tunnelEndpoint);
+        platformBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol] =
+                new OtlpProtocolValueProvider(
+                    tunnelConfig.OtlpStub.OtlpEndpoint,
+                    tunnelConfig.RuntimeSnapshotResolutionTimeout);
+        });
     }
 
-    private readonly record struct OtlpEndpointTarget(string Scheme, int Port);
+    private static string GetEndpointTransport(string? otlpProtocol)
+        => string.Equals(otlpProtocol, OtlpGrpcProtocol, StringComparison.OrdinalIgnoreCase) ? "http2" : "http";
+
+    private static string GetOtlpProtocol(EndpointAnnotation endpoint)
+        => string.Equals(endpoint.Transport, "http2", StringComparison.OrdinalIgnoreCase) ? OtlpGrpcProtocol : OtlpHttpProtobufProtocol;
+
+    private readonly record struct OtlpEndpointTarget(string Scheme, int Port, string Protocol);
+    private readonly record struct EndpointPortResolution(int? Port, bool HasUnresolvedExpression);
+
+    private sealed class OtlpProtocolValueProvider(
+        EndpointAnnotation endpoint,
+        TimeSpan resolutionTimeout) : IValueProvider
+    {
+        public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                await endpoint.AllocatedEndpointSnapshot
+                    .GetValueAsync(cancellationToken)
+                    .WaitAsync(resolutionTimeout, cancellationToken)
+                    .ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+            catch (TimeoutException ex)
+            {
+                throw new DistributedApplicationException(
+                    $"The MAUI OTLP protocol could not be determined because the dashboard did not publish a concrete OTLP listener within {resolutionTimeout:c}.",
+                    ex);
+            }
+
+            return GetOtlpProtocol(endpoint);
+        }
+    }
 }

--- a/src/Aspire.Hosting.Maui/Otlp/OtlpLoopbackResource.cs
+++ b/src/Aspire.Hosting.Maui/Otlp/OtlpLoopbackResource.cs
@@ -35,8 +35,7 @@ internal sealed class OtlpLoopbackResource : Resource, IResourceWithEndpoints
             port: port,
             isProxied: false)
         {
-            // TargetHost = localhost means this resource is running on the local machine
-            // When tunneled through dev tunnels, the service discovery will rewrite this to the tunnel URL
+            // Dev Tunnels only accepts localhost target endpoints.
             TargetHost = "localhost"
         };
 

--- a/src/Aspire.Hosting.Maui/README.md
+++ b/src/Aspire.Hosting.Maui/README.md
@@ -106,9 +106,11 @@ This method automatically:
 When you configure OTLP with dev tunnel, the following environment variables are automatically set:
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT`: The dev tunnel URL for the OTLP endpoint
-- `OTEL_EXPORTER_OTLP_PROTOCOL`: Set to `grpc` (standard Aspire configuration)
+- `OTEL_EXPORTER_OTLP_PROTOCOL`: Set to `http/protobuf` for the preferred dashboard OTLP/HTTP endpoint, or `grpc` when only OTLP/gRPC is available
 - `OTEL_SERVICE_NAME`: The resource name
 - `OTEL_RESOURCE_ATTRIBUTES`: Service instance ID
+
+When both dashboard OTLP endpoints are available, MAUI dev tunnels prefer OTLP/HTTP. Android and iOS environment targets are reevaluated when their resource restarts so updated tunnel settings are applied to the relaunched app.
 
 ## Example: Complete Aspire App with MAUI
 

--- a/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
@@ -76,33 +76,23 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the targets file
-            // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the file once
-            string? generatedFilePath = null;
+            var environmentTargetsDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-android-env").Path;
 
+            // Generate the stable targets file whenever arguments are reevaluated so resource
+            // restarts receive environment values changed since the previous launch.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the file once, even if this callback is invoked multiple times
-                if (generatedFilePath is null)
-                {
-                    generatedFilePath = await MauiEnvironmentHelper.CreateAndroidEnvironmentTargetsFileAsync(
-                        fileSystemService,
-                        resource,
-                        executionContext,
-                        logger,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-
-                    if (generatedFilePath is not null)
-                    {
-                        logger.LogInformation("Generated environment targets file for Android: {Path}", generatedFilePath);
-                    }
-                }
+                var generatedFilePath = await MauiEnvironmentHelper.CreateAndroidEnvironmentTargetsFileAsync(
+                    environmentTargetsDirectory,
+                    resource,
+                    executionContext,
+                    logger,
+                    context.CancellationToken
+                ).ConfigureAwait(false);
 
                 if (generatedFilePath is not null)
                 {
-                    // Add the targets file as an MSBuild property via command-line argument
+                    logger.LogInformation("Generated environment targets file for Android: {Path}", generatedFilePath);
                     var commandLineArg = $"-p:CustomAfterMicrosoftCommonTargets={generatedFilePath}";
                     context.Args.Add(commandLineArg);
                 }

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
 
-using System.Globalization;
 using System.Text;
 using System.Xml.Linq;
 using Aspire.Hosting.ApplicationModel;
@@ -24,14 +23,14 @@ internal static class MauiEnvironmentHelper
     /// <summary>
     /// Creates an MSBuild targets file for Android that sets environment variables.
     /// </summary>
-    /// <param name="fileSystemService">The file system service for managing temp files.</param>
+    /// <param name="tempDirectory">The resource-specific temporary directory for the targets file.</param>
     /// <param name="resource">The resource to collect environment variables from.</param>
     /// <param name="executionContext">The execution context.</param>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The path to the generated targets file, or null if no environment variables are present.</returns>
     public static async Task<string?> CreateAndroidEnvironmentTargetsFileAsync(
-        IFileSystemService fileSystemService,
+        string tempDirectory,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
         ILogger logger,
@@ -59,15 +58,8 @@ internal static class MauiEnvironmentHelper
             return null;
         }
 
-        // Create a temporary targets file
-        var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-android-env").Path;
-
-        // Prune old targets files
-        PruneOldTargets(tempDirectory, logger);
-
         var sanitizedName = SanitizeFileName(resource.Name + "-android");
-        var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-        var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
+        var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}.targets");
 
         // Generate the targets file content
         var targetsContent = GenerateAndroidTargetsFileContent(environmentVariables);
@@ -145,34 +137,6 @@ internal static class MauiEnvironmentHelper
         return stringWriter.ToString();
     }
 
-    private static void PruneOldTargets(string directory, ILogger logger)
-    {
-        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
-        var deletedFiles = new List<string>();
-
-        foreach (var file in Directory.EnumerateFiles(directory, "*.targets", SearchOption.TopDirectoryOnly))
-        {
-            try
-            {
-                var info = new FileInfo(file);
-                if (info.Exists && info.LastWriteTimeUtc < expiration)
-                {
-                    info.Delete();
-                    deletedFiles.Add(info.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Failed to prune stale Android environment targets file '{TargetsFile}'.", file);
-            }
-        }
-
-        if (deletedFiles.Count > 0)
-        {
-            logger.LogDebug("Pruned {Count} stale Android environment targets file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
-        }
-    }
-
     internal static string SanitizeFileName(string name)
     {
         var invalidCharacters = Path.GetInvalidFileNameChars();
@@ -211,14 +175,14 @@ internal static class MauiEnvironmentHelper
     /// <summary>
     /// Creates an MSBuild targets file for iOS that sets environment variables.
     /// </summary>
-    /// <param name="fileSystemService">The file system service for managing temp files.</param>
+    /// <param name="tempDirectory">The resource-specific temporary directory for the targets file.</param>
     /// <param name="resource">The resource to collect environment variables from.</param>
     /// <param name="executionContext">The execution context.</param>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The path to the generated targets file, or null if no environment variables are present.</returns>
     public static async Task<string?> CreateiOSEnvironmentTargetsFileAsync(
-        IFileSystemService fileSystemService,
+        string tempDirectory,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
         ILogger logger,
@@ -235,15 +199,8 @@ internal static class MauiEnvironmentHelper
             return null;
         }
 
-        // Create a temporary targets file
-        var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-mlaunch-env").Path;
-
-        // Prune old targets files
-        PruneOldTargetsiOS(tempDirectory, logger);
-
         var sanitizedName = SanitizeFileName(resource.Name + "-ios");
-        var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-        var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
+        var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}.targets");
 
         // Generate the targets file content
         var targetsContent = GenerateiOSTargetsFileContent(executionConfiguration.EnvironmentVariables.ToDictionary());
@@ -303,31 +260,4 @@ internal static class MauiEnvironmentHelper
         return stringWriter.ToString();
     }
 
-    private static void PruneOldTargetsiOS(string directory, ILogger logger)
-    {
-        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
-        var deletedFiles = new List<string>();
-
-        foreach (var file in Directory.EnumerateFiles(directory, "*.targets", SearchOption.TopDirectoryOnly))
-        {
-            try
-            {
-                var info = new FileInfo(file);
-                if (info.Exists && info.LastWriteTimeUtc < expiration)
-                {
-                    info.Delete();
-                    deletedFiles.Add(info.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Failed to prune stale iOS environment targets file '{TargetsFile}'.", file);
-            }
-        }
-
-        if (deletedFiles.Count > 0)
-        {
-            logger.LogDebug("Pruned {Count} stale iOS environment targets file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
-        }
-    }
 }

--- a/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
@@ -76,33 +76,23 @@ internal sealed class MauiiOSEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the targets file
-            // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the file once
-            string? generatedFilePath = null;
+            var environmentTargetsDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-mlaunch-env").Path;
 
+            // Generate the stable targets file whenever arguments are reevaluated so resource
+            // restarts receive environment values changed since the previous launch.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the file once, even if this callback is invoked multiple times
-                if (generatedFilePath is null)
-                {
-                    generatedFilePath = await MauiEnvironmentHelper.CreateiOSEnvironmentTargetsFileAsync(
-                        fileSystemService,
-                        resource,
-                        executionContext,
-                        logger,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-
-                    if (generatedFilePath is not null)
-                    {
-                        logger.LogInformation("Generated environment targets file for iOS: {Path}", generatedFilePath);
-                    }
-                }
+                var generatedFilePath = await MauiEnvironmentHelper.CreateiOSEnvironmentTargetsFileAsync(
+                    environmentTargetsDirectory,
+                    resource,
+                    executionContext,
+                    logger,
+                    context.CancellationToken
+                ).ConfigureAwait(false);
 
                 if (generatedFilePath is not null)
                 {
-                    // Add the targets file as an MSBuild property via command-line argument
+                    logger.LogInformation("Generated environment targets file for iOS: {Path}", generatedFilePath);
                     var commandLineArg = $"-p:CustomAfterMicrosoftCommonTargets={generatedFilePath}";
                     context.Args.Add(commandLineArg);
                 }

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREEXTENSION001 // Debug support APIs are experimental.
+#pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Maui;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Utilities;
@@ -552,6 +554,72 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+    [InlineData("android", "net10.0-android")]
+    [InlineData("ios", "net10.0-ios")]
+    public async Task MobileEnvironmentTargetsFileIsRegeneratedWhenResourceRestarts(string platform, string targetFramework)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent(targetFramework));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var resource = platform == "android"
+            ? (IResource)maui.AddAndroidEmulator().Resource
+            : maui.AddiOSSimulator().Resource;
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["RESTART_VALUE"] = "first";
+        }));
+
+        var existingArgumentCallbacks = resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().ToHashSet();
+
+        await using var app = appBuilder.Build();
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        IDistributedApplicationEventingSubscriber environmentSubscriber = platform == "android"
+            ? new MauiAndroidEnvironmentSubscriber(
+                executionContext,
+                app.Services.GetRequiredService<ResourceLoggerService>(),
+                app.Services.GetRequiredService<ResourceNotificationService>(),
+                app.Services.GetRequiredService<IFileSystemService>())
+            : new MauiiOSEnvironmentSubscriber(
+                executionContext,
+                app.Services.GetRequiredService<ResourceLoggerService>(),
+                app.Services.GetRequiredService<ResourceNotificationService>(),
+                app.Services.GetRequiredService<IFileSystemService>());
+        await environmentSubscriber.SubscribeAsync(eventing, executionContext, CancellationToken.None);
+        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource, app.Services), CancellationToken.None);
+
+        var targetsFileCallback = Assert.Single(
+            resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>(),
+            callback => !existingArgumentCallbacks.Contains(callback));
+
+        var firstPath = await EvaluateTargetsFileAsync(targetsFileCallback, resource);
+        Assert.Contains("RESTART_VALUE=first", await File.ReadAllTextAsync(firstPath));
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["RESTART_VALUE"] = "second";
+        }));
+
+        var secondPath = await EvaluateTargetsFileAsync(targetsFileCallback, resource);
+        Assert.Equal(firstPath, secondPath);
+        Assert.Contains("RESTART_VALUE=second", await File.ReadAllTextAsync(secondPath));
+
+        static async Task<string> EvaluateTargetsFileAsync(CommandLineArgsCallbackAnnotation callback, IResource resource)
+        {
+            var args = new List<object>();
+            await callback.Callback(new CommandLineArgsCallbackContext(args, resource, CancellationToken.None));
+            var property = Assert.Single(
+                args.OfType<string>(),
+                argument => argument.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+
+            return property["-p:CustomAfterMicrosoftCommonTargets=".Length..];
+        }
+    }
+
+    [Theory]
     [InlineData(true)]  // Device
     [InlineData(false)] // Emulator
     public void AddAndroid_HasEnvironmentAnnotation(bool isDevice)
@@ -670,7 +738,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task WithOtlpDevTunnel_AllocatesStubFromDynamicDashboardOtlpEndpoint()
+    public async Task WithOtlpDevTunnel_UsesGrpcWhenDashboardOnlyHasGrpcEndpoint()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
@@ -708,6 +776,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.Equal(55075, stubEndpoint.Port);
         Assert.Equal(55075, stubEndpoint.TargetPort);
         Assert.Equal("http://localhost:55075", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http2", stubEndpoint.Transport);
 
         var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
         tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
@@ -719,6 +788,162 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
         Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_PrefersHttpAndUsesConcreteTargetPort()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpGrpcEndpointName,
+            uriScheme: "http",
+            isProxied: true,
+            transport: "http2"));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+        await using var app = appBuilder.Build();
+
+        var httpEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>()
+            .Single(endpoint => endpoint.Name == KnownEndpointNames.OtlpHttpEndpointName);
+        httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 55076, targetPortExpression: "55077");
+        var grpcEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>()
+            .Single(endpoint => endpoint.Name == KnownEndpointNames.OtlpGrpcEndpointName);
+        grpcEndpoint.AllocatedEndpoint = new AllocatedEndpoint(grpcEndpoint, "localhost", 55078, targetPortExpression: "55079");
+
+        await appBuilder.Eventing.PublishAsync(
+            new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
+            CancellationToken.None);
+
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+        Assert.Equal(55077, stubEndpoint.Port);
+        Assert.Equal(55077, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:55077", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.Transport);
+
+        httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 55088, targetPortExpression: "55089");
+        await appBuilder.Eventing.PublishAsync(
+            new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
+            CancellationToken.None);
+        Assert.Equal(55077, stubEndpoint.Port);
+
+        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
+            new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+        var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services);
+
+        Assert.Equal("http/protobuf", environmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol]);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_UsesAllocatedProxyForNonlocalTargetHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        var dashboardEndpoint = new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true)
+        {
+            TargetHost = "192.0.2.1"
+        };
+        dashboard.Resource.Annotations.Add(dashboardEndpoint);
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+        await using var app = appBuilder.Build();
+
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(
+            dashboardEndpoint,
+            "localhost",
+            55076,
+            targetPortExpression: "55077");
+        await appBuilder.Eventing.PublishAsync(
+            new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
+            CancellationToken.None);
+
+        Assert.Equal(55076, tunnelConfig.OtlpStub.OtlpEndpoint.Port);
+        Assert.Equal("http://localhost:55076", tunnelConfig.OtlpStub.OtlpEndpoint.AllocatedEndpoint?.UriString);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_ResolvesTargetPortExpressionFromDashboardSnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+        await using var app = appBuilder.Build();
+
+        await app.Services.GetRequiredService<ResourceNotificationService>()
+            .PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
+            {
+                State = KnownResourceStates.Running,
+                EnvironmentVariables =
+                [
+                    new(
+                        KnownConfigNames.DashboardOtlpHttpEndpointUrl,
+                        "http://localhost:55077",
+                        IsFromSpec: false)
+                ]
+            });
+
+        var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single();
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(
+            dashboardEndpoint,
+            "localhost",
+            55076,
+            targetPortExpression: """{{- portForServing "dashboard-otlp-http" -}}""");
+
+        await appBuilder.Eventing.PublishAsync(
+            new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
+            CancellationToken.None);
+
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+        Assert.Equal(55077, stubEndpoint.Port);
+        Assert.Equal(55077, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:55077", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.Transport);
     }
 
     [Fact]
@@ -760,6 +985,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.Equal(18889, stubEndpoint.Port);
         Assert.Equal(18889, stubEndpoint.TargetPort);
         Assert.Equal("http://localhost:18889", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http2", stubEndpoint.Transport);
 
         await using var app = appBuilder.Build();
 
@@ -783,6 +1009,82 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             app.Services);
 
         Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
+        Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_PrefersConfiguredHttpEndpoint()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        using var appBuilder = TestDistributedApplicationBuilder.Create();
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost:18889";
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpHttpEndpointUrl] = "http://dashboard.localhost:18890";
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+
+        Assert.Equal(18890, stubEndpoint.Port);
+        Assert.Equal(18890, stubEndpoint.TargetPort);
+        Assert.Equal("http://localhost:18890", stubEndpoint.AllocatedEndpoint?.UriString);
+        Assert.Equal("http", stubEndpoint.Transport);
+
+        await using var app = appBuilder.Build();
+        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
+            new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+        var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services);
+
+        Assert.Equal("http/protobuf", environmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol]);
+    }
+
+    [Theory]
+    [InlineData("http://0.0.0.0:18890")]
+    [InlineData("http://[::]:18890")]
+    public void WithOtlpDevTunnel_AcceptsConfiguredWildcardBinding(string endpointUrl)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        using var appBuilder = TestDistributedApplicationBuilder.Create();
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpHttpEndpointUrl] = endpointUrl;
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+        Assert.Equal("http://localhost:18890", tunnelConfig.OtlpStub.OtlpEndpoint.AllocatedEndpoint?.UriString);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_DoesNotAddRunOnlyEnvironmentDuringPublish()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        using var appBuilder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpHttpEndpointUrl] = "http://localhost:18890";
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
+
+        var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Publish,
+            TestServiceProvider.Instance);
+
+        Assert.DoesNotContain(KnownOtelConfigNames.ExporterOtlpEndpoint, environmentVariables.Keys);
+        Assert.DoesNotContain(KnownOtelConfigNames.ExporterOtlpProtocol, environmentVariables.Keys);
     }
 
     [Fact]
@@ -831,20 +1133,183 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
             appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
 
-        Assert.Contains("does not have an allocated OTLP endpoint", exception.Message);
+        Assert.Contains("does not have a concrete OTLP endpoint", exception.Message);
         Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
         Assert.Contains(KnownEndpointNames.OtlpHttpEndpointName, exception.Message);
     }
 
     [Fact]
-    public void WithOtlpDevTunnel_ThrowsForInvalidConfiguredOtlpEndpoint()
+    public async Task WithOtlpDevTunnel_RejectsSyntheticStubEndpoint()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
         File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
 
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "not a url";
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        appBuilder.AddResource(new ContainerResource(KnownResourceNames.AspireDashboard));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddAndroidEmulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
+        stubEndpoint.Port = 12345;
+        stubEndpoint.TargetPort = 12345;
+        stubEndpoint.AllocatedEndpoint = new AllocatedEndpoint(stubEndpoint, "localhost", 12345);
+
+        await using var app = appBuilder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            appBuilder.Eventing.PublishAsync(
+                new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+                CancellationToken.None));
+
+        Assert.Contains("does not have a concrete OTLP endpoint", exception.Message);
+        Assert.False(tunnelConfig.IsOtlpEndpointResolved);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_TimesOutWaitingForConcreteDashboardListener()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        tunnelConfig.RuntimeSnapshotResolutionTimeout = TimeSpan.FromMilliseconds(50);
+
+        await using var app = appBuilder.Build();
+
+        var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single();
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(
+            dashboardEndpoint,
+            "localhost",
+            55076,
+            targetPortExpression: """{{- portForServing "dashboard-otlp-http" -}}""");
+        await app.Services.GetRequiredService<ResourceNotificationService>()
+            .PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
+            {
+                State = KnownResourceStates.Running
+            });
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            appBuilder.Eventing.PublishAsync(
+                new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+                CancellationToken.None));
+
+        Assert.Contains("did not publish a concrete OTLP listener", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_ProtocolEvaluationTimesOutWhenDashboardResolutionFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+        tunnelConfig.RuntimeSnapshotResolutionTimeout = TimeSpan.FromMilliseconds(50);
+        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
+        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
+            new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+        await using var app = appBuilder.Build();
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(async () =>
+            await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+                iosSimulator.Resource,
+                DistributedApplicationOperation.Run,
+                app.Services));
+
+        var resolutionException = Assert.IsType<DistributedApplicationException>(Assert.Single(exception.InnerExceptions));
+        Assert.Contains("protocol could not be determined", resolutionException.Message);
+    }
+
+    [Fact]
+    public async Task WithOtlpDevTunnel_FailsWhenDashboardTerminatesWhileWaiting()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
+        var dashboard = appBuilder.AddResource(new ExecutableResource(KnownResourceNames.AspireDashboard, "dashboard", ""));
+        dashboard.Resource.Annotations.Add(new EndpointAnnotation(
+            ProtocolType.Tcp,
+            name: KnownEndpointNames.OtlpHttpEndpointName,
+            uriScheme: "http",
+            isProxied: true));
+
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
+
+        await using var app = appBuilder.Build();
+
+        var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single();
+        dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(
+            dashboardEndpoint,
+            "localhost",
+            55076,
+            targetPortExpression: """{{- portForServing "dashboard-otlp-http" -}}""");
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
+        {
+            State = KnownResourceStates.Running
+        });
+
+        var beforeStartTask = appBuilder.Eventing.PublishAsync(
+            new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+            CancellationToken.None);
+        Assert.False(beforeStartTask.IsCompleted);
+
+        await notificationService.PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
+        {
+            State = KnownResourceStates.Exited
+        });
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => beforeStartTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Contains("terminated", exception.Message);
+        Assert.False(tunnelConfig.IsOtlpEndpointResolved);
+    }
+
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("http://localhost:0")]
+    [InlineData("https://example.com:4318")]
+    public void WithOtlpDevTunnel_ThrowsForInvalidConfiguredOtlpEndpoint(string endpointUrl)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Configuration[KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = endpointUrl;
 
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var androidEmulator = maui.AddAndroidEmulator();
@@ -852,7 +1317,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var exception = Assert.Throws<DistributedApplicationException>(() => androidEmulator.WithOtlpDevTunnel());
 
         Assert.Contains(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, exception.Message);
-        Assert.Contains("not a url", exception.Message);
+        Assert.Contains(endpointUrl, exception.Message);
     }
 
     // Helper methods

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -836,6 +836,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.Equal(55077, stubEndpoint.TargetPort);
         Assert.Equal("http://localhost:55077", stubEndpoint.AllocatedEndpoint?.UriString);
         Assert.Equal("http", stubEndpoint.Transport);
+        Assert.Equal("http", Assert.Single(appBuilder.Resources.OfType<DevTunnelPortResource>()).Options.Protocol);
 
         httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 55088, targetPortExpression: "55089");
         await appBuilder.Eventing.PublishAsync(
@@ -1033,6 +1034,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.Equal(18890, stubEndpoint.TargetPort);
         Assert.Equal("http://localhost:18890", stubEndpoint.AllocatedEndpoint?.UriString);
         Assert.Equal("http", stubEndpoint.Transport);
+        Assert.Equal("http", Assert.Single(appBuilder.Resources.OfType<DevTunnelPortResource>()).Options.Protocol);
 
         await using var app = appBuilder.Build();
         var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.DevTunnels;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Maui;
@@ -1195,6 +1196,13 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
         tunnelConfig.RuntimeSnapshotResolutionTimeout = TimeSpan.FromMilliseconds(50);
+        // Use a same-name stand-in to exercise the MAUI resolver without invoking the real
+        // DevTunnel resource's CLI-backed lifecycle after endpoint resolution recovers.
+        var resolutionEventResource = new DevTunnelResource(
+            tunnelConfig.DevTunnel.Resource.Name,
+            "test",
+            "devtunnel",
+            Environment.CurrentDirectory);
 
         await using var app = appBuilder.Build();
 
@@ -1212,7 +1220,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
             appBuilder.Eventing.PublishAsync(
-                new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+                new BeforeResourceStartedEvent(resolutionEventResource, app.Services),
                 CancellationToken.None));
 
         Assert.Contains("did not publish a concrete OTLP listener", exception.Message);
@@ -1236,7 +1244,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                 ]
             });
         await appBuilder.Eventing.PublishAsync(
-            new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+            new BeforeResourceStartedEvent(resolutionEventResource, app.Services),
             CancellationToken.None);
 
         tunnelConfig.TunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -910,7 +910,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             isProxied: true));
 
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
 
         await using var app = appBuilder.Build();
@@ -1098,17 +1098,24 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         ClearDashboardOtlpEndpointConfiguration(appBuilder.Configuration);
 
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-        maui.AddAndroidEmulator()
+        var androidEmulator = maui.AddAndroidEmulator()
             .WithOtlpDevTunnel();
 
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
 
         await using var app = appBuilder.Build();
 
+        var environmentTask = EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            androidEmulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services).AsTask();
+        Assert.False(environmentTask.IsCompleted);
+
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
             appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
 
         Assert.Contains("requires the Aspire dashboard", exception.Message);
+        await AssertEnvironmentResolutionFailsAsync(environmentTask, exception);
     }
 
     [Fact]
@@ -1185,7 +1192,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             isProxied: true));
 
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
         tunnelConfig.RuntimeSnapshotResolutionTimeout = TimeSpan.FromMilliseconds(50);
 
@@ -1209,10 +1216,42 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                 CancellationToken.None));
 
         Assert.Contains("did not publish a concrete OTLP listener", exception.Message);
+
+        var environmentTask = EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services).AsTask();
+        await AssertEnvironmentResolutionFailsAsync(environmentTask, exception);
+        Assert.Null(tunnelConfig.TunnelEndpoint.EndpointAnnotation.AllocatedEndpoint);
+
+        await app.Services.GetRequiredService<ResourceNotificationService>()
+            .PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
+            {
+                EnvironmentVariables =
+                [
+                    new(
+                        KnownConfigNames.DashboardOtlpHttpEndpointUrl,
+                        "http://localhost:55077",
+                        IsFromSpec: false)
+                ]
+            });
+        await appBuilder.Eventing.PublishAsync(
+            new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
+            CancellationToken.None);
+
+        tunnelConfig.TunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
+            new AllocatedEndpoint(tunnelConfig.TunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
+
+        var recoveredEnvironment = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services);
+        Assert.Equal("https://mobile-otlp.devtunnels.ms:443", recoveredEnvironment[KnownOtelConfigNames.ExporterOtlpEndpoint]);
+        Assert.Equal("http/protobuf", recoveredEnvironment[KnownOtelConfigNames.ExporterOtlpProtocol]);
     }
 
     [Fact]
-    public async Task WithOtlpDevTunnel_ProtocolEvaluationTimesOutWhenDashboardResolutionFails()
+    public async Task WithOtlpDevTunnel_EnvironmentEvaluationTimesOutWhenDashboardResolutionDoesNotStart()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
@@ -1231,10 +1270,6 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
         tunnelConfig.RuntimeSnapshotResolutionTimeout = TimeSpan.FromMilliseconds(50);
-        var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
-        tunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
-            new AllocatedEndpoint(tunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
-
         await using var app = appBuilder.Build();
 
         var exception = await Assert.ThrowsAsync<AggregateException>(async () =>
@@ -1243,8 +1278,10 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                 DistributedApplicationOperation.Run,
                 app.Services));
 
-        var resolutionException = Assert.IsType<DistributedApplicationException>(Assert.Single(exception.InnerExceptions));
-        Assert.Contains("protocol could not be determined", resolutionException.Message);
+        Assert.Equal(2, exception.InnerExceptions.Count);
+        Assert.All(exception.InnerExceptions, innerException => Assert.IsType<DistributedApplicationException>(innerException));
+        Assert.Contains(exception.InnerExceptions, innerException => innerException.Message.Contains("endpoint could not be determined", StringComparison.Ordinal));
+        Assert.Contains(exception.InnerExceptions, innerException => innerException.Message.Contains("protocol could not be determined", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -1266,7 +1303,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             isProxied: true));
 
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
-        maui.AddiOSSimulator().WithOtlpDevTunnel();
+        var iosSimulator = maui.AddiOSSimulator().WithOtlpDevTunnel();
         var tunnelConfig = maui.Resource.Annotations.OfType<OtlpDevTunnelConfigurationAnnotation>().Single();
 
         await using var app = appBuilder.Build();
@@ -1284,6 +1321,12 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             State = KnownResourceStates.Running
         });
 
+        var environmentTask = EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+            iosSimulator.Resource,
+            DistributedApplicationOperation.Run,
+            app.Services).AsTask();
+        Assert.False(environmentTask.IsCompleted);
+
         var beforeStartTask = appBuilder.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
             CancellationToken.None);
@@ -1297,6 +1340,9 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
             () => beforeStartTask.WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Contains("terminated", exception.Message);
+
+        await AssertEnvironmentResolutionFailsAsync(environmentTask, exception);
+
         Assert.False(tunnelConfig.IsOtlpEndpointResolved);
     }
 
@@ -1323,6 +1369,17 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
     }
 
     // Helper methods
+
+    private static async Task AssertEnvironmentResolutionFailsAsync(
+        Task<Dictionary<string, string>> environmentTask,
+        DistributedApplicationException expectedException)
+    {
+        var environmentException = await Assert.ThrowsAsync<AggregateException>(
+            () => environmentTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.All(
+            environmentException.InnerExceptions,
+            innerException => Assert.Same(expectedException, innerException));
+    }
 
     private static string CreateProjectContentWithout(string excludePlatform)
     {

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -1247,8 +1247,10 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.Contains("protocol could not be determined", resolutionException.Message);
     }
 
-    [Fact]
-    public async Task WithOtlpDevTunnel_FailsWhenDashboardTerminatesWhileWaiting()
+    [Theory]
+    [InlineData("Terminated")]
+    [InlineData(nameof(KnownResourceStates.Exited))]
+    public async Task WithOtlpDevTunnel_FailsWhenDashboardTerminatesWhileWaiting(string dashboardState)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
@@ -1289,7 +1291,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         await notificationService.PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
         {
-            State = KnownResourceStates.Exited
+            State = dashboardState
         });
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(


### PR DESCRIPTION
## Description

This extracts the MAUI OTLP dev-tunnel and mobile environment refresh work from #18591 into a focused follow-up to #19383. The launch-queue handoff remains isolated in #19383; this PR only addresses how MAUI resources reach the Aspire Dashboard OTLP listener and refresh mobile launch environments.

MAUI apps running on Android and iOS cannot reliably reach the AppHost's local OTLP listener directly. `WithOtlpDevTunnel()` now prefers the Dashboard OTLP/HTTP endpoint and configures `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, falling back to OTLP/gRPC only when HTTP is unavailable. It forwards to the concrete allocated listener port rather than an unrelated DCP proxy port. The DevTunnel port protocol tracks the resolved local listener's HTTP/HTTPS scheme, while the public relay endpoint remains HTTPS.

The resolver handles configured endpoint URLs, executable target ports, DCP target-port expressions, container/proxy endpoints, localhost TLDs, and wildcard local bindings. Resolution is one-shot for this focused slice and bounded when waiting for DCP snapshots. Dashboard-disabled, terminated, timeout, unresolved, synthetic-stub, and invalid-configuration cases fail with actionable errors instead of hanging. Endpoint and protocol environment providers are both bounded and observe the shared resolution failure, while a later successful resolution can recover without poisoning the DevTunnel endpoint lifecycle.

Android and iOS now rewrite stable per-resource MSBuild environment targets whenever launch arguments are reevaluated, so restarted MAUI resources receive current OTLP URL, protocol, and environment values.

### User-facing usage

The existing C# API is unchanged:

```csharp
var mauiApp = builder.AddMauiProject("mauiapp", "../MauiApp/MauiApp.csproj");

mauiApp.AddiOSSimulator()
    .WithOtlpDevTunnel();

mauiApp.AddAndroidEmulator()
    .WithOtlpDevTunnel();
```

`WithOtlpDevTunnel()` remains run-only and does not add tunnel environment values to published manifests.

### Scope

Included:

- Dashboard OTLP/HTTP preference and protocol selection
- Concrete allocated target-port and runtime-snapshot resolution
- Local DevTunnel port protocol synchronization with the resolved listener
- Bounded startup, endpoint, and protocol waits with clear failure paths
- Recovery of environment evaluation after a later successful listener allocation
- Android/iOS environment regeneration after resource restart

Deferred to a separate DevTunnels change:

- Long-running endpoint watcher reconciliation
- Post-start listener retargeting and stale-port cleanup
- Shared port allocation serialization
- Generic DevTunnel health recovery

No Aspire.Hosting core/DCP lifecycle, Dashboard, Foundry, playground, dependency, generated API, or snapshot files are changed.

### Validation

Rebased head `1a92e9e957c49de5373fdd9c542203212105730a` against `main` at `a33c3ad196add9798043b26dbd5fcebd8dad4d92`:

- `./restore.sh`
- `dotnet build src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj --no-restore -m:1` — succeeded with 0 warnings and 0 errors
- Focused dynamic/configured HTTP protocol and CLI-independent recovery tests — 3 passed
- Complete `Aspire.Hosting.Maui.Tests` project with `devtunnel` forced unavailable and quarantined/outerloop exclusions — 188 passed
- `git diff --check` and the eight-file MAUI-only allowlist check passed
- Final generic code review reported no findings
- Final Aspire architecture review reported no findings
- GitHub CI completed with 62 successful and 17 skipped checks, with no failures or incomplete checks
- Real iOS/Android execution was not attempted because the repo SDK has no MAUI workloads registered; existing iOS simulators, Android tooling, and Dev Tunnels were detected but are insufficient without those workloads

The first post-review CI run exposed a test-only dependency on the external `devtunnel` CLI on Linux and Windows. The recovery test now exercises MAUI's global resolver with a same-name stand-in resource, preserving failure/retry coverage while excluding the unrelated instance-scoped CLI lifecycle. An unrelated Windows VS Code launch-profile E2E timed out installing TypeScript dependencies on intermediate attempts; the exact `main` base had the same failure, and the final automatic retry passed.

Related PRs:

- Follow-up to #19383
- Focused replacement for the MAUI OTLP portion of #18591

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No