### PR TITLE
Fix Kubernetes hostname publishing and routing

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -580,8 +580,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     /// <summary>
     /// Resolves a <see cref="ReferenceExpression"/> for inclusion in a Kubernetes manifest
     /// produced by an ingress or gateway resource. When the expression wraps one or more
-    /// <see cref="ParameterResource"/> instances that have no value at publish time
-    /// (e.g., user-supplied parameters without defaults, or secrets), the expression is
+    /// <see cref="ParameterResource"/> instances that must remain deploy-time inputs
+    /// (for example, secrets or parameters without published defaults), the expression is
     /// rendered with Helm template placeholders (such as <c>{{ .Values.parameters.ingress.ingressclass }}</c>)
     /// and the parameters are captured for deploy-time resolution into a values override file.
     /// </summary>
@@ -594,31 +594,33 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     /// <param name="cancellationToken">The cancellation token.</param>
     private async Task<string> ResolveExpressionAsync(ReferenceExpression expression, string owningResourceName, CancellationToken cancellationToken)
     {
-        try
+        if (!expression.ValueProviders.OfType<ParameterResource>().Any(ShouldCaptureAsHelmValue))
         {
-            return (await expression.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
-        }
-        catch (MissingParameterValueException)
-        {
-            // One or more parameters in the expression have no value at publish time
-            // (e.g., a parameter created via AddParameter("ingressclass") with no default,
-            // or a secret parameter). Substitute each unresolved parameter with a Helm
-            // template reference into values.yaml so the resulting manifest is a valid
-            // Helm template and the value can be supplied at deploy time.
-            var owningResourceKey = owningResourceName.ToHelmValuesSectionName();
-            var args = new object[expression.ValueProviders.Count];
-
-            for (var i = 0; i < expression.ValueProviders.Count; i++)
+            try
             {
-                args[i] = await ResolveValueProviderAsync(
-                    expression.ValueProviders[i],
-                    owningResourceName,
-                    owningResourceKey,
-                    cancellationToken).ConfigureAwait(false);
+                return (await expression.GetValueAsync(cancellationToken).ConfigureAwait(false))!;
             }
-
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, expression.Format, args);
+            catch (MissingParameterValueException)
+            {
+                // Fall through to Helm-reference substitution below.
+            }
         }
+
+        // Parameters without published defaults may still have runtime values, but publish must
+        // preserve them as deploy-time inputs instead of leaking those values into generated YAML.
+        var owningResourceKey = owningResourceName.ToHelmValuesSectionName();
+        var args = new object[expression.ValueProviders.Count];
+
+        for (var i = 0; i < expression.ValueProviders.Count; i++)
+        {
+            args[i] = await ResolveValueProviderAsync(
+                expression.ValueProviders[i],
+                owningResourceName,
+                owningResourceKey,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return string.Format(System.Globalization.CultureInfo.InvariantCulture, expression.Format, args);
     }
 
     private async Task<string> ResolveValueProviderAsync(
@@ -629,19 +631,16 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         if (valueProvider is ParameterResource parameter)
         {
-            // Attempt to resolve this individual parameter first. The outer
-            // MissingParameterValueException from the whole-expression resolve attempt
-            // only tells us that *some* parameter in the expression was unresolved;
-            // others (e.g., those with `publishValueAsDefault: true`) may still have
-            // a value and should be inlined into the manifest rather than left as
-            // Helm placeholders. This keeps the published chart maximally self-contained.
-            try
+            if (!ShouldCaptureAsHelmValue(parameter))
             {
-                return (await parameter.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
-            }
-            catch (MissingParameterValueException)
-            {
-                // Fall through to Helm-reference substitution below.
+                try
+                {
+                    return (await parameter.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
+                }
+                catch (MissingParameterValueException)
+                {
+                    // Fall through to Helm-reference substitution below.
+                }
             }
 
             // Capture the parameter so HelmDeploymentEngine writes its resolved value to
@@ -671,6 +670,24 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         // `hosts: [""]`) that only fail loudly at deploy time. Letting it throw surfaces
         // the unresolved-parameter problem during publish.
         return (await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)) ?? string.Empty;
+    }
+
+    private static bool ShouldCaptureAsHelmValue(ParameterResource parameter)
+        => parameter.Secret || parameter.Default is null;
+
+    private async Task<List<string>> ResolveHostnamesAsync(
+        IEnumerable<ReferenceExpression> hostnames,
+        string owningResourceName,
+        CancellationToken cancellationToken)
+    {
+        var resolvedHostnames = new List<string>();
+
+        foreach (var hostname in hostnames)
+        {
+            resolvedHostnames.Add(await ResolveExpressionAsync(hostname, owningResourceName, cancellationToken).ConfigureAwait(false));
+        }
+
+        return resolvedHostnames;
     }
 
     private async Task ProcessIngressResources(DistributedApplicationModel model, Dictionary<IResource, KubernetesResource> deploymentTargets, ILogger logger, CancellationToken cancellationToken)
@@ -735,17 +752,40 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             ingress.Metadata.Annotations[key] = await ResolveExpressionAsync(value, ingressResource.Name, cancellationToken).ConfigureAwait(false);
         }
 
-        var pathsByHost = ingressResource.Paths.GroupBy(p => p.Host ?? string.Empty);
+        var resolvedHostnames = await ResolveHostnamesAsync(
+            ingressResource.Hostnames,
+            ingressResource.Name,
+            cancellationToken).ConfigureAwait(false);
+        var pathsByHost = new Dictionary<string, List<IngressPathConfig>>();
 
-        foreach (var hostGroup in pathsByHost)
+        foreach (var path in ingressResource.Paths)
+        {
+            if (path.Host is { } explicitHost)
+            {
+                AddPathForHost(explicitHost, path);
+            }
+            else if (resolvedHostnames.Count == 0)
+            {
+                AddPathForHost(string.Empty, path);
+            }
+            else
+            {
+                foreach (var hostname in resolvedHostnames)
+                {
+                    AddPathForHost(hostname, path);
+                }
+            }
+        }
+
+        foreach (var (host, paths) in pathsByHost)
         {
             var rule = new IngressRuleV1();
-            if (!string.IsNullOrEmpty(hostGroup.Key))
+            if (!string.IsNullOrEmpty(host))
             {
-                rule.Host = hostGroup.Key;
+                rule.Host = host;
             }
 
-            foreach (var pathRule in hostGroup)
+            foreach (var pathRule in paths)
             {
                 var backend = ResolveIngressBackend(pathRule.Endpoint, deploymentTargets, ingressResource.Name, logger);
                 if (backend is null)
@@ -783,16 +823,14 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 SecretName = await ResolveExpressionAsync(tls.SecretName, ingressResource.Name, cancellationToken).ConfigureAwait(false),
             };
 
-            foreach (var host in ingressResource.Hostnames)
-            {
-                tlsEntry.Hosts.Add(await ResolveExpressionAsync(host, ingressResource.Name, cancellationToken).ConfigureAwait(false));
-            }
+            tlsEntry.Hosts.AddRange(resolvedHostnames);
 
             ingress.Spec.Tls.Add(tlsEntry);
         }
 
-        // Auto-generate rules for TLS hosts that don't have explicit routes.
-        if (ingress.Spec.DefaultBackend is not null)
+        // A default backend remains catch-all even when hostnames are configured. Only synthesize
+        // host rules for TLS because some ingress controllers require each TLS host to have a rule.
+        if (ingress.Spec.DefaultBackend is not null && ingress.Spec.Tls.Count > 0)
         {
             var hostsWithRules = new HashSet<string>(
                 ingress.Spec.Rules
@@ -800,41 +838,37 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                     .Select(r => r.Host!),
                 StringComparer.OrdinalIgnoreCase);
 
-            foreach (var tls in ingressResource.TlsConfigs)
+            foreach (var resolvedHost in resolvedHostnames)
             {
-                foreach (var host in ingressResource.Hostnames)
+                if (hostsWithRules.Add(resolvedHost))
                 {
-                    var resolvedHost = await ResolveExpressionAsync(host, ingressResource.Name, cancellationToken).ConfigureAwait(false);
-                    if (!hostsWithRules.Contains(resolvedHost))
+                    ingress.Spec.Rules.Add(new IngressRuleV1
                     {
-                        ingress.Spec.Rules.Add(new IngressRuleV1
+                        Host = resolvedHost,
+                        Http = new HttpIngressRuleValueV1
                         {
-                            Host = resolvedHost,
-                            Http = new HttpIngressRuleValueV1
+                            Paths =
                             {
-                                Paths =
+                                new HttpIngressPathV1
                                 {
-                                    new HttpIngressPathV1
+                                    Path = "/",
+                                    PathType = IngressPathType.Prefix.ToKubernetesString(),
+                                    Backend = new IngressBackendV1
                                     {
-                                        Path = "/",
-                                        PathType = IngressPathType.Prefix.ToKubernetesString(),
-                                        Backend = new IngressBackendV1
+                                        Service = new IngressServiceBackendV1
                                         {
-                                            Service = new IngressServiceBackendV1
+                                            Name = ingress.Spec.DefaultBackend.Service.Name,
+                                            Port = new ServiceBackendPortV1
                                             {
-                                                Name = ingress.Spec.DefaultBackend.Service.Name,
-                                                Port = new ServiceBackendPortV1
-                                                {
-                                                    Name = ingress.Spec.DefaultBackend.Service.Port.Name,
-                                                    Number = ingress.Spec.DefaultBackend.Service.Port.Number
-                                                }
+                                                Name = ingress.Spec.DefaultBackend.Service.Port.Name,
+                                                Number = ingress.Spec.DefaultBackend.Service.Port.Number
                                             }
                                         }
                                     }
                                 }
                             }
-                        });
-                    }
+                        }
+                    });
                 }
             }
         }
@@ -846,6 +880,17 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         }
 
         return ingress;
+
+        void AddPathForHost(string host, IngressPathConfig path)
+        {
+            if (!pathsByHost.TryGetValue(host, out var paths))
+            {
+                paths = [];
+                pathsByHost.Add(host, paths);
+            }
+
+            paths.Add(path);
+        }
     }
 
     private static IngressBackendV1? ResolveIngressBackend(
@@ -1000,6 +1045,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             Metadata = { Name = gatewayName }
         };
+        var resolvedHostnames = await ResolveHostnamesAsync(
+            gatewayResource.Hostnames,
+            gatewayResource.Name,
+            cancellationToken).ConfigureAwait(false);
 
         gateway.Spec.GatewayClassName = await ResolveExpressionAsync(gatewayResource.GatewayClassName, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
@@ -1024,7 +1073,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         {
             var resolvedSecretName = await ResolveExpressionAsync(tls.SecretName, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
-            if (gatewayResource.Hostnames.Count == 0)
+            if (resolvedHostnames.Count == 0)
             {
                 // No hostnames specified — create an HTTPS listener without a hostname restriction.
                 // The hostname will be discovered from the Gateway's assigned address after deployment
@@ -1050,12 +1099,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
             else
             {
-                foreach (var host in gatewayResource.Hostnames)
+                foreach (var resolvedHost in resolvedHostnames)
                 {
                     var listenerName = tlsListenerIndex == 0 ? "https" : $"https-{tlsListenerIndex}";
                     tlsListenerIndex++;
-
-                    var resolvedHost = await ResolveExpressionAsync(host, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 
                     gateway.Spec.Listeners.Add(new GatewayListenerV1
                     {
@@ -1097,6 +1144,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             if (!string.IsNullOrEmpty(hostGroup.Key))
             {
                 httpRoute.Spec.Hostnames.Add(hostGroup.Key);
+            }
+            else
+            {
+                httpRoute.Spec.Hostnames.AddRange(resolvedHostnames);
             }
 
             foreach (var route in hostGroup)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -32,6 +32,9 @@ namespace Aspire.Hosting.Kubernetes;
 [AspireExport(ExposeProperties = true)]
 public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmentResource
 {
+    private const int HttpRouteHostnameLimit = 16;
+    private const string HttpRouteSpecDocumentationUrl = "https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproutespec";
+
     /// <summary>
     /// Gets or sets the name of the Helm chart to be generated.
     /// </summary>
@@ -1049,6 +1052,16 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             gatewayResource.Hostnames,
             gatewayResource.Name,
             cancellationToken).ConfigureAwait(false);
+
+        if (resolvedHostnames.Count > HttpRouteHostnameLimit &&
+            gatewayResource.Routes.Any(route => route.Host is null))
+        {
+            throw new InvalidOperationException(
+                $"Gateway '{gatewayResource.Name}' configures {resolvedHostnames.Count} hostnames that would be inherited by a hostless route, " +
+                $"but Kubernetes Gateway API HTTPRoute.spec.hostnames supports at most {HttpRouteHostnameLimit} entries. " +
+                $"Define explicit host-scoped routes with WithRoute(hostname, path, endpoint) so each HTTPRoute stays within the limit. " +
+                $"See the Kubernetes Gateway API documentation: {HttpRouteSpecDocumentationUrl}");
+        }
 
         gateway.Spec.GatewayClassName = await ResolveExpressionAsync(gatewayResource.GatewayClassName, gatewayResource.Name, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -89,9 +89,10 @@ public static class KubernetesGatewayExtensions
     }
 
     /// <summary>
-    /// Adds a path-based routing rule to the gateway. The rule matches all hosts and routes
-    /// traffic matching the specified path to the given endpoint's backing Kubernetes service.
-    /// This generates an <c>HTTPRoute</c> resource attached to the Gateway.
+    /// Adds a path-based routing rule to the gateway. The rule matches each hostname configured
+    /// with <see cref="WithHostname(IResourceBuilder{KubernetesGatewayResource}, string)"/>, or all
+    /// hosts when no hostname is configured, and routes matching traffic to the endpoint's backing
+    /// Kubernetes service. This generates an <c>HTTPRoute</c> resource attached to the Gateway.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="path">The URL path to match (e.g., <c>"/"</c> or <c>"/api"</c>). Must start with <c>/</c>.</param>
@@ -165,8 +166,9 @@ public static class KubernetesGatewayExtensions
 
     /// <summary>
     /// Adds a hostname that this gateway's routes match. Multiple hostnames can be added by calling
-    /// this method repeatedly. Hostnames are used as <c>hostnames</c> in generated <c>HTTPRoute</c>
-    /// resources and as HTTPS listener hostnames when TLS is configured.
+    /// this method repeatedly. Routes without an explicit host apply to each configured hostname.
+    /// Hostnames are used as <c>hostnames</c> in generated <c>HTTPRoute</c> resources and as HTTPS
+    /// listener hostnames when TLS is configured.
     /// </summary>
     /// <param name="builder">The gateway resource builder.</param>
     /// <param name="hostname">The hostname to match (e.g., <c>"api.example.com"</c>).</param>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -99,8 +99,9 @@ public static class KubernetesIngressExtensions
     }
 
     /// <summary>
-    /// Adds a path-based rule to the ingress. The rule matches all hosts and forwards
-    /// traffic matching the specified path to the given endpoint's backing Kubernetes service.
+    /// Adds a path-based rule to the ingress. The rule matches each hostname configured with
+    /// <see cref="WithHostname(IResourceBuilder{KubernetesIngressResource}, string)"/>, or all hosts
+    /// when no hostname is configured, and forwards matching traffic to the endpoint's backing Kubernetes service.
     /// </summary>
     /// <param name="builder">The ingress resource builder.</param>
     /// <param name="path">The URL path to match (e.g., <c>"/"</c> or <c>"/api"</c>). Must start with <c>/</c>.</param>
@@ -185,7 +186,8 @@ public static class KubernetesIngressExtensions
 
     /// <summary>
     /// Adds a hostname that this ingress matches. Multiple hostnames can be added by calling
-    /// this method repeatedly. If no hostnames are configured, the ingress matches all hosts.
+    /// this method repeatedly. Path rules without an explicit host apply to each configured
+    /// hostname. If no hostnames are configured, those rules match all hosts.
     /// </summary>
     /// <param name="builder">The ingress resource builder.</param>
     /// <param name="hostname">The hostname to match (e.g., <c>"api.example.com"</c>).</param>
@@ -300,6 +302,10 @@ public static class KubernetesIngressExtensions
     /// <param name="endpoint">The endpoint reference identifying the default backend service and port.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KubernetesIngressResource}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// Kubernetes default backends remain catch-all even when hostnames are configured. Use host-specific
+    /// path rules when traffic must be restricted by hostname.
+    /// </remarks>
     [AspireExport]
     public static IResourceBuilder<KubernetesIngressResource> WithDefaultBackend(
         this IResourceBuilder<KubernetesIngressResource> builder,

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -139,6 +139,100 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void AddGateway_WithRoute_InheritsMaximumSupportedHostnames()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+        var expectedHostnames = Enumerable.Range(1, 16)
+            .Select(index => $"host-{index}.example.com")
+            .ToArray();
+
+        foreach (var hostname in expectedHostnames)
+        {
+            gateway.WithHostname(hostname);
+        }
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        gateway.WithRoute("/", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var route = Assert.Single(gateway.Resource.GeneratedHttpRoutes);
+        Assert.Equal(expectedHostnames, route.Spec.Hostnames);
+    }
+
+    [Fact]
+    public void AddGateway_WithRoute_ExceedingMaximumSupportedHostnames_ThrowsOnPublish()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+
+        foreach (var index in Enumerable.Range(1, 17))
+        {
+            gateway.WithHostname($"host-{index}.example.com");
+        }
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        gateway.WithRoute("/", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        var aggregate = Assert.Throws<AggregateException>(app.Run);
+        var exception = aggregate.Flatten().InnerExceptions
+            .Select(e => e.InnerException)
+            .OfType<InvalidOperationException>()
+            .First(e => e.Message.StartsWith("Gateway 'public'", StringComparison.Ordinal));
+
+        Assert.Equal(
+            "Gateway 'public' configures 17 hostnames that would be inherited by a hostless route, " +
+            "but Kubernetes Gateway API HTTPRoute.spec.hostnames supports at most 16 entries. " +
+            "Define explicit host-scoped routes with WithRoute(hostname, path, endpoint) so each HTTPRoute stays within the limit. " +
+            "See the Kubernetes Gateway API documentation: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproutespec",
+            exception.Message);
+    }
+
+    [Fact]
+    public void AddGateway_WithHostRoutes_DoesNotApplyInheritedHostnameLimit()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public").WithGatewayClass("test");
+        var hostnames = Enumerable.Range(1, 17)
+            .Select(index => $"host-{index}.example.com")
+            .ToArray();
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        foreach (var hostname in hostnames)
+        {
+            gateway.WithHostname(hostname);
+            gateway.WithRoute(hostname, "/", api.GetEndpoint("http"));
+        }
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.Equal(hostnames.Length, gateway.Resource.GeneratedHttpRoutes.Count);
+        Assert.All(gateway.Resource.GeneratedHttpRoutes, route => Assert.Single(route.Spec.Hostnames));
+    }
+
+    [Fact]
     public async Task AddGateway_WithTls_GeneratesHttpsListener()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -82,6 +82,63 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var hostname = builder.AddParameter("hostname", "localhost");
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public")
+            .WithGatewayClass("nginx")
+            .WithHostname(hostname)
+            .WithTls();
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        gateway.WithRoute("/api", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var gatewayPath = Path.Combine(workspace.Path, "templates", "public", "public.yaml");
+        var routePath = Path.Combine(workspace.Path, "templates", "public", "route.yaml");
+        var valuesPath = Path.Combine(workspace.Path, "values.yaml");
+
+        await Verify(File.ReadAllText(gatewayPath), "yaml")
+            .AppendContentAsFile(File.ReadAllText(routePath), "yaml")
+            .AppendContentAsFile(File.ReadAllText(valuesPath), "yaml");
+    }
+
+    [Fact]
+    public async Task AddGateway_WithHostname_AppliesToHostlessRoute()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var gateway = k8s.AddGateway("public")
+            .WithGatewayClass("nginx")
+            .WithHostname("api.example.com")
+            .WithHostname("www.example.com");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        gateway.WithRoute("/api", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var routePath = Path.Combine(workspace.Path, "templates", "public", "route.yaml");
+
+        await Verify(File.ReadAllText(routePath), "yaml");
+    }
+
+    [Fact]
     public async Task AddGateway_WithTls_GeneratesHttpsListener()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -154,6 +154,83 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddIngress_WithRuntimeOnlyHostnameParameter_DefersValue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var hostname = builder.AddParameter("hostname", "localhost");
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithHostname(hostname)
+            .WithTls();
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        ingress.WithPath("/api", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(workspace.Path, "templates", "public", "public.yaml");
+        var valuesPath = Path.Combine(workspace.Path, "values.yaml");
+
+        await Verify(File.ReadAllText(ingressPath), "yaml")
+            .AppendContentAsFile(File.ReadAllText(valuesPath), "yaml");
+    }
+
+    [Fact]
+    public async Task AddIngress_WithHostname_AppliesToHostlessPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithHostname("api.example.com")
+            .WithHostname("www.example.com");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        ingress.WithPath("/api", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(workspace.Path, "templates", "public", "public.yaml");
+
+        await Verify(File.ReadAllText(ingressPath), "yaml");
+    }
+
+    [Fact]
+    public async Task AddIngress_HostnameWithDefaultBackendWithoutTls_DoesNotGenerateHostRule()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var ingress = k8s.AddIngress("public")
+            .WithHostname("api.example.com");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        ingress.WithDefaultBackend(api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var ingressPath = Path.Combine(workspace.Path, "templates", "public", "public.yaml");
+
+        await Verify(File.ReadAllText(ingressPath), "yaml");
+    }
+
+    [Fact]
     public async Task AddIngress_WithTls_GeneratesTlsSection()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithHostname_AppliesToHostlessRoute.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithHostname_AppliesToHostlessRoute.verified.yaml
@@ -1,0 +1,19 @@
+﻿---
+apiVersion: "gateway.networking.k8s.io/v1"
+kind: "HTTPRoute"
+metadata:
+  name: "public-route"
+spec:
+  parentRefs:
+    - name: "public"
+  hostnames:
+    - "api.example.com"
+    - "www.example.com"
+  rules:
+    - matches:
+        - path:
+            type: "PathPrefix"
+            value: "/api"
+      backendRefs:
+        - name: "myapi-service"
+          port: 8080

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#00.verified.yaml
@@ -1,0 +1,25 @@
+﻿---
+apiVersion: "gateway.networking.k8s.io/v1"
+kind: "Gateway"
+metadata:
+  name: "public"
+spec:
+  gatewayClassName: "nginx"
+  listeners:
+    - name: "http"
+      protocol: "HTTP"
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: "Same"
+    - name: "https"
+      protocol: "HTTPS"
+      port: 443
+      hostname: "{{ .Values.parameters.public.hostname }}"
+      tls:
+        mode: "Terminate"
+        certificateRefs:
+          - name: "public-tls"
+      allowedRoutes:
+        namespaces:
+          from: "Same"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#01.verified.yaml
@@ -1,0 +1,18 @@
+﻿---
+apiVersion: "gateway.networking.k8s.io/v1"
+kind: "HTTPRoute"
+metadata:
+  name: "public-route"
+spec:
+  parentRefs:
+    - name: "public"
+  hostnames:
+    - "{{ .Values.parameters.public.hostname }}"
+  rules:
+    - matches:
+        - path:
+            type: "PathPrefix"
+            value: "/api"
+      backendRefs:
+        - name: "myapi-service"
+          port: 8080

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesGatewayTests.AddGateway_WithRuntimeOnlyHostnameParameter_DefersValue#02.verified.yaml
@@ -1,0 +1,5 @@
+﻿parameters:
+  public:
+    hostname: ""
+secrets: {}
+config: {}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_HostnameWithDefaultBackendWithoutTls_DoesNotGenerateHostRule.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_HostnameWithDefaultBackendWithoutTls_DoesNotGenerateHostRule.verified.yaml
@@ -1,0 +1,11 @@
+﻿---
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "public"
+spec:
+  defaultBackend:
+    service:
+      name: "myapi-service"
+      port:
+        name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithHostname_AppliesToHostlessPath.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithHostname_AppliesToHostlessPath.verified.yaml
@@ -1,0 +1,27 @@
+﻿---
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "public"
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: "myapi-service"
+                port:
+                  name: "http"
+            pathType: "Prefix"
+            path: "/api"
+      host: "api.example.com"
+    - http:
+        paths:
+          - backend:
+              service:
+                name: "myapi-service"
+                port:
+                  name: "http"
+            pathType: "Prefix"
+            path: "/api"
+      host: "www.example.com"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithRuntimeOnlyHostnameParameter_DefersValue#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithRuntimeOnlyHostnameParameter_DefersValue#00.verified.yaml
@@ -1,0 +1,21 @@
+﻿---
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "public"
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: "myapi-service"
+                port:
+                  name: "http"
+            pathType: "Prefix"
+            path: "/api"
+      host: "{{ .Values.parameters.public.hostname }}"
+  tls:
+    - secretName: "public-tls"
+      hosts:
+        - "{{ .Values.parameters.public.hostname }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithRuntimeOnlyHostnameParameter_DefersValue#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesIngressTests.AddIngress_WithRuntimeOnlyHostnameParameter_DefersValue#01.verified.yaml
@@ -1,0 +1,5 @@
+﻿parameters:
+  public:
+    hostname: ""
+secrets: {}
+config: {}


### PR DESCRIPTION
## Description

Kubernetes publishing currently hardcodes runtime-only hostname parameter values and leaves hostless Ingress paths and Gateway routes as catch-all rules. This means `WithHostname(...)` does not provide the documented routing scope and `publishValueAsDefault: false` is not honored for these resources.

This change:

- preserves secrets and parameters without published defaults as owner-scoped Helm values;
- applies configured hostnames to hostless Ingress paths and Gateway `HTTPRoute` resources;
- keeps explicit per-route hostnames authoritative;
- preserves Kubernetes default backends as catch-all, including the existing TLS compatibility rule generation; and
- documents the hostname inheritance and default-backend behavior.

### User-facing usage

C# AppHost:

```csharp
var hostname = builder.AddParameter("hostname", "localhost");
var k8s = builder.AddKubernetesEnvironment("k8s");
var ingress = k8s.AddIngress("public")
    .WithHostname(hostname)
    .WithTls();

ingress.WithPath("/api", api.GetEndpoint("http"));
```

The generated Ingress now scopes the route and TLS configuration with a deploy-time value:

```yaml
spec:
  rules:
    - host: "{{ .Values.parameters.public.hostname }}"
  tls:
    - hosts:
        - "{{ .Values.parameters.public.hostname }}"
```

TypeScript AppHost:

```typescript
const k8s = await builder.addKubernetesEnvironment("k8s");
const ingress = await k8s.addIngress("public");
await ingress.withHostname("api.example.com");
await ingress.withIngressPath("/api", api.getEndpoint("http"));
```

### Validation

- `Aspire.Hosting.Kubernetes.Tests`: 287 passed
- `AzureKubernetesIngressTests`: 8 passed
- [Deployment E2E Tests](https://github.com/microsoft/aspire/actions/runs/32014982185): 42 of 42 deployment jobs passed

Fixes #17755

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No