### PR TITLE
Fix deployment E2E test matrix enumeration

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Aspire.Deployment.EndToEnd.Tests;
 
-[Trait("Partition", "Deployment")]
 [Trait("category", "deployment")]
 [Trait("provider", "azure")]
 public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)

--- a/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Xunit;
 
 namespace Infrastructure.Tests;
@@ -92,34 +91,4 @@ public class ScanTestPartitionsFromSourceGuardTests
             $"together:{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
     }
 
-    [Fact]
-    public void DeploymentEndToEndTestsUseClassMode()
-    {
-        var projectDirectory = Path.Combine(RepoRoot.Path, "tests", "Aspire.Deployment.EndToEnd.Tests");
-        var projectPath = Path.Combine(projectDirectory, "Aspire.Deployment.EndToEnd.Tests.csproj");
-        var project = XDocument.Load(projectPath);
-
-        Assert.Equal("true", project.Descendants("SplitTestsOnCI").Single().Value);
-
-        // A single Partition trait changes the entire split project from class mode to collection mode.
-        var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories))
-        {
-            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
-                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var content = File.ReadAllText(file);
-            if (s_anyPartitionTrait.IsMatch(content))
-            {
-                offenders.Add(Path.GetRelativePath(RepoRoot.Path, file).Replace('\\', '/'));
-            }
-        }
-
-        Assert.True(offenders.Count == 0,
-            "Deployment E2E tests must enumerate one CI job per class, but Partition traits switch the " +
-            $"project to collection mode:{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
-    }
 }

--- a/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
@@ -90,5 +90,4 @@ public class ScanTestPartitionsFromSourceGuardTests
             "form [Trait(\"Partition\", \"<literal>\")], or update the script's regex AND this guard " +
             $"together:{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
     }
-
 }

--- a/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/ScanTestPartitionsFromSourceGuardTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Infrastructure.Tests;
@@ -89,5 +90,36 @@ public class ScanTestPartitionsFromSourceGuardTests
             "attribute or non-literal value). Such a class would run in NO CI shard. Use the standalone " +
             "form [Trait(\"Partition\", \"<literal>\")], or update the script's regex AND this guard " +
             $"together:{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
+    }
+
+    [Fact]
+    public void DeploymentEndToEndTestsUseClassMode()
+    {
+        var projectDirectory = Path.Combine(RepoRoot.Path, "tests", "Aspire.Deployment.EndToEnd.Tests");
+        var projectPath = Path.Combine(projectDirectory, "Aspire.Deployment.EndToEnd.Tests.csproj");
+        var project = XDocument.Load(projectPath);
+
+        Assert.Equal("true", project.Descendants("SplitTestsOnCI").Single().Value);
+
+        // A single Partition trait changes the entire split project from class mode to collection mode.
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var content = File.ReadAllText(file);
+            if (s_anyPartitionTrait.IsMatch(content))
+            {
+                offenders.Add(Path.GetRelativePath(RepoRoot.Path, file).Replace('\\', '/'));
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Deployment E2E tests must enumerate one CI job per class, but Partition traits switch the " +
+            $"project to collection mode:{Environment.NewLine}{string.Join(Environment.NewLine, offenders)}");
     }
 }


### PR DESCRIPTION
## Description

The Deployment E2E workflow stopped generating one matrix job per test class after `AksPersistentVolumeDeploymentTests` introduced a `Partition` trait. The enumeration pipeline treats the presence of any partition trait as partition mode, so the affected [workflow run](https://github.com/microsoft/aspire/actions/runs/31867061431) collapsed the active deployment tests into two buckets.

This removes the accidental partition trait while retaining the deployment category and Azure provider traits.

Validation:

- The existing partition source guard passes.
- The source partition scan selects class mode.
- The CI partition generator emits 42 active class jobs and no collection buckets after applying the standard quarantine and outerloop exclusions.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No