### PR TITLE
Stabilize the Java extension E2E shards: cache the Maven distribution, bound the recorder install, and fix a cleanup race

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -747,11 +747,43 @@ jobs:
       - name: Install E2E recorder
         if: ${{ matrix.useXvfb }}
         run: |
+          # ffmpeg only powers the diagnostic screen recordings, and run-e2e.js already skips
+          # recording with a warning when the binary is missing. So this step must never be able to
+          # fail or stall a shard: it is strictly a nice-to-have for debugging flakes after the fact.
+          #
+          # It used to call apt-get unguarded, which talks to the Azure Ubuntu mirrors. That is a
+          # network dependency with no timeout, and a degraded mirror has hung this step past the
+          # job timeout - taking down shards (including ones with no Java or recording relevance)
+          # that were otherwise healthy. Bound every call and give up quietly instead.
           if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
             ffmpeg -version | Select-Object -First 1
-          } else {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends ffmpeg
+          }
+          else {
+            $installed = $false
+            $attempts = 2
+
+            for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+              # `timeout` (coreutils) kills a stalled child and exits 124, which is what converts an
+              # unresponsive mirror into a retryable failure rather than an open-ended wait.
+              sudo timeout 180 apt-get update
+
+              # Only the install decides success: `apt-get update` can time out while the install
+              # still succeeds from the indices already on the runner image.
+              sudo timeout 180 apt-get install -y --no-install-recommends ffmpeg
+              if ($LASTEXITCODE -eq 0) {
+                $installed = $true
+                break
+              }
+
+              if ($attempt -lt $attempts) {
+                Write-Host "::warning::Attempt $attempt to install ffmpeg failed; retrying."
+                Start-Sleep -Seconds 15
+              }
+            }
+
+            if (-not $installed) {
+              Write-Host '::warning::ffmpeg could not be installed; E2E screen recordings are disabled for this shard.'
+            }
           }
 
       - name: Run extension E2E tests

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -533,13 +533,25 @@ jobs:
           # whole Spring dependency tree inside the test's readiness budget. Cache the user-level Maven
           # and Gradle stores rather than a per-project directory: the specs run out of a generated
           # workspace copied from the playground, so only the shared caches survive the copy.
+          #
+          # `~/.m2/wrapper` holds the Maven distribution itself, which `mvnw` downloads from
+          # repo.maven.apache.org into `${MAVEN_USER_HOME}/wrapper/dists` because these projects pin
+          # `distributionType=only-script`. Without it cached, every run re-fetched Maven from Maven
+          # Central, so a single outage there failed the shard - the `~/.gradle/wrapper` entry below
+          # already gave Gradle the equivalent protection.
           path: |
             ~/.m2/repository
+            ~/.m2/wrapper
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: java-e2e-${{ runner.os }}-${{ hashFiles('playground/JavaSpringBoot/**/pom.xml', 'playground/JavaSpringBoot/**/build.gradle*', 'playground/JavaSpringBoot/**/gradle-wrapper.properties') }}
+          # `maven-wrapper.properties` participates in the key for the same reason
+          # `gradle-wrapper.properties` does: it carries the pinned `distributionUrl`, so the cache has
+          # to rotate when the Maven version changes. The `v2` prefix forces one rebuild of the entry,
+          # because actions/cache skips the save step on an exact key hit and the previously stored
+          # caches predate `~/.m2/wrapper`.
+          key: java-e2e-v2-${{ runner.os }}-${{ hashFiles('playground/JavaSpringBoot/**/pom.xml', 'playground/JavaSpringBoot/**/build.gradle*', 'playground/JavaSpringBoot/**/gradle-wrapper.properties', 'playground/JavaSpringBoot/**/maven-wrapper.properties') }}
           restore-keys: |
-            java-e2e-${{ runner.os }}-
+            java-e2e-v2-${{ runner.os }}-
 
       - name: Warm the Java dependency caches
         if: ${{ matrix.installJava }}
@@ -554,6 +566,32 @@ jobs:
           #
           # A resolution failure must not fail the job - it only means the specs pay the download cost
           # they paid before this step existed.
+          #
+          # Retry before giving up, though. Both wrappers fetch their own distribution on a cold cache,
+          # and a failure there is not merely a slower run: it leaves no Maven on the runner at all, so
+          # the build inside the spec exits 1, the resource never starts, and the shard fails 15 minutes
+          # later as "Timed out after 900000ms waiting for an HTTP endpoint for resource 'catalog'"
+          # rather than as the download error it actually is.
+          warm() {
+            local description=$1
+            local directory=$2
+            shift 2
+
+            local attempt
+            for attempt in 1 2 3; do
+              if ( cd "$directory" && "$@" ); then
+                return 0
+              fi
+
+              if [ "$attempt" -lt 3 ]; then
+                echo "warning: pre-resolving $description failed (attempt $attempt/3), retrying"
+                sleep $((attempt * 15))
+              fi
+            done
+
+            echo "warning: could not pre-resolve $description"
+          }
+
           cd playground/JavaSpringBoot
           for maven_project in catalog worker; do
             # `dependency:go-offline` resolves the dependency tree but not every plugin a real build
@@ -562,11 +600,11 @@ jobs:
             # deliberately not reused: the specs copy the playground without `target/` so each run
             # builds clean, which is the same reason the Gradle project below is compiled rather than
             # only resolved.
-            (cd "$maven_project" && ./mvnw --batch-mode --no-transfer-progress -q dependency:go-offline compile) \
-              || echo "warning: could not pre-resolve Maven dependencies for $maven_project"
+            warm "Maven dependencies for $maven_project" "$maven_project" \
+              ./mvnw --batch-mode --no-transfer-progress -q dependency:go-offline compile
           done
-          (cd orders && ./gradlew --no-daemon --quiet compileJava) \
-            || echo 'warning: could not pre-resolve Gradle dependencies for orders'
+          warm "Gradle dependencies for orders" orders \
+            ./gradlew --no-daemon --quiet compileJava
 
       - name: Install Java E2E prerequisites
         if: ${{ matrix.installJava }}

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -786,6 +786,13 @@ jobs:
             }
           }
 
+          # GitHub's pwsh wrapper appends `if ((Test-Path variable:/LASTEXITCODE)) { exit $LASTEXITCODE }`,
+          # so a failed apt-get would otherwise fail this step through the leftover exit code and take
+          # the shard down over a missing diagnostic recorder. Exit explicitly to hold the
+          # "this step must never fail the job" contract.
+          # https://docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#exit-codes-and-error-action-preference
+          exit 0
+
       - name: Run extension E2E tests
         working-directory: extension
         env:

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -763,13 +763,16 @@ jobs:
             $attempts = 2
 
             for ($attempt = 1; $attempt -le $attempts; $attempt++) {
-              # `timeout` (coreutils) kills a stalled child and exits 124, which is what converts an
+              # `timeout` (coreutils) bounds a stalled child and exits 124, which is what converts an
               # unresponsive mirror into a retryable failure rather than an open-ended wait.
-              sudo timeout 180 apt-get update
+              # `--kill-after` matters: plain `timeout` only sends SIGTERM, and apt/dpkg block or
+              # defer signals around critical sections, so without the escalation to SIGKILL a
+              # wedged child could still outlive its own timeout.
+              sudo timeout --kill-after=30 180 apt-get update
 
               # Only the install decides success: `apt-get update` can time out while the install
               # still succeeds from the indices already on the runner image.
-              sudo timeout 180 apt-get install -y --no-install-recommends ffmpeg
+              sudo timeout --kill-after=30 180 apt-get install -y --no-install-recommends ffmpeg
               if ($LASTEXITCODE -eq 0) {
                 $installed = $true
                 break

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -545,13 +545,13 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           # `maven-wrapper.properties` participates in the key for the same reason
-          # `gradle-wrapper.properties` does: it carries the pinned `distributionUrl`, so the cache has
-          # to rotate when the Maven version changes. The `v2` prefix forces one rebuild of the entry,
-          # because actions/cache skips the save step on an exact key hit and the previously stored
-          # caches predate `~/.m2/wrapper`.
-          key: java-e2e-v2-${{ runner.os }}-${{ hashFiles('playground/JavaSpringBoot/**/pom.xml', 'playground/JavaSpringBoot/**/build.gradle*', 'playground/JavaSpringBoot/**/gradle-wrapper.properties', 'playground/JavaSpringBoot/**/maven-wrapper.properties') }}
+          # `gradle-wrapper.properties` does: it carries the pinned `distributionUrl`, so the entry has
+          # to rotate when the Maven version changes. Otherwise the key would still hit exactly after a
+          # version bump, actions/cache would skip the save, and the newly downloaded distribution would
+          # never make it into the cache.
+          key: java-e2e-${{ runner.os }}-${{ hashFiles('playground/JavaSpringBoot/**/pom.xml', 'playground/JavaSpringBoot/**/build.gradle*', 'playground/JavaSpringBoot/**/gradle-wrapper.properties', 'playground/JavaSpringBoot/**/maven-wrapper.properties') }}
           restore-keys: |
-            java-e2e-v2-${{ runner.os }}-
+            java-e2e-${{ runner.os }}-
 
       - name: Warm the Java dependency caches
         if: ${{ matrix.installJava }}

--- a/extension/scripts/e2e-download-cache.js
+++ b/extension/scripts/e2e-download-cache.js
@@ -32,6 +32,12 @@ const UNREADABLE_DIRECTORY_ERROR_CODES = new Set(['ENOENT', 'ENOTDIR', 'ELOOP', 
 const MAX_PUBLISH_ATTEMPTS = 8;
 const MAX_CANDIDATE_CREATE_ATTEMPTS = 3;
 
+// A late writer racing cleanup settles within a few hundred milliseconds once its process is gone,
+// so a handful of sweeps covers it while still failing fast against a process that never stops
+// writing. See removeDirectoryContentsAndSelf for why re-sweeping is what clears ENOTEMPTY.
+const MAX_DIRECTORY_SWEEP_RETRIES = 5;
+const DIRECTORY_SWEEP_RETRY_DELAY_MS = 100;
+
 // Candidates only exist while a download is in flight, so a non-generation group child this old is
 // debris left by a crash or by an older cache layout. Published generations are never swept on
 // age; see sweepAbandonedGroupChildren.
@@ -549,11 +555,51 @@ function removePathWithoutFollowingLinks(targetPath, options = {}) {
     return;
   }
 
-  for (const entry of fs.readdirSync(targetPath)) {
-    removePathWithoutFollowingLinks(path.join(targetPath, entry), options);
-  }
+  removeDirectoryContentsAndSelf(targetPath, options);
+}
 
-  removeEmptyDirectory(targetPath, options);
+/**
+ * Empties a directory and removes it, re-listing it when `rmdir` reports it is not empty.
+ *
+ * A directory can gain an entry between the listing and the `rmdir`: the Java language server and
+ * Maven/Gradle daemons keep writing for a moment after a test finishes, so a tree that was walked
+ * empty is not empty by the time it is removed. Observed in CI as a shard that passed its tests and
+ * then failed in cleanup with `ENOTEMPTY: directory not empty, rmdir`.
+ *
+ * Retrying the `rmdir` alone cannot clear that, because the entry that appeared is still on disk -
+ * only a fresh listing can remove it - which is why this re-sweeps instead of leaning on the
+ * `maxRetries` budget. That budget stays useful for its own case: on Windows a removed entry can
+ * linger until the last handle closes, and there retrying the same `rmdir` does eventually succeed.
+ */
+function removeDirectoryContentsAndSelf(directoryPath, options) {
+  for (let sweep = 0; ; sweep++) {
+    let entries;
+    try {
+      entries = fs.readdirSync(directoryPath);
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        return;
+      }
+
+      throw error;
+    }
+
+    for (const entry of entries) {
+      removePathWithoutFollowingLinks(path.join(directoryPath, entry), options);
+    }
+
+    try {
+      removeEmptyDirectory(directoryPath, options);
+      return;
+    } catch (error) {
+      // Bounded so a process writing continuously fails the cleanup instead of hanging the shard.
+      if (!error || error.code !== 'ENOTEMPTY' || sweep >= MAX_DIRECTORY_SWEEP_RETRIES) {
+        throw error;
+      }
+
+      sleepSync((sweep + 1) * DIRECTORY_SWEEP_RETRY_DELAY_MS);
+    }
+  }
 }
 
 function removeEmptyDirectory(directoryPath, options) {

--- a/extension/src/test/e2eDownloadCache.test.ts
+++ b/extension/src/test/e2eDownloadCache.test.ts
@@ -2147,12 +2147,13 @@ suite('E2E download cache', () => {
 
         // A process that never stops writing has to surface as a cleanup failure rather than hang
         // the shard, so the sweeps are bounded.
-        withLateWriterDuringRemoval(refilled, Number.POSITIVE_INFINITY, () => {
+        const writes = withLateWriterDuringRemoval(refilled, Number.POSITIVE_INFINITY, () => {
             assert.throws(
                 () => cache.removePathWithoutFollowingLinks(refilled, { maxRetries: 0, retryDelay: 1 }),
                 /ENOTEMPTY/);
         });
 
+        assert.strictEqual(writes, 6);
         assert.ok(fs.existsSync(refilled));
     });
 

--- a/extension/src/test/e2eDownloadCache.test.ts
+++ b/extension/src/test/e2eDownloadCache.test.ts
@@ -423,6 +423,36 @@ function withLockedDirectoryRemoval(directoryPath: string, failureCount: number,
     return attempts;
 }
 
+/**
+ * Drops a new file into `directoryPath` right after it is listed, reproducing the cleanup race
+ * where a Java language server or build daemon is still writing while the run root is torn down.
+ *
+ * Hooking the listing rather than racing a real writer keeps this deterministic - a timing-based
+ * version of this test would only reproduce the bug intermittently.
+ */
+function withLateWriterDuringRemoval(directoryPath: string, writeCount: number, body: () => void): number {
+    const nodeFs = require('fs') as typeof fs;
+    const realReaddirSync = nodeFs.readdirSync;
+    let writes = 0;
+
+    try {
+        nodeFs.readdirSync = ((target: fs.PathLike, ...rest: unknown[]) => {
+            const entries = (realReaddirSync as (...args: unknown[]) => unknown)(target, ...rest);
+            if (target === directoryPath && writes < writeCount) {
+                nodeFs.writeFileSync(path.join(directoryPath, `late-writer-${writes++}.log`), 'written after listing');
+            }
+
+            return entries;
+        }) as typeof fs.readdirSync;
+
+        body();
+    } finally {
+        nodeFs.readdirSync = realReaddirSync;
+    }
+
+    return writes;
+}
+
 async function waitForPaths(pathsToCheck: string[], timeoutMs: number): Promise<void> {
     const deadline = Date.now() + timeoutMs;
 
@@ -2092,6 +2122,38 @@ suite('E2E download cache', () => {
         });
 
         assert.strictEqual(attempts, 3);
+    });
+
+    test('re-sweeps a directory that gains an entry between listing and removal', () => {
+        const root = createTestRoot('link-safe-removal-late-writer');
+        const refilled = path.join(root, 'refilled');
+        writeFile(path.join(refilled, 'existing.txt'), 'existing');
+
+        // A retry of the same rmdir can never clear this: the entry that appeared is still on disk,
+        // so only a fresh listing removes it. maxRetries is 0 here, matching Linux CI, to show the
+        // recovery comes from re-sweeping rather than from the lock retry budget.
+        const writes = withLateWriterDuringRemoval(refilled, 1, () => {
+            cache.removePathWithoutFollowingLinks(refilled, { maxRetries: 0, retryDelay: 1 });
+        });
+
+        assert.strictEqual(writes, 1);
+        assert.strictEqual(fs.existsSync(refilled), false);
+    });
+
+    test('gives up on a directory that keeps being refilled during removal', () => {
+        const root = createTestRoot('link-safe-removal-sweep-budget');
+        const refilled = path.join(root, 'refilled');
+        writeFile(path.join(refilled, 'existing.txt'), 'existing');
+
+        // A process that never stops writing has to surface as a cleanup failure rather than hang
+        // the shard, so the sweeps are bounded.
+        withLateWriterDuringRemoval(refilled, Number.POSITIVE_INFINITY, () => {
+            assert.throws(
+                () => cache.removePathWithoutFollowingLinks(refilled, { maxRetries: 0, retryDelay: 1 }),
+                /ENOTEMPTY/);
+        });
+
+        assert.ok(fs.existsSync(refilled));
     });
 
     test('replaces stale projected entries so a reused storage directory tracks the cache', () => {        const root = createTestRoot('replaces-stale-projection');

--- a/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -38,6 +38,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)TemporaryWorkspace.cs" Link="shared/TemporaryWorkspace.cs" />
+    <!-- Resolves pwsh from PATH for the workflow step tests, which replace PATH with a stub directory. -->
+    <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="shared/PathLookupHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eRecorderStepTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eRecorderStepTests.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests.Pipelines;
+
+/// <summary>
+/// Runs the <c>Install E2E recorder</c> step of <c>.github/workflows/extension-e2e-tests.yml</c>
+/// inside the same wrapper GitHub Actions builds around a <c>pwsh</c> step, pinning the contract
+/// that the step can never fail a shard.
+///
+/// ffmpeg only powers the diagnostic screen recordings, and run-e2e.js already skips recording with
+/// a warning when the binary is missing, so a failed install has to stay a warning. That was not
+/// true once: bounding the apt-get calls with <c>timeout</c> stopped them hanging, but the failed
+/// exit code then leaked out and failed six shards outright, because GitHub appends
+/// <c>if ((Test-Path -LiteralPath variable:/LASTEXITCODE)) { exit $LASTEXITCODE }</c> to every pwsh
+/// step. See
+/// https://docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#exit-codes-and-error-action-preference.
+///
+/// Running the step body on its own cannot catch that regression, because the appended epilogue is
+/// the thing that turns a leftover <c>$LASTEXITCODE</c> into a step failure. So these tests wrap the
+/// body the way GitHub does, and the always-fails case is covered twice: once as authored, and once
+/// with the explicit <c>exit 0</c> stripped, which must reproduce the original failure. Without that
+/// control the harness could pass while proving nothing.
+/// </summary>
+public sealed class ExtensionE2eRecorderStepTests(ITestOutputHelper testOutput)
+{
+    private const string RecorderStepName = "Install E2E recorder";
+
+    /// <summary>Exit code the apt-get stub uses for a failed install, distinct from the 124 that a real timeout returns.</summary>
+    private const int StubAptFailureExitCode = 100;
+
+    /// <summary>What GitHub wraps around the <c>run:</c> body of a pwsh step.</summary>
+    private const string GitHubPwshPrologue = "$ErrorActionPreference = 'stop'";
+    private const string GitHubPwshEpilogue = "if ((Test-Path -LiteralPath variable:/LASTEXITCODE)) { exit $LASTEXITCODE }";
+
+    private const string ExplicitSuccessExit = "exit 0";
+    private const string RetryBackoff = "Start-Sleep -Seconds 15";
+
+    private const string RetryWarning = "::warning::Attempt 1 to install ffmpeg failed; retrying.";
+    private const string GaveUpWarning = "::warning::ffmpeg could not be installed; E2E screen recordings are disabled for this shard.";
+
+    [Theory]
+    // As authored: every apt-get outcome has to leave the shard alive.
+    [InlineData("always-fails", true, 0, 2, new[] { RetryWarning, GaveUpWarning })]
+    [InlineData("fails-once", true, 0, 2, new[] { RetryWarning })]
+    [InlineData("succeeds", true, 0, 1, new string[0])]
+    // Control: the same body without its explicit exit must reproduce the shard-wide failure,
+    // otherwise the three cases above would pass even if the epilogue were not being applied.
+    [InlineData("always-fails", false, StubAptFailureExitCode, 2, new[] { RetryWarning, GaveUpWarning })]
+    [RequiresTools(["pwsh"])]
+    public async Task RecorderStepSurvivesEveryAptOutcome(
+        string aptBehavior,
+        bool keepExplicitExit,
+        int expectedExitCode,
+        int expectedInstallAttempts,
+        string[] expectedWarnings)
+    {
+        // The stubs below are shell scripts, and this step only ever runs on the Linux shards
+        // (`if: ${{ matrix.useXvfb }}`), so there is nothing to pin on Windows.
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "The recorder step and its stubs are Unix-only.");
+
+        using var workspace = TemporaryWorkspace.Create(testOutput);
+
+        var stepScript = ExtensionE2eWorkflow.StepScript(RecorderStepName);
+        var stubDirectory = CreateCommandStubs(workspace, aptBehavior, out var invocationLog, out var pwshPath);
+        var scriptPath = Path.Combine(workspace.Path, "step.ps1");
+        File.WriteAllText(scriptPath, BuildStepScript(stepScript, keepExplicitExit));
+
+        using var command = new PowerShellCommand(scriptPath, testOutput, label: aptBehavior)
+            .WithEnvironmentVariable("PATH", stubDirectory)
+            .WithTimeout(TimeSpan.FromMinutes(2));
+        var result = await command.ExecuteAsync();
+
+        var invocations = File.Exists(invocationLog) ? File.ReadAllLines(invocationLog) : [];
+        var installAttempts = invocations.Count(line => line.StartsWith("apt-get install", StringComparison.Ordinal));
+
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.Equal(expectedInstallAttempts, installAttempts);
+
+        // Distinguishes a genuine retry from a run that merely failed twice: both make two install
+        // attempts, and only the warnings say whether the second one succeeded. Without this, a
+        // stub that could not track attempts would quietly degrade fails-once into always-fails.
+        var warnings = result.Output
+            .Split('\n')
+            .Select(line => line.Trim('\r'))
+            .Where(line => line.StartsWith("::warning::", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(expectedWarnings, warnings);
+
+        // Plain `timeout` only sends SIGTERM, and apt/dpkg defer signals around critical sections,
+        // so without the escalation a wedged child can outlive its own timeout - the hang this step
+        // was bounded to prevent.
+        Assert.All(
+            invocations.Where(line => line.StartsWith("timeout ", StringComparison.Ordinal)),
+            line => Assert.Contains("--kill-after=", line, StringComparison.Ordinal));
+
+        Assert.NotEmpty(pwshPath);
+    }
+
+    /// <summary>
+    /// Wraps the step body the way the runner does before executing it.
+    ///
+    /// The authored cases deliberately run whatever the workflow says without first checking it for
+    /// an <c>exit 0</c>. Deleting that line then surfaces as the failure it actually causes - the
+    /// step exiting non-zero and taking the shard with it - rather than as a structural complaint
+    /// about the script's last line.
+    /// </summary>
+    private static string BuildStepScript(string stepScript, bool keepExplicitExit)
+    {
+        var body = stepScript.TrimEnd();
+        if (!keepExplicitExit)
+        {
+            // Only the control needs the line to exist, because it is built by removing it. Deriving
+            // the control this way rather than pasting a copy of the old body keeps it from drifting
+            // away from what the workflow actually runs.
+            Assert.EndsWith(ExplicitSuccessExit, body, StringComparison.Ordinal);
+            body = body[..body.LastIndexOf(ExplicitSuccessExit, StringComparison.Ordinal)].TrimEnd();
+        }
+
+        // Asserted before it is replaced, so shortening the wait here cannot quietly stop matching
+        // the workflow. The delay itself is not what these tests pin; the exit code contract is.
+        Assert.Contains(RetryBackoff, body, StringComparison.Ordinal);
+        body = body.Replace(RetryBackoff, "Start-Sleep -Milliseconds 50", StringComparison.Ordinal);
+
+        return string.Join(Environment.NewLine, [GitHubPwshPrologue, body, GitHubPwshEpilogue]);
+    }
+
+    /// <summary>
+    /// Builds a directory of stub executables that becomes the whole PATH for the step.
+    ///
+    /// Replacing PATH rather than prepending is deliberate: the step's first branch is
+    /// <c>Get-Command ffmpeg</c>, so a machine that happens to have ffmpeg installed would otherwise
+    /// silently skip the install path these tests exist to cover. pwsh is linked in because it has
+    /// to stay resolvable once PATH is replaced.
+    /// </summary>
+    private static string CreateCommandStubs(TemporaryWorkspace workspace, string aptBehavior, out string invocationLog, out string pwshPath)
+    {
+        var stubDirectory = workspace.CreateDirectory("stubs").FullName;
+        invocationLog = Path.Combine(workspace.Path, "invocations.log");
+        var attemptCounter = Path.Combine(workspace.Path, "install-attempts");
+
+        // `sudo timeout --kill-after=30 180 apt-get ...`, so both wrappers have to hand off to the
+        // rest of the command line for the apt-get stub to ever run.
+        WriteStub(stubDirectory, "sudo", $"""
+            #!/bin/sh
+            echo "sudo $*" >> "{invocationLog}"
+            exec "$@"
+            """);
+
+        WriteStub(stubDirectory, "timeout", $"""
+            #!/bin/sh
+            echo "timeout $*" >> "{invocationLog}"
+            while [ $# -gt 0 ]; do
+              case "$1" in
+                --kill-after=*) shift ;;
+                -k) shift 2 ;;
+                *) break ;;
+              esac
+            done
+            shift
+            exec "$@"
+            """);
+
+        // Only the install decides success; `apt-get update` is allowed to fail because the install
+        // can still succeed from the indices already on the runner image.
+        //
+        // The attempt count is kept with shell builtins alone. PATH is replaced by this directory,
+        // so external tools are deliberately unreachable, and reaching for one here would silently
+        // read zero attempts every time and turn the fails-once case into a second always-fails run.
+        WriteStub(stubDirectory, "apt-get", $"""
+            #!/bin/sh
+            echo "apt-get $*" >> "{invocationLog}"
+            if [ "$1" != "install" ]; then exit 0; fi
+            echo attempt >> "{attemptCounter}"
+            attempts=0
+            while read -r _line; do attempts=$((attempts + 1)); done < "{attemptCounter}"
+            case "{aptBehavior}" in
+              succeeds) exit 0 ;;
+              fails-once) [ "$attempts" -ge 2 ] && exit 0; exit {StubAptFailureExitCode} ;;
+              *) exit {StubAptFailureExitCode} ;;
+            esac
+            """);
+
+        pwshPath = PathLookupHelper.FindFullPathFromPath("pwsh") ?? string.Empty;
+        Assert.SkipWhen(pwshPath.Length == 0, "pwsh is not on PATH.");
+        File.CreateSymbolicLink(Path.Combine(stubDirectory, "pwsh"), pwshPath);
+
+        return stubDirectory;
+    }
+
+    private static void WriteStub(string directory, string name, string contents)
+    {
+        var stubPath = Path.Combine(directory, name);
+        File.WriteAllText(stubPath, contents);
+
+        // The test skips on Windows before reaching this, but Assert.SkipWhen is invisible to the
+        // platform-compatibility analyzer, so the guard has to be one it can see.
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(stubPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eRecorderStepTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eRecorderStepTests.cs
@@ -93,8 +93,18 @@ public sealed class ExtensionE2eRecorderStepTests(ITestOutputHelper testOutput)
         // Plain `timeout` only sends SIGTERM, and apt/dpkg defer signals around critical sections,
         // so without the escalation a wedged child can outlive its own timeout - the hang this step
         // was bounded to prevent.
+        var timeoutInvocations = invocations
+            .Where(line => line.StartsWith("timeout ", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(expectedInstallAttempts * 2, timeoutInvocations.Length);
+        for (var attempt = 0; attempt < expectedInstallAttempts; attempt++)
+        {
+            Assert.EndsWith("apt-get update", timeoutInvocations[attempt * 2], StringComparison.Ordinal);
+            Assert.Contains("apt-get install", timeoutInvocations[(attempt * 2) + 1], StringComparison.Ordinal);
+        }
+
         Assert.All(
-            invocations.Where(line => line.StartsWith("timeout ", StringComparison.Ordinal)),
+            timeoutInvocations,
             line => Assert.Contains("--kill-after=", line, StringComparison.Ordinal));
 
         Assert.NotEmpty(pwshPath);

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflow.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflow.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.RepresentationModel;
+
+namespace Infrastructure.Tests.Pipelines;
+
+/// <summary>
+/// Reads <c>.github/workflows/extension-e2e-tests.yml</c> so the tests that pin its contracts all
+/// resolve the same job and steps.
+/// </summary>
+internal static class ExtensionE2eWorkflow
+{
+    private const string WorkflowRelativePath = ".github/workflows/extension-e2e-tests.yml";
+
+    public static YamlMappingNode Job()
+    {
+        var yaml = new YamlStream();
+        using var reader = new StringReader(File.ReadAllText(Path.Combine(RepoRoot.Path, WorkflowRelativePath)));
+        yaml.Load(reader);
+
+        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
+        var jobs = (YamlMappingNode)root.Children[new YamlScalarNode("jobs")];
+
+        return (YamlMappingNode)jobs.Children[new YamlScalarNode("extension_e2e")];
+    }
+
+    public static IEnumerable<YamlMappingNode> Steps(YamlMappingNode job)
+        => ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>();
+
+    /// <summary>
+    /// Returns the <c>run:</c> body of the named step, so a test can execute the real script rather
+    /// than a copy that drifts from it.
+    /// </summary>
+    public static string StepScript(string stepName)
+    {
+        var step = Steps(Job()).Single(candidate => Scalar(candidate, "name") == stepName);
+
+        return Scalar(step, "run") ?? throw new InvalidOperationException($"Step '{stepName}' has no run script.");
+    }
+
+    public static string? Scalar(YamlMappingNode node, string key)
+        => node.Children.TryGetValue(new YamlScalarNode(key), out var value) && value is YamlScalarNode scalar
+            ? scalar.Value
+            : null;
+}

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -14,9 +14,7 @@ namespace Infrastructure.Tests.Pipelines;
 /// </summary>
 public sealed class ExtensionE2eWorkflowTests
 {
-    private const string WorkflowRelativePath = ".github/workflows/extension-e2e-tests.yml";
     private const string CallerWorkflowRelativePath = ".github/workflows/tests.yml";
-
     [Fact]
     public void AdvisoryShardRowsRemainIssueTrackedWithoutWeakeningRunnerStep()
     {
@@ -97,17 +95,7 @@ public sealed class ExtensionE2eWorkflowTests
         Assert.Equal(2, condition?.Split(unexpectedSkipCheck, StringSplitOptions.None).Length - 1);
     }
 
-    private static YamlMappingNode LoadExtensionE2eJob()
-    {
-        var yaml = new YamlStream();
-        using var reader = new StringReader(File.ReadAllText(Path.Combine(RepoRoot.Path, WorkflowRelativePath)));
-        yaml.Load(reader);
-
-        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
-        var jobs = (YamlMappingNode)root.Children[new YamlScalarNode("jobs")];
-
-        return (YamlMappingNode)jobs.Children[new YamlScalarNode("extension_e2e")];
-    }
+    private static YamlMappingNode LoadExtensionE2eJob() => ExtensionE2eWorkflow.Job();
 
     private static IEnumerable<YamlMappingNode> MatrixIncludeRows(YamlMappingNode job)
     {


### PR DESCRIPTION
## Description

The `VS Code extension E2E (Linux, java-apphost)` shard fails whenever `repo.maven.apache.org` has a transient blip. Hit twice while working on an unrelated PR; this is the root cause.

These projects pin `distributionType=only-script` in `maven-wrapper.properties`, so `mvnw` downloads the **Maven distribution itself** into `${MAVEN_USER_HOME}/wrapper/dists` (i.e. `~/.m2/wrapper`) on every run:

```
# playground/JavaSpringBoot/catalog/mvnw:146
MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
```

The cache step stored `~/.m2/repository` but **not** `~/.m2/wrapper`, so that download was never cached and Maven Central became a hard per-run dependency. Gradle already had exactly this protection via the `~/.gradle/wrapper` entry sitting two lines below — the gap was an asymmetry, not a deliberate choice.

### Why the failure looks unrelated

It is not merely a slower run. With no Maven on the runner, the build inside the spec exits 1, so `catalog` never starts and the shard fails ~15 minutes later as:

```
Error: Failed to apply E2E control revision ...: Timed out after 900000ms waiting for an HTTP endpoint
for resource 'catalog'. ... catalog-maven-build-xrecdqbj [state=Finished, exitCode=1]
```

The actual cause is 15 minutes earlier and only a warning, because the warm-up step is deliberately best-effort:

```
wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
warning: could not pre-resolve Maven dependencies for catalog
```

## Changes

- **Cache `~/.m2/wrapper`** so the Maven distribution survives between runs, mirroring `~/.gradle/wrapper`.
- **Add `maven-wrapper.properties` to the cache key.** It carries the pinned `distributionUrl`. Without it, a Maven version bump would still hit the key exactly, `actions/cache` would skip the save, and the newly downloaded distribution would never get stored. `gradle-wrapper.properties` is already in the hash for the same reason.
- **Retry the warm-up** (3 attempts, 15s/30s backoff) so one transient fetch failure on a cold cache is survivable. Matches the existing 3-attempt retry used by the `yarn install` step in this same workflow, and preserves the "must not fail the job" contract.

No key-prefix bump is needed. `actions/cache` derives its cache version from the configured `path` list ([`getCacheVersion`](https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts#L136-L159)) and sends that version on both the restore lookup and the save, so adding `~/.m2/wrapper` already makes the pre-existing entry unmatchable and lets the save run. Thanks to @copilot for catching an earlier version of this PR that bumped the prefix for a reason that did not hold.

## Second failure mode: the recorder install (found while validating this PR)

The first CI run on this branch hung four Linux shards on `Install E2E recorder`, two of which (`apphost-lifecycle-tools`, `command-palette`) were killed at their 75-minute job timeout. Neither installs Java, so this is a distinct cause from the Maven one above — and it is the same bug class: an unbounded network fetch with no timeout and no retry.

```yaml
sudo apt-get update
sudo apt-get install -y --no-install-recommends ffmpeg
```

It is chronic, not a one-off. `Install E2E recorder` durations on recent **successful** runs:

| Run | Slowest shard |
|---|---|
| 32083549955 | 1277s |
| 32088120641 | 775s |
| 32080488226 | 44s |

None of that failure is necessary. ffmpeg only powers the diagnostic screen recordings, and `run-e2e.js` already degrades gracefully without it:

```js
// extension/scripts/run-e2e.js:437
const ffmpegCheck = spawnSync('ffmpeg', ['-version'], { ... });
if (ffmpegCheck.error || ffmpegCheck.status !== 0) {
  console.warn('Skipping Aspire extension E2E recording because ffmpeg is not available.');
  return undefined;
}
```

So a nice-to-have was able to kill healthy shards. Now each `apt-get` is wrapped in `timeout`, retried once, and falls through to a warning. Worst case drops from unbounded to ~12 minutes, and the shard runs without recordings rather than dying.

**Scope note:** this touches all Linux E2E shards, not just Java. I widened it deliberately — it was the dominant failure of the java-apphost lane on this very PR, and it lives in the same file and the same bug class.

### Bounding it was not sufficient on its own

The first attempt wrapped `apt-get` in `timeout`, which did stop the hang — the step capped at ~390s instead of running to the 75-minute job timeout. But six shards then **failed** the step outright, because GitHub's `pwsh` wrapper appends:

```powershell
if ((Test-Path -LiteralPath variable:/LASTEXITCODE)) { exit $LASTEXITCODE }
```

So the exit code of the last failed `apt-get` became the step's exit code, and the warning fallback never mattered. That is documented under [exit codes and error action preference](https://docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#exit-codes-and-error-action-preference). The step now ends with an explicit `exit 0`.

My first round of local testing missed this because it ran the body with `pwsh -File`, without the prologue and epilogue GitHub injects. Corrected: the harness now reproduces the real wrapper, and includes a **control** — the pre-fix body must reproduce the CI failure, otherwise the harness proves nothing.

| Body | Scenario | apt install calls | Step exit |
|---|---|---|---|
| pre-fix (control) | apt always fails | 2 | **100** — reproduces the CI failure |
| fixed | apt always fails | 2 | 0 (warns, shard survives) |
| fixed | fails once, then succeeds | 2 | 0 |
| fixed | succeeds first try | 1 | 0 |

That harness is now committed as `tests/Infrastructure.Tests/Pipelines/ExtensionE2eRecorderStepTests.cs`, so removing the explicit `exit 0` or breaking the retry loop fails a test rather than a shard. It reads the step body out of the workflow YAML rather than copying it, so it cannot drift from what CI runs, and the control case is built by deleting the `exit 0` line from that same body.

Verified by mutation rather than by trusting a green run:

| Mutation | Result |
|---|---|
| removed `exit 0` | **expected exit 0, actual 100** — the shard-wide failure itself |
| retry loop cut to a single attempt | expected 2 install attempts, actual 1 |
| dropped `--kill-after` | timeout invocation assertion fails |
| removed the `timeout` wrapper entirely | expected 4 bounded calls, actual 0 |

Worst case is bounded at 2 x (180s update + 180s install) + 15s backoff, about 12 minutes, versus previously unbounded.

## Third failure mode: cleanup fails a shard whose tests passed

Run [32181748160](https://github.com/microsoft/aspire/actions/runs/32181748160) went green, but only on attempt 2. On attempt 1 both `java-apphost` shards failed **after their tests passed** — `mocha.json` recorded `"3 passing (3m)"` with `hasError: false`, and the job died in teardown:

```
AggregateError: One or more E2E cleanup steps failed:
Error: cleanup temporary run root: ENOTEMPTY: directory not empty, rmdir
```

`removePathWithoutFollowingLinks` lists a directory, removes what it saw, then `rmdir`s it. A Java language server or build daemon can still be writing when cleanup runs, so an entry can appear **between the listing and the `rmdir`**, and the directory is no longer empty.

`ENOTEMPTY` was already in `isRetryableRemovalError`, which makes this look handled. It is not: retrying the same `rmdir` can never clear it, because the entry that appeared is still on disk and nothing lists the directory again. Reproduced locally with a late writer:

| `maxRetries` | Result |
|---|---|
| 0 (the value used on Linux) | throws `ENOTEMPTY` immediately |
| 20 | **still throws `ENOTEMPTY`** |

And on Linux the budget is `0` anyway, while `cleanupTemporaryRunRoot`'s warn-and-continue fallback is Windows-only — so the shard failed outright.

The fix re-sweeps: on `ENOTEMPTY`, list the directory again and remove what appeared. It is bounded, so a process that never stops writing fails cleanup rather than hanging the shard. The retry budget keeps its own distinct purpose, where retrying the same `rmdir` genuinely does help — on Windows a removed entry can linger until the last handle closes.

The regression test hooks `readdirSync` to drop a file in after the listing rather than racing a real writer, so it reproduces deterministically instead of being flaky itself.

## Testing

- The `job:extension-e2e` target lists `.github/workflows/extension-e2e-tests.yml` among its trigger paths in `eng/github-ci/test-trigger-map.yml`, so this workflow-only change does select the java shards — confirmed by the `java-apphost` jobs actually being scheduled on this PR.
- YAML parses; the embedded script passes `bash -n`.
- Retry helper exercised against stubs: always-failing (3 attempts, warns, does **not** abort under `set -e`), flaky-then-succeeds (succeeds on attempt 3), healthy (no retries).
- Cleanup fix carries a **control**: the new re-sweep test fails without the change with the exact CI error (`ENOTEMPTY: directory not empty, rmdir`), and passes with it. Full extension unit suite green — **2263 passing, 0 failing**.
- Recorder step contract is pinned by an executable test that runs the real body inside GitHub's pwsh wrapper — `Infrastructure.Tests` green at **635 passing, 0 failing**.

## Result

On run [32169717681](https://github.com/microsoft/aspire/actions/runs/32169717681), **both `java-apphost` shards passed** — the lane this PR set out to fix. On the run before that they were killed at their 110-minute timeout. The Maven warm-up now completes in ~24s and `Post Cache` runs, confirming the distribution is being saved under the new path set.

`java-codelens` failed on that run only via the recorder step, which a later commit fixes.

Taken together this PR removes three independent ways the Java E2E lane could fail without any product bug: an uncached Maven distribution, an unbounded `apt-get`, and a cleanup race that failed shards whose tests had already passed.
