### PR TITLE
Make ProjectTemplates replacement incremental

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -13,6 +13,8 @@
     <Description>Aspire Template Pack for Microsoft Template Engine</Description>
     <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <_TemplateSourceRoot Condition="'$(_TemplateSourceRoot)' == ''">$(MSBuildThisFileDirectory)templates\</_TemplateSourceRoot>
+    <_ReplaceTextScriptPath Condition="'$(_ReplaceTextScriptPath)' == ''">$(RepoRoot)tools\scripts\replace-text.cs</_ReplaceTextScriptPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,12 +23,12 @@
 
   <ItemGroup>
     <!-- see https://github.com/microsoft/aspire/pull/1225 -->
-    <None Include="templates\**\*" />
+    <None Include="$(_TemplateSourceRoot)**\*" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- Template config files: .template.config\*.json -->
-    <TemplateConfigFiles Include="$(MSBuildThisFileDirectory)templates\**\.template.config\*.json">
+    <TemplateConfigFiles Include="$(_TemplateSourceRoot)**\.template.config\*.json">
       <PackagePath>content/templates/%(RecursiveDir)</PackagePath>
       <DestinationFile>$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)</DestinationFile>
     </TemplateConfigFiles>
@@ -34,21 +36,21 @@
     <TemplateConfigFilesObj Include="@(TemplateConfigFiles->'%(DestinationFile)')" />
 
     <!-- Template project files: *.csproj -->
-    <TemplateProjectFiles Include="$(MSBuildThisFileDirectory)templates\**\*.csproj">
+    <TemplateProjectFiles Include="$(_TemplateSourceRoot)**\*.csproj">
       <PackagePath>content/templates/%(RecursiveDir)</PackagePath>
       <DestinationFile>$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)</DestinationFile>
     </TemplateProjectFiles>
 
     <!-- Template project files: apphost.cs (singlefile only) -->
-    <TemplateProjectFiles Include="$(MSBuildThisFileDirectory)templates\aspire-apphost-singlefile\**\apphost.cs">
+    <TemplateProjectFiles Include="$(_TemplateSourceRoot)aspire-apphost-singlefile\**\apphost.cs">
       <PackagePath>content/templates/aspire-apphost-singlefile/%(RecursiveDir)</PackagePath>
       <DestinationFile>$(IntermediateOutputPath)content\templates\aspire-apphost-singlefile\%(RecursiveDir)%(Filename)%(Extension)</DestinationFile>
     </TemplateProjectFiles>
 
     <TemplateProjectFilesObj Include="@(TemplateProjectFiles->'%(DestinationFile)')" />
 
-    <TemplateFiles Include="$(MSBuildThisFileDirectory)templates\**\*"
-                   Exclude="$(MSBuildThisFileDirectory)templates\**\bin\**;$(MSBuildThisFileDirectory)templates\**\obj\**;$(MSBuildThisFileDirectory)templates\**\*.csproj;$(MSBuildThisFileDirectory)templates\aspire-apphost-singlefile\**\apphost.cs">
+    <TemplateFiles Include="$(_TemplateSourceRoot)**\*"
+                   Exclude="$(_TemplateSourceRoot)**\bin\**;$(_TemplateSourceRoot)**\obj\**;$(_TemplateSourceRoot)**\*.csproj;$(_TemplateSourceRoot)aspire-apphost-singlefile\**\apphost.cs;$(_TemplateSourceRoot)**\.template.config\*.json;$(_TemplateSourceRoot)**\.template.config\localize\templatestrings.*.json">
       <PackagePath>content/templates/%(RecursiveDir)</PackagePath>
     </TemplateFiles>
 
@@ -61,13 +63,11 @@
           AfterTargets="Build"
           DependsOnTargets="ReplacePackageVersionOnTemplates">
     <ItemGroup>
-      <Content Include="@(TemplateFilesObj);@(TemplateProjectFilesObj)" />
+      <Content Include="@(TemplateFilesObj);@(TemplateConfigFilesObj);@(TemplateProjectFilesObj);@(TemplateLocalizedStringsFilesObj)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="ReplacePackageVersionOnTemplates"
-          DependsOnTargets="CopyTemplatesToIntermediateOutputPath">
-
+  <Target Name="PrepareReplaceTextResponseFile">
     <PropertyGroup>
       <!-- Extract purely numeric portions before any '-' prerelease tag -->
       <_VersionBase>$(PackageVersion.Split('-')[0])</_VersionBase>
@@ -75,15 +75,16 @@
       <VersionMajor>$(_VersionBase.Split('.')[0])</VersionMajor>
       <VersionMinor>$(_VersionBase.Split('.')[1])</VersionMinor>
       <VersionMajorMinor>$(VersionMajor).$(VersionMinor)</VersionMajorMinor>
-      <_RspFilePath>$(IntermediateOutputPath)replace-text-args.rsp</_RspFilePath>
-      <_ReplaceTextScriptPath>$(RepoRoot)tools/scripts/replace-text.cs</_ReplaceTextScriptPath>
+      <_ReplaceTextRspFilePath>$(IntermediateOutputPath)replace-text-args.rsp</_ReplaceTextRspFilePath>
+      <_ReplaceTextStampPath>$(IntermediateOutputPath)replace-text.stamp</_ReplaceTextStampPath>
     </PropertyGroup>
 
     <ItemGroup>
       <!-- This is defined here as these files aren't guaranteed to exist until the build has run -->
-      <TemplateLocalizedStringsFiles Include="$(MSBuildThisFileDirectory)templates\**\.template.config\localize\templatestrings.*.json" />
+      <TemplateLocalizedStringsFiles Include="$(_TemplateSourceRoot)**\.template.config\localize\templatestrings.*.json" />
       <TemplateLocalizedStringsFilesDest Include="@(TemplateLocalizedStringsFiles)"
-                                         DestinationFile="$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)" />
+                                         DestinationFile="$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)"
+                                         PackagePath="content/templates/%(RecursiveDir)" />
       <TemplateLocalizedStringsFilesObj Include="@(TemplateLocalizedStringsFilesDest->'%(DestinationFile)')" />
     </ItemGroup>
 
@@ -126,31 +127,79 @@
       <_RspLines Include="@(Replacements)" />
     </ItemGroup>
 
-    <!-- Write the .rsp file -->
-    <WriteLinesToFile File="$(_RspFilePath)"
+    <!-- The response file captures both the source list and every replacement value. Keeping its
+         timestamp stable when the content is unchanged gives the replacement target one complete,
+         response-file-safe input for property changes. -->
+    <WriteLinesToFile File="$(_ReplaceTextRspFilePath)"
                       Lines="@(_RspLines)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
+    <ItemGroup>
+      <_ReplaceTextInputs Include="@(TemplateFiles);@(TemplateConfigFiles);@(TemplateProjectFiles);@(TemplateLocalizedStringsFiles);$(_ReplaceTextRspFilePath);$(_ReplaceTextScriptPath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="InvalidateReplacePackageVersionStampForMissingFiles"
+          DependsOnTargets="PrepareReplaceTextResponseFile">
+    <ItemGroup>
+      <_MissingReplaceTextSourceFiles Include="@(SourceFiles)" Condition="!Exists('%(Identity)')" />
+    </ItemGroup>
+
+    <!-- Incremental target inputs are the original templates, so explicitly invalidate the stamp
+         when an expected generated file is missing. -->
+    <Delete Files="$(_ReplaceTextStampPath)" Condition="'@(_MissingReplaceTextSourceFiles)' != ''" />
+  </Target>
+
+  <Target Name="ReplacePackageVersionOnTemplates"
+          DependsOnTargets="CopyTemplatesToIntermediateOutputPath;InvalidateReplacePackageVersionStampForMissingFiles"
+          Inputs="@(_ReplaceTextInputs)"
+          Outputs="$(_ReplaceTextStampPath)">
+
+    <!-- Replacement-owned files are recopied only when an original template, the script, or a
+         serialized replacement value changes. This avoids copying tokenized sources over generated
+         content on every ordinary Build. -->
+    <Copy SourceFiles="@(TemplateConfigFiles)"
+          DestinationFiles="@(TemplateConfigFilesObj)"
+          SkipUnchangedFiles="false" />
+    <Copy SourceFiles="@(TemplateProjectFiles)"
+          DestinationFiles="@(TemplateProjectFilesObj)"
+          SkipUnchangedFiles="false" />
+    <Copy SourceFiles="@(TemplateLocalizedStringsFiles)"
+          DestinationFiles="@(TemplateLocalizedStringsFilesObj)"
+          SkipUnchangedFiles="false" />
+
+    <ItemGroup>
+      <_MissingReplaceTextSourceFilesAfterCopy Include="@(SourceFiles)" Condition="!Exists('%(Identity)')" />
+    </ItemGroup>
+    <Error Text="Template replacement input was not generated: @(_MissingReplaceTextSourceFilesAfterCopy, ', ')"
+           Condition="'@(_MissingReplaceTextSourceFilesAfterCopy)' != ''" />
+
     <!-- Execute the script with the .rsp file, using double dash to pass arguments directly to the script -->
-    <Exec Command="dotnet &quot;$(_ReplaceTextScriptPath)&quot; -- @&quot;$(_RspFilePath)&quot;"
+    <Exec Command="dotnet &quot;$(_ReplaceTextScriptPath)&quot; -- @&quot;$(_ReplaceTextRspFilePath)&quot;"
           WorkingDirectory="$(MSBuildThisFileDirectory)"
           StandardOutputImportance="Normal"
           StandardErrorImportance="Normal" />
+    <Touch Files="$(_ReplaceTextStampPath)" AlwaysCreate="true" />
   </Target>
 
   <!-- Grabs the contents of the templates folder and copies them to IntermediateOutputPath directory -->
   <Target Name="CopyTemplatesToIntermediateOutputPath"
-          Inputs="@(TemplateFiles);@(TemplateProjectFiles)"
-          Outputs="@(TemplateFilesObj);@(TemplateProjectFilesObj)">
+          Inputs="@(TemplateFiles)"
+          Outputs="@(TemplateFilesObj)">
 
     <Copy SourceFiles="@(TemplateFiles)"
           DestinationFiles="@(TemplateFilesObj)"
           SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(TemplateProjectFiles)"
-          DestinationFiles="@(TemplateProjectFilesObj)"
-          SkipUnchangedFiles="true" />
+  </Target>
 
+  <Target Name="CleanReplacePackageVersionOnTemplates"
+          AfterTargets="Clean">
+    <PropertyGroup>
+      <_ReplaceTextRspFilePath>$(IntermediateOutputPath)replace-text-args.rsp</_ReplaceTextRspFilePath>
+      <_ReplaceTextStampPath>$(IntermediateOutputPath)replace-text.stamp</_ReplaceTextStampPath>
+    </PropertyGroup>
+    <Delete Files="$(_ReplaceTextRspFilePath);$(_ReplaceTextStampPath)" />
   </Target>
 
   <!--

--- a/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
+++ b/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
@@ -1,0 +1,360 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+public sealed class ProjectTemplatesIncrementalBuildTests : IDisposable
+{
+    private const string ReplacementOutputMarker = "Processed:";
+
+    private readonly TemporaryWorkspace _workspace;
+    private readonly ITestOutputHelper _output;
+    private readonly string _projectPath;
+    private readonly string _templatesRoot;
+    private readonly string _scriptPath;
+    private readonly string _artifactsPath;
+    private readonly string _packagesPath;
+    private readonly Dictionary<string, string> _properties = new(StringComparer.Ordinal);
+
+    public ProjectTemplatesIncrementalBuildTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _workspace = TemporaryWorkspace.Create(output);
+        _projectPath = Path.Combine(RepoRoot.Path, "src", "Aspire.ProjectTemplates", "Aspire.ProjectTemplates.csproj");
+        _templatesRoot = Path.Combine(_workspace.Path, "templates");
+        _scriptPath = Path.Combine(_workspace.Path, "replace-text.cs");
+        _artifactsPath = Path.Combine(_workspace.Path, "artifacts");
+        _packagesPath = Path.Combine(_workspace.Path, "packages");
+
+        CopyDirectory(Path.Combine(RepoRoot.Path, "src", "Aspire.ProjectTemplates", "templates"), _templatesRoot);
+        CreateTestReplacementScript(_scriptPath);
+
+        _properties["_TemplateSourceRoot"] = EnsureTrailingDirectorySeparator(_templatesRoot);
+        _properties["_ReplaceTextScriptPath"] = _scriptPath;
+        _properties["BaseOutputPath"] = EnsureTrailingDirectorySeparator(Path.Combine(_artifactsPath, "bin"));
+        _properties["BaseIntermediateOutputPath"] = EnsureTrailingDirectorySeparator(Path.Combine(_artifactsPath, "obj"));
+        _properties["PackageOutputPath"] = _packagesPath;
+        _properties["PackageVersion"] = "91.2.3-initial.1";
+    }
+
+    public void Dispose() => _workspace.Dispose();
+
+    [Fact]
+    [RequiresTools(["dotnet"])]
+    public async Task ReplacementIsIncrementalAndPackagedContentMatchesGeneratedTemplates()
+    {
+        (await RunDotNetAsync("restore")).EnsureSuccessful();
+
+        AssertReplacementRan(await BuildAsync());
+
+        var responseFile = GetSingleGeneratedFile("replace-text-args.rsp");
+        Assert.True(
+            new FileInfo(responseFile).Length > 8191,
+            $"Expected the response file to exceed the Windows command-line limit: {responseFile}");
+
+        AssertReplacementSkipped(await BuildAsync());
+
+        AppendText(Path.Combine(_templatesRoot, "aspire-empty", "aspire.config.json"));
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        AppendText(Path.Combine(
+            _templatesRoot,
+            "aspire-empty",
+            "AspireApplication.1.AppHost",
+            "AspireApplication.1.AppHost.csproj"));
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        AppendText(Path.Combine(
+            _templatesRoot,
+            "aspire-empty",
+            ".template.config",
+            "template.json"));
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        AppendText(Path.Combine(
+            _templatesRoot,
+            "aspire-empty",
+            ".template.config",
+            "localize",
+            "templatestrings.fr.json"));
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        AppendText(_scriptPath);
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        var replacementProperties = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["PackageVersion"] = "91.3.4-properties.2",
+            ["MicrosoftAspNetCoreOpenApiVersion"] = "101.0.1",
+            ["MicrosoftAspNetCoreOpenApiPreviewVersion"] = "102.0.2",
+            ["MicrosoftAspNetCoreOpenApiNet11Version"] = "103.0.3",
+            ["MicrosoftExtensionsHttpResilienceVersion"] = "104.0.4",
+            ["MicrosoftExtensionsServiceDiscoveryVersion"] = "105.0.5",
+            ["OpenTelemetryExporterOpenTelemetryProtocolVersion"] = "106.0.6",
+            ["OpenTelemetryInstrumentationExtensionsHostingVersion"] = "107.0.7",
+            ["OpenTelemetryInstrumentationAspNetCoreVersion"] = "108.0.8",
+            ["OpenTelemetryInstrumentationHttpVersion"] = "109.0.9",
+            ["OpenTelemetryInstrumentationRuntimeVersion"] = "110.0.10"
+        };
+
+        foreach (var (property, value) in replacementProperties)
+        {
+            _properties[property] = value;
+            (await RunPrepareResponseTargetAsync()).EnsureSuccessful();
+            Assert.Contains(value, File.ReadAllText(responseFile));
+        }
+        Assert.Contains("91.3", File.ReadAllText(responseFile));
+        AssertReplacementRan(await RunReplacementTargetAsync());
+
+        var generatedProject = Path.Combine(
+            GetGeneratedTemplatesRoot(),
+            "aspire-empty",
+            "AspireApplication.1.AppHost",
+            "AspireApplication.1.AppHost.csproj");
+        File.Delete(generatedProject);
+        AssertReplacementRan(await RunReplacementTargetAsync());
+        Assert.True(File.Exists(generatedProject));
+
+        AssertReplacementRan(await RunDotNetAsync("build", "--no-restore", "-t:Rebuild"));
+
+        (await RunDotNetAsync("clean")).EnsureSuccessful();
+        Assert.Empty(Directory.GetFiles(_artifactsPath, "replace-text.stamp", SearchOption.AllDirectories));
+        AssertReplacementRan(await BuildAsync());
+
+        var originalScript = File.ReadAllText(_scriptPath);
+        File.WriteAllText(_scriptPath, "System.Environment.Exit(42);");
+        var failedBuild = await BuildAsync();
+        Assert.NotEqual(0, failedBuild.ExitCode);
+        File.WriteAllText(_scriptPath, originalScript);
+        AssertReplacementRan(await BuildAsync());
+
+        var packResult = await RunDotNetAsync("pack", "--no-restore", "-c", "Debug");
+        packResult.EnsureSuccessful();
+
+        AssertGeneratedAndPackagedContent(replacementProperties);
+    }
+
+    private async Task<CommandResult> BuildAsync()
+        => await RunDotNetAsync("build", "--no-restore");
+
+    private async Task<CommandResult> RunReplacementTargetAsync()
+        => await RunDotNetAsync("msbuild", "-t:ReplacePackageVersionOnTemplates");
+
+    private async Task<CommandResult> RunPrepareResponseTargetAsync()
+        => await RunDotNetAsync("msbuild", "-t:PrepareReplaceTextResponseFile");
+
+    private async Task<CommandResult> RunDotNetAsync(string command, params string[] commandArguments)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                WorkingDirectory = RepoRoot.Path,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add(command);
+        process.StartInfo.ArgumentList.Add(_projectPath);
+        foreach (var argument in commandArguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+        process.StartInfo.ArgumentList.Add("-v:normal");
+        foreach (var (property, value) in _properties)
+        {
+            process.StartInfo.ArgumentList.Add($"-p:{property}={value}");
+        }
+
+        _output.WriteLine($"Executing: {process.StartInfo.FileName} {string.Join(' ', process.StartInfo.ArgumentList)}");
+
+        process.Start();
+        // Read both streams concurrently to avoid deadlock when a redirected pipe buffer fills.
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            process.Kill(entireProcessTree: true);
+            throw;
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
+        var combinedOutput = $"{output}{Environment.NewLine}{error}";
+        _output.WriteLine(combinedOutput);
+
+        return new CommandResult(process.StartInfo, process.ExitCode, combinedOutput);
+    }
+
+    private void AssertGeneratedAndPackagedContent(IReadOnlyDictionary<string, string> replacementProperties)
+    {
+        var replacements = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["!!REPLACE_WITH_LATEST_VERSION!!"] = replacementProperties["PackageVersion"],
+            ["!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!"] = "91.3",
+            ["!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!"] = replacementProperties["MicrosoftAspNetCoreOpenApiVersion"],
+            ["!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!"] = replacementProperties["MicrosoftAspNetCoreOpenApiPreviewVersion"],
+            ["!!REPLACE_WITH_ASPNETCORE_OPENAPI_11_VERSION!!"] = replacementProperties["MicrosoftAspNetCoreOpenApiNet11Version"],
+            ["!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!"] = replacementProperties["MicrosoftExtensionsHttpResilienceVersion"],
+            ["!!REPLACE_WITH_SERVICE_DISCOVERY_VERSION!!"] = replacementProperties["MicrosoftExtensionsServiceDiscoveryVersion"],
+            ["!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!"] = replacementProperties["OpenTelemetryExporterOpenTelemetryProtocolVersion"],
+            ["!!REPLACE_WITH_OTEL_HOSTING_VERSION!!"] = replacementProperties["OpenTelemetryInstrumentationExtensionsHostingVersion"],
+            ["!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!"] = replacementProperties["OpenTelemetryInstrumentationAspNetCoreVersion"],
+            ["!!REPLACE_WITH_OTEL_HTTP_VERSION!!"] = replacementProperties["OpenTelemetryInstrumentationHttpVersion"],
+            ["!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!"] = replacementProperties["OpenTelemetryInstrumentationRuntimeVersion"]
+        };
+
+        var generatedRoot = GetGeneratedTemplatesRoot();
+        var sourceFiles = Directory.GetFiles(_templatesRoot, "*", SearchOption.AllDirectories);
+        Assert.Equal(sourceFiles.Length, Directory.GetFiles(generatedRoot, "*", SearchOption.AllDirectories).Length);
+
+        foreach (var sourceFile in sourceFiles)
+        {
+            var relativePath = Path.GetRelativePath(_templatesRoot, sourceFile);
+            var generatedFile = Path.Combine(generatedRoot, relativePath);
+            Assert.True(File.Exists(generatedFile), $"Missing generated template: {relativePath}");
+
+            if (IsReplacementOwnedFile(relativePath))
+            {
+                var expected = File.ReadAllText(sourceFile);
+                foreach (var (find, replace) in replacements)
+                {
+                    expected = expected.Replace(find, replace, StringComparison.Ordinal);
+                }
+
+                Assert.Equal(expected, File.ReadAllText(generatedFile));
+            }
+            else
+            {
+                Assert.Equal(File.ReadAllBytes(sourceFile), File.ReadAllBytes(generatedFile));
+            }
+        }
+
+        var packagePath = Assert.Single(Directory.GetFiles(_packagesPath, "*.nupkg"));
+        using var package = ZipFile.OpenRead(packagePath);
+        var packagedTemplates = package.Entries
+            .Where(entry => entry.FullName.StartsWith("content/templates/", StringComparison.Ordinal) &&
+                            !entry.FullName.EndsWith('/'))
+            .ToDictionary(
+                entry => entry.FullName["content/templates/".Length..].Replace('/', Path.DirectorySeparatorChar),
+                StringComparer.Ordinal);
+
+        Assert.Equal(sourceFiles.Length + (OperatingSystem.IsWindows() ? 1 : 0), packagedTemplates.Count);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Contains("aspire-templates.cat", packagedTemplates);
+        }
+
+        foreach (var generatedFile in Directory.GetFiles(generatedRoot, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(generatedRoot, generatedFile);
+            var entry = packagedTemplates[relativePath];
+            using var entryStream = entry.Open();
+            using var memoryStream = new MemoryStream();
+            entryStream.CopyTo(memoryStream);
+            Assert.Equal(File.ReadAllBytes(generatedFile), memoryStream.ToArray());
+        }
+    }
+
+    private string GetGeneratedTemplatesRoot()
+    {
+        var contentDirectories = Directory.GetDirectories(_artifactsPath, "content", SearchOption.AllDirectories);
+        var contentDirectory = Assert.Single(contentDirectories);
+        return Path.Combine(contentDirectory, "templates");
+    }
+
+    private string GetSingleGeneratedFile(string fileName)
+        => Assert.Single(Directory.GetFiles(_artifactsPath, fileName, SearchOption.AllDirectories));
+
+    private static bool IsReplacementOwnedFile(string relativePath)
+    {
+        var normalizedPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+        var fileName = Path.GetFileName(relativePath);
+
+        var normalizedDirectory = Path.GetDirectoryName(normalizedPath)?.Replace(Path.DirectorySeparatorChar, '/');
+
+        return relativePath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
+               normalizedPath.Equals("aspire-apphost-singlefile/apphost.cs", StringComparison.OrdinalIgnoreCase) ||
+               normalizedPath.Contains("/.template.config/", StringComparison.Ordinal) &&
+               (normalizedDirectory?.EndsWith("/.template.config", StringComparison.Ordinal) == true ||
+                fileName.StartsWith("templatestrings.", StringComparison.Ordinal) &&
+                fileName.EndsWith(".json", StringComparison.Ordinal));
+    }
+
+    private static void AppendText(string path)
+        => File.AppendAllText(path, $"{Environment.NewLine} ");
+
+    private static string EnsureTrailingDirectorySeparator(string path)
+        => Path.EndsInDirectorySeparator(path) ? path : $"{path}{Path.DirectorySeparatorChar}";
+
+    private static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var sourceFile in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var destinationFile = Path.Combine(
+                destinationDirectory,
+                Path.GetRelativePath(sourceDirectory, sourceFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+            File.Copy(sourceFile, destinationFile);
+        }
+    }
+
+    private static void CreateTestReplacementScript(string path)
+    {
+        // The production response file has this shape, with one unquoted argument per line:
+        //   --files
+        //   C:\path with spaces\template.json
+        //   --replacements
+        //   token
+        //   value
+        // This package-free test script keeps the integration test fast while exercising the same
+        // response-file boundary and replacement ordering as the production file-based app.
+        File.WriteAllText(
+            path,
+            """
+            var responseArgument = args.Single(argument => argument.StartsWith('@'));
+            var lines = File.ReadAllLines(responseArgument[1..].Trim('"'));
+            var replacementsIndex = Array.IndexOf(lines, "--replacements");
+            var files = lines[1..replacementsIndex];
+            var replacements = lines[(replacementsIndex + 1)..];
+
+            foreach (var file in files)
+            {
+                var content = File.ReadAllText(file);
+                for (var index = 0; index < replacements.Length; index += 2)
+                {
+                    content = content.Replace(replacements[index], replacements[index + 1], StringComparison.Ordinal);
+                }
+                File.WriteAllText(file, content);
+            }
+
+            Console.WriteLine($"Processed: {files.Length} file(s)");
+            """);
+    }
+
+    private static void AssertReplacementRan(CommandResult result)
+    {
+        result.EnsureSuccessful();
+        Assert.Contains(ReplacementOutputMarker, result.Output);
+    }
+
+    private static void AssertReplacementSkipped(CommandResult result)
+    {
+        result.EnsureSuccessful();
+        Assert.DoesNotContain(ReplacementOutputMarker, result.Output);
+    }
+}

--- a/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
+++ b/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
@@ -127,7 +127,14 @@ public sealed class ProjectTemplatesIncrementalBuildTests : IDisposable
         AssertReplacementRan(await BuildAsync());
 
         var originalScript = File.ReadAllText(_scriptPath);
-        File.WriteAllText(_scriptPath, "System.Environment.Exit(42);");
+        File.WriteAllText(
+            _scriptPath,
+            """
+            // Licensed to the .NET Foundation under one or more agreements.
+            // The .NET Foundation licenses this file to you under the MIT license.
+
+            System.Environment.Exit(42);
+            """);
         var failedBuild = await BuildAsync();
         Assert.NotEqual(0, failedBuild.ExitCode);
         File.WriteAllText(_scriptPath, originalScript);
@@ -326,6 +333,9 @@ public sealed class ProjectTemplatesIncrementalBuildTests : IDisposable
         File.WriteAllText(
             path,
             """
+            // Licensed to the .NET Foundation under one or more agreements.
+            // The .NET Foundation licenses this file to you under the MIT license.
+
             var responseArgument = args.Single(argument => argument.StartsWith('@'));
             var lines = File.ReadAllLines(responseArgument[1..].Trim('"'));
             var replacementsIndex = Array.IndexOf(lines, "--replacements");

--- a/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
+++ b/tests/Infrastructure.Tests/ProjectTemplates/ProjectTemplatesIncrementalBuildTests.cs
@@ -11,6 +11,7 @@ namespace Infrastructure.Tests;
 public sealed class ProjectTemplatesIncrementalBuildTests : IDisposable
 {
     private const string ReplacementOutputMarker = "Processed:";
+    private const string CatalogFileName = "aspire-templates.cat";
 
     private readonly TemporaryWorkspace _workspace;
     private readonly ITestOutputHelper _output;
@@ -259,10 +260,26 @@ public sealed class ProjectTemplatesIncrementalBuildTests : IDisposable
                 entry => entry.FullName["content/templates/".Length..].Replace('/', Path.DirectorySeparatorChar),
                 StringComparer.Ordinal);
 
-        Assert.Equal(sourceFiles.Length + (OperatingSystem.IsWindows() ? 1 : 0), packagedTemplates.Count);
-        if (OperatingSystem.IsWindows())
+        // GenerateCatalogFiles is Windows-only and additionally skips when makecat.exe is missing,
+        // which is only a hard error for CI/official builds. Deriving the expectation from what the
+        // build actually emitted keeps this assertion exercised on every OS instead of leaving a
+        // Windows-only branch that never runs, and avoids demanding the Windows SDK locally.
+        var generatedCatalogs = Directory.GetFiles(_artifactsPath, CatalogFileName, SearchOption.AllDirectories);
+        Assert.True(
+            generatedCatalogs.Length <= 1,
+            $"Expected at most one generated catalog: {string.Join(", ", generatedCatalogs)}");
+
+        Assert.Equal(sourceFiles.Length + generatedCatalogs.Length, packagedTemplates.Count);
+        foreach (var generatedCatalog in generatedCatalogs)
         {
-            Assert.Contains("aspire-templates.cat", packagedTemplates);
+            Assert.True(
+                packagedTemplates.TryGetValue(CatalogFileName, out var catalogEntry),
+                $"Expected the generated catalog to be packaged: {generatedCatalog}");
+
+            using var catalogStream = catalogEntry!.Open();
+            using var catalogBytes = new MemoryStream();
+            catalogStream.CopyTo(catalogBytes);
+            Assert.Equal(File.ReadAllBytes(generatedCatalog), catalogBytes.ToArray());
         }
 
         foreach (var generatedFile in Directory.GetFiles(generatedRoot, "*", SearchOption.AllDirectories))


### PR DESCRIPTION
## Description

ProjectTemplates replacement currently runs after every Build, even when neither the template inputs nor replacement values changed. This makes the response-file preparation stable and the replacement target incremental while preserving generated and packaged output.

## Summary

- Split stable response-file preparation from template replacement.
- Make replacement incremental across template, project, localization, script, and every replacement-value change.
- Invalidate through Clean, Rebuild, and missing generated output while preserving response-file, Pack, Windows catalog ordering, and error semantics.
- Add focused cross-platform regression coverage.

## Performance

- HOBL matched warm whole-solution evidence on x64: Windows mean 77.761883s -> 73.405682s, 5.6% faster; baseline/candidate ratio 1.059344, 95% CI 1.025741..1.093331.
- WSL mean 51.938818s -> 51.887158s; ratio 1.000996, 95% CI 0.904533..1.084117, so no confirmed regression.
- Cold results were single-pair and neutral, so no cold performance claim is made.
- This is x64 evidence. ARM64 performance remains a separate hardware gate.

## Validation

- Windows focused regression and production Clean, Build, unchanged Build, Rebuild, and Pack smoke tests.
- WSL-native focused test passed 1/1, plus production Clean, Build, unchanged Build, Pack, changed replacement value/input, long response file, and failure propagation coverage.
- Generated and packaged content matched exactly: 314 Windows entries including the catalog and 313 Linux entries, with no remaining replacement tokens.
- Formatting and diff checks passed, the branch is clean, and final independent review found no significant issues.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No