### PR TITLE
Restore dashboard unsecured endpoint FWLink

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -160,7 +160,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
                     options.Link = new()
                     {
                         Text = Loc[nameof(Resources.Layout.MessageUnsecuredEndpointLink)],
-                        Href = "https://aspire.dev/dashboard/security-considerations/",
+                        Href = "https://aka.ms/aspire/api-endpoint-unsecured",
                         Target = "_blank"
                     };
                     options.Intent = MessageIntent.Warning;


### PR DESCRIPTION
## Description

The unsecured endpoint warning in the dashboard UI should continue using the established `aka.ms` FWLink. A stable redirect allows the destination documentation to change without requiring a dashboard update.

This restores the message bar link from the direct security-considerations URL to `https://aka.ms/aspire/api-endpoint-unsecured`. No dashboard layout, authentication behavior, or security defaults are changed.

### User-facing usage

Selecting **More information** from the unsecured endpoint warning continues through the established FWLink to the current security guidance.

Validation: `dotnet build src/Aspire.Dashboard/Aspire.Dashboard.csproj --no-restore`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No