### PR TITLE
Re-enable Docker Compose CLI E2E deployment tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
-using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
 
@@ -18,8 +17,6 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
     private const string ProjectName = "AspireDockerDeployTest";
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/15930")]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15882")]
     public async Task CreateAndDeployToDockerCompose()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
@@ -118,8 +115,6 @@ builder.Build().Run();
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/15930")]
-    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15871")]
     public async Task CreateAndDeployToDockerComposeInteractive()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();


### PR DESCRIPTION
## Description

Re-enables `DockerDeploymentTests.CreateAndDeployToDockerCompose` and `DockerDeploymentTests.CreateAndDeployToDockerComposeInteractive`, which were disabled twice over (`[ActiveIssue]` **and** `[QuarantinedTest]`) and therefore ran in **no** workflow — not even the quarantine one.

### Root cause, per attribute

Neither disabling reason still applies.

**1. `[QuarantinedTest]` — originally #15511, via #15515.** Not flakiness. On release branches `StabilizePackageVersion=true` created a version split: stable packages resolved as `13.2.0` / assembly `13.2.0.0`, while `SuppressFinalPackageVersion=true` packages such as `Aspire.Hosting.Docker` resolved as `13.2.0-ci` / assembly `42.42.42.42`, producing a **CS1705 assembly version mismatch**. #15883 later relabelled the quarantine URLs to the per-test failing-test issues #15882 / #15871.

**2. `[ActiveIssue("#15930")]` — via #15931.** At the time, both tests installed the CLI behind an `if (isCI)` guard **with no `else` branch**, so outside a PR context nothing was installed and they failed at `aspire new` with `bash: aspire: command not found`. That is exactly the captured signature in #15882 and #15871 — so those two issues are the same defect as #15930, not distinct Docker bugs.

Worth noting: issue #15930's body states *"Docker-based tests don't have this problem"*, yet lists these two as affected. That is not a contradiction — at the time of #15931 these tests called `CliE2ETestHelpers.CreateTestTerminal()`, a **bare (non-Docker) terminal**. They only moved to `CreateDockerTestTerminal()` later, in the harness unification. The `ActiveIssue` was correct when applied and is stale now.

### Why they pass now

The harness work in #16131, #16298 and #16454 replaced the ad-hoc install block with `CliInstallStrategy.Detect()` + `InstallAspireCliAsync()`. `Detect()` now ends in explicit fallbacks:

```csharp
if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) ||
    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS")))
{
    return FromQuality(CliInstallQuality.Dev);   // CI fallback
}
return LatestGa();                               // local fallback
```

That is precisely the missing `else` branch #15930 described. `VerifyPullRequestCliVersionAsync()` also no-ops when there is no PR head SHA. The fix landed months ago; nobody removed the attributes.

### Why the class had no CI job

`eng/scripts/split-test-projects-for-ci.ps1` enumerates per-class jobs with `--filter-not-trait quarantined=true`, so a class whose tests are *all* quarantined disappears from the matrix entirely. Removing `ActiveIssue` alone would **not** have produced a job — both attributes had to go.

Verified with CI's exact filter set:

| | Enumerated classes | `DockerDeploymentTests` present |
|---|---|---|
| Before | 81 | no |
| After | 82 | **yes** |

Confirmed in real CI on this PR: there are now 82 `Cli.EndToEnd-*` jobs and `Tests / Cli.EndToEnd-DockerDeploymentTests (ubuntu-latest)` exists and passes.

### Evidence

**CI (authoritative):** `Cli.EndToEnd-DockerDeploymentTests` — **pass, 5m33s**. The test step itself ran 2m38s, consistent with two real Compose deployments (an all-skipped class job returns in seconds under `--ignore-exit-code 8`). Whole-PR status: 363 pass, 0 fail.

**Local (macOS arm64, Docker 29.4.3, `ASPIRE_E2E_ARCHIVE` localhive build):** these were quarantined for suspected flakiness, so the class was run **10 times**, not once:

| Iterations | Test executions | Pass rate | Per-iteration time |
|---|---|---|---|
| 10 | 20 | **100%** | 142–156s |

No flakes, no retries, no assertion changes. Attributes were removed with `QuarantineTools` (`-u -m activeissue`, then `-u`) per `AGENTS.md`, not by hand.

Fixes #15930
Fixes #15882
Fixes #15871

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes <!-- re-enables existing E2E scenario tests -->
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
