### PR TITLE
Use Blazor gateway CLI during development

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -131,10 +131,8 @@
   </Folder>
   <Folder Name="/playground/BlazorStandalone/">
     <Project Path="playground/BlazorStandalone/BlazorStandalone.AppHost/BlazorStandalone.AppHost.csproj" />
-    <Project Path="playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/BlazorStandalone.ClientServiceDefaults.csproj" />
     <Project Path="playground/BlazorStandalone/BlazorStandalone.TimeApi/BlazorStandalone.TimeApi.csproj" />
     <Project Path="playground/BlazorStandalone/BlazorStandalone.WeatherApi/BlazorStandalone.WeatherApi.csproj" />
-    <Project Path="playground/BlazorStandalone/BlazorStandalone/BlazorStandalone.csproj" />
   </Folder>
   <Folder Name="/playground/AspireWithJavaScript/">
     <Project Path="playground/AspireWithJavaScript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -56,13 +56,16 @@
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />
 
-    <!-- Exclude only the MAUI client project as it requires the .NET MAUI workload.
+    <!-- Exclude the MAUI client project as it requires the .NET MAUI workload.
+         The BlazorStandalone browser projects require the separately installed .NET 11 SDK.
          Other projects in the AspireWithMaui playground can still be built.
          The aspireify-eval projects are intentionally un-aspirified sample apps used
          as eval inputs for the aspireify skill — they do not import the repo's
          Directory.Build.props/targets and are not meant to be built by CI. -->
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj"
                     Exclude="$(RepoRoot)playground\AspireWithMaui\AspireWithMaui.MauiClient\*.csproj;
+                             $(RepoRoot)playground\BlazorStandalone\BlazorStandalone\*.csproj;
+                             $(RepoRoot)playground\BlazorStandalone\BlazorStandalone.ClientServiceDefaults\*.csproj;
                              $(RepoRoot)playground\aspireify-eval\**\*.csproj"
                     Condition="'$(SkipPlaygroundProjects)' != 'true'"/>
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -157,6 +157,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.7.26381.103">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="9.0.14">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>19c07820cb72aafc554c3bc8fe3c54010f5123f0</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -153,6 +153,10 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
       <Sha>324a351f7f1ae6c17b6a8661903e2a7921a7d75c</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.Components.Gateway.Cli" Version="11.0.0-preview.7.26381.103">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e2c1e00b3d0f96afb892fb261d5921565b400246</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="9.0.14">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>19c07820cb72aafc554c3bc8fe3c54010f5123f0</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,6 +72,7 @@
   <PropertyGroup Label="BlazorAssets">
     <MicrosoftAspNetCoreAppInternalAssetsNet10Version>10.0.8</MicrosoftAspNetCoreAppInternalAssetsNet10Version>
     <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
+    <MicrosoftAspNetCoreComponentsGatewayCliVersion>11.0.0-preview.7.26381.103</MicrosoftAspNetCoreComponentsGatewayCliVersion>
   </PropertyGroup>
   <!-- .NET 11.0 Package Versions used by project templates -->
   <PropertyGroup Label="Net11Preview">

--- a/playground/BlazorStandalone/BlazorStandalone.AppHost/AppHost.cs
+++ b/playground/BlazorStandalone/BlazorStandalone.AppHost/AppHost.cs
@@ -11,7 +11,7 @@ var timeApi = builder.AddProject<Projects.BlazorStandalone_TimeApi>("timeapi")
 // The resource name becomes the URL path prefix (e.g., "app" → served at /app/).
 // WithReference declares service dependencies that the gateway will proxy via YARP.
 // Using a specific named endpoint ensures only that endpoint is forwarded to the gateway.
-var blazorApp = builder.AddBlazorWasmProject<Projects.BlazorStandalone>("app")
+var blazorApp = builder.AddBlazorWasmApp("app", "../BlazorStandalone/BlazorStandalone.csproj")
     .WithReference(weatherApi)
     .WithReference(timeApi.GetEndpoint("api"));
 

--- a/playground/BlazorStandalone/BlazorStandalone.AppHost/BlazorStandalone.AppHost.csproj
+++ b/playground/BlazorStandalone/BlazorStandalone.AppHost/BlazorStandalone.AppHost.csproj
@@ -24,10 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BlazorStandalone.WeatherApi\BlazorStandalone.WeatherApi.csproj" />
-    <ProjectReference Include="..\BlazorStandalone.TimeApi\BlazorStandalone.TimeApi.csproj" />
-    <!-- WASM project reference needed for IProjectMetadata discovery by AddBlazorWasmProject -->
-    <ProjectReference Include="..\BlazorStandalone\BlazorStandalone.csproj" />
+    <ProjectReference Include="..\BlazorStandalone.WeatherApi\BlazorStandalone.WeatherApi.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\BlazorStandalone.TimeApi\BlazorStandalone.TimeApi.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
 </Project>

--- a/playground/BlazorStandalone/BlazorStandalone.AppHost/BlazorStandalone.AppHost.csproj
+++ b/playground/BlazorStandalone/BlazorStandalone.AppHost/BlazorStandalone.AppHost.csproj
@@ -18,6 +18,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Blazor" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Dotnet" />
     <!-- AppHost runs on .NET 10; pin Http to 10.x to match Aspire.Hosting -->
     <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="$(MicrosoftExtensionsHttpPreviewVersion)" />
   </ItemGroup>

--- a/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/BlazorStandalone.ClientServiceDefaults.csproj
+++ b/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/BlazorStandalone.ClientServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/Extensions.cs
+++ b/playground/BlazorStandalone/BlazorStandalone.ClientServiceDefaults/Extensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
@@ -65,17 +66,15 @@ public static class BlazorClientExtensions
         var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
         var otlpEndpoint = new Uri(baseAddress, $"{otlpPathBase}/");
 
-        // Wire HttpClientFactory for all OTLP exporter instances via IPostConfigureOptions.
-        // This runs during options resolution for all 3 signals (traces, metrics, logging),
-        // and has access to the DI container to resolve ILoggerFactory.
-        builder.Services.AddSingleton<IPostConfigureOptions<OtlpExporterOptions>>(sp =>
+        // Resolving ILoggerFactory while OtlpExporterOptions are being created cycles back through
+        // the OpenTelemetry logger provider on .NET 11. Remove this workaround when
+        // https://github.com/dotnet/aspnetcore/issues/67259 is fixed.
+        var exporterLogger = NullLoggerFactory.Instance.CreateLogger("Aspire.OtlpExport");
+        builder.Services.AddSingleton<IPostConfigureOptions<OtlpExporterOptions>>(
+            new PostConfigureOptions<OtlpExporterOptions>(null, options =>
         {
-            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("Aspire.OtlpExport");
-            return new PostConfigureOptions<OtlpExporterOptions>(null, o =>
-            {
-                o.HttpClientFactory = () => new HttpClient(new BackgroundExportHandler(pipeline, logger));
-            });
-        });
+            options.HttpClientFactory = () => new HttpClient(new BackgroundExportHandler(pipeline, exporterLogger));
+        }));
 
         builder.Logging.AddOpenTelemetry(logging =>
         {

--- a/playground/BlazorStandalone/BlazorStandalone/BlazorStandalone.csproj
+++ b/playground/BlazorStandalone/BlazorStandalone/BlazorStandalone.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Enable WebAssembly diagnostics for OpenTelemetry tracing -->
@@ -9,6 +9,7 @@
     <EventSourceSupport>true</EventSourceSupport>
     <!-- Enable Activity/DiagnosticSource support for distributed tracing -->
     <HttpActivityPropagationSupport>true</HttpActivityPropagationSupport>
+    <StaticWebAssetSpaFallbackEnabled>true</StaticWebAssetSpaFallbackEnabled>
   </PropertyGroup>
 
   <!-- Runtime configuration options for HttpClient activity propagation -->
@@ -20,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />

--- a/playground/BlazorStandalone/Directory.Build.props
+++ b/playground/BlazorStandalone/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..'))</RepoRoot>
+    <RepositoryEngineeringDir>$(RepoRoot)eng\</RepositoryEngineeringDir>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+</Project>

--- a/playground/BlazorStandalone/Directory.Packages.props
+++ b/playground/BlazorStandalone/Directory.Packages.props
@@ -1,10 +1,18 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <!-- Pin packages compatible with net10.0 and the WASM client. -->
+  <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled
+      Condition="'$(MSBuildProjectName)' == 'BlazorStandalone' or '$(MSBuildProjectName)' == 'BlazorStandalone.ClientServiceDefaults'">false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!-- Pin the .NET 11 Preview 7 packages that provide the SDK-generated SPA fallback contract. -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftAspNetCoreComponentsGatewayCliVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftAspNetCoreComponentsGatewayCliVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftAspNetCoreComponentsGatewayCliVersion)" />
+    <PackageVersion Update="Microsoft.Extensions.Configuration.EnvironmentVariables"
+                    Version="$(MicrosoftAspNetCoreComponentsGatewayCliVersion)"
+                    Condition="'$(MSBuildProjectName)' == 'BlazorStandalone' or '$(MSBuildProjectName)' == 'BlazorStandalone.ClientServiceDefaults'" />
   </ItemGroup>
 </Project>

--- a/playground/BlazorStandalone/README.md
+++ b/playground/BlazorStandalone/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to integrate a **standalone Blazor WebAssembly** application with Aspire, enabling full observability (logs, traces) and service discovery without requiring a hosted Blazor Server backend.
 
-During local development, the gateway runs from the official .NET tool and requires the .NET 11 Preview 7 SDK or later. Publishing continues to use the generated file-based gateway.
+During local development, the gateway runs from the official .NET tool and requires the .NET 11 Preview 7 SDK or later. The standalone client targets .NET 11 and enables the SDK's `StaticWebAssetSpaFallbackEnabled` fallback generation. Publishing continues to use the generated file-based gateway.
 
 ## Overview
 

--- a/playground/BlazorStandalone/README.md
+++ b/playground/BlazorStandalone/README.md
@@ -2,9 +2,11 @@
 
 This sample demonstrates how to integrate a **standalone Blazor WebAssembly** application with Aspire, enabling full observability (logs, traces) and service discovery without requiring a hosted Blazor Server backend.
 
+During local development, the gateway runs from the official .NET tool and requires the .NET 11 Preview 7 SDK or later. Publishing continues to use the generated file-based gateway.
+
 ## Overview
 
-For **standalone** Blazor WebAssembly applications, there is no server-side Blazor host. This sample uses the `Aspire.Hosting.Blazor` package to automatically generate a **Gateway** (an ASP.NET Core + YARP reverse proxy) that:
+For **standalone** Blazor WebAssembly applications, there is no server-side Blazor host. This sample uses the `Aspire.Hosting.Blazor` package to run the official Blazor **Gateway** (an ASP.NET Core + YARP reverse proxy) that:
 
 - Serves the WASM static files under a path prefix (e.g., `/app/`)
 - Exposes a `/_blazor/_configuration` endpoint with service URLs and OTLP settings
@@ -62,11 +64,11 @@ var gateway = builder.AddBlazorGateway("gateway")
 builder.Build().Run();
 ```
 
-At startup, the hosting layer:
+During development startup, the hosting layer:
 1. Reads the WASM project's `staticwebassets.build.json` manifest to locate static files
-2. Generates a `Gateway.cs` script that configures YARP routes for each WASM client
+2. Configures the official `Microsoft.AspNetCore.Components.Gateway.Cli` tool for each WASM client
 3. Builds a client configuration JSON with service URLs and OTLP settings
-4. Launches the gateway as a project resource
+4. Launches the gateway CLI while preserving the gateway's project resource in the Aspire dashboard
 
 ### Step 2: Gateway Exposes Configuration Endpoint
 

--- a/playground/BlazorStandalone/global.json
+++ b/playground/BlazorStandalone/global.json
@@ -1,0 +1,17 @@
+{
+  "sdk": {
+    "version": "11.0.100-preview.7.26381.103",
+    "rollForward": "latestPatch",
+    "allowPrerelease": true,
+    "paths": [
+      "$host$"
+    ]
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.0",
+    "Microsoft.Build.Traversal": "3.2.0",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26324.4",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26324.4",
+    "Microsoft.DotNet.SharedFramework.Sdk": "10.0.0-beta.26324.4"
+  }
+}

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -17,6 +17,7 @@
          app and the WASM client projects target this version, so published containers must use
          matching SDK/runtime base images. -->
     <BlazorGatewayDotNetImageTag>10.0</BlazorGatewayDotNetImageTag>
+    <BlazorWasmSdkImageTag>11.0.100-preview.7</BlazorWasmSdkImageTag>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,6 +29,10 @@
       <_Parameter1>BlazorGatewayDotNetImageTag</_Parameter1>
       <_Parameter2>$(BlazorGatewayDotNetImageTag)</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BlazorWasmSdkImageTag</_Parameter1>
+      <_Parameter2>$(BlazorWasmSdkImageTag)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="Utils\PathLookupHelper.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" Link="Utils\KnownRelationshipTypes.cs" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -21,6 +21,10 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>BlazorGatewayCliVersion</_Parameter1>
+      <_Parameter2>$(MicrosoftAspNetCoreComponentsGatewayCliVersion)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>BlazorGatewayDotNetImageTag</_Parameter1>
       <_Parameter2>$(BlazorGatewayDotNetImageTag)</_Parameter2>
     </AssemblyAttribute>

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.ApplicationModel.Docker;
@@ -13,6 +14,8 @@ using Microsoft.Extensions.Logging;
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // DockerfileBuilder is experimental
 #pragma warning disable ASPIRECSHARPAPPS001 // AddCSharpApp is experimental
 #pragma warning disable ASPIREDOTNETPROJECT001 // AddDotnetProject is experimental
+#pragma warning disable ASPIREEXTENSION001 // WithLaunchToolArgs is experimental
+#pragma warning disable ASPIREPROJECTS001 // ProjectLaunchArgsOverrideAnnotation is experimental
 
 namespace Aspire.Hosting;
 
@@ -22,14 +25,16 @@ namespace Aspire.Hosting;
 [Experimental("ASPIREBLAZOR001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public static class BlazorGatewayExtensions
 {
+    private static readonly string s_blazorGatewayCliVersion = GetAssemblyMetadataValue("BlazorGatewayCliVersion");
     private static readonly string s_dotNetImageTag = GetDotNetImageTag();
     private const string DotNetSdkImageRepo = "mcr.microsoft.com/dotnet/sdk";
     private const string DotNetAspNetImageRepo = "mcr.microsoft.com/dotnet/aspnet";
+    private const string BlazorGatewayCliPackageId = "Microsoft.AspNetCore.Components.Gateway.Cli";
 
     /// <summary>
-    /// Registers the built-in Blazor Gateway as a file-based C# app.
-    /// The gateway is shipped as Gateway.cs alongside this library and launched
-    /// via <c>AddCSharpApp</c>. No separate project is needed.
+    /// Registers the built-in Blazor Gateway.
+    /// During development the gateway runs from the official .NET tool. The file-based app
+    /// shipped with this package remains the publish implementation.
     /// </summary>
     [AspireExport]
     public static IResourceBuilder<ProjectResource> AddBlazorGateway(
@@ -41,6 +46,36 @@ public static class BlazorGatewayExtensions
             .WithHttpEndpoint()
             .WithHttpsEndpoint();
 
+        if (builder.ExecutionContext.IsRunMode)
+        {
+            // Keep the ProjectResource shape and project defaults for dashboard and endpoint behavior, but force
+            // process execution so IDEs do not launch the file-based app represented by its project metadata.
+            gateway
+                .WithAnnotation(new ExecutableAnnotation
+                {
+                    Command = "dotnet",
+                    WorkingDirectory = builder.AppHostDirectory
+                })
+                .WithAnnotation(new ProjectLaunchArgsOverrideAnnotation(["run"]))
+                .WithLaunchToolArgs(context =>
+                {
+                    context.Args.Add("tool");
+                    context.Args.Add("exec");
+                    context.Args.Add(BlazorGatewayCliPackageId);
+                    context.Args.Add("--version");
+                    context.Args.Add(s_blazorGatewayCliVersion);
+                    context.Args.Add("--yes");
+                    context.Args.Add("--");
+                }, showInCommandLine: false)
+                .WithArgs(
+                    "--environment", builder.Environment.EnvironmentName,
+                    "--Logging:LogLevel:Microsoft=Warning",
+                    "--Logging:LogLevel:Microsoft.Hosting.Lifetime=Information",
+                    "--Logging:LogLevel:System.Net.Http.HttpClient.OtlpExporter=Warning")
+                .WithRequiredCommand(
+                    "dotnet",
+                    context => ValidateDotnetSdkVersionAsync(context, builder.AppHostDirectory));
+        }
         if (builder.ExecutionContext.IsPublishMode)
         {
             var gatewayDir = Path.GetDirectoryName(gatewayPath)!;
@@ -777,5 +812,102 @@ public static class BlazorGatewayExtensions
         }
 
         return tag;
+    }
+
+    private static string GetAssemblyMetadataValue(string key)
+    {
+        return typeof(BlazorGatewayExtensions).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyMetadataAttribute), inherit: false)
+            .OfType<System.Reflection.AssemblyMetadataAttribute>()
+            .FirstOrDefault(attribute => attribute.Key == key)
+            ?.Value
+            ?? throw new InvalidOperationException($"Assembly metadata '{key}' is required.");
+    }
+
+    private static async Task<RequiredCommandValidationResult> ValidateDotnetSdkVersionAsync(
+        RequiredCommandValidationContext context,
+        string workingDirectory)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = context.ResolvedPath,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        process.StartInfo.ArgumentList.Add("--version");
+
+        if (!process.Start())
+        {
+            return context.Failure("The .NET SDK version could not be determined.");
+        }
+
+        // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(context.CancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(context.CancellationToken);
+        await process.WaitForExitAsync(context.CancellationToken).ConfigureAwait(false);
+        var stdout = (await stdoutTask.ConfigureAwait(false)).Trim();
+        var stderr = (await stderrTask.ConfigureAwait(false)).Trim();
+
+        var stableVersion = stdout.Split('-', 2)[0];
+        if (process.ExitCode == 0
+            && Version.TryParse(stableVersion, out var version)
+            && IsCompatibleDotnetSdkVersion(stdout, version))
+        {
+            return context.Success();
+        }
+
+        var detectedVersion = string.IsNullOrEmpty(stdout) ? "unknown" : stdout;
+        var details = string.IsNullOrEmpty(stderr) ? string.Empty : $" {stderr}";
+        return context.Failure(
+            $"The Blazor gateway requires the .NET 11 Preview 7 SDK or later. Detected version: {detectedVersion}.{details}");
+    }
+
+    internal static bool IsCompatibleDotnetSdkVersion(string versionText)
+    {
+        var stableVersion = versionText.Split('-', 2)[0];
+        return Version.TryParse(stableVersion, out var version)
+            && IsCompatibleDotnetSdkVersion(versionText, version);
+    }
+
+    private static bool IsCompatibleDotnetSdkVersion(string versionText, Version version)
+    {
+        if (version.Major > 11)
+        {
+            return true;
+        }
+
+        if (version.Major < 11)
+        {
+            return false;
+        }
+
+        var separatorIndex = versionText.IndexOf('-');
+        if (separatorIndex < 0)
+        {
+            return true;
+        }
+
+        var prerelease = versionText[(separatorIndex + 1)..];
+        if (prerelease.StartsWith("rc.", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        const string PreviewPrefix = "preview.";
+        if (!prerelease.StartsWith(PreviewPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var previewNumberEnd = prerelease.IndexOf('.', PreviewPrefix.Length);
+        var previewNumber = previewNumberEnd < 0
+            ? prerelease[PreviewPrefix.Length..]
+            : prerelease[PreviewPrefix.Length..previewNumberEnd];
+        return int.TryParse(previewNumber, out var value) && value >= 7;
     }
 }

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -27,6 +27,7 @@ public static class BlazorGatewayExtensions
 {
     private static readonly string s_blazorGatewayCliVersion = GetAssemblyMetadataValue("BlazorGatewayCliVersion");
     private static readonly string s_dotNetImageTag = GetDotNetImageTag();
+    private static readonly string s_blazorWasmSdkImageTag = GetAssemblyMetadataValue("BlazorWasmSdkImageTag");
     private const string DotNetSdkImageRepo = "mcr.microsoft.com/dotnet/sdk";
     private const string DotNetAspNetImageRepo = "mcr.microsoft.com/dotnet/aspnet";
     private const string BlazorGatewayCliPackageId = "Microsoft.AspNetCore.Components.Gateway.Cli";
@@ -364,13 +365,7 @@ public static class BlazorGatewayExtensions
                 await EndpointsManifestTransformer.MergeRuntimeManifestsAsync(manifests, mergedRuntimePath, context.Logger, context.CancellationToken).ConfigureAwait(false);
                 context.EnvironmentVariables["staticWebAssets"] = mergedRuntimePath;
 
-                GatewayConfigurationBuilder.EmitProxyConfiguration(
-                    context.EnvironmentVariables,
-                    registeredApps,
-                    gatewayEndpoint,
-                    httpGatewayEndpoint,
-                    httpOtlpEndpointUrl,
-                    proxyRouteOrder: int.MinValue);
+                GatewayConfigurationBuilder.EmitProxyConfiguration(context.EnvironmentVariables, registeredApps, gatewayEndpoint, httpGatewayEndpoint, httpOtlpEndpointUrl);
             });
         }
 
@@ -387,10 +382,24 @@ public static class BlazorGatewayExtensions
     private static ProjectInfo GetProjectInfo(string projectPath, string appHostDirectory)
     {
         var projectDir = Path.GetDirectoryName(projectPath)!;
-        var solutionRoot = Path.GetFullPath(Path.Combine(appHostDirectory, ".."));
+        var solutionRoot = GetSolutionRoot(appHostDirectory);
         var relativeProjectPath = Path.GetRelativePath(solutionRoot, projectDir)
             .Replace('\\', '/');
         return new ProjectInfo(solutionRoot, relativeProjectPath);
+    }
+
+    internal static string GetSolutionRoot(string appHostDirectory)
+    {
+        for (var directory = new DirectoryInfo(appHostDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (directory.EnumerateFiles("*.sln", SearchOption.TopDirectoryOnly).Any()
+                || directory.EnumerateFiles("*.slnx", SearchOption.TopDirectoryOnly).Any())
+            {
+                return directory.FullName;
+            }
+        }
+
+        return Path.GetFullPath(Path.Combine(appHostDirectory, ".."));
     }
 
     private static void MirrorGatewayStateToClients<TGateway>(IResourceBuilder<TGateway> gateway)
@@ -545,22 +554,19 @@ public static class BlazorGatewayExtensions
             .WithImage("placeholder")
             .WithContainerFilesSource("/app/output");
 
-        companion.WithDockerfileFactory(project.SolutionRoot, ctx =>
+        companion.WithDockerfileFactory(project.SolutionRoot, async context =>
         {
-            return $$"""
-                FROM {{DotNetSdkImageRepo}}:{{s_dotNetImageTag}} AS build
-                WORKDIR /src
-                COPY . .
-                RUN dotnet publish "{{relativeProjectPath}}" -c Release -o /app/publish
+            ILogger logger = context.Services.GetService<ILogger<BlazorWasmAppResource>>() is { } typedLogger
+                ? typedLogger
+                : Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+            var targetFramework = await BlazorWasmAppBuilder.GetTargetFrameworkAsync(
+                wasmApp.Resource.ProjectPath,
+                logger,
+                context.CancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Unable to determine the target framework for '{wasmApp.Resource.ProjectPath}'.");
 
-                # Prefix asset paths and add SPA fallback endpoint
-                RUN mkdir -p /app/output/wwwroot/{{pathPrefix}} && \
-                    cp -r /app/publish/wwwroot/* /app/output/wwwroot/{{pathPrefix}}/ && \
-                    dotnet run "{{scriptRelativePath}}" -- \
-                        /app/publish/*.staticwebassets.endpoints.json \
-                        {{pathPrefix}} \
-                        /app/output/{{pathPrefix}}.endpoints.json
-                """;
+            var sdkImageTag = GetBlazorWasmSdkImageTag(targetFramework);
+            return BuildBlazorWasmPublishDockerfile(relativeProjectPath, scriptRelativePath, pathPrefix, sdkImageTag);
         });
 
         gateway.WithAnnotation(new ContainerFilesDestinationAnnotation
@@ -568,6 +574,35 @@ public static class BlazorGatewayExtensions
             Source = companion.Resource,
             DestinationPath = "."
         });
+    }
+
+    internal static string BuildBlazorWasmPublishDockerfile(
+        string relativeProjectPath,
+        string scriptRelativePath,
+        string pathPrefix,
+        string sdkImageTag)
+    {
+        return $$"""
+            FROM {{DotNetSdkImageRepo}}:{{sdkImageTag}} AS build
+            WORKDIR /src
+            COPY . .
+            RUN dotnet publish "{{relativeProjectPath}}" -c Release -o /app/publish
+
+            # Prefix asset paths and add SPA fallback endpoint
+            RUN mkdir -p /app/output/wwwroot/{{pathPrefix}} && \
+                cp -r /app/publish/wwwroot/* /app/output/wwwroot/{{pathPrefix}}/ && \
+                dotnet run "{{scriptRelativePath}}" -- \
+                    /app/publish/*.staticwebassets.endpoints.json \
+                    {{pathPrefix}} \
+                    /app/output/{{pathPrefix}}.endpoints.json
+            """;
+    }
+
+    internal static string GetBlazorWasmSdkImageTag(string targetFramework)
+    {
+        return targetFramework.StartsWith("net11.", StringComparison.OrdinalIgnoreCase)
+            ? s_blazorWasmSdkImageTag
+            : s_dotNetImageTag;
     }
 
     private static string GetScriptPath(string scriptName)

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -51,6 +51,13 @@ public static class BlazorGatewayExtensions
             // Keep the ProjectResource shape and project defaults for dashboard and endpoint behavior, but force
             // process execution so IDEs do not launch the file-based app represented by its project metadata.
             gateway
+                .WithInitialState(new CustomResourceSnapshot
+                {
+                    ResourceType = "Project",
+                    Properties = [
+                        new(CustomResourceKnownProperties.Source, string.Empty)
+                    ]
+                })
                 .WithAnnotation(new ExecutableAnnotation
                 {
                     Command = "dotnet",
@@ -357,7 +364,13 @@ public static class BlazorGatewayExtensions
                 await EndpointsManifestTransformer.MergeRuntimeManifestsAsync(manifests, mergedRuntimePath, context.Logger, context.CancellationToken).ConfigureAwait(false);
                 context.EnvironmentVariables["staticWebAssets"] = mergedRuntimePath;
 
-                GatewayConfigurationBuilder.EmitProxyConfiguration(context.EnvironmentVariables, registeredApps, gatewayEndpoint, httpGatewayEndpoint, httpOtlpEndpointUrl);
+                GatewayConfigurationBuilder.EmitProxyConfiguration(
+                    context.EnvironmentVariables,
+                    registeredApps,
+                    gatewayEndpoint,
+                    httpGatewayEndpoint,
+                    httpOtlpEndpointUrl,
+                    proxyRouteOrder: int.MinValue);
             });
         }
 

--- a/src/Aspire.Hosting.Blazor/BlazorWasmAppBuilder.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorWasmAppBuilder.cs
@@ -21,7 +21,7 @@ internal static class BlazorWasmAppBuilder
     {
         var psi = new ProcessStartInfo
         {
-            FileName = GetDotNetCommandPath(),
+            FileName = "dotnet",
             Arguments = $"build \"{projectPath}\"",
             WorkingDirectory = Path.GetDirectoryName(projectPath)!,
             RedirectStandardOutput = true,
@@ -64,7 +64,7 @@ internal static class BlazorWasmAppBuilder
     {
         var psi = new ProcessStartInfo
         {
-            FileName = GetDotNetCommandPath(),
+            FileName = "dotnet",
             Arguments = $"msbuild \"{projectPath}\" -t:ResolveStaticWebAssetsConfiguration -getProperty:StaticWebAssetEndpointsBuildManifestPath -getProperty:StaticWebAssetDevelopmentManifestPath",
             WorkingDirectory = Path.GetDirectoryName(projectPath)!,
             RedirectStandardOutput = true,
@@ -122,20 +122,73 @@ internal static class BlazorWasmAppBuilder
         return (endpoints, runtime);
     }
 
-    private static string GetDotNetCommandPath()
+    public static async Task<string?> GetTargetFrameworkAsync(
+        string projectPath,
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
-        return Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } dotnetHostPath
-            ? dotnetHostPath
-            : "dotnet";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"msbuild \"{projectPath}\" -getProperty:TargetFramework -getProperty:TargetFrameworks",
+            WorkingDirectory = Path.GetDirectoryName(projectPath)!,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = StartProcess(psi, logger, projectPath);
+        if (process is null)
+        {
+            return null;
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            BlazorGatewayLog.MsBuildTargetFailed(logger, projectPath, stdout, stderr);
+            return null;
+        }
+
+        MSBuildPropertiesOutput? output;
+        try
+        {
+            output = JsonSerializer.Deserialize(stdout.Trim(), ManifestJsonContext.Default.MSBuildPropertiesOutput);
+        }
+        catch (JsonException ex)
+        {
+            BlazorGatewayLog.ManifestJsonParseFailed(logger, projectPath, ex);
+            return null;
+        }
+
+        var properties = output?.Properties;
+        if (!string.IsNullOrEmpty(properties?.TargetFramework))
+        {
+            return properties.TargetFramework;
+        }
+
+        return properties?.TargetFrameworks
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
     }
 
     private static Process? StartProcess(ProcessStartInfo startInfo, ILogger logger, string projectPath)
     {
         try
         {
+            // On Windows, Process.Start searches the AppHost executable directory before PATH.
+            // Resolve explicitly so the project-scoped global.json is evaluated by the PATH-selected SDK host.
+            startInfo.FileName = PathLookupHelper.ResolveExecutablePath(startInfo.FileName);
             return Process.Start(startInfo);
         }
-        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or FileNotFoundException)
         {
             BlazorGatewayLog.ProcessStartFailed(logger, startInfo.FileName, projectPath, ex.Message);
             return null;

--- a/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
@@ -23,7 +23,8 @@ internal static class GatewayConfigurationBuilder
         List<GatewayAppRegistration> apps,
         EndpointReference gatewayEndpoint,
         EndpointReference? httpGatewayEndpoint = null,
-        object? httpOtlpEndpoint = null)
+        object? httpOtlpEndpoint = null,
+        int? proxyRouteOrder = null)
     {
         var addedClusters = new HashSet<string>();
         var httpClientEndpoint = httpGatewayEndpoint ?? (gatewayEndpoint.IsHttp ? gatewayEndpoint : null);
@@ -64,7 +65,7 @@ internal static class GatewayConfigurationBuilder
                 reg.OtlpPrefix);
 
             EmitYarpRoutes(env, prefix, reg.Resource.Name, services, reg.ProxyBlazorTelemetry, addedClusters,
-                reg.OtlpPrefix, httpOtlpEndpoint);
+                reg.OtlpPrefix, httpOtlpEndpoint, proxyRouteOrder);
         }
 
         if (apps.Any(app => app.ProxyBlazorTelemetry))
@@ -134,7 +135,8 @@ internal static class GatewayConfigurationBuilder
         bool proxyBlazorTelemetry,
         HashSet<string>? addedClusters,
         string otlpPrefix = DefaultOtlpPrefix,
-        object? httpOtlpEndpoint = null)
+        object? httpOtlpEndpoint = null,
+        int? proxyRouteOrder = null)
     {
         var pathBase = prefix != null ? $"/{prefix}" : "";
 
@@ -146,6 +148,10 @@ internal static class GatewayConfigurationBuilder
             env[$"ReverseProxy__Routes__{routeId}__ClusterId"] = clusterId;
             env[$"ReverseProxy__Routes__{routeId}__Match__Path"] = $"{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}/{{**catch-all}}";
             env[$"ReverseProxy__Routes__{routeId}__Transforms__0__PathRemovePrefix"] = $"{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
+            if (proxyRouteOrder is not null)
+            {
+                env[$"ReverseProxy__Routes__{routeId}__Order"] = proxyRouteOrder.Value;
+            }
 
             // Use endpoint name as destination ID for named endpoints so multiple named
             // endpoints on the same service each get their own destination in the cluster.
@@ -162,6 +168,10 @@ internal static class GatewayConfigurationBuilder
             env[$"ReverseProxy__Routes__{otlpRouteId}__ClusterId"] = "cluster-otlp-dashboard";
             env[$"ReverseProxy__Routes__{otlpRouteId}__Match__Path"] = $"{pathBase}/{otlpPrefix}/{{**catch-all}}";
             env[$"ReverseProxy__Routes__{otlpRouteId}__Transforms__0__PathRemovePrefix"] = $"{pathBase}/{otlpPrefix}";
+            if (proxyRouteOrder is not null)
+            {
+                env[$"ReverseProxy__Routes__{otlpRouteId}__Order"] = proxyRouteOrder.Value;
+            }
 
             if (env.TryGetValue("OTEL_EXPORTER_OTLP_HEADERS", out var headersObj) && headersObj is string headersStr)
             {

--- a/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Blazor/GatewayConfigurationBuilder.cs
@@ -23,8 +23,7 @@ internal static class GatewayConfigurationBuilder
         List<GatewayAppRegistration> apps,
         EndpointReference gatewayEndpoint,
         EndpointReference? httpGatewayEndpoint = null,
-        object? httpOtlpEndpoint = null,
-        int? proxyRouteOrder = null)
+        object? httpOtlpEndpoint = null)
     {
         var addedClusters = new HashSet<string>();
         var httpClientEndpoint = httpGatewayEndpoint ?? (gatewayEndpoint.IsHttp ? gatewayEndpoint : null);
@@ -65,7 +64,7 @@ internal static class GatewayConfigurationBuilder
                 reg.OtlpPrefix);
 
             EmitYarpRoutes(env, prefix, reg.Resource.Name, services, reg.ProxyBlazorTelemetry, addedClusters,
-                reg.OtlpPrefix, httpOtlpEndpoint, proxyRouteOrder);
+                reg.OtlpPrefix, httpOtlpEndpoint);
         }
 
         if (apps.Any(app => app.ProxyBlazorTelemetry))
@@ -135,8 +134,7 @@ internal static class GatewayConfigurationBuilder
         bool proxyBlazorTelemetry,
         HashSet<string>? addedClusters,
         string otlpPrefix = DefaultOtlpPrefix,
-        object? httpOtlpEndpoint = null,
-        int? proxyRouteOrder = null)
+        object? httpOtlpEndpoint = null)
     {
         var pathBase = prefix != null ? $"/{prefix}" : "";
 
@@ -148,10 +146,6 @@ internal static class GatewayConfigurationBuilder
             env[$"ReverseProxy__Routes__{routeId}__ClusterId"] = clusterId;
             env[$"ReverseProxy__Routes__{routeId}__Match__Path"] = $"{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}/{{**catch-all}}";
             env[$"ReverseProxy__Routes__{routeId}__Transforms__0__PathRemovePrefix"] = $"{pathBase}/{svc.ApiPrefix}/{svc.ServiceName}";
-            if (proxyRouteOrder is not null)
-            {
-                env[$"ReverseProxy__Routes__{routeId}__Order"] = proxyRouteOrder.Value;
-            }
 
             // Use endpoint name as destination ID for named endpoints so multiple named
             // endpoints on the same service each get their own destination in the cluster.
@@ -168,10 +162,6 @@ internal static class GatewayConfigurationBuilder
             env[$"ReverseProxy__Routes__{otlpRouteId}__ClusterId"] = "cluster-otlp-dashboard";
             env[$"ReverseProxy__Routes__{otlpRouteId}__Match__Path"] = $"{pathBase}/{otlpPrefix}/{{**catch-all}}";
             env[$"ReverseProxy__Routes__{otlpRouteId}__Transforms__0__PathRemovePrefix"] = $"{pathBase}/{otlpPrefix}";
-            if (proxyRouteOrder is not null)
-            {
-                env[$"ReverseProxy__Routes__{otlpRouteId}__Order"] = proxyRouteOrder.Value;
-            }
 
             if (env.TryGetValue("OTEL_EXPORTER_OTLP_HEADERS", out var headersObj) && headersObj is string headersStr)
             {

--- a/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
+++ b/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -24,6 +25,13 @@ internal static class EndpointsManifestTransformer
             ManifestJsonContext.Default.EndpointsManifest)
             ?? throw new InvalidOperationException($"Failed to deserialize endpoints manifest from '{manifestPath}'.");
 
+        // .NET 11 can generate SPA fallback endpoints when StaticWebAssetSpaFallbackEnabled is set.
+        // Replace SDK-generated or previously transformed fallbacks so the gateway has one identity
+        // fallback with the route shape and content-encoding behavior expected by this integration.
+        manifest.Endpoints = manifest.Endpoints
+            .Where(endpoint => endpoint.Route is not ("{**fallback:nonfile}" or "{**path:nonfile}"))
+            .ToArray();
+
         var fallbackEndpoints = new List<EndpointEntry>();
 
         foreach (var ep in manifest.Endpoints)
@@ -43,7 +51,13 @@ internal static class EndpointsManifestTransformer
                     // Deep-clone via round-trip serialization, then patch route and cache header
                     var fallbackJson = JsonSerializer.Serialize(ep, ManifestJsonContext.Relaxed.EndpointEntry);
                     var fallback = JsonSerializer.Deserialize(fallbackJson, ManifestJsonContext.Default.EndpointEntry)!;
-                    fallback.Route = "{**path:nonfile}";
+                    fallback.Route = "{**fallback:nonfile}";
+                    // The official gateway maps configuration and proxy endpoints alongside static assets.
+                    // Keep the SPA fallback last so those endpoints handle matching requests first.
+                    fallback.ExtensionData ??= [];
+                    fallback.ExtensionData["Order"] = JsonSerializer.SerializeToElement(
+                        int.MaxValue.ToString(CultureInfo.InvariantCulture),
+                        ManifestJsonContext.Default.String);
                     if (fallback.ResponseHeaders is not null)
                     {
                         foreach (var header in fallback.ResponseHeaders)

--- a/src/Aspire.Hosting.Blazor/Manifests/MSBuildPropertiesOutput.cs
+++ b/src/Aspire.Hosting.Blazor/Manifests/MSBuildPropertiesOutput.cs
@@ -18,6 +18,8 @@ internal sealed class MSBuildManifestProperties
 {
     public string StaticWebAssetEndpointsBuildManifestPath { get; set; } = "";
     public string StaticWebAssetDevelopmentManifestPath { get; set; } = "";
+    public string TargetFramework { get; set; } = "";
+    public string TargetFrameworks { get; set; } = "";
 
     [JsonExtensionData]
     public Dictionary<string, System.Text.Json.JsonElement>? ExtensionData { get; set; }

--- a/src/Aspire.Hosting.Blazor/Manifests/ManifestJsonContext.cs
+++ b/src/Aspire.Hosting.Blazor/Manifests/ManifestJsonContext.cs
@@ -15,6 +15,7 @@ namespace Aspire.Hosting;
 [JsonSerializable(typeof(EndpointsManifest))]
 [JsonSerializable(typeof(DevelopmentManifest))]
 [JsonSerializable(typeof(MSBuildPropertiesOutput))]
+[JsonSerializable(typeof(string))]
 [JsonSourceGenerationOptions(
     WriteIndented = true)]
 internal partial class ManifestJsonContext : JsonSerializerContext

--- a/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
+++ b/src/Aspire.Hosting.Blazor/Scripts/Gateway.cs.in
@@ -88,7 +88,7 @@ foreach (var appConfig in appConfigs.Values)
         app.MapGroup(appConfig.PathPrefix!).MapStaticAssets(appConfig.EndpointsManifest)
             .Add(ep =>
             {
-                if (ep is RouteEndpointBuilder reb && reb.RoutePattern.RawText?.Contains("{**path") == true)
+                if (ep is RouteEndpointBuilder reb && reb.RoutePattern.RawText?.Contains(":nonfile}", StringComparison.Ordinal) == true)
                 {
                     reb.Order = int.MaxValue;
                 }

--- a/src/Aspire.Hosting.Blazor/Scripts/PrefixEndpoints.cs
+++ b/src/Aspire.Hosting.Blazor/Scripts/PrefixEndpoints.cs
@@ -14,6 +14,7 @@
 //
 // Usage: dotnet run PrefixEndpoints.cs -- <manifest-path> <prefix> <output-path>
 
+using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -31,6 +32,10 @@ var outputPath = args[2];
 var manifest = JsonSerializer.Deserialize(
     File.ReadAllText(manifestPath),
     ManifestJsonContext.Default.EndpointsManifest)!;
+
+manifest.Endpoints = manifest.Endpoints
+    .Where(endpoint => endpoint.Route is not ("{**fallback:nonfile}" or "{**path:nonfile}"))
+    .ToArray();
 
 var fallbackEndpoints = new List<EndpointEntry>();
 
@@ -51,7 +56,11 @@ foreach (var ep in manifest.Endpoints)
             // Deep-clone via round-trip serialization, then patch route and cache header
             var fallbackJson = JsonSerializer.Serialize(ep, ManifestJsonContext.Default.EndpointEntry);
             var fallback = JsonSerializer.Deserialize(fallbackJson, ManifestJsonContext.Default.EndpointEntry)!;
-            fallback.Route = "{**path:nonfile}";
+            fallback.Route = "{**fallback:nonfile}";
+            fallback.ExtensionData ??= [];
+            fallback.ExtensionData["Order"] = JsonSerializer.SerializeToElement(
+                int.MaxValue.ToString(CultureInfo.InvariantCulture),
+                ManifestJsonContext.Default.String);
             if (fallback.ResponseHeaders is not null)
             {
                 foreach (var header in fallback.ResponseHeaders)
@@ -118,6 +127,7 @@ class EndpointResponseHeader
 
 [JsonSerializable(typeof(EndpointsManifest))]
 [JsonSerializable(typeof(EndpointEntry))]
+[JsonSerializable(typeof(string))]
 [JsonSourceGenerationOptions(
     WriteIndented = true)]
 partial class ManifestJsonContext : JsonSerializerContext

--- a/src/Shared/Model/ResourceSourceViewModel.cs
+++ b/src/Shared/Model/ResourceSourceViewModel.cs
@@ -9,6 +9,13 @@ internal record ResourceSource(string Value, string OriginalValue)
 {
     public static ResourceSource? GetSourceModel(string? resourceType, IReadOnlyDictionary<string, string?> properties)
     {
+        // An explicitly empty source suppresses the inferred project, executable, or container source.
+        if (properties.TryGetValue(KnownProperties.Resource.Source, out var explicitSource) &&
+            explicitSource is { Length: 0 })
+        {
+            return null;
+        }
+
         // NOTE project and tools are also executables, so check for those first
         if (string.Equals(resourceType, KnownResourceTypes.Project, StringComparisons.ResourceType) &&
             properties.TryGetValue(KnownProperties.Project.Path, out var projectPath) &&

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -175,6 +175,18 @@ public sealed class ResourceSourceViewModelTests
                 ValueToVisualize: "source-value",
                 Tooltip: "source-value"));
 
+        // Explicitly empty source suppresses inferred source metadata.
+        data.Add(new TestData(
+                ResourceType: "Project",
+                ExecutablePath: "path/to/executable",
+                ExecutableArguments: ["arg1"],
+                AppArgs: ["arg1"],
+                AppArgsSensitivity: [false],
+                ProjectPath: "path/to/project",
+                ContainerImage: null,
+                SourceProperty: string.Empty),
+            null);
+
         // Executable path without arguments
         data.Add(new TestData(
                 ResourceType: "Executable",

--- a/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
@@ -117,6 +117,61 @@ public class AddBlazorGatewayTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void BlazorWasmPublishCompanion_UsesNet11Sdk()
+    {
+        var dockerfile = BlazorGatewayExtensions.BuildBlazorWasmPublishDockerfile(
+            "Blazor/Blazor.csproj",
+            ".aspire/scripts/PrefixEndpoints.cs",
+            "app",
+            BlazorGatewayExtensions.GetBlazorWasmSdkImageTag("net11.0"));
+
+        Assert.StartsWith("FROM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7 AS build", dockerfile);
+        Assert.Contains("RUN dotnet publish \"Blazor/Blazor.csproj\" -c Release -o /app/publish", dockerfile);
+    }
+
+    [Theory]
+    [InlineData("net8.0", "10.0")]
+    [InlineData("net10.0", "10.0")]
+    [InlineData("net11.0", "11.0.100-preview.7")]
+    public void GetBlazorWasmSdkImageTag_SelectsCompatibleSdk(string targetFramework, string expected)
+    {
+        Assert.Equal(expected, BlazorGatewayExtensions.GetBlazorWasmSdkImageTag(targetFramework));
+    }
+
+    [Fact]
+    public void GetSolutionRoot_UsesNearestSolutionAncestor()
+    {
+        var solutionRoot = Directory.CreateTempSubdirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(solutionRoot.FullName, "Test.slnx"), "<Solution />");
+            var appHostDirectory = Directory.CreateDirectory(Path.Combine(solutionRoot.FullName, "src", "AppHost")).FullName;
+
+            Assert.Equal(solutionRoot.FullName, BlazorGatewayExtensions.GetSolutionRoot(appHostDirectory));
+        }
+        finally
+        {
+            solutionRoot.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetSolutionRoot_WithoutSolution_UsesAppHostParent()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var appHostDirectory = Directory.CreateDirectory(Path.Combine(directory.FullName, "AppHost")).FullName;
+
+            Assert.Equal(directory.FullName, BlazorGatewayExtensions.GetSolutionRoot(appHostDirectory));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void WithBlazorClientApp_RunModeGateway_ForwardsServiceReferences()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
@@ -32,6 +32,12 @@ public class AddBlazorGatewayTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(builder.AppHostDirectory, executable.WorkingDirectory);
         Assert.Single(gateway.Resource.Annotations.OfType<ProjectLaunchArgsOverrideAnnotation>());
 
+        var initialSnapshot = Assert.Single(gateway.Resource.Annotations.OfType<ResourceSnapshotAnnotation>()).InitialSnapshot;
+        var source = Assert.Single(
+            initialSnapshot.Properties,
+            property => property.Name == CustomResourceKnownProperties.Source);
+        Assert.Equal(string.Empty, source.Value);
+
         Assert.Collection(
             gateway.Resource.Annotations.OfType<EndpointAnnotation>().OrderBy(endpoint => endpoint.Name),
             endpoint => Assert.Equal("http", endpoint.Name),

--- a/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/AddBlazorGatewayTests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable ASPIREDOCKERFILEBUILDER001 // DockerfileBuilder is experimental
+#pragma warning disable ASPIREPROJECTS001 // ProjectLaunchArgsOverrideAnnotation is experimental
+
+namespace Aspire.Hosting.Blazor.Tests;
+
+public class AddBlazorGatewayTests(ITestOutputHelper testOutputHelper)
+{
+    private const string GatewayPackageId = "Microsoft.AspNetCore.Components.Gateway.Cli";
+    private const string GatewayPackageVersion = "11.0.0-preview.7.26381.103";
+
+    [Fact]
+    public void AddBlazorGateway_PreservesProjectResourceApiAndUsesToolForRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        IResourceBuilder<ProjectResource> gateway = builder.AddBlazorGateway("gateway");
+
+        Assert.EndsWith(
+            Path.Combine("Scripts", "Gateway.cs"),
+            gateway.Resource.GetProjectMetadata().ProjectPath);
+
+        var executable = Assert.Single(gateway.Resource.Annotations.OfType<ExecutableAnnotation>());
+        Assert.Equal("dotnet", executable.Command);
+        Assert.Equal(builder.AppHostDirectory, executable.WorkingDirectory);
+        Assert.Single(gateway.Resource.Annotations.OfType<ProjectLaunchArgsOverrideAnnotation>());
+
+        Assert.Collection(
+            gateway.Resource.Annotations.OfType<EndpointAnnotation>().OrderBy(endpoint => endpoint.Name),
+            endpoint => Assert.Equal("http", endpoint.Name),
+            endpoint => Assert.Equal("https", endpoint.Name));
+    }
+
+    [Fact]
+    public async Task AddBlazorGateway_ConfiguresGatewayToolArguments()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var gateway = builder.AddBlazorGateway("gateway");
+        using var app = builder.Build();
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(gateway.Resource);
+
+        Assert.Collection(
+            args,
+            arg => Assert.Equal("tool", arg),
+            arg => Assert.Equal("exec", arg),
+            arg => Assert.Equal(GatewayPackageId, arg),
+            arg => Assert.Equal("--version", arg),
+            arg => Assert.Equal(GatewayPackageVersion, arg),
+            arg => Assert.Equal("--yes", arg),
+            arg => Assert.Equal("--", arg),
+            arg => Assert.Equal("--environment", arg),
+            arg => Assert.Equal(builder.Environment.EnvironmentName, arg),
+            arg => Assert.Equal("--Logging:LogLevel:Microsoft=Warning", arg),
+            arg => Assert.Equal("--Logging:LogLevel:Microsoft.Hosting.Lifetime=Information", arg),
+            arg => Assert.Equal("--Logging:LogLevel:System.Net.Http.HttpClient.OtlpExporter=Warning", arg));
+    }
+
+    [Theory]
+    [InlineData("10.0.201", false)]
+    [InlineData("11.0.100-preview.6.26359.118", false)]
+    [InlineData("11.0.100-preview.7.26381.103", true)]
+    [InlineData("11.0.100-preview.8.26400.1", true)]
+    [InlineData("11.0.100-rc.1.26400.1", true)]
+    [InlineData("11.0.100", true)]
+    [InlineData("12.0.100-preview.1.27000.1", true)]
+    [InlineData("invalid", false)]
+    public void IsCompatibleDotnetSdkVersion_RequiresNet11Preview7OrLater(string version, bool expected)
+    {
+        Assert.Equal(expected, BlazorGatewayExtensions.IsCompatibleDotnetSdkVersion(version));
+    }
+
+    [Fact]
+    public async Task AddBlazorGateway_InPublishMode_UsesFileBasedGateway()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        IResourceBuilder<ProjectResource> gateway = builder.AddBlazorGateway("gateway");
+
+        var container = Assert.Single(builder.Resources.OfType<ContainerResource>());
+        Assert.Equal("gateway", container.Name);
+
+        var build = Assert.Single(container.Annotations.OfType<DockerfileBuildAnnotation>());
+        Assert.NotNull(build.DockerfileFactory);
+
+        var context = new DockerfileFactoryContext
+        {
+            Services = builder.Services.BuildServiceProvider(),
+            Resource = container,
+            CancellationToken = CancellationToken.None
+        };
+
+        var dockerfile = await build.DockerfileFactory(context);
+
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build", dockerfile);
+        Assert.Contains("COPY Gateway.cs .", dockerfile);
+        Assert.Contains("RUN dotnet publish Gateway.cs -c Release -o /app/publish", dockerfile);
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/aspnet:10.0", dockerfile);
+        Assert.Contains("COPY --from=build /app/publish .", dockerfile);
+        Assert.Contains("ENTRYPOINT [\"dotnet\",\"Gateway.dll\"]", dockerfile);
+        Assert.DoesNotContain(GatewayPackageId, dockerfile);
+
+        Assert.Empty(gateway.Resource.Annotations.OfType<ProjectLaunchArgsOverrideAnnotation>());
+        Assert.Empty(gateway.Resource.Annotations.OfType<ExecutableAnnotation>());
+    }
+
+    [Fact]
+    public void WithBlazorClientApp_RunModeGateway_ForwardsServiceReferences()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var weatherApi = builder.AddProject<TestProjectMetadata>("weatherapi")
+            .WithHttpEndpoint();
+        var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj")
+            .WithReference(weatherApi);
+
+        var gateway = builder.AddBlazorGateway("gateway")
+            .WithBlazorClientApp(wasmApp);
+
+        var endpointReference = Assert.Single(
+            gateway.Resource.Annotations.OfType<EndpointReferenceAnnotation>(),
+            annotation => annotation.Resource.Name == "weatherapi");
+
+        Assert.True(endpointReference.UseAllEndpoints);
+        Assert.Same(gateway.Resource, wasmApp.Resource.Parent);
+    }
+
+    private sealed class TestProjectMetadata : IProjectMetadata
+    {
+        public string ProjectPath => "TestProject/TestProject.csproj";
+
+        public LaunchSettings LaunchSettings { get; } = new();
+    }
+}

--- a/tests/Aspire.Hosting.Blazor.Tests/EndpointsManifestTransformerTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/EndpointsManifestTransformerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json;
 
 namespace Aspire.Hosting.Blazor.Tests;
@@ -70,9 +71,69 @@ public class EndpointsManifestTransformerTests : IDisposable
         // Should have original + fallback
         Assert.Equal(2, transformed.Endpoints.Length);
 
-        var fallback = transformed.Endpoints.Single(ep => ep.Route == "{**path:nonfile}");
+        var fallback = transformed.Endpoints.Single(ep => ep.Route == "{**fallback:nonfile}");
         Assert.Equal("store/index.html", fallback.AssetFile);
+        Assert.Equal(JsonValueKind.String, fallback.ExtensionData!["Order"].ValueKind);
+        Assert.Equal(int.MaxValue.ToString(CultureInfo.InvariantCulture), fallback.ExtensionData!["Order"].GetString());
         Assert.Contains(fallback.ResponseHeaders!, h => h.Name == "Cache-Control" && h.Value == "no-store");
+    }
+
+    [Fact]
+    public async Task PrefixEndpointsAssetFile_ReplacesSdkGeneratedFallbackEndpoints()
+    {
+        var manifest = new EndpointsManifest
+        {
+            Endpoints =
+            [
+                new EndpointEntry
+                {
+                    Route = "index.html",
+                    AssetFile = "index.html",
+                    ResponseHeaders = [new EndpointResponseHeader { Name = "Cache-Control", Value = "max-age=3600" }]
+                },
+                new EndpointEntry
+                {
+                    Route = "{**fallback:nonfile}",
+                    AssetFile = "index.html",
+                    ExtensionData = new Dictionary<string, JsonElement>
+                    {
+                        ["Order"] = JsonSerializer.SerializeToElement(int.MaxValue.ToString(CultureInfo.InvariantCulture))
+                    }
+                },
+                new EndpointEntry
+                {
+                    Route = "{**fallback:nonfile}",
+                    AssetFile = "index.html.gz",
+                    Selectors = [new EndpointSelector { Name = "Content-Encoding" }],
+                    ExtensionData = new Dictionary<string, JsonElement>
+                    {
+                        ["Order"] = JsonSerializer.SerializeToElement(int.MaxValue.ToString(CultureInfo.InvariantCulture))
+                    }
+                }
+            ]
+        };
+
+        var manifestPath = Path.Combine(_tempDir, "endpoints.json");
+        await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(manifest, ManifestJsonContext.Default.EndpointsManifest));
+
+        var result = await EndpointsManifestTransformer.PrefixEndpointsAssetFileAsync(manifestPath, "store", CancellationToken.None);
+        var transformed = JsonSerializer.Deserialize(result, ManifestJsonContext.Default.EndpointsManifest)!;
+
+        Assert.Collection(
+            transformed.Endpoints,
+            endpoint =>
+            {
+                Assert.Equal("index.html", endpoint.Route);
+                Assert.Equal("store/index.html", endpoint.AssetFile);
+            },
+            fallback =>
+            {
+                Assert.Equal("{**fallback:nonfile}", fallback.Route);
+                Assert.Equal("store/index.html", fallback.AssetFile);
+                Assert.Null(fallback.Selectors);
+                Assert.Equal(JsonValueKind.String, fallback.ExtensionData!["Order"].ValueKind);
+                Assert.Equal(int.MaxValue.ToString(CultureInfo.InvariantCulture), fallback.ExtensionData!["Order"].GetString());
+            });
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
@@ -32,28 +32,6 @@ public class GatewayConfigurationBuilderTests(ITestOutputHelper testOutputHelper
     }
 
     [Fact]
-    public void EmitProxyConfiguration_WithProxyRouteOrder_PrioritizesApiAndOtlpRoutes()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-
-        var gateway = builder.AddProject<TestProjectMetadata>("gateway")
-            .WithHttpsEndpoint();
-        var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj");
-        var registration = new GatewayAppRegistration(wasmApp, "store", Svc("weatherapi"));
-        var env = new Dictionary<string, object>();
-
-        GatewayConfigurationBuilder.EmitProxyConfiguration(
-            env,
-            [registration],
-            gateway.GetEndpoint("https"),
-            httpOtlpEndpoint: "http://localhost:4318",
-            proxyRouteOrder: int.MinValue);
-
-        Assert.Equal(int.MinValue, env["ReverseProxy__Routes__route-store-weatherapi__Order"]);
-        Assert.Equal(int.MinValue, env["ReverseProxy__Routes__route-otlp-store__Order"]);
-    }
-
-    [Fact]
     public void EmitProxyConfiguration_EmitsYarpCluster_ForService()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/GatewayConfigurationBuilderTests.cs
@@ -32,6 +32,28 @@ public class GatewayConfigurationBuilderTests(ITestOutputHelper testOutputHelper
     }
 
     [Fact]
+    public void EmitProxyConfiguration_WithProxyRouteOrder_PrioritizesApiAndOtlpRoutes()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var gateway = builder.AddProject<TestProjectMetadata>("gateway")
+            .WithHttpsEndpoint();
+        var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj");
+        var registration = new GatewayAppRegistration(wasmApp, "store", Svc("weatherapi"));
+        var env = new Dictionary<string, object>();
+
+        GatewayConfigurationBuilder.EmitProxyConfiguration(
+            env,
+            [registration],
+            gateway.GetEndpoint("https"),
+            httpOtlpEndpoint: "http://localhost:4318",
+            proxyRouteOrder: int.MinValue);
+
+        Assert.Equal(int.MinValue, env["ReverseProxy__Routes__route-store-weatherapi__Order"]);
+        Assert.Equal(int.MinValue, env["ReverseProxy__Routes__route-otlp-store__Order"]);
+    }
+
+    [Fact]
     public void EmitProxyConfiguration_EmitsYarpCluster_ForService()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);


### PR DESCRIPTION
## Description

Standalone Blazor WebAssembly apps now use the official Blazor Gateway CLI during local development instead of launching Aspire's generated file-based gateway. This keeps development aligned with the ASP.NET Core gateway implementation while preserving the existing `AddBlazorGateway` API, project resource/dashboard experience, endpoints, certificates, telemetry, and client resource relationships.

The run-mode project resource is launched as a process through:

```text
dotnet tool exec Microsoft.AspNetCore.Components.Gateway.Cli --version 11.0.0-preview.7.26381.103 --yes -- ...
```

The CLI version is centrally pinned and requires the .NET 11 Preview 7 SDK or later. Publish behavior intentionally retains the generated `Gateway.cs` and its existing SDK 10 runtime image.

The standalone WASM client now targets .NET 11 Preview 7 and enables the SDK's canonical SPA fallback contract:

```xml
<TargetFramework>net11.0</TargetFramework>
<StaticWebAssetSpaFallbackEnabled>true</StaticWebAssetSpaFallbackEnabled>
```

Aspire removes SDK-generated or legacy fallback endpoints before adding one path-prefixed identity fallback using the canonical `{**fallback:nonfile}` route and string `Order="2147483647"`. The same transformation is used during publish. Existing net10 clients retain the SDK 10 publish image, while net11 clients use the Preview 7 SDK image.

The built-in gateway also suppresses the obsolete `Gateway.cs` source display while retaining its `ProjectResource` model shape.

### User-facing usage

The existing C# API is unchanged:

```csharp
var blazorApp = builder.AddBlazorWasmApp("app", "../Blazor/Blazor.csproj");

builder.AddBlazorGateway("gateway")
    .WithBlazorClientApp(blazorApp);
```

### Validation

- All 82 `Aspire.Hosting.Blazor.Tests` passed.
- All 8 `ResourceSourceViewModel` dashboard model cases passed.
- SDK 10 AppHost restore/build succeeds without warnings or errors.
- SDK 11 Preview 7 client restore/build succeeds without warnings or errors.
- The SDK-generated manifest contains identity and compressed `{**fallback:nonfile}` endpoints with string order.
- Aspire's transformed development and publish manifests contain exactly one prefixed identity fallback with no content-encoding selector.
- Playwright validates configuration JSON, weather/time service discovery, OTLP proxying, rendered UI, no browser console errors, and dashboard source suppression.
- A live run uses an SDK 10 AppHost/services with the project-scoped SDK 11 client and gateway CLI.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No