### PR TITLE
Update available external dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,28 +101,28 @@
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="NuGet.Resolver" Version="7.6.0" />
     <!-- external dependencies -->
-    <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <!-- axe-core accessibility engine wrapper for Playwright. The MIT-licensed .NET wrapper's
          major.minor tracks the embedded axe-core version, so 4.11.x runs axe-core 4.11.x.
          Test-only dependency; pinned to a version present on the dotnet-public feed mirror. -->
     <PackageVersion Include="Deque.AxeCore.Playwright" Version="4.11.3" />
     <PackageVersion Include="DnsClient" Version="1.8.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.83.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.83.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
-    <PackageVersion Include="Hex1b" Version="0.163.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.163.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.163.0" />
+    <PackageVersion Include="Hex1b" Version="0.165.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.165.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.165.0" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
-    <PackageVersion Include="JsonPatch.Net" Version="5.0.2" />
-    <PackageVersion Include="Markdig" Version="1.2.0" />
+    <PackageVersion Include="JsonPatch.Net" Version="5.0.3" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->
@@ -133,36 +133,36 @@
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.8.0" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="OpenAI" Version="2.12.0" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.200" />
-    <PackageVersion Include="Polly.Core" Version="8.6.6" />
-    <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
+    <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.300" />
+    <PackageVersion Include="Polly.Core" Version="8.7.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.7.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageVersion Include="Qdrant.Client" Version="1.18.1" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
+    <PackageVersion Include="Qdrant.Client" Version="1.19.0" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.2" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.5.0" />
     <PackageVersion Include="Tuf" Version="0.5.0" />
-    <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.48" />
+    <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.51" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryExporterOpenTelemetryProtocolVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryInstrumentationExtensionsHostingVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationAspNetCoreVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationHttpVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryInstrumentationRuntimeVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.17.0" />
     <!-- build dependencies -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
@@ -198,7 +198,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.8.0" />
     <!-- playground apps dependencies for javascript -->
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.57.0" />
+    <PackageVersion Include="Azure.Core" Version="1.61.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,12 +55,12 @@
     <MicrosoftExtensionsServiceDiscoveryVersion>10.8.0</MicrosoftExtensionsServiceDiscoveryVersion>
     <MicrosoftExtensionsServiceDiscoveryYarpVersion>10.8.0</MicrosoftExtensionsServiceDiscoveryYarpVersion>
     <!-- OpenTelemetry (OTel) -->
-    <OpenTelemetryInstrumentationAspNetCoreVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreVersion>
-    <OpenTelemetryInstrumentationHttpVersion>1.15.1</OpenTelemetryInstrumentationHttpVersion>
-    <OpenTelemetryInstrumentationExtensionsHostingVersion>1.15.3</OpenTelemetryInstrumentationExtensionsHostingVersion>
-    <OpenTelemetryInstrumentationRuntimeVersion>1.15.1</OpenTelemetryInstrumentationRuntimeVersion>
-    <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.15.3</OpenTelemetryExporterOpenTelemetryProtocolVersion>
-    <AzureMonitorOpenTelemetryExporterVersion>1.8.0</AzureMonitorOpenTelemetryExporterVersion>
+    <OpenTelemetryInstrumentationAspNetCoreVersion>1.17.0</OpenTelemetryInstrumentationAspNetCoreVersion>
+    <OpenTelemetryInstrumentationHttpVersion>1.17.0</OpenTelemetryInstrumentationHttpVersion>
+    <OpenTelemetryInstrumentationExtensionsHostingVersion>1.17.0</OpenTelemetryInstrumentationExtensionsHostingVersion>
+    <OpenTelemetryInstrumentationRuntimeVersion>1.17.0</OpenTelemetryInstrumentationRuntimeVersion>
+    <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.17.0</OpenTelemetryExporterOpenTelemetryProtocolVersion>
+    <AzureMonitorOpenTelemetryExporterVersion>1.8.3</AzureMonitorOpenTelemetryExporterVersion>
     <!-- Aspire.Cli uses a preview version of StreamJsonRpc which is needed for native AOT support. -->
     <StreamJsonRpcPackageVersionForCli>2.23.32-alpha</StreamJsonRpcPackageVersionForCli>
     <!-- MicroBuild.Core version for VS Code extension signing -->

--- a/playground/Qdrant/Qdrant.ApiService/Program.cs
+++ b/playground/Qdrant/Qdrant.ApiService/Program.cs
@@ -84,7 +84,7 @@ app.MapGet("/create", async (QdrantClient client, ILogger<Program> logger) =>
 
 app.MapGet("/search", async (QdrantClient client) =>
 {
-    var results = await client.SearchAsync("movie_collection", new[] { 0.12217915f, -0.034832448f }, limit: 3);
+    var results = await client.QueryAsync("movie_collection", new[] { 0.12217915f, -0.034832448f }, limit: 3);
     return results.Select(titles => titles.Payload["title"].StringValue);
 });
 

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -46,6 +46,13 @@
                   },
                   "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
                 },
+                "Compression": {
+                  "enum": [
+                    "None",
+                    "GZip"
+                  ],
+                  "description": "Gets or sets the compression method to use when sending telemetry."
+                },
                 "Endpoint": {
                   "type": "string",
                   "format": "uri",
@@ -104,6 +111,13 @@
                     }
                   },
                   "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                },
+                "Compression": {
+                  "enum": [
+                    "None",
+                    "GZip"
+                  ],
+                  "description": "Gets or sets the compression method to use when sending telemetry."
                 },
                 "Endpoint": {
                   "type": "string",

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -59,7 +59,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
 
             await CreateTestDataAsync(qdrantClient, token);
 
-            var results = await qdrantClient.SearchAsync(CollectionName, s_testVector, limit: 1, cancellationToken: token);
+            var results = await qdrantClient.QueryAsync(CollectionName, s_testVector, limit: 1, cancellationToken: token);
             Assert.Collection(results,
                 r => Assert.Equal("Test", r.Payload["title"].StringValue));
         }, cts.Token);
@@ -189,7 +189,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
                         {
                             var qdrantClient = host.Services.GetRequiredService<QdrantClient>();
 
-                            var results = await qdrantClient.SearchAsync(CollectionName, s_testVector, limit: 1, cancellationToken: token);
+                            var results = await qdrantClient.QueryAsync(CollectionName, s_testVector, limit: 1, cancellationToken: token);
                             Assert.Collection(results,
                                 r => Assert.Equal("Test", r.Payload["title"].StringValue));
                         }, cts.Token);


### PR DESCRIPTION
## Description

Updates external NuGet dependencies whose latest recommended versions are already available from the repository's internal feeds. Packages still awaiting internal-feed ingestion are intentionally deferred to a follow-up draft PR.

This also updates three Qdrant sample/test call sites from the obsolete `SearchAsync` API to `QueryAsync`, as required by Qdrant.Client 1.19.0, and aligns the OpenTelemetry package family at 1.17.0 where stable versions are available.

Validation:
- Repository restore succeeds using the configured internal feeds.
- Repository compilation completes; the final build target is blocked only by the local machine not having Windows SDK `makecat.exe` installed.
- Qdrant test project: 24 tests pass; 6 container functional tests cannot run because Docker Desktop is offline.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No