### PR TITLE
Harden dashboard Blazor WebSocket origin validation

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -513,7 +513,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // upgrades before SignalR allocates a connection or circuit.
         _app.Use(async (context, next) =>
         {
-            if (context.Request.Path.Equals("/_blazor", StringComparisons.UrlPath) &&
+            if (context.Request.Path.StartsWithSegments("/_blazor", StringComparisons.UrlPath) &&
                 context.WebSockets.IsWebSocketRequest &&
                 !WebSocketOriginValidator.IsSameOrigin(context, out var originLogValue))
             {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -508,6 +508,24 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.UseAntiforgery();
         _app.UseWebSockets();
 
+        // Browsers don't apply CORS restrictions to WebSocket upgrades. Only the
+        // dashboard frontend should establish a Blazor circuit, so reject cross-site
+        // upgrades before SignalR allocates a connection or circuit.
+        _app.Use(async (context, next) =>
+        {
+            if (context.Request.Path.Equals("/_blazor", StringComparisons.UrlPath) &&
+                context.WebSockets.IsWebSocketRequest &&
+                !WebSocketOriginValidator.IsSameOrigin(context, out var originLogValue))
+            {
+                _logger.LogWarning("Rejecting Blazor WebSocket upgrade with disallowed Origin '{Origin}'.", originLogValue);
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync("Origin not allowed.").ConfigureAwait(false);
+                return;
+            }
+
+            await next(context).ConfigureAwait(false);
+        });
+
         _app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 
         // Terminal WebSocket proxy

--- a/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
+++ b/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Validates that a browser WebSocket request originated from the dashboard.
+/// </summary>
+internal static class WebSocketOriginValidator
+{
+    internal static bool IsSameOrigin(HttpContext context, out string originLogValue)
+    {
+        var origin = context.Request.Headers.Origin.ToString();
+        originLogValue = string.IsNullOrEmpty(origin) ? "(none)" : origin;
+
+        if (string.IsNullOrEmpty(origin) ||
+            !Uri.TryCreate(origin, UriKind.Absolute, out var originUri) ||
+            !string.Equals(originUri.Scheme, context.Request.Scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var expectedHost = context.Request.Host;
+        if (!expectedHost.HasValue)
+        {
+            return false;
+        }
+
+        // Uri.Authority omits default ports, so construct the authority explicitly
+        // and compare it with HostString's equivalent normalized representation.
+        var originAuthority = originUri.IsDefaultPort
+            ? originUri.Host
+            : originUri.Host + ":" + originUri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        return string.Equals(originAuthority, expectedHost.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
+++ b/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
@@ -26,12 +26,12 @@ internal static class WebSocketOriginValidator
             return false;
         }
 
-        // Uri.Authority omits default ports, so construct the authority explicitly
-        // and compare it with HostString's equivalent normalized representation.
-        var originAuthority = originUri.IsDefaultPort
-            ? originUri.Host
-            : originUri.Host + ":" + originUri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (!Uri.TryCreate($"{context.Request.Scheme}://{expectedHost}", UriKind.Absolute, out var expectedUri))
+        {
+            return false;
+        }
 
-        return string.Equals(originAuthority, expectedHost.ToString(), StringComparison.OrdinalIgnoreCase);
+        return string.Equals(originUri.Host, expectedUri.Host, StringComparison.OrdinalIgnoreCase) &&
+            originUri.Port == expectedUri.Port;
     }
 }

--- a/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
+++ b/src/Aspire.Dashboard/Model/WebSocketOriginValidator.cs
@@ -20,6 +20,16 @@ internal static class WebSocketOriginValidator
             return false;
         }
 
+        // This prevents a page on another website from opening a WebSocket to the dashboard because the
+        // browser sends that page's origin, which won't match the dashboard's host.
+        //
+        // Request.Host is client-controlled, so this same-origin check does not prevent DNS rebinding. In
+        // authenticated modes, dashboard cookies are host-scoped and aren't sent to the attacker's host;
+        // authorization remains the security boundary for sensitive data and operations. Deployments using
+        // unsecured mode must rely on network isolation or host filtering to prevent rebinding access.
+        //
+        // The security documentation discusses hardening host access when anonymous access is enabled:
+        // https://aspire.dev/dashboard/security-considerations/
         var expectedHost = context.Request.Host;
         if (!expectedHost.HasValue)
         {

--- a/src/Aspire.Dashboard/Terminal/TerminalWebSocketProxy.cs
+++ b/src/Aspire.Dashboard/Terminal/TerminalWebSocketProxy.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Net.WebSockets;
 using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.Terminal;
 
@@ -115,7 +116,7 @@ internal static class TerminalWebSocketProxy
         // so a missing Origin on a WS request is itself suspicious — reject.
         //
         // See: https://datatracker.ietf.org/doc/html/rfc6455#section-10.2
-        if (!IsAllowedOrigin(context, out var originLogValue))
+        if (!WebSocketOriginValidator.IsSameOrigin(context, out var originLogValue))
         {
             logger.LogWarning(
                 "Rejecting terminal WebSocket upgrade {ConnectionId} with disallowed Origin '{Origin}'.",
@@ -472,43 +473,7 @@ internal static class TerminalWebSocketProxy
     /// </remarks>
     internal static bool IsAllowedOrigin(HttpContext context, out string originLogValue)
     {
-        var origin = context.Request.Headers.Origin.ToString();
-        originLogValue = string.IsNullOrEmpty(origin) ? "(none)" : origin;
-
-        if (string.IsNullOrEmpty(origin))
-        {
-            return false;
-        }
-
-        if (!Uri.TryCreate(origin, UriKind.Absolute, out var originUri))
-        {
-            return false;
-        }
-
-        // Compare against the request's own scheme + host. When behind a reverse proxy
-        // with UseForwardedHeaders, these reflect the public-facing values, so the
-        // browser's Origin (= the page's public URL) lines up automatically.
-        if (!string.Equals(originUri.Scheme, context.Request.Scheme, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var expectedHost = context.Request.Host;
-        if (!expectedHost.HasValue)
-        {
-            return false;
-        }
-
-        // Uri.Authority drops a default port (e.g. :443 for https, :80 for http); use
-        // Host + ":" + Port directly and let HostString.ToString() apply the same rule.
-        // Compare both with and without explicit port to handle the default-port case.
-        var originAuthority = originUri.IsDefaultPort
-            ? originUri.Host
-            : originUri.Host + ":" + originUri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-        var expectedAuthority = expectedHost.ToString();
-
-        return string.Equals(originAuthority, expectedAuthority, StringComparison.OrdinalIgnoreCase);
+        return WebSocketOriginValidator.IsSameOrigin(context, out originLogValue);
     }
 
     private readonly struct ValueStopwatch

--- a/tests/Aspire.Dashboard.Tests/Integration/BlazorWebSocketOriginTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/BlazorWebSocketOriginTests.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.InternalTesting;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+public class BlazorWebSocketOriginTests(ITestOutputHelper testOutputHelper)
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("https://evil.example.com")]
+    public async Task BlazorWebSocket_InvalidOrigin_ReturnsForbidden(string? origin)
+    {
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
+        await app.StartAsync().DefaultTimeout();
+
+        var frontendUri = new Uri(app.FrontendSingleEndPointAccessor().GetResolvedAddress());
+        using var client = new HttpClient { BaseAddress = frontendUri };
+        using var request = CreateWebSocketUpgradeRequest(origin);
+        using var response = await client.SendAsync(request).DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("Origin not allowed.", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task BlazorWebSocket_SameOrigin_UpgradeSucceeds()
+    {
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
+        await app.StartAsync().DefaultTimeout();
+
+        var frontendUri = new Uri(app.FrontendSingleEndPointAccessor().GetResolvedAddress());
+        using var client = new ClientWebSocket();
+        client.Options.SetRequestHeader("Origin", frontendUri.GetLeftPart(UriPartial.Authority));
+
+        await client.ConnectAsync(CreateWebSocketUri(frontendUri), CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(WebSocketState.Open, client.State);
+        await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None).DefaultTimeout();
+    }
+
+    private static HttpRequestMessage CreateWebSocketUpgradeRequest(string? origin)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/_blazor")
+        {
+            Version = HttpVersion.Version11,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact
+        };
+        request.Headers.TryAddWithoutValidation("Connection", "Upgrade");
+        request.Headers.TryAddWithoutValidation("Upgrade", "websocket");
+        request.Headers.TryAddWithoutValidation("Sec-WebSocket-Version", "13");
+        request.Headers.TryAddWithoutValidation("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+        if (origin is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Origin", origin);
+        }
+
+        return request;
+    }
+
+    private static Uri CreateWebSocketUri(Uri frontendUri)
+    {
+        return new UriBuilder(frontendUri)
+        {
+            Scheme = frontendUri.Scheme == Uri.UriSchemeHttps ? "wss" : "ws",
+            Path = "/_blazor"
+        }.Uri;
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/BlazorWebSocketOriginTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/BlazorWebSocketOriginTests.cs
@@ -11,16 +11,17 @@ namespace Aspire.Dashboard.Tests.Integration;
 public class BlazorWebSocketOriginTests(ITestOutputHelper testOutputHelper)
 {
     [Theory]
-    [InlineData(null)]
-    [InlineData("https://evil.example.com")]
-    public async Task BlazorWebSocket_InvalidOrigin_ReturnsForbidden(string? origin)
+    [InlineData(null, "/_blazor")]
+    [InlineData("https://evil.example.com", "/_blazor")]
+    [InlineData("https://evil.example.com", "/_blazor/")]
+    public async Task BlazorWebSocket_InvalidOrigin_ReturnsForbidden(string? origin, string path)
     {
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
         await app.StartAsync().DefaultTimeout();
 
         var frontendUri = new Uri(app.FrontendSingleEndPointAccessor().GetResolvedAddress());
         using var client = new HttpClient { BaseAddress = frontendUri };
-        using var request = CreateWebSocketUpgradeRequest(origin);
+        using var request = CreateWebSocketUpgradeRequest(origin, path);
         using var response = await client.SendAsync(request).DefaultTimeout();
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -43,9 +44,9 @@ public class BlazorWebSocketOriginTests(ITestOutputHelper testOutputHelper)
         await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None).DefaultTimeout();
     }
 
-    private static HttpRequestMessage CreateWebSocketUpgradeRequest(string? origin)
+    private static HttpRequestMessage CreateWebSocketUpgradeRequest(string? origin, string path)
     {
-        var request = new HttpRequestMessage(HttpMethod.Get, "/_blazor")
+        var request = new HttpRequestMessage(HttpMethod.Get, path)
         {
             Version = HttpVersion.Version11,
             VersionPolicy = HttpVersionPolicy.RequestVersionExact

--- a/tests/Aspire.Dashboard.Tests/Model/WebSocketOriginValidatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/WebSocketOriginValidatorTests.cs
@@ -13,6 +13,8 @@ public class WebSocketOriginValidatorTests
     [InlineData("https", "dashboard.example.com", "https://dashboard.example.com", true)]
     [InlineData("https", "dashboard.example.com:8443", "https://dashboard.example.com:8443", true)]
     [InlineData("https", "dashboard.example.com", "https://dashboard.example.com:443", true)]
+    [InlineData("https", "dashboard.example.com:443", "https://dashboard.example.com", true)]
+    [InlineData("http", "dashboard.example.com:80", "http://dashboard.example.com", true)]
     [InlineData("HTTPS", "Dashboard.Example.Com", "https://dashboard.example.com", true)]
     [InlineData("http", "localhost:5101", "http://localhost:5101", true)]
     [InlineData("https", "dashboard.example.com", "http://dashboard.example.com", false)]

--- a/tests/Aspire.Dashboard.Tests/Model/WebSocketOriginValidatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/WebSocketOriginValidatorTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public class WebSocketOriginValidatorTests
+{
+    [Theory]
+    [InlineData("https", "dashboard.example.com", "https://dashboard.example.com", true)]
+    [InlineData("https", "dashboard.example.com:8443", "https://dashboard.example.com:8443", true)]
+    [InlineData("https", "dashboard.example.com", "https://dashboard.example.com:443", true)]
+    [InlineData("HTTPS", "Dashboard.Example.Com", "https://dashboard.example.com", true)]
+    [InlineData("http", "localhost:5101", "http://localhost:5101", true)]
+    [InlineData("https", "dashboard.example.com", "http://dashboard.example.com", false)]
+    [InlineData("https", "dashboard.example.com", "https://evil.example.com", false)]
+    [InlineData("https", "dashboard.example.com:8443", "https://dashboard.example.com:8444", false)]
+    [InlineData("http", "localhost:5101", "http://localhost:5100", false)]
+    [InlineData("https", "dashboard.example.com", "not-a-uri", false)]
+    [InlineData("https", "dashboard.example.com", "/relative", false)]
+    [InlineData("https", "dashboard.example.com", null, false)]
+    [InlineData("https", null, "https://dashboard.example.com", false)]
+    public void IsSameOrigin_MatchesRequestSchemeAndHost(string scheme, string? host, string? origin, bool expected)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = scheme;
+
+        if (host is not null)
+        {
+            context.Request.Host = HostString.FromUriComponent(host);
+        }
+
+        if (origin is not null)
+        {
+            context.Request.Headers.Origin = origin;
+        }
+
+        var result = WebSocketOriginValidator.IsSameOrigin(context, out _);
+
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Description

The dashboard's Blazor Server WebSocket endpoint accepted upgrade requests without validating that the browser originated from the dashboard. A page on another origin could therefore attempt to establish a `/_blazor` connection using the developer's dashboard session.

This change validates the `Origin` header for Blazor WebSocket upgrades before a circuit is allocated. Missing, malformed, or cross-origin values are rejected with `403 Forbidden`, while requests whose scheme, host, and port match the dashboard continue normally. The terminal WebSocket endpoint now uses the same shared validator so both browser-facing WebSocket paths apply consistent origin checks.

### Security considerations

This change mitigates cross-site WebSocket hijacking against the dashboard's Blazor endpoint. It assumes legitimate browser WebSocket upgrades include an `Origin` header matching the effective request scheme and host; forwarded headers continue to provide those effective values when the dashboard is behind a configured reverse proxy. A formal security review has not yet been completed.

Validation:

```text
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-class "*.WebSocketOriginValidatorTests" --filter-class "*.BlazorWebSocketOriginTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 16, Failed: 0, Skipped: 0
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No