### PR TITLE
[release/13.5] Fix mixed-quality staging package discovery

### DIFF
--- a/.agents/skills/cli-channel-debugging/SKILL.md
+++ b/.agents/skills/cli-channel-debugging/SKILL.md
@@ -48,7 +48,7 @@ or `aspire doctor`'s child invocations — treat them as process-local test affo
 | Env var | Effect |
 |---|---|
 | `ASPIRE_CLI_CHANNEL` | Identity channel: `stable`, `staging`, `daily`, `local`, or `pr-<N>`. Drives hive selection and staging-feed provenance. |
-| `ASPIRE_CLI_VERSION` | Informational version (e.g. `13.5.0-preview.1.26310.9`). Drives version-shape (quality) decisions, version pins, the skew warning, and `--version` output. |
+| `ASPIRE_CLI_VERSION` | Informational version (e.g. `13.5.0-preview.1.26310.9`). Drives version pins, the skew warning, and `--version` output. |
 | `ASPIRE_CLI_COMMIT` | Source commit SHA. Drives the staging darc feed name (`darc-pub-microsoft-aspire-<sha8>`). |
 | `ASPIRE_CLI_PACKAGES` | A flat directory of `.nupkg` files (e.g. `artifacts/packages/<Config>/Shipping`). The CLI synthesizes a package channel **named after `ASPIRE_CLI_CHANNEL`** that maps `Aspire*` to this directory (everything else → nuget.org), **replacing** any same-named built-in/discovered/PR channel. See the cleanliness caveat below. |
 | `ASPIRE_CLI_NUGET_SERVICE_INDEX` | Replaces the canonical `https://api.nuget.org/v3/index.json` URL the CLI writes into **newly generated** `NuGet.config` files. Never rewrites URLs read from existing configs. |
@@ -73,7 +73,7 @@ lookups, or `--version`. Set with `aspire config set -g <key> <value>`.
 | Config key | Effect |
 |---|---|
 | `overrideCliIdentityChannel` | Identity used for **staging-feed decisions only** (validated against the known channel set). |
-| `overrideCliInformationalVersion` | Version that staging SHA-derivation and version-shape checks read. |
+| `overrideCliInformationalVersion` | Informational version used to derive the staging SHA-specific feed URL. |
 | `overrideStagingFeed` | Forces staging to be available and points it at an explicit feed URL. |
 | `stagingPinToCliVersion` | When `true` (and using the shared feed), pins resolution to the CLI version. |
 
@@ -192,7 +192,7 @@ Reuse `instanceId`s across turns so "the daily terminal" stays the same panel th
 | 3 | PR build identity + CI-built packages, local CLI | `pr-<N>` | `~/.aspire/hives/pr-<N>/packages` | `get-aspire-cli-pr.sh --pr <N>`, then `ASPIRE_CLI_CHANNEL=pr-<N>` |
 | 4 | Latest daily, local CLI | `daily` | dnceng/dotnet9 daily feed | `ASPIRE_CLI_CHANNEL=daily` + `ASPIRE_CLI_VERSION` (+ `ASPIRE_CLI_COMMIT`) |
 | 5 | Staging, unstable version | `staging` | `darc-pub-microsoft-aspire-<sha8>` feed (quality Both) | `ASPIRE_CLI_CHANNEL=staging` + prerelease `ASPIRE_CLI_VERSION` + `ASPIRE_CLI_COMMIT` |
-| 6 | Staging, stable version | `staging` | `darc-pub-microsoft-aspire-<sha8>` feed (quality Stable) | `ASPIRE_CLI_CHANNEL=staging` + stable-shaped `ASPIRE_CLI_VERSION` + `ASPIRE_CLI_COMMIT` |
+| 6 | Staging, stable version | `staging` | `darc-pub-microsoft-aspire-<sha8>` feed (quality Both) | `ASPIRE_CLI_CHANNEL=staging` + stable-shaped `ASPIRE_CLI_VERSION` + `ASPIRE_CLI_COMMIT` |
 | 7 | Released build repro | `stable` | nuget.org | `ASPIRE_CLI_CHANNEL=stable` + released `ASPIRE_CLI_VERSION` |
 | 7b | Released repro + CLI+hosting fix spanning packages | `stable` | locally rebuilt `Shipping` dir | as 7 + `ASPIRE_CLI_PACKAGES=<clean-rebuilt-dir>` |
 
@@ -264,13 +264,14 @@ ASPIRE_CLI_VERSION=13.4.0-preview.1.26280.6 \
 ASPIRE_CLI_COMMIT=<full-commit-sha> \
   dotnet run --project src/Aspire.Cli -- <cmd>
 
-# 6 — stable-shaped version -> quality Stable (the #17527 stabilizing-build scenario)
+# 6 — stable-shaped version -> quality Both (the #17527 stabilizing-build scenario)
 ASPIRE_CLI_CHANNEL=staging ASPIRE_CLI_VERSION=13.4.0 ASPIRE_CLI_COMMIT=<full-commit-sha> \
   dotnet run --project src/Aspire.Cli -- <cmd>
 ```
 
 Staging feed provenance is derived from the commit: `darc-pub-microsoft-aspire-<sha8>`. The
-version **shape** controls only which versions on that feed are eligible (Stable vs Both).
+channel uses `Both` for either version shape because a stable-shaped build can still publish
+prerelease-only integrations alongside stable packages.
 Alternatively, `eng/scripts/debug-staging.sh` / `debug-stable.sh` exercise the same routing via
 the legacy config keys — see `docs/cli-staging-validation.md`.
 

--- a/docs/cli-staging-validation.md
+++ b/docs/cli-staging-validation.md
@@ -10,8 +10,9 @@ A staging-identity CLI is an official release-branch build whose own commit alwa
 a SHA-specific `darc-pub-microsoft-aspire-<commit>` feed carrying its matching packages
 (prerelease-shaped `13.4.0-preview.*` and stable-shaped `13.4.0` alike). Feed
 **provenance** is decided by the CLI's baked build **identity** (`AspireCliChannel`),
-while version **filtering** (the channel quality) is decided by the CLI's **version
-shape**. See `PackagingService.ShouldUseSharedStagingFeed`.
+and official staging identities use `Both` quality because one build can publish stable
+packages alongside integrations that deliberately remain prerelease. See
+`PackagingService.ShouldUseSharedStagingFeed`.
 
 A locally built CLI bakes a `local` identity and an unstamped informational version, so
 it never synthesizes a staging channel and never derives a darc feed. The two diagnostic
@@ -26,7 +27,7 @@ package-directory lookups):
 | Config key | Purpose |
 | --- | --- |
 | `overrideCliIdentityChannel` | Forces the identity used for staging-feed routing decisions. Must be a valid channel (`stable`, `staging`, `daily`, `local`, or `pr-<N>`); invalid values are ignored and the real identity is used. |
-| `overrideCliInformationalVersion` | Forces the informational version that both the SHA-derivation provider and the version-shape (quality) predicate read. The part after `+` (truncated to 8 chars) builds the darc URL; the version part determines stable-vs-prerelease shape. |
+| `overrideCliInformationalVersion` | Forces the informational version used to derive the darc URL. The part after `+` is truncated to 8 characters for the feed name. |
 
 **Both overrides are required** to reach the darc path from a local build:
 
@@ -75,19 +76,19 @@ identity/feed can't silently resolve packages on a normal invocation.
    `dnceng/.../dotnet9` daily feed.
 
 To simulate a **stable**-shaped staging build, use a stable-shaped version override
-(e.g. `13.4.0+<full-commit-hash>`); the channel quality becomes `Stable` while the feed
-stays the darc feed.
+(e.g. `13.4.0+<full-commit-hash>`). The channel still uses `Both` quality because the
+SHA feed can contain prerelease-only integrations alongside stable packages.
 
 ## Helper scripts
 
 `eng/scripts/debug-staging.{sh,ps1}` and `eng/scripts/debug-stable.{sh,ps1}` wrap the
 recipe above. Both target identity `staging` and expect the **same** darc feed; they
-differ only in version shape/quality:
+differ only in version shape:
 
 | Script | Version shape | Expected quality | Scenario |
 | --- | --- | --- | --- |
 | `debug-staging` | prerelease (`13.4.0-preview.*`) | `Both` | [#17744](https://github.com/microsoft/aspire/issues/17744) — the bug this PR fixes |
-| `debug-stable` | stable (`13.4.0`) | `Stable` | [#17527](https://github.com/microsoft/aspire/issues/17527) — stable-shaped release build |
+| `debug-stable` | stable (`13.4.0`) | `Both` | [#17527](https://github.com/microsoft/aspire/issues/17527) — stable-shaped release build |
 
 Each script computes the expected `darc-pub-microsoft-aspire-<sha8>` feed and supports
 three modes:
@@ -142,7 +143,7 @@ shell/subshell environment, so nothing is written to global or per-project confi
 | Identity | Version shape | Expected feed | Expected quality |
 | --- | --- | --- | --- |
 | `staging` | prerelease | `darc-pub-microsoft-aspire-<sha8>` | `Both` |
-| `staging` | stable | `darc-pub-microsoft-aspire-<sha8>` | `Stable` |
-| `daily` | any | shared `dnceng/.../dotnet9` daily feed | `Both` |
+| `staging` | stable | `darc-pub-microsoft-aspire-<sha8>` | `Both` |
+| `daily` | any | shared `dnceng/.../dotnet9` daily feed | `Prerelease` |
 | `local` / `pr-<N>` | any | local/PR hive + implicit (no staging synthesis) | n/a |
 | `stable` | stable | nuget.org | `Stable` |

--- a/eng/scripts/debug-aspire-channel.ps1
+++ b/eng/scripts/debug-aspire-channel.ps1
@@ -17,9 +17,9 @@
 
       overrideCliIdentityChannel       - forces the identity used for staging-feed
                                          routing decisions (here: 'staging').
-      overrideCliInformationalVersion  - forces the informational version the SHA
-                                         derivation and version-shape (quality)
-                                         checks read, e.g. 13.4.0-preview.1.x+<sha>.
+      overrideCliInformationalVersion  - forces the informational version used to
+                                         derive the SHA-specific feed URL, e.g.
+                                         13.4.0-preview.1.x+<sha>.
 
     Both flow into IConfiguration from environment variables (used here) OR from
     aspire.config.json, and are scoped to staging feed routing only. A CLI run
@@ -29,8 +29,8 @@
     The script runs 'aspire add <package> --debug' in a throwaway directory whose
     aspire.config.json pins channel: staging, then asserts the debug log contains
       Resolved 'staging' channel: feed=<expected darc feed>, quality=<expected>
-    The 'aspire add' step is expected to fail later (there is no real apphost
-    project in the scratch directory); only the feed-routing log line is validated.
+    A minimal TypeScript AppHost lets 'aspire add' reach package discovery; only
+    the feed-routing log line is validated.
 #>
 
 Set-StrictMode -Version Latest
@@ -58,7 +58,7 @@ function Invoke-DebugChannel {
 
     switch ($Kind) {
         'staging' { $kindLabel = 'staging (prerelease-shaped)'; $defaultVersion = $script:DefaultStagingVersion; $expectedQuality = 'Both' }
-        'stable'  { $kindLabel = 'staging (stable-shaped)';     $defaultVersion = $script:DefaultStableVersion;  $expectedQuality = 'Stable' }
+        'stable'  { $kindLabel = 'staging (stable-shaped)';     $defaultVersion = $script:DefaultStableVersion;  $expectedQuality = 'Both' }
     }
 
     if ([string]::IsNullOrEmpty($Sha)) {
@@ -161,9 +161,8 @@ function Invoke-DebugChannel {
     }
 
     # Throwaway working directory pinned to channel: staging so 'aspire add'
-    # filters to the synthesized staging channel. No real apphost project lives
-    # here, so 'add' will ultimately fail after feed routing has already been
-    # logged -- that is expected.
+    # filters to the synthesized staging channel. A minimal TypeScript AppHost is
+    # enough to reach package discovery without scaffolding a complete project.
     $scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("aspire-debug-" + [System.Guid]::NewGuid().ToString('N'))
     New-Item -ItemType Directory -Path $scratch | Out-Null
     try {
@@ -172,10 +171,11 @@ function Invoke-DebugChannel {
   "channel": "staging"
 }
 '@ | Set-Content -Path (Join-Path $scratch 'aspire.config.json') -Encoding utf8
+        Set-Content -Path (Join-Path $scratch 'apphost.ts') -Value '' -NoNewline
 
         $log = Join-Path $scratch 'aspire-debug.log'
         Write-Host ">> Running: aspire add $Package --debug $($PassThrough -join ' ')"
-        Write-Host '   (feed routing is logged before the add step fails on the missing apphost)'
+        Write-Host '   (only feed routing is validated; the add result itself is ignored)'
         Write-Host ''
 
         # The overrides are scoped to THIS invocation only (set then removed), so

--- a/eng/scripts/debug-aspire-channel.sh
+++ b/eng/scripts/debug-aspire-channel.sh
@@ -16,9 +16,9 @@
 #
 #   overrideCliIdentityChannel       - forces the identity used for staging-feed
 #                                      routing decisions (here: `staging`).
-#   overrideCliInformationalVersion  - forces the informational version the SHA
-#                                      derivation and version-shape (quality)
-#                                      checks read, e.g. `13.4.0-preview.1.x+<sha>`.
+#   overrideCliInformationalVersion  - forces the informational version used to
+#                                      derive the SHA-specific feed URL, e.g.
+#                                      `13.4.0-preview.1.x+<sha>`.
 #
 # Both flow into IConfiguration from environment variables (used here) OR from
 # aspire.config.json, and are scoped to staging feed routing only -- they do NOT
@@ -32,8 +32,8 @@
 # aspire.config.json pins `channel: staging`, then asserts the debug log contains
 #   Resolved 'staging' channel: feed=<expected darc feed>, quality=<expected>
 # where the feed is the SHA-specific darc-pub-microsoft-aspire-<first8-of-sha>
-# feed. The `aspire add` step is expected to fail later (there is no real apphost
-# project in the scratch directory); only the feed-routing log line is validated.
+# feed. A minimal TypeScript AppHost lets `aspire add` reach package discovery;
+# only the feed-routing log line is validated.
 
 set -euo pipefail
 
@@ -102,7 +102,7 @@ run_debug_channel() {
 
     case "$kind" in
         staging) KIND_LABEL="staging (prerelease-shaped)"; DEFAULT_VERSION="$DEFAULT_STAGING_VERSION"; EXPECTED_QUALITY="Both" ;;
-        stable)  KIND_LABEL="staging (stable-shaped)";    DEFAULT_VERSION="$DEFAULT_STABLE_VERSION";  EXPECTED_QUALITY="Stable" ;;
+        stable)  KIND_LABEL="staging (stable-shaped)";    DEFAULT_VERSION="$DEFAULT_STABLE_VERSION";  EXPECTED_QUALITY="Both" ;;
         *) say_err "unknown kind '$kind'"; return 2 ;;
     esac
 
@@ -234,9 +234,9 @@ ENV
     fi
 
     # Throwaway working directory pinned to channel: staging so 'aspire add'
-    # filters to the synthesized staging channel. Created securely; cleaned up
-    # on exit. No real apphost project lives here, so 'add' will ultimately fail
-    # after feed routing has already been logged -- that is expected.
+    # filters to the synthesized staging channel. A minimal TypeScript AppHost is
+    # enough to reach package discovery without scaffolding a complete project.
+    # Created securely and cleaned up on exit.
     local scratch
     scratch="$(mktemp -d)"
     trap 'rm -rf "$scratch"' RETURN
@@ -245,10 +245,11 @@ ENV
   "channel": "staging"
 }
 JSON
+    : > "${scratch}/apphost.ts"
 
     local log="${scratch}/aspire-debug.log"
     say ">> Running: aspire add ${package} --debug ${passthrough[*]:-}"
-    say "   (feed routing is logged before the add step fails on the missing apphost)"
+    say "   (only feed routing is validated; the add result itself is ignored)"
     say ""
 
     # The overrides are scoped to THIS invocation only (no export, no persisted

--- a/eng/scripts/debug-stable.ps1
+++ b/eng/scripts/debug-stable.ps1
@@ -8,7 +8,8 @@
 .DESCRIPTION
     This is the scenario from https://github.com/microsoft/aspire/issues/17527:
     a stable-shaped release-branch build still resolves from its own darc feed
-    (quality=Stable), not nuget.org.
+    (quality=Both), not nuget.org. Both keeps prerelease-only integrations from
+    that same build discoverable.
 
     See docs/cli-staging-validation.md for the full validation matrix.
 

--- a/eng/scripts/debug-stable.sh
+++ b/eng/scripts/debug-stable.sh
@@ -5,7 +5,8 @@
 #
 # This is the scenario from https://github.com/microsoft/aspire/issues/17527:
 # a stable-shaped release-branch build still resolves from its own darc feed
-# (quality=Stable), not nuget.org.
+# (quality=Both), not nuget.org. Both keeps prerelease-only integrations from
+# that same build discoverable.
 #
 # See docs/cli-staging-validation.md for the full validation matrix.
 

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -57,9 +57,9 @@ internal class PackagingService : IPackagingService
     //   overrideCliIdentityChannel        - forces the identity used for staging-feed decisions
     //                                       (validated against the known channel set). Set to
     //                                       `staging` to exercise the staging-identity darc path.
-    //   overrideCliInformationalVersion   - forces the AssemblyInformationalVersion that the SHA
-    //                                       derivation and version-shape (quality) checks read,
-    //                                       e.g. `13.4.0-preview.1.26280.6+<full-commit-hash>`.
+    //   overrideCliInformationalVersion   - forces the AssemblyInformationalVersion used to derive
+    //                                       the SHA-specific feed URL, e.g.
+    //                                       `13.4.0-preview.1.26280.6+<full-commit-hash>`.
     //
     // NOTE: These only route to a feed; they do not create one. They are typically useful only
     // once the darc-pub-microsoft-aspire-<sha> feed actually exists for the specific commit/version
@@ -86,11 +86,6 @@ internal class PackagingService : IPackagingService
     private readonly IConfiguration _configuration;
     private readonly ILogger<PackagingService> _logger;
     private readonly Func<string?> _processPathProvider;
-    // Predicate used by staging-channel synthesis to decide whether the running CLI is built
-    // from a stable-shaped version (no semver prerelease tag). Defaults to inspecting the
-    // current Aspire.Cli assembly's InformationalVersion; tests inject a deterministic value
-    // because the version baked into the test-host assembly varies by build configuration.
-    private readonly Func<bool> _isStableShapedCliVersion;
     // Provides the running CLI's AssemblyInformationalVersion (which carries the +<commitHash>
     // build metadata used to derive the SHA-specific darc-pub-microsoft-aspire-<hash> staging
     // feed). Defaults to reading the Aspire.Cli assembly; tests inject a deterministic value
@@ -112,7 +107,6 @@ internal class PackagingService : IPackagingService
         IConfiguration configuration,
         ILogger<PackagingService> logger,
         Func<string?>? processPathProvider = null,
-        Func<bool>? isStableShapedCliVersion = null,
         Func<string?>? cliInformationalVersionProvider = null)
     {
         _executionContext = executionContext;
@@ -121,7 +115,6 @@ internal class PackagingService : IPackagingService
         _configuration = configuration;
         _logger = logger;
         _processPathProvider = processPathProvider ?? (() => Environment.ProcessPath);
-        _isStableShapedCliVersion = isStableShapedCliVersion ?? IsStableShapedCliVersionDefault;
         _cliInformationalVersionProvider = cliInformationalVersionProvider ?? GetCliInformationalVersionDefault;
         _stagingUnavailableReasonCache = new Lazy<string?>(ComputeStagingChannelUnavailableReason);
     }
@@ -201,26 +194,15 @@ internal class PackagingService : IPackagingService
             //     The user picked staging deliberately; they get the broadest matching window.
             //   - `stagingFeatureEnabled` only (no other staging signal): Stable. Preserves the
             //     pre-existing behavior of the staging feature flag.
-            //   - `stagingIdentityChannel` (the running CLI itself self-identifies as staging):
-            //     follows the CLI build's version shape so the eligible version window matches the
-            //     packages the build actually shipped.
-            //       * Stable-shaped (e.g. "13.4.0", produced during release stabilization when
-            //         StabilizePackageVersion=true) → Stable, so resolution prefers the stable-shaped
-            //         packages on the darc feed (the #17527 scenario).
-            //       * Prerelease-shaped (e.g. "13.4.0-preview.1.123") → Both, so prerelease-tagged
-            //         packages on the darc feed remain eligible.
+            //   - `stagingIdentityChannel` (the running CLI itself self-identifies as staging): Both.
+            //     A single official staging build can publish stable-shaped packages and deliberately
+            //     prerelease-only integrations from the same SHA-specific feed. Restricting a
+            //     stable-shaped staging CLI to Stable hides those integrations from broad discovery.
+            //     See https://github.com/microsoft/aspire/issues/19423.
             PackageChannelQuality defaultQuality;
             if (stagingIdentityChannel)
             {
-                // When the running CLI's identity itself is staging, the synthesized channel's
-                // quality MUST follow the CLI build's version shape regardless of how synthesis
-                // was triggered. `init` and many other commands pass requestedChannelName=staging
-                // when identity is staging, so checking `stagingChannelRequested` first would
-                // short-circuit this path and re-introduce the #17527 version-filtering mismatch on
-                // stabilizing builds.
-                defaultQuality = _isStableShapedCliVersion()
-                    ? PackageChannelQuality.Stable
-                    : PackageChannelQuality.Both;
+                defaultQuality = PackageChannelQuality.Both;
             }
             else if (stagingChannelConfigured || stagingChannelRequested)
             {
@@ -343,35 +325,6 @@ internal class PackagingService : IPackagingService
 
         var packagesDirectory = new DirectoryInfo(Path.Combine(installPrefix.FullName, "hives", identityChannel, "packages"));
         return packagesDirectory.Exists ? packagesDirectory : null;
-    }
-
-    // Returns true when the running CLI's identity version is stable-shaped (no semver prerelease
-    // tag). Used by the staging-channel synthesis to route stabilizing builds to the SHA-derived
-    // darc feed instead of the shared dotnet9 daily feed. Reads CliExecutionContext.IdentitySdkVersion
-    // so ASPIRE_CLI_VERSION / sidecar overrides drive the routing, not the physical binary version.
-    private bool IsStableShapedCliVersionFromIdentity()
-    {
-        var version = _executionContext.IdentitySdkVersion;
-        return !string.IsNullOrEmpty(version) && !version.Contains('-');
-    }
-
-    // Default version-shape predicate. Honors the overrideCliInformationalVersion diagnostic
-    // override (so a locally built CLI can present as stable- or prerelease-shaped for staging
-    // validation) before falling back to the resolved identity version (which already reflects
-    // ASPIRE_CLI_VERSION / the install sidecar).
-    private bool IsStableShapedCliVersionDefault()
-    {
-        var overrideVersion = _configuration[OverrideCliInformationalVersionConfigKey];
-        if (!string.IsNullOrEmpty(overrideVersion))
-        {
-            // Stable-shaped == no semver prerelease tag. Strip build metadata (+<hash>) first so a
-            // commit hash that happens to contain '-' can't be misread as a prerelease tag. Example:
-            //   "13.4.0-preview.1.26280.6+abcd-ef12" -> version part "13.4.0-preview.1.26280.6" -> prerelease
-            //   "13.4.0+abcd-ef12"                   -> version part "13.4.0"                   -> stable
-            return !StripBuildMetadata(overrideVersion).Contains('-');
-        }
-
-        return IsStableShapedCliVersionFromIdentity();
     }
 
     // Default informational-version provider. Honors the overrideCliInformationalVersion diagnostic

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -2389,6 +2389,194 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddCommandPrompter_StagingChannelPreservesAllChannelChoices()
+    {
+        List<string>? displayedLabels = null;
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (_, choices, formatter, _) =>
+            {
+                var choicesList = choices.Cast<object>().ToList();
+                displayedLabels = choicesList.Select(formatter).ToList();
+                return choicesList.First();
+            }
+        };
+        var prompter = new AddCommandPrompter(interactionService);
+        var cache = new FakeNuGetPackageCache();
+        var implicitChannel = PackageChannel.CreateImplicitChannel(cache, new TestFeatures(), NullLogger.Instance);
+        var stagingChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], cache, new TestFeatures(), NullLogger.Instance);
+        var dailyChannel = PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, [new PackageMapping("Aspire*", "daily")], cache, new TestFeatures(), NullLogger.Instance);
+        var prChannel = PackageChannel.CreateExplicitChannel("pr-19404", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "pr-19404")], cache, new TestFeatures(), NullLogger.Instance);
+        var packages = new[]
+        {
+            ("azure-kubernetes", CreatePackage("Aspire.Hosting.Azure.Kubernetes", "13.5.0-preview.1.26415.2"), stagingChannel),
+            ("azure-kubernetes", CreatePackage("Aspire.Hosting.Azure.Kubernetes", "13.4.3"), implicitChannel),
+            ("azure-kubernetes", CreatePackage("Aspire.Hosting.Azure.Kubernetes", "13.6.0-preview.1.26415.1"), dailyChannel),
+            ("azure-kubernetes", CreatePackage("Aspire.Hosting.Azure.Kubernetes", "13.6.0-pr.19404.gf51e8e1d"), prChannel)
+        };
+
+        var result = await prompter.PromptForIntegrationVersionAsync(packages, PackageChannelNames.Staging, CancellationToken.None).DefaultTimeout();
+
+        Assert.Collection(
+            Assert.IsType<List<string>>(displayedLabels),
+            label => Assert.Equal(PackageChannelNames.Staging, label),
+            label => Assert.Contains("13.4.3", label, StringComparison.Ordinal),
+            label => Assert.Equal(PackageChannelNames.Daily, label),
+            label => Assert.Equal("pr-19404", label));
+        Assert.Equal("13.5.0-preview.1.26415.2", result.Package.Version);
+        Assert.Same(stagingChannel, result.Channel);
+    }
+
+    [Theory]
+    // The staging channel can see the current SHA package alongside an older NuGet.org fallback.
+    // A same-line stable package outranks its preview, while a current-line preview-only integration
+    // outranks a stable package from the previous release.
+    [InlineData("13.5.0", "13.5.0-preview.1.26415.2", "13.5.0")]
+    [InlineData("13.4.6", "13.5.0-preview.1.26415.2", "13.5.0-preview.1.26415.2")]
+    public async Task AddCommandPrompter_StagingChannelSelectsHighestVersionAcrossPackageQualities(
+        string stableVersion,
+        string prereleaseVersion,
+        string expectedVersion)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+                Task.FromResult<IEnumerable<NuGetPackage>>(
+                [CreatePackage("Aspire.Hosting.Redis", prerelease ? prereleaseVersion : stableVersion)])
+        };
+        var stagingChannel = PackageChannel.CreateExplicitChannel(
+            PackageChannelNames.Staging,
+            PackageChannelQuality.Both,
+            [new PackageMapping("Aspire*", "staging")],
+            cache,
+            new TestFeatures(),
+            NullLogger.Instance);
+        var packages = (await stagingChannel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout())
+            .Select(package => ("redis", package, stagingChannel))
+            .ToArray();
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (_, choices, _, _) => choices.Cast<object>().First()
+        };
+        var prompter = new AddCommandPrompter(interactionService);
+
+        var result = await prompter.PromptForIntegrationVersionAsync(packages, PackageChannelNames.Staging, CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(expectedVersion, result.Package.Version);
+        Assert.Same(stagingChannel, result.Channel);
+    }
+
+    [Theory]
+    [InlineData(KnownLanguageId.CSharp, PackageChannelNames.Staging, "13.5.0", "13.5.0-preview.1.26415.2")]
+    [InlineData(KnownLanguageId.TypeScript, PackageChannelNames.Staging, "13.5.0", "13.5.0-preview.1.26415.2")]
+    [InlineData(KnownLanguageId.CSharp, PackageChannelNames.Daily, "13.6.0-preview.1.26415.1", "13.6.0-preview.1.26415.1")]
+    [InlineData(KnownLanguageId.TypeScript, PackageChannelNames.Daily, "13.6.0-preview.1.26415.1", "13.6.0-preview.1.26415.1")]
+    [InlineData(KnownLanguageId.CSharp, "pr-19404", "13.6.0-pr.19404.gf51e8e1d", "13.6.0-pr.19404.gf51e8e1d")]
+    [InlineData(KnownLanguageId.TypeScript, "pr-19404", "13.6.0-pr.19404.gf51e8e1d", "13.6.0-pr.19404.gf51e8e1d")]
+    public async Task AddCommandNonInteractiveSelectsExpectedVersionAcrossLanguageAndChannelMatrix(
+        string languageId,
+        string targetChannel,
+        string cliVersion,
+        string expectedPackageVersion)
+    {
+        const string packageId = "Aspire.Hosting.Azure.Kubernetes";
+        const string stagingVersion = "13.5.0-preview.1.26415.2";
+        const string dailyVersion = "13.6.0-preview.1.26415.1";
+        const string prVersion = "13.6.0-pr.19404.gf51e8e1d";
+
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var isTypeScript = string.Equals(languageId, KnownLanguageId.TypeScript, StringComparison.Ordinal);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, isTypeScript ? "apphost.ts" : "AppHost.csproj"));
+        File.WriteAllText(appHostFile.FullName, isTypeScript ? string.Empty : "<Project />");
+
+        if (isTypeScript)
+        {
+            File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), $$"""
+                {
+                  "channel": "{{targetChannel}}"
+                }
+                """);
+        }
+
+        // Force every channel into discovery so each matrix cell proves precedence against
+        // competing implicit, staging, daily, and PR candidates.
+        var hivesDirectory = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
+        hivesDirectory.Create();
+        hivesDirectory.CreateSubdirectory("pr-19404");
+
+        var addedPackageId = string.Empty;
+        var addedPackageVersion = string.Empty;
+        var promptedForVersion = false;
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            LanguageId = languageId,
+            DisplayName = isTypeScript ? "TypeScript (Node.js)" : "C# (.NET)",
+            CanHandleCallback = file => string.Equals(file.FullName, appHostFile.FullName, StringComparison.Ordinal),
+            AddPackageAsyncCallback = (context, _) =>
+            {
+                addedPackageId = context.PackageId;
+                addedPackageVersion = context.PackageVersion;
+                return Task.FromResult(true);
+            }
+        };
+
+        // C# resolves its configured feed through the implicit NuGet.config channel. TypeScript
+        // keeps nuget.org implicit and persists the selected explicit channel in aspire.config.json.
+        var implicitVersion = !isTypeScript && !string.Equals(targetChannel, "pr-19404", StringComparison.Ordinal)
+            ? expectedPackageVersion
+            : "13.4.3";
+        var implicitCache = CreateIntegrationPackageCache(packageId, implicitVersion);
+        var stagingCache = CreateIntegrationPackageCache(packageId, stagingVersion);
+        var dailyCache = CreateIntegrationPackageCache(packageId, dailyVersion);
+        var prCache = CreateIntegrationPackageCache(packageId, prVersion);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CliExecutionContextFactory = _ => TestExecutionContextHelper.CreateExecutionContext(
+                workspace.WorkspaceRoot,
+                identityChannel: targetChannel,
+                identityVersion: cliVersion);
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.AppHostProjectFactory = _ => projectFactory;
+            options.AddCommandPrompterFactory = sp =>
+            {
+                var prompter = new TestAddCommandPrompter(sp.GetRequiredService<IInteractionService>());
+                prompter.PromptForIntegrationVersionCallback = _ =>
+                {
+                    promptedForVersion = true;
+                    throw new InvalidOperationException("The channel matrix must resolve deterministically without prompting.");
+                };
+                return prompter;
+            };
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>(
+                [
+                    PackageChannel.CreateImplicitChannel(implicitCache, new TestFeatures(), NullLogger.Instance, currentCliVersion: cliVersion),
+                    // Official staging feeds contain stable packages alongside integrations that
+                    // deliberately remain prerelease, so staging discovery always uses Both.
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Staging, PackageChannelQuality.Both, [new PackageMapping("Aspire*", "staging")], stagingCache, new TestFeatures(), NullLogger.Instance, currentCliVersion: cliVersion),
+                    PackageChannel.CreateExplicitChannel(PackageChannelNames.Daily, PackageChannelQuality.Prerelease, [new PackageMapping("Aspire*", "daily")], dailyCache, new TestFeatures(), NullLogger.Instance, currentCliVersion: cliVersion),
+                    PackageChannel.CreateExplicitChannel("pr-19404", PackageChannelQuality.Both, [new PackageMapping("Aspire*", "pr-19404")], prCache, new TestFeatures(), NullLogger.Instance, currentCliVersion: cliVersion)
+                ])
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse($"add {packageId} --apphost \"{appHostFile.FullName}\"");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.False(promptedForVersion);
+        Assert.Equal(packageId, addedPackageId);
+        Assert.Equal(expectedPackageVersion, addedPackageVersion);
+    }
+
+    [Fact]
     public async Task AddCommandNonInteractiveTypeScriptAppHostPinnedToDailyPrefersDailyChannelOverImplicitStable()
     {
         // Regression for https://github.com/microsoft/aspire/issues/18114.
@@ -3321,6 +3509,18 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             Id = id,
             Source = "nuget",
             Version = version
+        };
+    }
+
+    private static FakeNuGetPackageCache CreateIntegrationPackageCache(string packageId, string version)
+    {
+        var package = CreatePackage(packageId, version);
+        var isPrerelease = version.Contains('-', StringComparison.Ordinal);
+
+        return new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+                Task.FromResult<IEnumerable<NuGetPackage>>(prerelease || !isPrerelease ? [package] : [])
         };
     }
 

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Packaging;
 
@@ -235,6 +236,153 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task GetIntegrationPackagesAsync_WithStableRemoteSource_QueriesOnlyStablePackages()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var stableSearches = 0;
+        var prereleaseSearches = 0;
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                if (prerelease)
+                {
+                    Interlocked.Increment(ref prereleaseSearches);
+                    return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    [
+                        new() { Id = "Aspire.Hosting.Azure.Kubernetes", Version = "13.5.0-preview.1" },
+                        new() { Id = "Aspire.Hosting.Redis", Version = "13.6.0-preview.1" }
+                    ]);
+                }
+
+                Interlocked.Increment(ref stableSearches);
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                [
+                    new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" }
+                ]);
+            }
+        };
+        var channel = PackageChannel.CreateExplicitChannel(
+            PackageChannelNames.Stable,
+            PackageChannelQuality.Stable,
+            [new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)],
+            cache,
+            new TestFeatures(),
+            NullLogger.Instance);
+
+        var packages = (await channel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout()).ToArray();
+
+        Assert.Equal(1, stableSearches);
+        Assert.Equal(0, prereleaseSearches);
+        var package = Assert.Single(packages);
+        Assert.Equal("Aspire.Hosting.Redis", package.Id);
+        Assert.Equal("13.5.0", package.Version);
+    }
+
+    [Fact]
+    public async Task GetIntegrationPackagesAsync_WithPrereleaseRemoteSource_QueriesOnlyPrereleaseAndFiltersStableNoise()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var stableSearches = 0;
+        var prereleaseSearches = 0;
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                if (!prerelease)
+                {
+                    Interlocked.Increment(ref stableSearches);
+                    return Task.FromResult<IEnumerable<NuGetPackage>>([]);
+                }
+
+                Interlocked.Increment(ref prereleaseSearches);
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                [
+                    new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" },
+                    new() { Id = "Aspire.Hosting.Redis", Version = "13.6.0-preview.1" }
+                ]);
+            }
+        };
+        var channel = PackageChannel.CreateExplicitChannel(
+            PackageChannelNames.Daily,
+            PackageChannelQuality.Prerelease,
+            [new PackageMapping("Aspire*", "https://daily.example/v3/index.json")],
+            cache,
+            new TestFeatures(),
+            NullLogger.Instance);
+
+        var packages = (await channel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout()).ToArray();
+
+        Assert.Equal(0, stableSearches);
+        Assert.Equal(1, prereleaseSearches);
+        var package = Assert.Single(packages);
+        Assert.Equal("Aspire.Hosting.Redis", package.Id);
+        Assert.Equal("13.6.0-preview.1", package.Version);
+    }
+
+    [Fact]
+    public async Task GetIntegrationPackagesAsync_WithBothRemoteSource_ReturnsStableAndPrereleasePackages()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var stableSearches = 0;
+        var prereleaseSearches = 0;
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                if (prerelease)
+                {
+                    Interlocked.Increment(ref prereleaseSearches);
+                    return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    [
+                        new() { Id = "Aspire.Hosting.Azure.Kubernetes", Version = "13.6.0-pr.19404.gf51e8e1d" },
+                        new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" },
+                        new() { Id = "Aspire.Hosting.Redis", Version = "13.6.0-preview.1" }
+                    ]);
+                }
+
+                Interlocked.Increment(ref stableSearches);
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                [
+                    new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" }
+                ]);
+            }
+        };
+        var channel = PackageChannel.CreateExplicitChannel(
+            "pr-19404",
+            PackageChannelQuality.Both,
+            [new PackageMapping("Aspire*", "https://pr.example/v3/index.json")],
+            cache,
+            new TestFeatures(),
+            NullLogger.Instance);
+
+        var packages = (await channel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout())
+            .OrderBy(package => package.Id, StringComparer.Ordinal)
+            .ThenBy(package => package.Version, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(1, stableSearches);
+        Assert.Equal(1, prereleaseSearches);
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Azure.Kubernetes", package.Id);
+                Assert.Equal("13.6.0-pr.19404.gf51e8e1d", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Redis", package.Id);
+                Assert.Equal("13.5.0", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Redis", package.Id);
+                Assert.Equal("13.6.0-preview.1", package.Version);
+            });
+    }
+
+    [Fact]
     public async Task GetIntegrationPackagesAsync_WithStableLocalSource_ReturnsOnlyStablePackages()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -270,6 +418,34 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
         var package = Assert.Single(packages);
         Assert.Equal("Aspire.Hosting.Redis", package.Id);
         Assert.Equal("13.5.0-preview.1", package.Version);
+    }
+
+    [Fact]
+    public async Task GetIntegrationPackagesAsync_WithBothLocalSource_ReturnsLatestPackageAcrossQualities()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var packagesDirectory = workspace.CreateDirectory("packages");
+
+        File.WriteAllText(Path.Combine(packagesDirectory.FullName, "Aspire.Hosting.Redis.13.5.0.nupkg"), string.Empty);
+        File.WriteAllText(Path.Combine(packagesDirectory.FullName, "Aspire.Hosting.Redis.13.6.0-preview.1.nupkg"), string.Empty);
+        File.WriteAllText(Path.Combine(packagesDirectory.FullName, "Aspire.Hosting.Azure.Kubernetes.13.6.0-pr.19404.gf51e8e1d.nupkg"), string.Empty);
+
+        var channel = CreateLocalChannel(packagesDirectory, PackageChannelQuality.Both);
+
+        var packages = (await channel.GetIntegrationPackagesAsync(workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout()).ToArray();
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Azure.Kubernetes", package.Id);
+                Assert.Equal("13.6.0-pr.19404.gf51e8e1d", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Redis", package.Id);
+                Assert.Equal("13.6.0-preview.1", package.Version);
+            });
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Xml.Linq;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Packaging;
 
@@ -65,7 +66,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
                 [PackagingService.OverrideStagingFeedConfigKey] = "https://example.com/nuget/v3/index.json"
             })
             .Build();
-        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
@@ -83,39 +84,105 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task GetChannelsAsync_WhenIdentityChannelIsStagingOnStableShapedCli_DefaultsToStableQuality()
+    public async Task GetChannelsAsync_WhenIdentityChannelIsStagingOnStableShapedCli_DiscoversMixedPackageQualities()
     {
-        // Regression test for https://github.com/microsoft/aspire/issues/17527: during release
-        // stabilization the staging CLI ships with a stable-shaped version (e.g. "13.4.0"). The
-        // shared dotnet9 daily feed only carries prerelease-tagged 13.4.0-preview.* packages,
-        // so a stabilizing staging CLI must route Aspire.* to the SHA-derived darc-pub-aspire-<hash>
-        // feed instead — which requires defaulting the synthesized staging channel quality to
-        // Stable (so useSharedFeed in CreateStagingChannel resolves false). No overrideStagingFeed
-        // is set: the injected informational version makes the darc derivation deterministic so the
-        // test exercises (and asserts) the real SHA-feed routing rather than an override crutch.
+        // A stable-shaped staging build publishes a mixed set to one SHA-specific feed: most
+        // packages are stable, while integrations with SuppressFinalPackageVersion remain
+        // prerelease. The channel must query both qualities for integration and polyglot-tag
+        // discovery; changing the generic Stable contract would expose these packages on released
+        // channels too. Regression test for https://github.com/microsoft/aspire/issues/19423.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir, identityChannel: PackageChannelNames.Staging);
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(
+            tempDir,
+            hivesDirectory: hivesDir,
+            identityChannel: PackageChannelNames.Staging,
+            identityVersion: "13.5.0");
+
+        var stableIntegrationSearches = 0;
+        var prereleaseIntegrationSearches = 0;
+        var stableTagSearches = 0;
+        var prereleaseTagSearches = 0;
+        var cache = new FakeNuGetPackageCache
+        {
+            GetIntegrationPackagesAsyncCallback = (_, prerelease, _, _) =>
+            {
+                if (prerelease)
+                {
+                    Interlocked.Increment(ref prereleaseIntegrationSearches);
+                }
+                else
+                {
+                    Interlocked.Increment(ref stableIntegrationSearches);
+                }
+
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    prerelease
+                        ? [new() { Id = "Aspire.Hosting.Azure.Kubernetes", Version = "13.5.0-preview.1.26415.2" }]
+                        : [new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" }]);
+            },
+            GetPackagesAsyncCallback = (_, query, _, prerelease, _, _, _) =>
+            {
+                Assert.Equal("tags:polyglot", query);
+                if (prerelease)
+                {
+                    Interlocked.Increment(ref prereleaseTagSearches);
+                }
+                else
+                {
+                    Interlocked.Increment(ref stableTagSearches);
+                }
+
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    prerelease
+                        ? [new() { Id = "Aspire.Hosting.Azure.Kubernetes", Version = "13.5.0-preview.1.26415.2" }]
+                        : [new() { Id = "Aspire.Hosting.Redis", Version = "13.5.0" }]);
+            }
+        };
 
         var packagingService = new PackagingService(
             executionContext,
-            new FakeNuGetPackageCache(),
+            cache,
             new TestFeatures(),
             new ConfigurationBuilder().Build(),
             NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => true,
-            cliInformationalVersionProvider: () => "13.4.0+abcdef1234567890abcdef1234567890abcdef12");
+            cliInformationalVersionProvider: () => "13.5.0+abcdef1234567890abcdef1234567890abcdef12");
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
         var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
-        Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
+        Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
 
         var aspireMapping = Assert.Single(stagingChannel.Mappings!, m => m.PackageFilter == "Aspire*");
         Assert.Equal(
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-abcdef12/nuget/v3/index.json",
             aspireMapping.Source);
+
+        var packages = (await stagingChannel.GetIntegrationPackagesAsync(tempDir, CancellationToken.None).DefaultTimeout())
+            .OrderBy(package => package.Id, StringComparer.Ordinal)
+            .ToArray();
+        var polyglotPackageIds = (await stagingChannel.GetPolyglotCompatiblePackageIdsAsync(tempDir, CancellationToken.None).DefaultTimeout())
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Collection(
+            packages,
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Azure.Kubernetes", package.Id);
+                Assert.Equal("13.5.0-preview.1.26415.2", package.Version);
+            },
+            package =>
+            {
+                Assert.Equal("Aspire.Hosting.Redis", package.Id);
+                Assert.Equal("13.5.0", package.Version);
+            });
+        Assert.Equal(["Aspire.Hosting.Azure.Kubernetes", "Aspire.Hosting.Redis"], polyglotPackageIds);
+        Assert.Equal(1, stableIntegrationSearches);
+        Assert.Equal(1, prereleaseIntegrationSearches);
+        Assert.Equal(1, stableTagSearches);
+        Assert.Equal(1, prereleaseTagSearches);
     }
 
     [Fact]
@@ -140,7 +207,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             new TestFeatures(),
             new ConfigurationBuilder().Build(),
             NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => false,
             cliInformationalVersionProvider: () => "13.4.0-preview.1.26280.6+abcdef1234567890abcdef1234567890abcdef12");
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -164,9 +230,8 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
     public async Task GetChannelsAsync_WhenIdentityChannelIsStagingStableShaped_RoutesAspirePackagesToDarcFeed()
     {
         // Regression guard for https://github.com/microsoft/aspire/issues/17527: a stable-shaped
-        // staging CLI ("13.4.0") must resolve Aspire.* from its SHA-specific darc feed with Stable
-        // quality (version filtering). The fix keeps this behavior while also covering the
-        // prerelease-shaped case above.
+        // staging CLI ("13.4.0") must resolve Aspire.* from its SHA-specific darc feed. Its quality
+        // remains Both because that feed can also contain deliberately prerelease-only packages.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
@@ -178,13 +243,12 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             new TestFeatures(),
             new ConfigurationBuilder().Build(),
             NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => true,
             cliInformationalVersionProvider: () => "13.4.0+abcdef1234567890abcdef1234567890abcdef12");
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
         var stagingChannel = channels.First(c => c.Name == PackageChannelNames.Staging);
-        Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
+        Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
 
         var aspireMapping = Assert.Single(stagingChannel.Mappings!, m => m.PackageFilter == "Aspire*");
         Assert.Equal(
@@ -218,7 +282,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             new TestFeatures(),
             configuration,
             NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => false,
             cliInformationalVersionProvider: () => "13.4.0-preview.1.26280.6+abcdef1234567890abcdef1234567890abcdef12");
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -248,7 +311,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             new TestFeatures(),
             new ConfigurationBuilder().Build(),
             logger,
-            isStableShapedCliVersion: () => false,
             cliInformationalVersionProvider: () => "13.4.0-preview.1.26280.6"); // no '+<commit>' build metadata
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
@@ -274,20 +336,21 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
     // shared dotnet9 daily feed, an explicit override always wins, and an identity with no staging
     // opt-in synthesizes no channel at all.
     [Theory]
-    [InlineData(PackageChannelNames.Staging, false, false, false, null, ExpectedStagingFeed.Darc)]        // staging identity, prerelease-shaped
-    [InlineData(PackageChannelNames.Staging, true, false, false, null, ExpectedStagingFeed.Darc)]         // staging identity, stable-shaped
-    [InlineData(PackageChannelNames.Staging, false, false, false, "https://example.com/o/v3/index.json", ExpectedStagingFeed.Override)] // override always wins
-    [InlineData(PackageChannelNames.Stable, false, false, true, null, ExpectedStagingFeed.Shared)]        // stable identity + config channel=staging => Both => shared
-    [InlineData(PackageChannelNames.Stable, false, true, false, null, ExpectedStagingFeed.Darc)]          // stable identity + feature flag only => Stable => darc
-    [InlineData(PackageChannelNames.Daily, false, true, false, null, ExpectedStagingFeed.Darc)]           // daily identity + feature flag only => Stable => darc
-    [InlineData(PackageChannelNames.Local, false, false, false, null, ExpectedStagingFeed.Absent)]        // local identity, no opt-in => no channel
+    [InlineData(PackageChannelNames.Staging, "13.4.0-preview.1.26280.6+abcdef1234567890abcdef1234567890abcdef12", false, false, null, ExpectedStagingFeed.Darc, "Both")] // staging identity, prerelease-shaped
+    [InlineData(PackageChannelNames.Staging, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", false, false, null, ExpectedStagingFeed.Darc, "Both")] // staging identity, stable-shaped
+    [InlineData(PackageChannelNames.Staging, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", false, false, "https://example.com/o/v3/index.json", ExpectedStagingFeed.Override, "Both")] // override always wins
+    [InlineData(PackageChannelNames.Stable, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", false, true, null, ExpectedStagingFeed.Shared, "Both")] // stable identity + config channel=staging => Both => shared
+    [InlineData(PackageChannelNames.Stable, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", true, false, null, ExpectedStagingFeed.Darc, "Stable")] // stable identity + feature flag only => Stable => darc
+    [InlineData(PackageChannelNames.Daily, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", true, false, null, ExpectedStagingFeed.Darc, "Stable")] // daily identity + feature flag only => Stable => darc
+    [InlineData(PackageChannelNames.Local, "13.4.0+abcdef1234567890abcdef1234567890abcdef12", false, false, null, ExpectedStagingFeed.Absent, null)] // local identity, no opt-in => no channel
     public async Task GetChannelsAsync_StagingFeedRoutingDecisionTable(
         string identityChannel,
-        bool isStableShaped,
+        string informationalVersion,
         bool featureEnabled,
         bool configChannelStaging,
         string? overrideFeed,
-        ExpectedStagingFeed expected)
+        ExpectedStagingFeed expected,
+        string? expectedQuality)
     {
         const string DarcUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-abcdef12/nuget/v3/index.json";
         const string SharedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json";
@@ -320,8 +383,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             features,
             configuration,
             NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => isStableShaped,
-            cliInformationalVersionProvider: () => "13.4.0+abcdef1234567890abcdef1234567890abcdef12");
+            cliInformationalVersionProvider: () => informationalVersion);
 
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
         var stagingChannel = channels.SingleOrDefault(c => c.Name == PackageChannelNames.Staging);
@@ -333,6 +395,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         }
 
         Assert.NotNull(stagingChannel);
+        Assert.Equal(Enum.Parse<PackageChannelQuality>(expectedQuality!), stagingChannel.Quality);
         var aspireSource = Assert.Single(stagingChannel.Mappings!, m => m.PackageFilter == "Aspire*").Source;
         var expectedSource = expected switch
         {
@@ -385,10 +448,10 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task GetChannelsAsync_WhenVersionOverrideIsStableShaped_DefaultsToStableQuality()
+    public async Task GetChannelsAsync_WhenVersionOverrideIsStableShaped_UsesBothQuality()
     {
-        // A stable-shaped (no semver prerelease tag) version override drives the quality predicate to
-        // Stable, mirroring how an official stable-shaped staging build is filtered.
+        // Version shape does not narrow an official staging identity: its SHA feed can contain
+        // stable packages and deliberately prerelease-only integrations from the same build.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
@@ -407,7 +470,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
 
         var stagingChannel = Assert.Single(channels, c => c.Name == PackageChannelNames.Staging);
-        Assert.Equal(PackageChannelQuality.Stable, stagingChannel.Quality);
+        Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
         Assert.Equal(
             "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-abcdef12/nuget/v3/index.json",
             Assert.Single(stagingChannel.Mappings!, m => m.PackageFilter == "Aspire*").Source);
@@ -518,34 +581,6 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
 
         Assert.DoesNotContain(PackageChannelNames.Staging, channels.Select(c => c.Name));
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("diagnostic overrides are active"));
-    }
-
-    [Theory]
-    [InlineData("13.4.0+abcd-ef1234567890", true)]               // hyphen only in build metadata => stable-shaped
-    [InlineData("13.4.0-preview.1.26280.6+abcd-ef1234567890", false)] // semver prerelease tag => prerelease-shaped
-    public async Task GetChannelsAsync_VersionOverrideStableShapeIgnoresBuildMetadataHyphens(string overrideVersion, bool expectStableQuality)
-    {
-        // StripBuildMetadata removes the '+<commit>' before the prerelease-tag check, so a commit hash
-        // containing '-' must not be misread as a semver prerelease tag.
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var tempDir = workspace.WorkspaceRoot;
-        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
-        var executionContext = TestExecutionContextHelper.CreateExecutionContext(tempDir, hivesDirectory: hivesDir, identityChannel: PackageChannelNames.Local);
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [PackagingService.OverrideCliIdentityChannelConfigKey] = PackageChannelNames.Staging,
-                [PackagingService.OverrideCliInformationalVersionConfigKey] = overrideVersion,
-            })
-            .Build();
-
-        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), new TestFeatures(), configuration, NullLogger<PackagingService>.Instance);
-
-        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
-
-        var stagingChannel = Assert.Single(channels, c => c.Name == PackageChannelNames.Staging);
-        Assert.Equal(expectStableQuality ? PackageChannelQuality.Stable : PackageChannelQuality.Both, stagingChannel.Quality);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -449,8 +449,8 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     public async Task TryCreateTemporaryNuGetConfig_StagingRequested_FromRealPackagingService_EmitsStableGlobalPackagesFolderOutsideTempDir()
     {
         // End-to-end pin for the staging temp-config hang fix: when the real PackagingService
-        // synthesizes the staging channel (here driven by overrideStagingFeed on a stable-shaped
-        // CLI so configureGlobalPackagesFolder lands true), the temporary nuget.config used by
+        // synthesizes the staging channel (here driven by overrideStagingFeed on a staging
+        // identity so configureGlobalPackagesFolder lands true), the temporary nuget.config used by
         // PrebuiltAppHostServer must point globalPackagesFolder at an absolute path that survives
         // the TemporaryNuGetConfig.Dispose recursive delete. Otherwise BundleNuGetService restores
         // staging assemblies into <temp>/.nugetpackages, bakes those paths into
@@ -473,8 +473,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             new FakeNuGetPackageCache(),
             new TestFeatures(),
             configuration,
-            NullLogger<PackagingService>.Instance,
-            isStableShapedCliVersion: () => true);
+            NullLogger<PackagingService>.Instance);
 
         var server = CreateServerWithPackagingService(workspace, packagingService, executionContext);
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -36,6 +36,8 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
 
     public Func<AppHostProjectContext, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
 
+    public Func<AddPackageContext, CancellationToken, Task<bool>>? AddPackageAsyncCallback { get; set; }
+
     public Func<UpdatePackagesContext, CancellationToken, Task<UpdatePackagesResult>>? UpdatePackagesAsyncCallback { get; set; }
 
     public string LanguageId { get; set; } = "csharp";
@@ -227,7 +229,9 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
         }
 
         public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+            => _factory.AddPackageAsyncCallback is not null
+                ? _factory.AddPackageAsyncCallback(context, cancellationToken)
+                : throw new NotImplementedException();
 
         public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
             => _factory.UpdatePackagesAsyncCallback is not null

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -621,14 +621,7 @@ internal sealed class CliServiceCollectionTestOptions
         var nuGetPackageCache = serviceProvider.GetRequiredService<INuGetPackageCache>();
         var features = serviceProvider.GetRequiredService<IFeatures>();
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-        // Force prerelease-shaped CLI version semantics in tests so PackagingService's
-        // identity-staging quality default does not depend on whether the test-host assembly
-        // was produced under StabilizePackageVersion=true. Without this, tests that rely on
-        // the shared-daily routing for `staging` identity (quality=Both → useSharedFeed=true)
-        // would fail under the stabilization-check job which builds with a stable-shaped
-        // version (no '-' suffix) baked in. Tests that specifically exercise the stable-shape
-        // branch construct PackagingService directly with isStableShapedCliVersion: () => true.
-        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance, isStableShapedCliVersion: () => false);
+        return new PackagingService(executionContext, nuGetPackageCache, features, configuration, NullLogger<PackagingService>.Instance);
     };
 
     public Func<IServiceProvider, IDiskCache> DiskCacheFactory { get; set; } = (IServiceProvider serviceProvider) => new NullDiskCache();


### PR DESCRIPTION
Backport of #19426 to release/13.5

/cc @mitchdenny

## Customer Impact

With stable-shaped 13.5 staging builds, TypeScript AppHosts cannot discover build-matched prerelease-only integrations from the SHA-specific staging feed. For example, Azure Kubernetes `13.5.0-preview.1.26415.2` is available to C# AppHosts but omitted for TypeScript, leaving users with unrelated daily/PR-hive versions instead.

## Testing

On `release/13.5`, restore succeeded and 30 focused `Aspire.Cli.Tests` passed covering `PackagingService`, `PackageChannel`, `AddCommand`, and `PrebuiltAppHostServer`; parser checks also passed for the changed Bash and PowerShell debug scripts. The source PR additionally passed the full CLI test project and C#/TypeScript runtime matrices across PR, daily, staging, and released identities, including `aspire new`, `aspire init`, Redis, and Azure Kubernetes.

## Risk

Low. The production change is scoped to official staging identities and their SHA-specific feed. Released Stable and Daily remain strict, feature-flag-only staging remains Stable, and existing exact-package fallback is unchanged. The release conflict was test-only and preserves the release test set plus the source PR's quality-contract regressions.

## Regression?

Yes — #17452 caused generated polyglot AppHosts to persist their CLI channel, activating the latent stable-only narrowing behavior. #17728 restored prerelease discovery for packages already on NuGet.org; this backport fixes the remaining packages available only from the current SHA-specific staging feed.
