### PR TITLE
Bound Dotnet project pipeline tests

### DIFF
--- a/tests/Aspire.Hosting.Dotnet.Tests/Aspire.Hosting.Dotnet.Tests.csproj
+++ b/tests/Aspire.Hosting.Dotnet.Tests/Aspire.Hosting.Dotnet.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
@@ -912,17 +912,19 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
             fragment => Assert.Contains(fragment, exception.Message));
     }
 
-    private static Task ExecutePipelineAsync(DistributedApplication app)
+    private static async Task ExecutePipelineAsync(DistributedApplication app)
     {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
         var pipeline = app.Services.GetRequiredService<IDistributedApplicationPipeline>();
         var context = new PipelineContext(
             app.Services.GetRequiredService<DistributedApplicationModel>(),
             app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
             app.Services,
             app.Services.GetRequiredService<ILogger<DotnetProjectResourceTests>>(),
-            CancellationToken.None);
+            cts.Token);
 
-        return pipeline.ExecuteAsync(context);
+        await pipeline.ExecuteAsync(context).WaitAsync(cts.Token);
     }
 
     private static string CreateProjectDirectory(string workspacePath)

--- a/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
@@ -13,6 +13,7 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -915,7 +916,7 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
     private static async Task ExecutePipelineAsync(DistributedApplication app)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        cts.CancelAfter(TimeSpan.FromSeconds(30));
+        cts.CancelAfter(TestConstants.LongTimeoutTimeSpan);
         var pipeline = app.Services.GetRequiredService<IDistributedApplicationPipeline>();
         var context = new PipelineContext(
             app.Services.GetRequiredService<DistributedApplicationModel>(),


### PR DESCRIPTION
## Description

Pipeline regression tests for `DotnetProjectResource` publishing previously executed with `CancellationToken.None`. A deadlock or long-running pipeline regression could therefore stall until the test runner's much longer session timeout.

This change gives each pipeline execution a linked 30-second cancellation token, passes it through `PipelineContext`, and bounds the await with the same token. The linked token also preserves cancellation requested by the test framework.

Validated with:

```bash
dotnet test --project tests/Aspire.Hosting.Dotnet.Tests/Aspire.Hosting.Dotnet.Tests.csproj --no-launch-profile -- --filter-class '*.DotnetProjectResourceTests' --filter-not-trait 'quarantined=true' --filter-not-trait 'outerloop=true'
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
