### PR TITLE
Harden interaction file uploads

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -510,9 +510,10 @@ internal static class InteractionCommands
                 foreach (var updatedInput in result.Data)
                 {
                     var value = updatedInput.Value;
-                    if (updatedInput.InputType == InputType.File && updatedInput.Files is { Count: > 0 })
+                    using var files = updatedInput.GetFiles();
+                    if (updatedInput.InputType == InputType.File && files.Count > 0)
                     {
-                        value += $" (Files: {string.Join(", ", updatedInput.Files.Select(f => f.Name))})";
+                        value += $" (Files: {string.Join(", ", files.Select(f => f.Name))})";
                     }
                     logger.LogInformation("Input: {Name} = {Value}", updatedInput.Name, value);
                 }
@@ -1008,12 +1009,13 @@ internal static class InteractionCommands
                 }
 
                 var input = result.Data;
-                if (input.Files is not { Count: > 0 })
+                using var files = input.GetFiles();
+                if (files.Count == 0)
                 {
                     return CommandResults.Failure("No file was uploaded.");
                 }
 
-                var file = input.Files[0];
+                var file = files[0];
                 var content = await file.ReadAllBytesAsync(commandContext.CancellationToken);
 
                 var resourceLoggerService = commandContext.Services.GetRequiredService<ResourceLoggerService>();
@@ -1054,7 +1056,8 @@ internal static class InteractionCommands
                 }
 
                 var input = result.Data;
-                if (input.Files is not { Count: > 0 })
+                using var files = input.GetFiles();
+                if (files.Count == 0)
                 {
                     return CommandResults.Failure("No certificates were uploaded.");
                 }
@@ -1063,7 +1066,7 @@ internal static class InteractionCommands
                 var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
 
                 var fileDetails = new List<object>();
-                foreach (var file in input.Files)
+                foreach (var file in files)
                 {
                     var bytes = await file.ReadAllBytesAsync(commandContext.CancellationToken);
                     logger.LogInformation("Installed certificate '{FileName}' ({Size} bytes)", file.Name, bytes.Length);
@@ -1076,7 +1079,7 @@ internal static class InteractionCommands
                     Value = json,
                     Format = CommandResultFormat.Json
                 };
-                return CommandResults.Success($"Installed {input.Files.Count} certificate(s).", resultData);
+                return CommandResults.Success($"Installed {files.Count} certificate(s).", resultData);
             }, new CommandOptions
             {
                 Description = "Upload TLS certificate files to install on the resource.",

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -129,7 +129,7 @@ internal static class IDistributedApplicationBuilderExtensions
             var appName = multiInputResult.Canceled ? "default-app" : (multiInputResult.Data?["ApplicationName"]?.Value ?? "default-app");
             var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?["ApplicationVersion"]?.Value ?? "1.0.0");
             var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?["SSLCertificateType"]?.Value ?? "self-signed");
-            var certFiles = multiInputResult.Canceled ? null : multiInputResult.Data?["CertificateFile"]?.Files;
+            using var certFiles = multiInputResult.Canceled ? null : multiInputResult.Data?["CertificateFile"]?.GetFiles();
 
             if (certFiles is { Count: > 0 })
             {

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -227,15 +227,12 @@ public partial class InteractionsInputDialog : IAsyncDisposable
             : Loc[nameof(Resources.Dialogs.InteractionFilePlaceholder)];
     }
 
-    // Maximum number of files that can be selected in a single file input change event.
-    private const int MaxFileCount = 100;
-
     private async Task OnInputFileChangeAsync(InputViewModel inputModel, InputFileChangeEventArgs args)
     {
         var maxFileSize = GetMaxFileSize(inputModel);
         var fileReferences = new List<FileReferenceViewModel>();
 
-        foreach (var file in args.GetMultipleFiles(MaxFileCount))
+        foreach (var file in args.GetMultipleFiles(InteractionHelpers.MaxFileCount))
         {
             if (file.Size > maxFileSize)
             {

--- a/src/Aspire.Hosting/Ats/InteractionExports.cs
+++ b/src/Aspire.Hosting/Ats/InteractionExports.cs
@@ -353,6 +353,20 @@ internal sealed class InteractionInputBuilder
     }
 
     /// <summary>
+    /// Releases uploaded files associated with the input.
+    /// </summary>
+    /// <remarks>
+    /// Call this after processing the file paths returned by the prompt. Releasing the files deletes the
+    /// server-side temporary files before AppHost shutdown and is idempotent. Files that are not released are
+    /// deleted when the AppHost shuts down.
+    /// </remarks>
+    [AspireExport]
+    public void ReleaseFiles()
+    {
+        Input.GetFiles().Dispose();
+    }
+
+    /// <summary>
     /// Attaches a callback that dynamically loads or updates the input after the prompt starts.
     /// </summary>
     /// <param name="callback">The callback invoked to load the input. Use the supplied context to read other inputs and update this input.</param>

--- a/src/Aspire.Hosting/Ats/InteractionExports.cs
+++ b/src/Aspire.Hosting/Ats/InteractionExports.cs
@@ -273,9 +273,10 @@ internal static class InteractionExports
             // DynamicLoading is intentionally omitted: it holds the non-serializable LoadCallback delegate.
         };
 
-        if (input.Files is { Count: > 0 })
+        var files = input.GetFiles();
+        if (files.Count > 0)
         {
-            result.SetFiles(input.Files);
+            result.SetFiles(new InteractionFileCollection(files));
         }
 
         return result;

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -256,13 +256,13 @@ internal sealed class DashboardServiceData : IDisposable
             if (submittedInputsByName.TryGetValue(input.Name, out var submittedInput))
             {
                 var files = input.InputType == InputType.File
-                    ? ResolveAndValidateFiles(fileUploadStore, submittedInput.Value, interactionId, input.Name)
+                    ? GetAcceptedFiles(fileUploadStore, submittedInput.Value, interactionId, input.Name)
                     : null;
                 inputDtos.Add(new InputDto(input.Name, submittedInput.Value, input.InputType, files));
             }
             else if (input.InputType == InputType.File)
             {
-                var files = ResolveAndValidateFiles(fileUploadStore, jsonValue: null, interactionId, input.Name);
+                var files = GetAcceptedFiles(fileUploadStore, jsonValue: null, interactionId, input.Name);
                 inputDtos.Add(new InputDto(input.Name, input.Value ?? string.Empty, input.InputType, files));
             }
         }
@@ -270,14 +270,31 @@ internal sealed class DashboardServiceData : IDisposable
         return inputDtos;
     }
 
-    internal static IReadOnlyList<InputFileDto>? ResolveAndValidateFiles(
+    internal static IReadOnlyList<InputFileDto>? GetAcceptedFiles(
         IInteractionFileUploadStore fileUploadStore,
         string? jsonValue,
         int interactionId,
         string inputName)
     {
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, interactionId, inputName);
-        return InteractionFileUploadStore.ValidateFileReferences(jsonValue, inputName, files);
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(interactionId, inputName);
+        if (files.Count == 0)
+        {
+            files = null;
+        }
+        files = InteractionFileUploadStore.ValidateFileReferences(jsonValue, inputName, files);
+        if (files is null)
+        {
+            return null;
+        }
+
+        fileUploadStore.MarkFilesAccepted(interactionId, inputName, files.Select(file => file.Id).ToArray());
+        return files
+            .Select(file => new InputFileDto(
+                file.Id,
+                file.Name,
+                file.FilePath,
+                () => fileUploadStore.RemoveEntry(interactionId, file.Id)))
+            .ToArray();
     }
 
     public static void ProcessInputs(IServiceProvider serviceProvider, ILogger logger, Interaction.InputsInteractionInfo inputsInfo, List<InputDto> inputDtos, bool dependencyChange, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -253,7 +253,7 @@ internal sealed class DashboardServiceData : IDisposable
         return new InputDto(i.Name, i.Value, inputType);
     }
 
-    public record InputFileDto(string Id, string Name, string FilePath);
+    public record InputFileDto(string Id, string Name, string FilePath, Action? Delete = null);
 
     public record InputDto(string Name, string Value, InputType InputType, IReadOnlyList<InputFileDto>? Files = null);
 
@@ -289,12 +289,20 @@ internal sealed class DashboardServiceData : IDisposable
                         var interactionFiles = requestInput.Files
                             .Select(f => new InteractionFile(f.Id, f.Name, f.FilePath))
                             .ToArray();
-                        modelInput.SetFiles(interactionFiles);
+                        modelInput.SetFiles(new InteractionFileCollection(
+                            interactionFiles,
+                            () =>
+                            {
+                                foreach (var file in requestInput.Files)
+                                {
+                                    file.Delete?.Invoke();
+                                }
+                            }));
                     }
                     else
                     {
                         // Clear stale file references when the selection is empty.
-                        modelInput.SetFiles([]);
+                        modelInput.SetFiles(new InteractionFileCollection([]));
                     }
                 }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -212,12 +212,16 @@ internal sealed class DashboardServiceData : IDisposable
                     case WatchInteractionsRequestUpdate.KindOneofCase.InputsDialog:
                         var inputsInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
                         var options = (InputsDialogInteractionOptions)interaction.Options;
+                        var submittedInputs = request.InputsDialog.InputItems
+                            .Select(i => new InputDto(i.Name, i.Value, DashboardService.MapInputType(i.InputType)))
+                            .ToList();
+                        var inputDtos = CreateInputDtos(_fileUploadStore, interaction.InteractionId, inputsInfo, submittedInputs);
 
                         ProcessInputs(
                             serviceProvider,
                             logger,
                             inputsInfo,
-                            request.InputsDialog.InputItems.Select(i => MapInputDto(interaction.InteractionId, inputsInfo, i)).ToList(),
+                            inputDtos,
                             request.ResponseUpdate,
                             interaction.CancellationToken);
 
@@ -230,32 +234,51 @@ internal sealed class DashboardServiceData : IDisposable
             cancellationToken).ConfigureAwait(false);
     }
 
-    private InputDto MapInputDto(int interactionId, Interaction.InputsInteractionInfo inputsInfo, Aspire.DashboardService.Proto.V1.InteractionInput i)
-    {
-        if (!inputsInfo.Inputs.TryGetByName(i.Name, out var modelInput))
-        {
-            return new InputDto(i.Name, i.Value, DashboardService.MapInputType(i.InputType));
-        }
-
-        var inputType = modelInput.InputType;
-
-        // For file inputs, Value contains a JSON array of objects with file IDs and names.
-        // Resolve each ID to the temp file path and build InputFileDto entries.
-        if (inputType == InputType.File)
-        {
-            var files = InteractionFileUploadStore.ResolveFileReferences(_fileUploadStore, i.Value, interactionId, i.Name, _logger);
-            if (files is not null)
-            {
-                return new InputDto(i.Name, i.Value, inputType, files);
-            }
-        }
-
-        return new InputDto(i.Name, i.Value, inputType);
-    }
-
     public record InputFileDto(string Id, string Name, string FilePath, Action? Delete = null);
 
     public record InputDto(string Name, string Value, InputType InputType, IReadOnlyList<InputFileDto>? Files = null);
+
+    internal static List<InputDto> CreateInputDtos(
+        IInteractionFileUploadStore fileUploadStore,
+        int interactionId,
+        Interaction.InputsInteractionInfo inputsInfo,
+        IReadOnlyList<InputDto> submittedInputs)
+    {
+        var submittedInputsByName = new Dictionary<string, InputDto>(StringComparers.InteractionInputName);
+        foreach (var submittedInput in submittedInputs)
+        {
+            submittedInputsByName[submittedInput.Name] = submittedInput;
+        }
+
+        var inputDtos = new List<InputDto>(inputsInfo.Inputs.Count);
+        foreach (var input in inputsInfo.Inputs)
+        {
+            if (submittedInputsByName.TryGetValue(input.Name, out var submittedInput))
+            {
+                var files = input.InputType == InputType.File
+                    ? ResolveAndValidateFiles(fileUploadStore, submittedInput.Value, interactionId, input.Name)
+                    : null;
+                inputDtos.Add(new InputDto(input.Name, submittedInput.Value, input.InputType, files));
+            }
+            else if (input.InputType == InputType.File)
+            {
+                var files = ResolveAndValidateFiles(fileUploadStore, jsonValue: null, interactionId, input.Name);
+                inputDtos.Add(new InputDto(input.Name, input.Value ?? string.Empty, input.InputType, files));
+            }
+        }
+
+        return inputDtos;
+    }
+
+    internal static IReadOnlyList<InputFileDto>? ResolveAndValidateFiles(
+        IInteractionFileUploadStore fileUploadStore,
+        string? jsonValue,
+        int interactionId,
+        string inputName)
+    {
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, interactionId, inputName);
+        return InteractionFileUploadStore.ValidateFileReferences(jsonValue, inputName, files);
+    }
 
     public static void ProcessInputs(IServiceProvider serviceProvider, ILogger logger, Interaction.InputsInteractionInfo inputsInfo, List<InputDto> inputDtos, bool dependencyChange, CancellationToken cancellationToken)
     {
@@ -277,7 +300,7 @@ internal sealed class DashboardServiceData : IDisposable
                 incomingValue = (bool.TryParse(incomingValue, out var b) && b) ? "true" : "false";
             }
 
-            if (!string.Equals(modelInput.Value ?? string.Empty, incomingValue ?? string.Empty))
+            if (!string.Equals(modelInput.Value ?? string.Empty, incomingValue ?? string.Empty) || requestInput.InputType == InputType.File)
             {
                 modelInput.Value = incomingValue;
 

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -26,7 +26,12 @@ internal interface IInteractionFileUploadStore
     /// <summary>
     /// Gets the completed uploads for an interaction input.
     /// </summary>
-    IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName);
+    IReadOnlyList<InteractionFileUpload> GetCompletedFiles(int interactionId, string inputName);
+
+    /// <summary>
+    /// Marks validated uploads as resolved into the accepted interaction result.
+    /// </summary>
+    void MarkFilesAccepted(int interactionId, string inputName, IReadOnlyList<string> fileIds);
 
     /// <summary>
     /// Removes a file entry from an interaction and cleans up its uploaded content.

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -24,14 +24,9 @@ internal interface IInteractionFileUploadStore
     void CompleteUpload(int interactionId, string fileId);
 
     /// <summary>
-    /// Gets the file path for a given file ID, interaction ID, and input name.
+    /// Gets the completed uploads for an interaction input.
     /// </summary>
-    string? GetFilePath(string fileId, int interactionId, string inputName);
-
-    /// <summary>
-    /// Gets the original file name for a given interaction and file ID.
-    /// </summary>
-    string? GetFileName(int interactionId, string fileId);
+    IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName);
 
     /// <summary>
     /// Removes a file entry from an interaction and cleans up its uploaded content.
@@ -48,3 +43,5 @@ internal interface IInteractionFileUploadStore
     /// </summary>
     void CancelInteraction(int interactionId);
 }
+
+internal sealed record InteractionFileUpload(string Id, string Name, string FilePath);

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -39,7 +39,7 @@ internal interface IInteractionFileUploadStore
     void RemoveEntry(int interactionId, string fileId);
 
     /// <summary>
-    /// Marks an interaction as completed.
+    /// Marks an interaction as completed while retaining uploads for the caller to process.
     /// </summary>
     void CompleteInteraction(int interactionId);
 

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -9,9 +9,9 @@ namespace Aspire.Hosting;
 internal interface IInteractionFileUploadStore
 {
     /// <summary>
-    /// Registers an interaction that can own uploaded files.
+    /// Registers an interaction and the file inputs that can own uploaded files.
     /// </summary>
-    void StartInteraction(int interactionId);
+    void StartInteraction(int interactionId, IReadOnlyList<(string InputName, int MaxFileCount)> fileInputs);
 
     /// <summary>
     /// Creates a new entry for an uploaded file and returns the file ID and path.

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -60,6 +60,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 throw new InvalidOperationException($"Interaction '{interactionId}' is not accepting file uploads for input '{inputName}'.");
             }
 
+            // Each client submits one file selection per input during an interaction. Multi-file selections upload
+            // their files sequentially as part of that single selection, so every upload counts toward this limit.
             // Count uploads in progress as reserved slots so concurrent requests cannot exceed the input's limit.
             var fileCount = interaction.Files.Values.Count(entry => string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName));
             if (fileCount >= maxFileCount)
@@ -278,7 +280,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 logger.LogWarning("Received unknown file ID '{FileId}' in interaction input '{InputName}'. Skipping.", fileRef.Id, inputName);
                 continue;
             }
-            var fileName = string.IsNullOrEmpty(fileRef.Name) ? store.GetFileName(interactionId, fileRef.Id) ?? "" : fileRef.Name;
+            var fileName = store.GetFileName(interactionId, fileRef.Id) ?? "";
             files.Add(new InputFileDto(fileRef.Id, fileName, filePath, () => store.RemoveEntry(interactionId, fileRef.Id)));
         }
 

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -187,6 +187,10 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             interactionId,
             interaction.Files.Count);
 
+        // The interaction completes before the prompt task returns, so its uploads must remain available for the
+        // caller to process. The returned InteractionFileCollection owns their cleanup: .NET callers dispose the
+        // collection from GetFiles(), and ATS callers invoke ReleaseFiles() on the original input builder. Store
+        // disposal at AppHost shutdown is only a fallback for callers that do not release their files earlier.
         foreach (var entry in interaction.Files.Values)
         {
             lock (entry)

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -102,8 +102,11 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         bool removeEntry;
         lock (entry)
         {
-            entry.UploadComplete = true;
-            removeEntry = entry.InteractionState == FileInteractionState.Canceled;
+            removeEntry = entry.State == FileEntryState.DiscardWhenComplete;
+            if (entry.State == FileEntryState.Uploading)
+            {
+                entry.State = FileEntryState.Uploaded;
+            }
         }
 
         _logger.LogDebug(
@@ -119,30 +122,30 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     }
 
     /// <summary>
-    /// Gets the file path for a given file ID, interaction ID, and input name.
+    /// Gets the completed uploads for an interaction input.
     /// </summary>
-    public string? GetFilePath(string fileId, int interactionId, string inputName)
+    public IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName)
     {
-        if (!TryGetEntry(interactionId, fileId, out var entry))
+        if (!_interactions.TryGetValue(interactionId, out var interaction))
         {
-            return null;
+            return [];
         }
 
-        lock (entry)
+        var files = new List<InteractionFileUpload>();
+        foreach (var (fileId, entry) in interaction.Files)
         {
-            return entry.UploadComplete &&
-                string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
-                    ? entry.TempFile.Path
-                    : null;
+            lock (entry)
+            {
+                if (entry.State is FileEntryState.Uploaded or FileEntryState.Resolved &&
+                    string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
+                {
+                    entry.State = FileEntryState.Resolved;
+                    files.Add(new InteractionFileUpload(fileId, entry.OriginalFileName, entry.TempFile.Path));
+                }
+            }
         }
-    }
 
-    /// <summary>
-    /// Gets the original file name for a given file ID.
-    /// </summary>
-    public string? GetFileName(int interactionId, string fileId)
-    {
-        return TryGetEntry(interactionId, fileId, out var entry) ? entry.OriginalFileName : null;
+        return files;
     }
 
     /// <summary>
@@ -187,15 +190,25 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             interactionId,
             interaction.Files.Count);
 
-        // The interaction completes before the prompt task returns, so its uploads must remain available for the
-        // caller to process. The returned InteractionFileCollection owns their cleanup: .NET callers dispose the
-        // collection from GetFiles(), and ATS callers invoke ReleaseFiles() on the original input builder. Store
-        // disposal at AppHost shutdown is only a fallback for callers that do not release their files earlier.
-        foreach (var entry in interaction.Files.Values)
+        // Resolved entries belong to the accepted result and remain available for caller disposal. An entry that
+        // became Uploaded after the resolved snapshot was taken was not accepted and is removed. Uploads still being
+        // written are marked for deletion after their writer closes the file handle.
+        foreach (var (fileId, entry) in interaction.Files)
         {
+            bool removeEntry;
             lock (entry)
             {
-                entry.InteractionState = FileInteractionState.Complete;
+                removeEntry = entry.State == FileEntryState.Uploaded;
+                entry.State = entry.State switch
+                {
+                    FileEntryState.Uploading => FileEntryState.DiscardWhenComplete,
+                    _ => entry.State
+                };
+            }
+
+            if (removeEntry)
+            {
+                RemoveEntry(interactionId, fileId);
             }
         }
 
@@ -227,8 +240,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             bool removeEntry;
             lock (entry)
             {
-                entry.InteractionState = FileInteractionState.Canceled;
-                removeEntry = entry.UploadComplete;
+                removeEntry = entry.State is FileEntryState.Uploaded or FileEntryState.Resolved;
+                entry.State = FileEntryState.DiscardWhenComplete;
             }
 
             if (removeEntry)
@@ -241,54 +254,68 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     }
 
     /// <summary>
-    /// Resolves a JSON-encoded file reference array into InputFileDto entries.
-    /// Returns null if the value is empty, malformed, or contains no resolvable files.
+    /// Resolves completed uploads for an interaction input into InputFileDto entries.
     /// </summary>
-    public static IReadOnlyList<InputFileDto>? ResolveFileReferences(IInteractionFileUploadStore store, string? jsonValue, int interactionId, string inputName, ILogger logger)
+    public static IReadOnlyList<InputFileDto>? ResolveFiles(IInteractionFileUploadStore store, int interactionId, string inputName)
     {
-        if (string.IsNullOrEmpty(jsonValue))
-        {
-            return null;
-        }
+        var files = store.GetFiles(interactionId, inputName)
+            .Select(file => new InputFileDto(
+                file.Id,
+                file.Name,
+                file.FilePath,
+                () => store.RemoveEntry(interactionId, file.Id)))
+            .ToArray();
 
-        FileReference?[]? fileRefs;
+        return files.Length > 0 ? files : null;
+    }
+
+    /// <summary>
+    /// Validates that client-submitted file IDs exactly match the resolved files and returns them in client order.
+    /// </summary>
+    public static IReadOnlyList<InputFileDto>? ValidateFileReferences(string? jsonValue, string inputName, IReadOnlyList<InputFileDto>? files)
+    {
+        // Clients submit file selections as: [{"Id":"<upload-id>","Name":"<display-name>"}].
+        // Only Id participates in validation; Name is untrusted and resolved metadata remains authoritative.
+        FileReference?[] fileReferences;
         try
         {
-            fileRefs = JsonSerializer.Deserialize<FileReference?[]>(jsonValue);
+            fileReferences = string.IsNullOrEmpty(jsonValue)
+                ? []
+                : JsonSerializer.Deserialize<FileReference?[]>(jsonValue) ?? throw CreateFileMismatchException(inputName);
         }
         catch (JsonException ex)
         {
-            logger.LogWarning(ex, "Failed to deserialize file references for interaction input '{InputName}'. Treating as empty.", inputName);
-            return null;
+            throw CreateFileMismatchException(inputName, ex);
         }
 
-        if (fileRefs is not { Length: > 0 })
+        var filesById = (files ?? []).ToDictionary(file => file.Id, StringComparer.Ordinal);
+        if (fileReferences.Length != filesById.Count)
         {
-            return null;
+            throw CreateFileMismatchException(inputName);
         }
 
-        var files = new List<InputFileDto>(fileRefs.Length);
-        for (var idx = 0; idx < fileRefs.Length; idx++)
+        var orderedFiles = new InputFileDto[fileReferences.Length];
+        for (var i = 0; i < fileReferences.Length; i++)
         {
-            var fileRef = fileRefs[idx];
-            if (fileRef is null || string.IsNullOrEmpty(fileRef.Id))
+            if (fileReferences[i] is not { Id.Length: > 0 } fileReference)
             {
-                logger.LogWarning("Received malformed file reference in interaction input '{InputName}'. Skipping.", inputName);
-                continue;
+                throw CreateFileMismatchException(inputName);
             }
 
-            var filePath = store.GetFilePath(fileRef.Id, interactionId, inputName);
-            if (filePath is null)
+            if (!filesById.Remove(fileReference.Id, out var file))
             {
-                // Unknown file ID — skip to prevent using client-supplied IDs as arbitrary file paths.
-                logger.LogWarning("Received unknown file ID '{FileId}' in interaction input '{InputName}'. Skipping.", fileRef.Id, inputName);
-                continue;
+                throw CreateFileMismatchException(inputName);
             }
-            var fileName = store.GetFileName(interactionId, fileRef.Id) ?? "";
-            files.Add(new InputFileDto(fileRef.Id, fileName, filePath, () => store.RemoveEntry(interactionId, fileRef.Id)));
+
+            orderedFiles[i] = file;
         }
 
-        return files.Count > 0 ? files : null;
+        return orderedFiles.Length > 0 ? orderedFiles : null;
+    }
+
+    private static InvalidOperationException CreateFileMismatchException(string inputName, Exception? innerException = null)
+    {
+        return new InvalidOperationException($"Submitted files for input '{inputName}' do not match the completed uploads.", innerException);
     }
 
     public void Dispose()
@@ -317,12 +344,9 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         _interactions.Clear();
     }
 
-    // Shared type used by ResolveFileReferences for JSON deserialization of file input values.
-    // The shape matches what the Dashboard sends: [{"Id":"...","Name":"..."}]
     private sealed class FileReference
     {
         public string? Id { get; set; }
-        public string? Name { get; set; }
     }
 
     private bool TryGetEntry(int interactionId, string fileId, [NotNullWhen(true)] out FileEntry? entry)
@@ -348,8 +372,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         public TempFile TempFile { get; } = tempFile;
         public string InputName { get; } = inputName;
         public string OriginalFileName { get; } = originalFileName;
-        public bool UploadComplete { get; set; }
-        public FileInteractionState InteractionState { get; set; }
+        public FileEntryState State { get; set; }
     }
 
     private sealed class FileInteraction(IReadOnlyList<(string InputName, int MaxFileCount)> fileInputs)
@@ -367,5 +390,13 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         InProgress,
         Complete,
         Canceled
+    }
+
+    private enum FileEntryState
+    {
+        Uploading,
+        Uploaded,
+        Resolved,
+        DiscardWhenComplete
     }
 }

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -279,7 +279,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 continue;
             }
             var fileName = string.IsNullOrEmpty(fileRef.Name) ? store.GetFileName(interactionId, fileRef.Id) ?? "" : fileRef.Name;
-            files.Add(new InputFileDto(fileRef.Id, fileName, filePath));
+            files.Add(new InputFileDto(fileRef.Id, fileName, filePath, () => store.RemoveEntry(interactionId, fileRef.Id)));
         }
 
         return files.Count > 0 ? files : null;

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -7,7 +7,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using static Aspire.Hosting.Dashboard.DashboardServiceData;
 
 namespace Aspire.Hosting.Dashboard;
 
@@ -124,7 +123,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// <summary>
     /// Gets the completed uploads for an interaction input.
     /// </summary>
-    public IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName)
+    public IReadOnlyList<InteractionFileUpload> GetCompletedFiles(int interactionId, string inputName)
     {
         if (!_interactions.TryGetValue(interactionId, out var interaction))
         {
@@ -136,16 +135,40 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         {
             lock (entry)
             {
-                if (entry.State is FileEntryState.Uploaded or FileEntryState.Resolved &&
+                if (entry.State is FileEntryState.Uploaded or FileEntryState.Accepted &&
                     string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
                 {
-                    entry.State = FileEntryState.Resolved;
                     files.Add(new InteractionFileUpload(fileId, entry.OriginalFileName, entry.TempFile.Path));
                 }
             }
         }
 
         return files;
+    }
+
+    /// <summary>
+    /// Marks validated uploads as accepted into the interaction result.
+    /// </summary>
+    public void MarkFilesAccepted(int interactionId, string inputName, IReadOnlyList<string> fileIds)
+    {
+        foreach (var fileId in fileIds)
+        {
+            if (!TryGetEntry(interactionId, fileId, out var entry))
+            {
+                throw CreateFileMismatchException(inputName);
+            }
+
+            lock (entry)
+            {
+                if (entry.State is not (FileEntryState.Uploaded or FileEntryState.Accepted) ||
+                    !string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
+                {
+                    throw CreateFileMismatchException(inputName);
+                }
+
+                entry.State = FileEntryState.Accepted;
+            }
+        }
     }
 
     /// <summary>
@@ -190,8 +213,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             interactionId,
             interaction.Files.Count);
 
-        // Resolved entries belong to the accepted result and remain available for caller disposal. An entry that
-        // became Uploaded after the resolved snapshot was taken was not accepted and is removed. Uploads still being
+        // Accepted entries belong to the result and remain available for caller disposal. An entry that became
+        // Uploaded after the completed-file snapshot was taken was not accepted and is removed. Uploads still being
         // written are marked for deletion after their writer closes the file handle.
         foreach (var (fileId, entry) in interaction.Files)
         {
@@ -240,7 +263,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             bool removeEntry;
             lock (entry)
             {
-                removeEntry = entry.State is FileEntryState.Uploaded or FileEntryState.Resolved;
+                removeEntry = entry.State is FileEntryState.Uploaded or FileEntryState.Accepted;
                 entry.State = FileEntryState.DiscardWhenComplete;
             }
 
@@ -254,25 +277,9 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     }
 
     /// <summary>
-    /// Resolves completed uploads for an interaction input into InputFileDto entries.
+    /// Validates that client-submitted file IDs exactly match the completed files and returns them in client order.
     /// </summary>
-    public static IReadOnlyList<InputFileDto>? ResolveFiles(IInteractionFileUploadStore store, int interactionId, string inputName)
-    {
-        var files = store.GetFiles(interactionId, inputName)
-            .Select(file => new InputFileDto(
-                file.Id,
-                file.Name,
-                file.FilePath,
-                () => store.RemoveEntry(interactionId, file.Id)))
-            .ToArray();
-
-        return files.Length > 0 ? files : null;
-    }
-
-    /// <summary>
-    /// Validates that client-submitted file IDs exactly match the resolved files and returns them in client order.
-    /// </summary>
-    public static IReadOnlyList<InputFileDto>? ValidateFileReferences(string? jsonValue, string inputName, IReadOnlyList<InputFileDto>? files)
+    public static IReadOnlyList<InteractionFileUpload>? ValidateFileReferences(string? jsonValue, string inputName, IReadOnlyList<InteractionFileUpload>? files)
     {
         // Clients submit file selections as: [{"Id":"<upload-id>","Name":"<display-name>"}].
         // Only Id participates in validation; Name is untrusted and resolved metadata remains authoritative.
@@ -294,7 +301,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             throw CreateFileMismatchException(inputName);
         }
 
-        var orderedFiles = new InputFileDto[fileReferences.Length];
+        var orderedFiles = new InteractionFileUpload[fileReferences.Length];
         for (var i = 0; i < fileReferences.Length; i++)
         {
             if (fileReferences[i] is not { Id.Length: > 0 } fileReference)
@@ -396,7 +403,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     {
         Uploading,
         Uploaded,
-        Resolved,
+        Accepted,
         DiscardWhenComplete
     }
 }

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -7,7 +7,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using static Aspire.Hosting.Dashboard.DashboardServiceData;
 
 namespace Aspire.Hosting.Dashboard;
@@ -22,11 +21,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     private readonly ILogger<InteractionFileUploadStore> _logger;
     private int _disposed;
 
-    public InteractionFileUploadStore(IFileSystemService fileSystemService)
-        : this(fileSystemService, NullLogger<InteractionFileUploadStore>.Instance)
-    {
-    }
-
     public InteractionFileUploadStore(IFileSystemService fileSystemService, ILogger<InteractionFileUploadStore> logger)
     {
         _tempFileSystem = fileSystemService.TempDirectory;
@@ -34,11 +28,11 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     }
 
     /// <summary>
-    /// Registers an interaction that can own uploaded files.
+    /// Registers an interaction and the file inputs that can own uploaded files.
     /// </summary>
-    public void StartInteraction(int interactionId)
+    public void StartInteraction(int interactionId, IReadOnlyList<(string InputName, int MaxFileCount)> fileInputs)
     {
-        if (_interactions.TryAdd(interactionId, new FileInteraction()))
+        if (_interactions.TryAdd(interactionId, new FileInteraction(fileInputs)))
         {
             _logger.LogDebug("Started tracking file uploads for interaction {InteractionId}.", interactionId);
         }
@@ -61,16 +55,28 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 throw new InvalidOperationException($"Interaction '{interactionId}' is not accepting file uploads.");
             }
 
-            // Sanitize the file name to prevent path traversal attacks.
-            // Strip directory components for both Unix (/) and Windows (\) separators
-            // regardless of the current platform, since the name comes from a remote client.
+            if (!interaction.FileInputLimits.TryGetValue(inputName, out var maxFileCount))
+            {
+                throw new InvalidOperationException($"Interaction '{interactionId}' is not accepting file uploads for input '{inputName}'.");
+            }
+
+            // Count uploads in progress as reserved slots so concurrent requests cannot exceed the input's limit.
+            var fileCount = interaction.Files.Values.Count(entry => string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName));
+            if (fileCount >= maxFileCount)
+            {
+                var fileLabel = maxFileCount == 1 ? "file" : "files";
+                throw new InvalidOperationException($"File input '{inputName}' accepts at most {maxFileCount} {fileLabel}.");
+            }
+
+            // Keep only the leaf name as metadata. The client-supplied name is never used for the
+            // on-disk path because filename rules vary by platform and some names have special semantics.
             var lastSep = originalFileName.AsSpan().LastIndexOfAny('/', '\\');
             var safeName = lastSep >= 0 ? originalFileName[(lastSep + 1)..] : originalFileName;
 
-            var tempFile = _tempFileSystem.CreateTempFile(string.IsNullOrEmpty(safeName) ? null : safeName);
+            var tempFile = _tempFileSystem.CreateTempFile();
             var fileId = Guid.NewGuid().ToString("N");
 
-            interaction.Files[fileId] = new FileEntry(tempFile, inputName);
+            interaction.Files[fileId] = new FileEntry(tempFile, inputName, safeName);
             _logger.LogDebug(
                 "Created uploaded file entry {FileId} for interaction {InteractionId}, input {InputName}, and file {FileName}.",
                 fileId,
@@ -134,7 +140,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// </summary>
     public string? GetFileName(int interactionId, string fileId)
     {
-        return TryGetEntry(interactionId, fileId, out var entry) ? Path.GetFileName(entry.TempFile.Path) : null;
+        return TryGetEntry(interactionId, fileId, out var entry) ? entry.OriginalFileName : null;
     }
 
     /// <summary>
@@ -331,17 +337,22 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         }
     }
 
-    private sealed class FileEntry(TempFile tempFile, string inputName)
+    private sealed class FileEntry(TempFile tempFile, string inputName, string originalFileName)
     {
         public TempFile TempFile { get; } = tempFile;
         public string InputName { get; } = inputName;
+        public string OriginalFileName { get; } = originalFileName;
         public bool UploadComplete { get; set; }
         public FileInteractionState InteractionState { get; set; }
     }
 
-    private sealed class FileInteraction
+    private sealed class FileInteraction(IReadOnlyList<(string InputName, int MaxFileCount)> fileInputs)
     {
         public ConcurrentDictionary<string, FileEntry> Files { get; } = new(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, int> FileInputLimits { get; } = fileInputs.ToDictionary(
+            fileInput => fileInput.InputName,
+            fileInput => fileInput.MaxFileCount,
+            StringComparers.InteractionInputName);
         public FileInteractionState State { get; set; }
     }
 

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -528,7 +528,7 @@ public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, 
 /// </summary>
 public sealed class InteractionFile
 {
-    private int _disposed;
+    private bool _disposed;
 
     internal InteractionFile(string id, string name, string filePath)
     {
@@ -559,7 +559,7 @@ public sealed class InteractionFile
     /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
     public Stream OpenRead()
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ObjectDisposedException.ThrowIf(_disposed, this);
         return new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
     }
 
@@ -571,11 +571,11 @@ public sealed class InteractionFile
     /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
     public Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ObjectDisposedException.ThrowIf(_disposed, this);
         return File.ReadAllBytesAsync(FilePath, cancellationToken);
     }
 
-    internal void MarkDisposed() => Interlocked.Exchange(ref _disposed, 1);
+    internal void MarkDisposed() => _disposed = true;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -285,6 +285,7 @@ public sealed class InteractionInput
     private string _name = null!;
     private bool _required;
     private InputLoadOptions? _dynamicLoading;
+    private InteractionFileCollection _files = new([]);
 
     internal string EffectiveLabel => string.IsNullOrWhiteSpace(Label) ? Name : Label;
     internal InputLoadingState? DynamicLoadingState { get; set; }
@@ -297,7 +298,10 @@ public sealed class InteractionInput
 
     internal void SetRequired(bool required) => _required = required;
 
-    internal void SetFiles(IReadOnlyList<InteractionFile>? files) => Files = files;
+    internal void SetFiles(InteractionFileCollection files)
+    {
+        _files = files;
+    }
 
     internal void SetDynamicLoading(InputLoadOptions? dynamicLoading) => _dynamicLoading = dynamicLoading;
 
@@ -434,11 +438,78 @@ public sealed class InteractionInput
     /// Gets the files associated with this <see cref="InputType.File"/> input.
     /// Populated after the user selects file(s) and the interaction completes.
     /// </summary>
+    /// <remarks>
+    /// This property does not provide ownership of the uploaded files. Use <see cref="GetFiles"/> and dispose the
+    /// returned collection when the files are no longer needed.
+    /// </remarks>
+    [Obsolete("Use GetFiles() and dispose the returned collection when the files are no longer needed.")]
     // Excluded from the ATS surface: InteractionFile holds non-serializable methods (OpenRead, ReadAllBytesAsync)
     // and refers to server-local file paths. Polyglot app hosts receive file metadata through the manually defined
     // InteractionInputFile interface in base.mts, populated by ToResultInput.
     [AspireExportIgnore(Reason = "InteractionFile contains non-serializable methods and server-local paths; polyglot callers use InteractionInputFile from base.mts.")]
-    public IReadOnlyList<InteractionFile>? Files { get; private set; }
+    public IReadOnlyList<InteractionFile>? Files => _files.Count > 0 ? _files : null;
+
+    /// <summary>
+    /// Gets the files associated with this <see cref="InputType.File"/> input.
+    /// </summary>
+    /// <returns>
+    /// A disposable collection of uploaded files. Disposing the collection deletes the uploaded files from disk.
+    /// </returns>
+    /// <remarks>
+    /// The returned collection is owned by this input. Dispose it when the files are no longer needed. After disposal,
+    /// the file metadata remains available but file content can no longer be opened or read.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "InteractionFileCollection owns server-local files and implements IDisposable, which is not ATS-compatible.")]
+    public InteractionFileCollection GetFiles() => _files;
+}
+
+/// <summary>
+/// Represents the uploaded files associated with an interaction input.
+/// </summary>
+/// <remarks>
+/// Dispose the collection when its files are no longer needed. Disposing the collection deletes the uploaded files
+/// from disk. Disposal is idempotent.
+/// </remarks>
+[AspireExportIgnore(Reason = "InteractionFileCollection owns server-local files and implements IDisposable, which is not ATS-compatible.")]
+public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, IDisposable
+{
+    private readonly IReadOnlyList<InteractionFile> _files;
+    private Action? _dispose;
+
+    internal InteractionFileCollection(IReadOnlyList<InteractionFile> files, Action? dispose = null)
+    {
+        _files = files;
+        _dispose = dispose;
+    }
+
+    /// <summary>
+    /// Gets the number of uploaded files in the collection.
+    /// </summary>
+    public int Count => _files.Count;
+
+    /// <summary>
+    /// Gets an uploaded file by its zero-based index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the file.</param>
+    /// <returns>The uploaded file at the specified index.</returns>
+    public InteractionFile this[int index] => _files[index];
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the uploaded files.
+    /// </summary>
+    /// <returns>An enumerator for the uploaded files.</returns>
+    public IEnumerator<InteractionFile> GetEnumerator() => _files.GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Deletes the uploaded files from disk.
+    /// </summary>
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _dispose, null)?.Invoke();
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -456,8 +456,10 @@ public sealed class InteractionInput
     /// A disposable collection of uploaded files. Disposing the collection deletes the uploaded files from disk.
     /// </returns>
     /// <remarks>
-    /// The returned collection is owned by this input. Dispose it when the files are no longer needed. After disposal,
-    /// the file metadata remains available but file content can no longer be opened or read.
+    /// The caller owns the returned collection and must dispose it when the files are no longer needed to delete the
+    /// temporary files before AppHost shutdown. After disposal, the file metadata remains available but new content
+    /// reads cannot be started. Streams opened before disposal remain usable until those streams are disposed. Files
+    /// that are not disposed are deleted when the AppHost shuts down.
     /// </remarks>
     [AspireExportIgnore(Reason = "InteractionFileCollection owns server-local files and implements IDisposable, which is not ATS-compatible.")]
     public InteractionFileCollection GetFiles() => _files;
@@ -468,7 +470,8 @@ public sealed class InteractionInput
 /// </summary>
 /// <remarks>
 /// Dispose the collection when its files are no longer needed. Disposing the collection deletes the uploaded files
-/// from disk. Disposal is idempotent.
+/// from disk and prevents new content reads. Streams opened before disposal remain usable until those streams are
+/// disposed. Disposal is idempotent.
 /// </remarks>
 [AspireExportIgnore(Reason = "InteractionFileCollection owns server-local files and implements IDisposable, which is not ATS-compatible.")]
 public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, IDisposable
@@ -504,7 +507,8 @@ public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>
-    /// Deletes the uploaded files from disk.
+    /// Deletes the uploaded files from disk and prevents new content reads. Streams that are already open remain
+    /// usable until those streams are disposed.
     /// </summary>
     public void Dispose()
     {
@@ -556,11 +560,15 @@ public sealed class InteractionFile
     /// Opens a read-only stream for the file content.
     /// </summary>
     /// <returns>A <see cref="Stream"/> for reading the file.</returns>
+    /// <remarks>
+    /// The returned stream remains usable if the owning <see cref="InteractionFileCollection"/> is disposed. Dispose
+    /// the stream when reading is complete so the operating system can finish reclaiming the deleted file.
+    /// </remarks>
     /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
     public Stream OpenRead()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete, bufferSize: 4096, useAsync: true);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -579,8 +579,20 @@ public sealed class InteractionFile
     /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
     public Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        return File.ReadAllBytesAsync(FilePath, cancellationToken);
+        // File.ReadAllBytesAsync opens with FileShare.Read, which can prevent the owning collection from deleting
+        // the temporary file on Windows while a read is in progress. OpenRead also shares deletion.
+        var stream = OpenRead();
+        return ReadAllBytesAsyncCore(stream, cancellationToken);
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsyncCore(Stream stream, CancellationToken cancellationToken)
+    {
+        await using (stream.ConfigureAwait(false))
+        {
+            var bytes = new byte[stream.Length];
+            await stream.ReadExactlyAsync(bytes, cancellationToken).ConfigureAwait(false);
+            return bytes;
+        }
     }
 
     internal void MarkDisposed() => _disposed = true;

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -508,7 +508,18 @@ public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, 
     /// </summary>
     public void Dispose()
     {
-        Interlocked.Exchange(ref _dispose, null)?.Invoke();
+        var dispose = Interlocked.Exchange(ref _dispose, null);
+        if (dispose is null)
+        {
+            return;
+        }
+
+        foreach (var file in _files)
+        {
+            file.MarkDisposed();
+        }
+
+        dispose();
     }
 }
 
@@ -517,6 +528,8 @@ public sealed class InteractionFileCollection : IReadOnlyList<InteractionFile>, 
 /// </summary>
 public sealed class InteractionFile
 {
+    private int _disposed;
+
     internal InteractionFile(string id, string name, string filePath)
     {
         Id = id;
@@ -543,14 +556,26 @@ public sealed class InteractionFile
     /// Opens a read-only stream for the file content.
     /// </summary>
     /// <returns>A <see cref="Stream"/> for reading the file.</returns>
-    public Stream OpenRead() => new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+    /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
+    public Stream OpenRead()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        return new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+    }
 
     /// <summary>
     /// Reads all bytes of the file asynchronously.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A byte array containing the file content.</returns>
-    public Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default) => File.ReadAllBytesAsync(FilePath, cancellationToken);
+    /// <exception cref="ObjectDisposedException">The owning <see cref="InteractionFileCollection"/> has been disposed.</exception>
+    public Task<byte[]> ReadAllBytesAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        return File.ReadAllBytesAsync(FilePath, cancellationToken);
+    }
+
+    internal void MarkDisposed() => Interlocked.Exchange(ref _disposed, 1);
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -562,7 +562,23 @@ internal class InteractionService : IInteractionService
                 {
                     var value = input.Value = input.Value?.Trim();
 
-                    if (string.IsNullOrEmpty(value))
+                    if (input.InputType == InputType.File)
+                    {
+                        var files = input.GetFiles();
+                        if (input.Required && files.Count == 0)
+                        {
+                            context.AddValidationError(input, "Value is required.");
+                        }
+                        else
+                        {
+                            var maxFileCount = InteractionHelpers.GetMaxFileCount(input.AllowMultipleFiles);
+                            if (files.Count > maxFileCount)
+                            {
+                                context.AddValidationError(input, $"File count exceeds the maximum of {maxFileCount}.");
+                            }
+                        }
+                    }
+                    else if (string.IsNullOrEmpty(value))
                     {
                         if (input.Required)
                         {
@@ -602,25 +618,6 @@ internal class InteractionService : IInteractionService
                                 if (!int.TryParse(value, CultureInfo.InvariantCulture, out _))
                                 {
                                     context.AddValidationError(input, "Value must be a valid number.");
-                                }
-                                break;
-                            case InputType.File:
-                                // File input values contain serialized JSON file references (id + name).
-                                // The consumer reads files via InteractionFile.OpenRead() / ReadAllBytesAsync() on the collection returned by GetFiles().
-                                // Validate that required file inputs actually have resolved files, not just
-                                // a non-empty JSON string like "[]".
-                                var files = input.GetFiles();
-                                if (input.Required && files.Count == 0)
-                                {
-                                    context.AddValidationError(input, "Value is required.");
-                                }
-                                else if (files.Count is var fileCount)
-                                {
-                                    var maxFileCount = InteractionHelpers.GetMaxFileCount(input.AllowMultipleFiles);
-                                    if (fileCount > maxFileCount)
-                                    {
-                                        context.AddValidationError(input, $"File count exceeds the maximum of {maxFileCount}.");
-                                    }
                                 }
                                 break;
                             default:

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -195,7 +195,11 @@ internal class InteractionService : IInteractionService
             var newState = new Interaction(title, message, options, new Interaction.InputsInteractionInfo(inputCollection), interactionCts.Token);
             if (hasFileInputs)
             {
-                _fileUploadStore.StartInteraction(newState.InteractionId);
+                var fileInputs = inputs
+                    .Where(input => input.InputType == InputType.File)
+                    .Select(input => (input.Name, InteractionHelpers.GetMaxFileCount(input.AllowMultipleFiles)))
+                    .ToArray();
+                _fileUploadStore.StartInteraction(newState.InteractionId, fileInputs);
             }
             AddInteractionUpdate(newState);
 
@@ -608,6 +612,14 @@ internal class InteractionService : IInteractionService
                                 if (input.Required && (input.Files is null || input.Files.Count == 0))
                                 {
                                     context.AddValidationError(input, "Value is required.");
+                                }
+                                else if (input.Files is { Count: var fileCount })
+                                {
+                                    var maxFileCount = InteractionHelpers.GetMaxFileCount(input.AllowMultipleFiles);
+                                    if (fileCount > maxFileCount)
+                                    {
+                                        context.AddValidationError(input, $"File count exceeds the maximum of {maxFileCount}.");
+                                    }
                                 }
                                 break;
                             default:

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -606,14 +606,15 @@ internal class InteractionService : IInteractionService
                                 break;
                             case InputType.File:
                                 // File input values contain serialized JSON file references (id + name).
-                                // The consumer reads files via InteractionFile.OpenRead() / ReadAllBytesAsync() on the Files collection.
+                                // The consumer reads files via InteractionFile.OpenRead() / ReadAllBytesAsync() on the collection returned by GetFiles().
                                 // Validate that required file inputs actually have resolved files, not just
                                 // a non-empty JSON string like "[]".
-                                if (input.Required && (input.Files is null || input.Files.Count == 0))
+                                var files = input.GetFiles();
+                                if (input.Required && files.Count == 0)
                                 {
                                     context.AddValidationError(input, "Value is required.");
                                 }
-                                else if (input.Files is { Count: var fileCount })
+                                else if (files.Count is var fileCount)
                                 {
                                     var maxFileCount = InteractionHelpers.GetMaxFileCount(input.AllowMultipleFiles);
                                     if (fileCount > maxFileCount)

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -491,7 +491,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
 
         if (matchingInput.InputType == InputType.File)
         {
-            var files = DashboardServiceData.ResolveAndValidateFiles(_fileUploadStore, value, interactionId, matchingInput.Name);
+            var files = DashboardServiceData.GetAcceptedFiles(_fileUploadStore, value, interactionId, matchingInput.Name);
             if (files is not null)
             {
                 return new InputDto(matchingInput.Name, value, matchingInput.InputType, files);

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -413,10 +413,11 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                     {
                         var options = (InputsDialogInteractionOptions)interaction.Options;
 
+                        var dtos = new List<InputDto>();
+
                         // Set values for all inputs if we have responses
                         if (responses is not null)
                         {
-                            var dtos = new List<InputDto>();
                             for (var i = 0; i < responses.Length; i++)
                             {
                                 var responseAnswer = responses[i];
@@ -437,15 +438,16 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
 
                                 dtos.Add(CreateInputDto(interactionId, matchingInput, responseAnswer));
                             }
-
-                            DashboardServiceData.ProcessInputs(
-                                serviceProvider,
-                                logger,
-                                inputsInfo,
-                                dtos,
-                                dependencyChange: updateResponse,
-                                interaction.CancellationToken);
                         }
+
+                        dtos = DashboardServiceData.CreateInputDtos(_fileUploadStore, interactionId, inputsInfo, dtos);
+                        DashboardServiceData.ProcessInputs(
+                            serviceProvider,
+                            logger,
+                            inputsInfo,
+                            dtos,
+                            dependencyChange: updateResponse,
+                            interaction.CancellationToken);
 
                         return new InteractionCompletionState
                         {
@@ -481,8 +483,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
     }
 
     /// <summary>
-    /// Creates an InputDto, resolving file references from the InteractionFileUploadStore for File inputs.
-    /// The CLI sends Value as JSON [{"Id":"...","Name":"..."}] matching the dashboard format.
+    /// Creates an InputDto, resolving completed uploads from the InteractionFileUploadStore for File inputs.
     /// </summary>
     private InputDto CreateInputDto(int interactionId, InteractionInput matchingInput, PublishingPromptInputAnswer responseAnswer)
     {
@@ -490,7 +491,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
 
         if (matchingInput.InputType == InputType.File)
         {
-            var files = InteractionFileUploadStore.ResolveFileReferences(_fileUploadStore, value, interactionId, matchingInput.Name, _logger);
+            var files = DashboardServiceData.ResolveAndValidateFiles(_fileUploadStore, value, interactionId, matchingInput.Name);
             if (files is not null)
             {
                 return new InputDto(matchingInput.Name, value, matchingInput.InputType, files);

--- a/src/Aspire.Hosting/Utils/FileSystemService.cs
+++ b/src/Aspire.Hosting/Utils/FileSystemService.cs
@@ -27,7 +27,7 @@ internal sealed class FileSystemService : IFileSystemService, IDisposable
 
         // Check configuration to preserve temp files for debugging
         _preserveTempFiles = configuration["ASPIRE_PRESERVE_TEMP_FILES"] is not null;
-        
+
         _tempDirectory = new TempFileSystemService(this);
     }
 

--- a/src/Shared/InteractionHelpers.cs
+++ b/src/Shared/InteractionHelpers.cs
@@ -15,6 +15,9 @@ internal static partial class InteractionHelpers
     // to prevent possible abuse of interactions API.
     public const int DefaultMaxLength = 8000;
 
+    // Limits multi-file inputs to a practical number of files while preventing unbounded submissions.
+    public const int MaxFileCount = 100;
+
     [GeneratedRegex("[^a-z0-9]+")]
     private static partial Regex NonAlphanumericRegex();
 
@@ -28,6 +31,8 @@ internal static partial class InteractionHelpers
 
         return configuredInputLength.Value;
     }
+
+    public static int GetMaxFileCount(bool allowMultipleFiles) => allowMultipleFiles ? MaxFileCount : 1;
 
     public static string LabelToName(string label)
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Model.Interaction;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.DashboardService.Proto.V1;
 using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
@@ -69,6 +70,55 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
         });
     }
 
+    [Theory]
+    [InlineData(InteractionHelpers.MaxFileCount, true)]
+    [InlineData(InteractionHelpers.MaxFileCount + 1, false)]
+    public async Task Render_MultipleFileSelection_ValidatesMaximumFileCount(int fileCount, bool expectedAccepted)
+    {
+        var cut = SetUpDialog(out var dialogService);
+        var interaction = new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            InputsDialog = new InteractionInputsDialog()
+        };
+        interaction.InputsDialog.InputItems.Add(new InteractionInput
+        {
+            Name = "artifacts",
+            Label = "Artifacts",
+            InputType = InputType.File,
+            AllowMultipleFiles = true
+        });
+        var viewModel = new InteractionsInputsDialogViewModel
+        {
+            Interaction = interaction,
+            Message = string.Empty,
+            OnSubmitCallback = (_, _) => Task.CompletedTask
+        };
+        await dialogService.ShowDialogAsync<InteractionsInputDialog>(viewModel, new DialogParameters
+        {
+            Title = "Upload"
+        });
+        var files = Enumerable.Range(0, fileCount)
+            .Select(i => (IBrowserFile)new TestBrowserFile($"file-{i}.txt"))
+            .ToArray();
+        var inputFile = cut.FindComponent<FluentInputFile>();
+        var args = new InputFileChangeEventArgs(files);
+
+        if (expectedAccepted)
+        {
+            await cut.InvokeAsync(() => inputFile.Instance.OnInputFileChange.InvokeAsync(args));
+
+            cut.WaitForAssertion(() => Assert.Equal(fileCount, cut.FindAll(".uploaded-file-container").Count));
+        }
+        else
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => cut.InvokeAsync(() => inputFile.Instance.OnInputFileChange.InvokeAsync(args)));
+
+            Assert.Contains(InteractionHelpers.MaxFileCount.ToString(), exception.Message, StringComparison.Ordinal);
+        }
+    }
+
     private IRenderedFragment SetUpDialog(out IDialogService dialogService)
     {
         Services.AddSingleton<IDashboardClient>(new TestDashboardClient());
@@ -108,5 +158,15 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
             Message = string.Empty,
             OnSubmitCallback = (_, _) => Task.CompletedTask
         };
+    }
+
+    private sealed class TestBrowserFile(string name) : IBrowserFile
+    {
+        public string Name { get; } = name;
+        public DateTimeOffset LastModified { get; } = DateTimeOffset.UnixEpoch;
+        public long Size => 0;
+        public string ContentType => "text/plain";
+
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream();
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -17807,6 +17807,7 @@ func (s *inputsInteractionResult) Inputs() InteractionInputCollection {
 // InteractionInputBuilder is the public interface for handle type InteractionInputBuilder.
 type InteractionInputBuilder interface {
 	handleReference
+	ReleaseFiles() error
 	WithChoiceOptions(choices []*InteractionChoiceOption) InteractionInputBuilder
 	WithDynamicLoading(callback func(arg InteractionInputLoadContext), options ...*DynamicLoadingOptions) InteractionInputBuilder
 	WithValue(value string) InteractionInputBuilder
@@ -17821,6 +17822,17 @@ type interactionInputBuilder struct {
 // newInteractionInputBuilderFromHandle wraps an existing handle as InteractionInputBuilder.
 func newInteractionInputBuilderFromHandle(h *handle, c *client) InteractionInputBuilder {
 	return &interactionInputBuilder{resourceBuilderBase: newResourceBuilderBase(h, c)}
+}
+
+// ReleaseFiles releases uploaded files associated with the input.
+func (s *interactionInputBuilder) ReleaseFiles() error {
+	if s.err != nil { return s.err }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"context": s.handle.ToJSON(),
+	}
+	_, err := s.client.invokeCapability(ctx, "Aspire.Hosting.Ats/releaseFiles", reqArgs)
+	return err
 }
 
 // WithChoiceOptions sets the choice options for the input.

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -16738,6 +16738,13 @@ public class InteractionInputBuilder extends HandleWrapperBase {
         return (InteractionInputBuilder) result;
     }
 
+    /** Releases uploaded files associated with the input. */
+    public void releaseFiles() {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("context", AspireClient.serializeValue(getHandle()));
+        getClient().invokeCapability("Aspire.Hosting.Ats/releaseFiles", reqArgs);
+    }
+
     public InteractionInputBuilder withDynamicLoading(AspireAction1<InteractionInputLoadContext> callback) {
         return withDynamicLoading(callback, null);
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -5801,6 +5801,14 @@ class InteractionInputBuilder:
         )
         return typing.cast(InteractionInputBuilder, result)
 
+    def release_files(self) -> None:
+        """Releases uploaded files associated with the input."""
+        rpc_args: dict[str, typing.Any] = {'context': self._handle}
+        self._client.invoke_capability(
+            'Aspire.Hosting.Ats/releaseFiles',
+            rpc_args
+        )
+
     def with_dynamic_loading(self, callback: typing.Callable[[InteractionInputLoadContext], None], *, options: DynamicLoadingOptions | None = None) -> InteractionInputBuilder:
         """Attaches a callback that dynamically loads or updates the input after the prompt starts."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -13288,6 +13288,14 @@ impl InteractionInputBuilder {
         Ok(InteractionInputBuilder::new(handle, self.client.clone()))
     }
 
+    /// Releases uploaded files associated with the input.
+    pub fn release_files(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("context".to_string(), self.handle.to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting.Ats/releaseFiles", args)?;
+        Ok(())
+    }
+
     /// Attaches a callback that dynamically loads or updates the input after the prompt starts.
     pub fn with_dynamic_loading(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static, options: Option<DynamicLoadingOptions>) -> Result<InteractionInputBuilder, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -6746,6 +6746,14 @@ export interface InteractionInputBuilder {
      */
     withValue(value: string): InteractionInputBuilderPromise;
     /**
+     * Releases uploaded files associated with the input.
+     *
+     * Call this after processing the file paths returned by the prompt. Releasing the files deletes the
+     * server-side temporary files before AppHost shutdown and is idempotent. Files that are not released are
+     * deleted when the AppHost shuts down.
+     */
+    releaseFiles(): InteractionInputBuilderPromise;
+    /**
      * Attaches a callback that dynamically loads or updates the input after the prompt starts.
      * @param callback The callback invoked to load the input. Use the supplied context to read other inputs and update this input.
      * @param options Additional options.
@@ -6767,6 +6775,14 @@ export interface InteractionInputBuilderPromise extends PromiseLike<InteractionI
      * @returns The same builder handle.
      */
     withValue(value: string): InteractionInputBuilderPromise;
+    /**
+     * Releases uploaded files associated with the input.
+     *
+     * Call this after processing the file paths returned by the prompt. Releasing the files deletes the
+     * server-side temporary files before AppHost shutdown and is idempotent. Files that are not released are
+     * deleted when the AppHost shuts down.
+     */
+    releaseFiles(): InteractionInputBuilderPromise;
     /**
      * Attaches a callback that dynamically loads or updates the input after the prompt starts.
      * @param callback The callback invoked to load the input. Use the supplied context to read other inputs and update this input.
@@ -6832,6 +6848,27 @@ class InteractionInputBuilderImpl implements InteractionInputBuilder {
     }
 
     /** @internal */
+    async _releaseFilesInternal(): Promise<InteractionInputBuilder> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting.Ats/releaseFiles',
+            rpcArgs
+        );
+        return this;
+    }
+
+    /**
+     * Releases uploaded files associated with the input.
+     *
+     * Call this after processing the file paths returned by the prompt. Releasing the files deletes the
+     * server-side temporary files before AppHost shutdown and is idempotent. Files that are not released are
+     * deleted when the AppHost shuts down.
+     */
+    releaseFiles(): InteractionInputBuilderPromise {
+        return new InteractionInputBuilderPromiseImpl(this._releaseFilesInternal(), this._client);
+    }
+
+    /** @internal */
     async _withDynamicLoadingInternal(callback: (arg: InteractionInputLoadContext) => Promise<void>, options?: DynamicLoadingOptions): Promise<InteractionInputBuilder> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as InteractionInputLoadContextHandle;
@@ -6880,6 +6917,10 @@ class InteractionInputBuilderPromiseImpl implements InteractionInputBuilderPromi
 
     withValue(value: string): InteractionInputBuilderPromise {
         return new InteractionInputBuilderPromiseImpl(this._promise.then(obj => obj.withValue(value)), this._client);
+    }
+
+    releaseFiles(): InteractionInputBuilderPromise {
+        return new InteractionInputBuilderPromiseImpl(this._promise.then(obj => obj.releaseFiles()), this._client);
     }
 
     withDynamicLoading(callback: (arg: InteractionInputLoadContext) => Promise<void>, options?: DynamicLoadingOptions): InteractionInputBuilderPromise {

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsExportsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsExportsTests.cs
@@ -139,7 +139,7 @@ public class AtsExportsTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.WorkspaceRoot.FullName, "artifact.zip");
         await File.WriteAllTextAsync(tempFile, "test content");
-        data.Inputs["artifact"].SetFiles([new InteractionFile("file-1", "artifact.zip", tempFile)]);
+        data.Inputs["artifact"].SetFiles(new InteractionFileCollection([new InteractionFile("file-1", "artifact.zip", tempFile)]));
 
         data.CompletionTcs.SetResult(InteractionResult.Ok(data.Inputs));
 
@@ -147,8 +147,8 @@ public class AtsExportsTests(ITestOutputHelper outputHelper)
 
         Assert.False(result.Canceled);
         Assert.Equal("/repo/artifact.zip", result.Inputs["artifact"].Value);
-        Assert.NotNull(result.Inputs["artifact"].Files);
-        var file = Assert.Single(result.Inputs["artifact"].Files!);
+        using var files = result.Inputs["artifact"].GetFiles();
+        var file = Assert.Single(files);
         Assert.Equal("artifact.zip", file.Name);
         Assert.Equal(1024, result.Inputs["artifact"].MaxFileSize);
     }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsExportsTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsExportsTests.cs
@@ -120,18 +120,17 @@ public class AtsExportsTests(ITestOutputHelper outputHelper)
     public async Task PromptInputs_ResultCarriesSubmittedFileMetadataByName()
     {
         var interactionService = new TestInteractionService();
+        var input = InteractionExports.CreateFileInput(interactionService, "artifact", new CreateInteractionInputOptions
+        {
+            Label = "Artifact",
+            MaxFileSize = 1024
+        });
 
         var promptTask = InteractionExports.PromptInputs(
             interactionService,
             "Upload",
             "Select a file.",
-            [
-                InteractionExports.CreateFileInput(interactionService, "artifact", new CreateInteractionInputOptions
-                {
-                    Label = "Artifact",
-                    MaxFileSize = 1024
-                }),
-            ]);
+            [input]);
 
         var data = await interactionService.Interactions.Reader.ReadAsync();
         data.Inputs["artifact"].Value = "/repo/artifact.zip";
@@ -139,7 +138,10 @@ public class AtsExportsTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var tempFile = Path.Combine(workspace.WorkspaceRoot.FullName, "artifact.zip");
         await File.WriteAllTextAsync(tempFile, "test content");
-        data.Inputs["artifact"].SetFiles(new InteractionFileCollection([new InteractionFile("file-1", "artifact.zip", tempFile)]));
+        var releaseCount = 0;
+        data.Inputs["artifact"].SetFiles(new InteractionFileCollection(
+            [new InteractionFile("file-1", "artifact.zip", tempFile)],
+            () => releaseCount++));
 
         data.CompletionTcs.SetResult(InteractionResult.Ok(data.Inputs));
 
@@ -147,10 +149,16 @@ public class AtsExportsTests(ITestOutputHelper outputHelper)
 
         Assert.False(result.Canceled);
         Assert.Equal("/repo/artifact.zip", result.Inputs["artifact"].Value);
-        using var files = result.Inputs["artifact"].GetFiles();
+        var files = result.Inputs["artifact"].GetFiles();
         var file = Assert.Single(files);
         Assert.Equal("artifact.zip", file.Name);
         Assert.Equal(1024, result.Inputs["artifact"].MaxFileSize);
+
+        input.ReleaseFiles();
+        input.ReleaseFiles();
+
+        Assert.Equal(1, releaseCount);
+        Assert.Equal("artifact.zip", file.Name);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
@@ -68,7 +68,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
         var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
         Assert.Equal(data, await File.ReadAllBytesAsync(filePath));
         Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
-        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetFiles(interactionId, inputName)).Name);
+        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetCompletedFiles(interactionId, inputName)).Name);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
@@ -68,7 +68,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
         var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
         Assert.Equal(data, await File.ReadAllBytesAsync(filePath));
         Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
-        Assert.Equal(expectedFileName, fileUploadStore.GetFileName(interactionId, response.FileId));
+        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetFiles(interactionId, inputName)).Name);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
@@ -19,7 +19,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
         var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
         const int interactionId = 1;
         const string inputName = "File";
-        fileUploadStore.StartInteraction(interactionId);
+        fileUploadStore.StartInteraction(interactionId, [(inputName, InteractionHelpers.MaxFileCount)]);
         var data = Encoding.UTF8.GetBytes("uploaded content");
 
         var response = await target.UploadFileAsync(new UploadFileRequest
@@ -37,6 +37,62 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
 
         Assert.Null(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
         Assert.False(File.Exists(filePath));
+    }
+
+    [Theory]
+    [InlineData("../../../etc/passwd", "passwd")]
+    [InlineData("..\\..\\windows\\system32\\evil.exe", "evil.exe")]
+    [InlineData("bad*.txt", "bad*.txt")]
+    [InlineData("bad:name.txt", "bad:name.txt")]
+    [InlineData("CON.txt", "CON.txt")]
+    [InlineData("bad\0name.txt", "bad\0name.txt")]
+    public async Task UploadFileAsync_MaliciousFileName_UsesRandomDiskName(string fileName, string expectedFileName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+        var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
+        const int interactionId = 1;
+        const string inputName = "File";
+        fileUploadStore.StartInteraction(interactionId, [(inputName, 1)]);
+        byte[] data = [1, 2, 3];
+
+        var response = await target.UploadFileAsync(new UploadFileRequest
+        {
+            Data = data,
+            FileName = fileName,
+            InteractionId = interactionId,
+            InputName = inputName
+        });
+
+        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
+        Assert.Equal(data, await File.ReadAllBytesAsync(filePath));
+        Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
+        Assert.Equal(expectedFileName, fileUploadStore.GetFileName(interactionId, response.FileId));
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_ExceedsInputFileCountLimit_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+        var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
+        const int interactionId = 1;
+        const string inputName = "File";
+        fileUploadStore.StartInteraction(interactionId, [(inputName, 1)]);
+        var request = new UploadFileRequest
+        {
+            Data = [1],
+            FileName = "file.txt",
+            InteractionId = interactionId,
+            InputName = inputName
+        };
+        await target.UploadFileAsync(request);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.UploadFileAsync(request));
+
+        Assert.Equal($"File input '{inputName}' accepts at most 1 file.", exception.Message);
     }
 
     [Theory]
@@ -87,7 +143,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
         var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
         const int interactionId = 1;
         const string inputName = "File";
-        fileUploadStore.StartInteraction(interactionId);
+        fileUploadStore.StartInteraction(interactionId, [(inputName, 1)]);
         using var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
@@ -100,7 +156,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
         }, cancellationTokenSource.Token));
 
         fileUploadStore.CompleteInteraction(interactionId);
-        fileUploadStore.StartInteraction(interactionId);
+        fileUploadStore.StartInteraction(interactionId, [(inputName, 1)]);
         var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", interactionId, inputName);
 
         Assert.True(File.Exists(replacementPath));

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1098,8 +1098,52 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var result = await resultTask;
         var resultInputs = Assert.IsType<InteractionInputCollection>(result.Data);
 
-        Assert.Null(resultInputs[textInput.Name].Files);
+        Assert.Empty(resultInputs[textInput.Name].GetFiles());
         Assert.Equal(value, resultInputs[textInput.Name].Value);
+    }
+
+    [Fact]
+    public async Task SendInteractionRequestAsync_DisposeFiles_DeletesUploadedFiles()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        var interactionService = new InteractionService(
+            NullLogger<InteractionService>.Instance,
+            new DistributedApplicationOptions(),
+            new ServiceCollection().BuildServiceProvider(),
+            new ConfigurationBuilder().Build(),
+            fileUploadStore);
+        using var dashboardServiceData = CreateDashboardServiceData(interactionService: interactionService, fileUploadStore: fileUploadStore);
+        var input = new InteractionInput { Name = "File", InputType = InputType.File, Required = true };
+        var resultTask = interactionService.PromptInputAsync("Upload", "Select a file", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        var (fileId, filePath) = fileUploadStore.CreateEntry("document.txt", interaction.InteractionId, input.Name);
+        await File.WriteAllTextAsync(filePath, "content");
+        fileUploadStore.CompleteUpload(interaction.InteractionId, fileId);
+        var request = new WatchInteractionsRequestUpdate
+        {
+            InteractionId = interaction.InteractionId,
+            InputsDialog = new InteractionInputsDialog()
+        };
+        request.InputsDialog.InputItems.Add(new Aspire.DashboardService.Proto.V1.InteractionInput
+        {
+            Name = input.Name,
+            InputType = Aspire.DashboardService.Proto.V1.InputType.File,
+            Value = $"[{{\"Id\":\"{fileId}\",\"Name\":\"document.txt\"}}]"
+        });
+
+        await dashboardServiceData.SendInteractionRequestAsync(request, CancellationToken.None);
+        var result = await resultTask;
+        var resultInput = Assert.IsType<InteractionInput>(result.Data);
+        var files = resultInput.GetFiles();
+        Assert.Equal(filePath, Assert.Single(files).FilePath);
+        Assert.True(File.Exists(filePath));
+
+        files.Dispose();
+        files.Dispose();
+
+        Assert.False(File.Exists(filePath));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, interaction.InteractionId, input.Name));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1136,14 +1136,25 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var result = await resultTask;
         var resultInput = Assert.IsType<InteractionInput>(result.Data);
         var files = resultInput.GetFiles();
-        Assert.Equal(filePath, Assert.Single(files).FilePath);
+        var file = Assert.Single(files);
+        Assert.Equal(filePath, file.FilePath);
         Assert.True(File.Exists(filePath));
+        Assert.Equal("content", Encoding.UTF8.GetString(await file.ReadAllBytesAsync()));
+        await using (var stream = file.OpenRead())
+        using (var reader = new StreamReader(stream))
+        {
+            Assert.Equal("content", await reader.ReadToEndAsync());
+        }
 
         files.Dispose();
         files.Dispose();
 
         Assert.False(File.Exists(filePath));
         Assert.Null(fileUploadStore.GetFilePath(fileId, interaction.InteractionId, input.Name));
+        Assert.Throws<ObjectDisposedException>(file.OpenRead);
+        await Assert.ThrowsAsync<ObjectDisposedException>(ReadAllBytesAfterDisposeAsync);
+
+        Task ReadAllBytesAfterDisposeAsync() => file.ReadAllBytesAsync();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -882,7 +882,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, 1, "File"));
         Assert.True(File.Exists(filePath));
         Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
-        Assert.Equal(expectedFileName, fileUploadStore.GetFileName(1, response.FileId));
+        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetFiles(1, "File")).Name);
     }
 
     [Fact]
@@ -1103,7 +1103,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task SendInteractionRequestAsync_DisposeFiles_DeletesUploadedFiles()
+    public async Task SendInteractionRequestAsync_UsesAuthoritativeFilesAndDisposeDeletesUploads()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
@@ -1114,12 +1114,15 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new ConfigurationBuilder().Build(),
             fileUploadStore);
         using var dashboardServiceData = CreateDashboardServiceData(interactionService: interactionService, fileUploadStore: fileUploadStore);
-        var input = new InteractionInput { Name = "File", InputType = InputType.File, Required = true };
+        var input = new InteractionInput { Name = "File", InputType = InputType.File, Required = true, AllowMultipleFiles = true };
         var resultTask = interactionService.PromptInputAsync("Upload", "Select a file", input);
         var interaction = Assert.Single(interactionService.GetCurrentInteractions());
         var (fileId, filePath) = fileUploadStore.CreateEntry("document.txt", interaction.InteractionId, input.Name);
+        var (secondFileId, secondFilePath) = fileUploadStore.CreateEntry("second.txt", interaction.InteractionId, input.Name);
         await File.WriteAllTextAsync(filePath, "content");
+        await File.WriteAllTextAsync(secondFilePath, "second content");
         fileUploadStore.CompleteUpload(interaction.InteractionId, fileId);
+        fileUploadStore.CompleteUpload(interaction.InteractionId, secondFileId);
         var request = new WatchInteractionsRequestUpdate
         {
             InteractionId = interaction.InteractionId,
@@ -1129,16 +1132,21 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         {
             Name = input.Name,
             InputType = Aspire.DashboardService.Proto.V1.InputType.File,
-            Value = $"[{{\"Id\":\"{fileId}\",\"Name\":\"document.txt\"}}]"
+            Value = $"[{{\"Id\":\"{fileId}\",\"Name\":\"spoofed.txt\"}},{{\"Id\":\"{secondFileId}\",\"Name\":\"also-spoofed.txt\"}}]"
         });
-
         await dashboardServiceData.SendInteractionRequestAsync(request, CancellationToken.None);
         var result = await resultTask;
         var resultInput = Assert.IsType<InteractionInput>(result.Data);
         var files = resultInput.GetFiles();
-        var file = Assert.Single(files);
+        Assert.Equal(2, files.Count);
+        var file = files[0];
+        var secondFile = files[1];
         Assert.Equal(filePath, file.FilePath);
+        Assert.Equal("document.txt", file.Name);
+        Assert.Equal(secondFilePath, secondFile.FilePath);
+        Assert.Equal("second.txt", secondFile.Name);
         Assert.True(File.Exists(filePath));
+        Assert.True(File.Exists(secondFilePath));
         Assert.Equal("content", Encoding.UTF8.GetString(await file.ReadAllBytesAsync()));
         await using var stream = file.OpenRead();
         using var reader = new StreamReader(stream);
@@ -1149,8 +1157,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         files.Dispose();
 
         Assert.False(File.Exists(filePath));
+        Assert.False(File.Exists(secondFilePath));
         Assert.Equal("content", Encoding.UTF8.GetString(await readAllBytesTask));
         Assert.Null(fileUploadStore.GetFilePath(fileId, interaction.InteractionId, input.Name));
+        Assert.Null(fileUploadStore.GetFilePath(secondFileId, interaction.InteractionId, input.Name));
         Assert.Throws<ObjectDisposedException>(file.OpenRead);
         await Assert.ThrowsAsync<ObjectDisposedException>(ReadAllBytesAfterDisposeAsync);
 
@@ -1158,7 +1168,43 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task UploadFile_ThenResolveFileReferences_ResolvesCorrectly()
+    public async Task SendInteractionRequestAsync_MismatchedFiles_Throws()
+    {
+        var fileUploadStore = new TestInteractionFileUploadStore();
+        var interactionService = new InteractionService(
+            NullLogger<InteractionService>.Instance,
+            new DistributedApplicationOptions(),
+            new ServiceCollection().BuildServiceProvider(),
+            new ConfigurationBuilder().Build(),
+            fileUploadStore);
+        using var dashboardServiceData = CreateDashboardServiceData(interactionService: interactionService, fileUploadStore: fileUploadStore);
+        var input = new InteractionInput { Name = "File", InputType = InputType.File };
+        var resultTask = interactionService.PromptInputAsync("Upload", "Select a file", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        var (fileId, _) = fileUploadStore.CreateEntry("document.txt", interaction.InteractionId, input.Name);
+        fileUploadStore.CompleteUpload(interaction.InteractionId, fileId);
+        var request = new WatchInteractionsRequestUpdate
+        {
+            InteractionId = interaction.InteractionId,
+            InputsDialog = new InteractionInputsDialog()
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            dashboardServiceData.SendInteractionRequestAsync(request, CancellationToken.None));
+
+        Assert.Equal("Submitted files for input 'File' do not match the completed uploads.", exception.Message);
+        await dashboardServiceData.SendInteractionRequestAsync(
+            new WatchInteractionsRequestUpdate
+            {
+                InteractionId = interaction.InteractionId,
+                Complete = new InteractionComplete()
+            },
+            CancellationToken.None);
+        Assert.True((await resultTask).Canceled);
+    }
+
+    [Fact]
+    public async Task UploadFile_ThenResolveFiles_ResolvesCorrectly()
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
@@ -1175,9 +1221,9 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var uploadResponse = await dashboardService.UploadFile(requestStream, context);
 
-        // Resolve the file reference using the same store
-        var json = $"[{{\"Id\":\"{uploadResponse.FileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "CertInput", NullLogger.Instance);
+        var json = $"[{{\"Id\":\"{uploadResponse.FileId}\"}}]";
+        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "CertInput");
+        InteractionFileUploadStore.ValidateFileReferences(json, "CertInput", resolvedFiles);
 
         Assert.NotNull(resolvedFiles);
         var file = Assert.Single(resolvedFiles);
@@ -1191,25 +1237,27 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void ResolveFileReferences_UnknownId_ReturnsNull()
+    public void ResolveFiles_UnknownInteraction_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-        var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
-
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "TestInput");
+        InteractionFileUploadStore.ValidateFileReferences(jsonValue: null, "TestInput", result);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void ResolveFileReferences_MalformedJson_ReturnsNull()
+    public void ResolveFiles_UnknownInput_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-        var json = "not-valid-json";
+        fileUploadStore.StartInteraction(1, [("File", 1)]);
+        var (fileId, _) = fileUploadStore.CreateEntry("file.txt", 1, "File");
+        fileUploadStore.CompleteUpload(1, fileId);
 
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "OtherFile");
+        InteractionFileUploadStore.ValidateFileReferences(jsonValue: null, "OtherFile", result);
 
         Assert.Null(result);
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -882,7 +882,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, 1, "File"));
         Assert.True(File.Exists(filePath));
         Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
-        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetFiles(1, "File")).Name);
+        Assert.Equal(expectedFileName, Assert.Single(fileUploadStore.GetCompletedFiles(1, "File")).Name);
     }
 
     [Fact]
@@ -1222,7 +1222,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var uploadResponse = await dashboardService.UploadFile(requestStream, context);
 
         var json = $"[{{\"Id\":\"{uploadResponse.FileId}\"}}]";
-        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "CertInput");
+        var resolvedFiles = fileUploadStore.GetCompletedFiles(1, "CertInput");
         InteractionFileUploadStore.ValidateFileReferences(json, "CertInput", resolvedFiles);
 
         Assert.NotNull(resolvedFiles);
@@ -1241,10 +1241,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-        var result = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "TestInput");
+        var result = fileUploadStore.GetCompletedFiles(1, "TestInput");
         InteractionFileUploadStore.ValidateFileReferences(jsonValue: null, "TestInput", result);
 
-        Assert.Null(result);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -1256,10 +1256,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var (fileId, _) = fileUploadStore.CreateEntry("file.txt", 1, "File");
         fileUploadStore.CompleteUpload(1, fileId);
 
-        var result = InteractionFileUploadStore.ResolveFiles(fileUploadStore, 1, "OtherFile");
+        var result = fileUploadStore.GetCompletedFiles(1, "OtherFile");
         InteractionFileUploadStore.ValidateFileReferences(jsonValue: null, "OtherFile", result);
 
-        Assert.Null(result);
+        Assert.Empty(result);
     }
 
     private static DashboardServiceImpl CreateDashboardService(

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -833,8 +833,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var data = new byte[1024]; // 1 KB
@@ -857,13 +857,66 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         Assert.False(File.Exists(filePath));
     }
 
+    [Theory]
+    [InlineData("../../../etc/passwd", "passwd")]
+    [InlineData("..\\..\\windows\\system32\\evil.exe", "evil.exe")]
+    [InlineData("bad*.txt", "bad*.txt")]
+    [InlineData("bad:name.txt", "bad:name.txt")]
+    [InlineData("CON.txt", "CON.txt")]
+    [InlineData("bad\0name.txt", "bad\0name.txt")]
+    public async Task UploadFile_MaliciousFileName_UsesRandomDiskName(string fileName, string expectedFileName)
+    {
+        var dashboardServiceData = CreateDashboardServiceData();
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", 1)]);
+        var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
+
+        var context = TestServerCallContext.Create();
+        var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
+        requestStream.AddMessage(new UploadFileChunk { FileName = fileName, InteractionId = 1, InputName = "File" });
+        requestStream.Complete();
+
+        var response = await dashboardService.UploadFile(requestStream, context);
+
+        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, 1, "File"));
+        Assert.True(File.Exists(filePath));
+        Assert.NotEqual(expectedFileName, Path.GetFileName(filePath));
+        Assert.Equal(expectedFileName, fileUploadStore.GetFileName(1, response.FileId));
+    }
+
+    [Fact]
+    public async Task UploadFile_ExceedsInputFileCountLimit_ThrowsFailedPrecondition()
+    {
+        var dashboardServiceData = CreateDashboardServiceData();
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", 1)]);
+        var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
+
+        var firstContext = TestServerCallContext.Create();
+        var firstRequestStream = new TestAsyncStreamReader<UploadFileChunk>(firstContext);
+        firstRequestStream.AddMessage(new UploadFileChunk { FileName = "first.txt", InteractionId = 1, InputName = "File" });
+        firstRequestStream.Complete();
+        await dashboardService.UploadFile(firstRequestStream, firstContext);
+
+        var secondContext = TestServerCallContext.Create();
+        var secondRequestStream = new TestAsyncStreamReader<UploadFileChunk>(secondContext);
+        secondRequestStream.AddMessage(new UploadFileChunk { FileName = "second.txt", InteractionId = 1, InputName = "File" });
+        secondRequestStream.Complete();
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() => dashboardService.UploadFile(secondRequestStream, secondContext));
+        Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
+        Assert.Equal("File input 'File' accepts at most 1 file.", exception.Status.Detail);
+    }
+
     [Fact]
     public async Task UploadFile_ExceedsConfiguredSizeLimit_ThrowsResourceExhausted()
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -884,7 +937,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(StatusCode.ResourceExhausted, ex.StatusCode);
 
         fileUploadStore.CancelInteraction(1);
-        fileUploadStore.StartInteraction(1);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", 1, "File");
         Assert.True(File.Exists(replacementPath));
     }
@@ -894,8 +947,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -924,8 +977,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -953,7 +1006,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -977,8 +1030,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("File", InteractionHelpers.MaxFileCount)]);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -997,7 +1050,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -1054,8 +1107,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-        fileUploadStore.StartInteraction(1);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1, [("CertInput", InteractionHelpers.MaxFileCount)]);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         // Upload a file
@@ -1086,7 +1139,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
@@ -1098,7 +1151,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
@@ -1179,4 +1232,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             // Ok if this error is thrown.
         }
     }
+
+    private static InteractionFileUploadStore CreateFileUploadStore(IFileSystemService fileSystemService) =>
+        new(fileSystemService, NullLogger<InteractionFileUploadStore>.Instance);
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1143,11 +1143,13 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         await using var stream = file.OpenRead();
         using var reader = new StreamReader(stream);
         Assert.Equal("content", await reader.ReadToEndAsync());
+        var readAllBytesTask = file.ReadAllBytesAsync();
 
         files.Dispose();
         files.Dispose();
 
         Assert.False(File.Exists(filePath));
+        Assert.Equal("content", Encoding.UTF8.GetString(await readAllBytesTask));
         Assert.Null(fileUploadStore.GetFilePath(fileId, interaction.InteractionId, input.Name));
         Assert.Throws<ObjectDisposedException>(file.OpenRead);
         await Assert.ThrowsAsync<ObjectDisposedException>(ReadAllBytesAfterDisposeAsync);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1140,11 +1140,9 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(filePath, file.FilePath);
         Assert.True(File.Exists(filePath));
         Assert.Equal("content", Encoding.UTF8.GetString(await file.ReadAllBytesAsync()));
-        await using (var stream = file.OpenRead())
-        using (var reader = new StreamReader(stream))
-        {
-            Assert.Equal("content", await reader.ReadToEndAsync());
-        }
+        await using var stream = file.OpenRead();
+        using var reader = new StreamReader(stream);
+        Assert.Equal("content", await reader.ReadToEndAsync());
 
         files.Dispose();
         files.Dispose();

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -26,7 +26,8 @@ public class InteractionFileUploadStoreTests
         Assert.NotNull(fileId);
         Assert.NotEmpty(fileId);
         Assert.NotEqual("test.txt", Path.GetFileName(filePath));
-        Assert.Equal("test.txt", fileUploadStore.GetFileName(InteractionId, fileId));
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+        Assert.Equal("test.txt", Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
         Assert.True(File.Exists(filePath));
     }
 
@@ -73,8 +74,9 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        Assert.Equal("cert.pem", fileUploadStore.GetFileName(InteractionId, fileId));
+        Assert.Equal("cert.pem", Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
     }
 
     [Fact]
@@ -100,6 +102,8 @@ public class InteractionFileUploadStoreTests
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
         fileUploadStore.CompleteInteraction(InteractionId);
 
         Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
@@ -121,6 +125,8 @@ public class InteractionFileUploadStoreTests
         var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
         fileUploadStore.CompleteUpload(InteractionId, fileId1);
         fileUploadStore.CompleteUpload(InteractionId, fileId2);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId1, fileId2), InputName, files);
         fileUploadStore.CompleteInteraction(InteractionId);
 
         fileUploadStore.RemoveEntry(InteractionId, fileId1);
@@ -146,7 +152,7 @@ public class InteractionFileUploadStoreTests
         var otherInteractionId = InteractionId + 1;
         StartInteraction(fileUploadStore, otherInteractionId);
 
-        Assert.Null(fileUploadStore.GetFileName(otherInteractionId, fileId));
+        Assert.Empty(fileUploadStore.GetFiles(otherInteractionId, InputName));
         fileUploadStore.CompleteUpload(otherInteractionId, fileId);
         fileUploadStore.RemoveEntry(otherInteractionId, fileId);
         fileUploadStore.CancelInteraction(InteractionId);
@@ -161,7 +167,7 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void CompleteInteraction_UploadInProgress_KeepsFile()
+    public void CompleteInteraction_UntransferredUploadInProgress_RemovesFileAfterUploadCompletes()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
@@ -171,6 +177,11 @@ public class InteractionFileUploadStoreTests
 
         Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
+
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.False(File.Exists(filePath));
     }
 
     [Fact]
@@ -221,17 +232,39 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void CompleteInteraction_KeepsFile()
+    public void CompleteInteraction_TransferredUploadKeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
         fileUploadStore.CompleteInteraction(InteractionId);
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void CompleteInteraction_UploadCompletedAfterResolution_RemovesLateFile()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        var (acceptedFileId, acceptedFilePath) = CreateEntry(fileUploadStore, "accepted.bin");
+        var (lateFileId, lateFilePath) = fileUploadStore.CreateEntry("late.bin", InteractionId, InputName);
+        fileUploadStore.CompleteUpload(InteractionId, acceptedFileId);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        _ = InteractionFileUploadStore.ValidateFileReferences(FileReferences(acceptedFileId), InputName, files);
+
+        fileUploadStore.CompleteUpload(InteractionId, lateFileId);
+        fileUploadStore.CompleteInteraction(InteractionId);
+
+        Assert.Equal(acceptedFilePath, fileUploadStore.GetFilePath(acceptedFileId, InteractionId, InputName));
+        Assert.True(File.Exists(acceptedFilePath));
+        Assert.Null(fileUploadStore.GetFilePath(lateFileId, InteractionId, InputName));
+        Assert.False(File.Exists(lateFilePath));
     }
 
     [Fact]
@@ -262,10 +295,11 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         Assert.NotEqual(maliciousFileName, filePath);
         Assert.NotEqual(expectedLeafName, Path.GetFileName(filePath));
-        Assert.Equal(expectedLeafName, fileUploadStore.GetFileName(InteractionId, fileId));
+        Assert.Equal(expectedLeafName, Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
     }
 
     [Theory]
@@ -279,10 +313,11 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, originalFileName);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         Assert.True(File.Exists(filePath));
         Assert.NotEqual(originalFileName, Path.GetFileName(filePath));
-        Assert.Equal(originalFileName, fileUploadStore.GetFileName(InteractionId, fileId));
+        Assert.Equal(originalFileName, Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
     }
 
     [Theory]
@@ -346,116 +381,130 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_ValidReference_ResolvesCorrectly()
+    public void ValidateFileReferences_ReturnsFilesInClientOrder()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
-        File.WriteAllText(filePath, "certificate-content");
-        fileUploadStore.CompleteUpload(InteractionId, fileId);
+        var (firstFileId, firstFilePath) = CreateEntry(fileUploadStore, "first.pem", "CertInput");
+        var (secondFileId, secondFilePath) = fileUploadStore.CreateEntry("second.pem", InteractionId, "CertInput");
+        fileUploadStore.CompleteUpload(InteractionId, secondFileId);
+        fileUploadStore.CompleteUpload(InteractionId, firstFileId);
 
-        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
+        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(
+            fileUploadStore,
+            InteractionId,
+            "CertInput");
+        resolvedFiles = InteractionFileUploadStore.ValidateFileReferences(
+            FileReferences(secondFileId, firstFileId),
+            "CertInput",
+            resolvedFiles);
 
         Assert.NotNull(resolvedFiles);
-        var file = Assert.Single(resolvedFiles);
-        Assert.Equal(fileId, file.Id);
-        Assert.Equal("cert.pem", file.Name);
-        Assert.Equal(filePath, file.FilePath);
+        Assert.Collection(
+            resolvedFiles,
+            file =>
+            {
+                Assert.Equal(secondFileId, file.Id);
+                Assert.Equal("second.pem", file.Name);
+                Assert.Equal(secondFilePath, file.FilePath);
+            },
+            file =>
+            {
+                Assert.Equal(firstFileId, file.Id);
+                Assert.Equal("first.pem", file.Name);
+                Assert.Equal(firstFilePath, file.FilePath);
+            });
     }
 
     [Fact]
-    public void ResolveFileReferences_ClientProvidedName_UsesStoredFileName()
+    public void ResolveFiles_UsesStoredFileName()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "../../../cert.pem", "CertInput");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"../../target\"}}]";
-
-        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
+        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, "CertInput");
+        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), "CertInput", resolvedFiles);
 
         var file = Assert.Single(resolvedFiles!);
         Assert.Equal("cert.pem", file.Name);
     }
 
     [Fact]
-    public void ResolveFileReferences_DifferentInputName_ReturnsNull()
+    public void ValidateFileReferences_MismatchedSubmission_Throws()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        var (firstFileId, _) = CreateEntry(fileUploadStore, "first.txt");
+        var (secondFileId, _) = fileUploadStore.CreateEntry("second.txt", InteractionId, InputName);
+        fileUploadStore.CompleteUpload(InteractionId, firstFileId);
+        fileUploadStore.CompleteUpload(InteractionId, secondFileId);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        var mismatchedValues = new[]
+        {
+            "[]",
+            FileReferences(firstFileId),
+            FileReferences(firstFileId, "unknown"),
+            FileReferences(firstFileId, firstFileId),
+            "not-json",
+            "[null]"
+        };
+
+        foreach (var value in mismatchedValues)
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                InteractionFileUploadStore.ValidateFileReferences(value, InputName, files));
+
+            Assert.Equal($"Submitted files for input '{InputName}' do not match the completed uploads.", exception.Message);
+        }
+    }
+
+    [Fact]
+    public void ValidateFileReferences_DifferentInputName_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
-        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "OtherFile", NullLogger.Instance);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, "OtherFile");
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), "OtherFile", files));
 
-        Assert.Null(result);
+        Assert.Equal("Submitted files for input 'OtherFile' do not match the completed uploads.", exception.Message);
     }
 
     [Fact]
-    public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
+    public void ValidateFileReferences_DifferentInteractionId_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
-        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId + 1, InputName, NullLogger.Instance);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId + 1, InputName);
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files));
 
-        Assert.Null(result);
+        Assert.Equal($"Submitted files for input '{InputName}' do not match the completed uploads.", exception.Message);
     }
 
     [Fact]
-    public void ResolveFileReferences_UnknownId_ReturnsNull()
+    public void ValidateFileReferences_UploadInProgress_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-        var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
+        var (fileId, _) = CreateEntry(fileUploadStore, "file.txt");
 
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files));
 
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ResolveFileReferences_MalformedJson_ReturnsNull()
-    {
-        using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-        var json = "not-valid-json";
-
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
-
-        Assert.Null(result);
-    }
-
-    [Theory]
-    [InlineData("[null]")]
-    [InlineData("[{\"Id\":null}]")]
-    [InlineData("[{\"Id\":\"\"}]")]
-    public void ResolveFileReferences_MalformedReference_ReturnsNull(string json)
-    {
-        using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
-
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ResolveFileReferences_EmptyValue_ReturnsNull()
-    {
-        using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
-
-        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
-
-        Assert.Null(result);
+        Assert.Equal($"Submitted files for input '{InputName}' do not match the completed uploads.", exception.Message);
     }
 
     [Fact]
@@ -507,10 +556,15 @@ public class InteractionFileUploadStoreTests
         fileUploadStore.StartInteraction(interactionId, [(inputName, maxFileCount)]);
     }
 
+    private static string FileReferences(params string[] fileIds) =>
+        $"[{string.Join(',', fileIds.Select(fileId => $"{{\"Id\":\"{fileId}\"}}"))}]";
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference<InteractionFile> CompleteInteractionWithFile(InteractionFileUploadStore fileUploadStore, string fileId, string filePath)
     {
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
+        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
         fileUploadStore.CompleteInteraction(InteractionId);
         return new WeakReference<InteractionFile>(interactionFile);
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -366,6 +366,22 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
+    public void ResolveFileReferences_ClientProvidedName_UsesStoredFileName()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+
+        var (fileId, _) = CreateEntry(fileUploadStore, "../../../cert.pem", "CertInput");
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"../../target\"}}]";
+
+        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
+
+        var file = Assert.Single(resolvedFiles!);
+        Assert.Equal("cert.pem", file.Name);
+    }
+
+    [Fact]
     public void ResolveFileReferences_DifferentInputName_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -27,7 +27,7 @@ public class InteractionFileUploadStoreTests
         Assert.NotEmpty(fileId);
         Assert.NotEqual("test.txt", Path.GetFileName(filePath));
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        Assert.Equal("test.txt", Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
+        Assert.Equal("test.txt", Assert.Single(fileUploadStore.GetCompletedFiles(InteractionId, InputName)).Name);
         Assert.True(File.Exists(filePath));
     }
 
@@ -76,7 +76,7 @@ public class InteractionFileUploadStoreTests
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        Assert.Equal("cert.pem", Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
+        Assert.Equal("cert.pem", Assert.Single(fileUploadStore.GetCompletedFiles(InteractionId, InputName)).Name);
     }
 
     [Fact]
@@ -102,8 +102,7 @@ public class InteractionFileUploadStoreTests
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
-        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
+        ResolveValidateAndMarkFiles(fileUploadStore, FileReferences(fileId));
         fileUploadStore.CompleteInteraction(InteractionId);
 
         Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
@@ -125,8 +124,7 @@ public class InteractionFileUploadStoreTests
         var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
         fileUploadStore.CompleteUpload(InteractionId, fileId1);
         fileUploadStore.CompleteUpload(InteractionId, fileId2);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
-        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId1, fileId2), InputName, files);
+        ResolveValidateAndMarkFiles(fileUploadStore, FileReferences(fileId1, fileId2));
         fileUploadStore.CompleteInteraction(InteractionId);
 
         fileUploadStore.RemoveEntry(InteractionId, fileId1);
@@ -152,7 +150,7 @@ public class InteractionFileUploadStoreTests
         var otherInteractionId = InteractionId + 1;
         StartInteraction(fileUploadStore, otherInteractionId);
 
-        Assert.Empty(fileUploadStore.GetFiles(otherInteractionId, InputName));
+        Assert.Empty(fileUploadStore.GetCompletedFiles(otherInteractionId, InputName));
         fileUploadStore.CompleteUpload(otherInteractionId, fileId);
         fileUploadStore.RemoveEntry(otherInteractionId, fileId);
         fileUploadStore.CancelInteraction(InteractionId);
@@ -239,8 +237,7 @@ public class InteractionFileUploadStoreTests
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
-        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
+        ResolveValidateAndMarkFiles(fileUploadStore, FileReferences(fileId));
         fileUploadStore.CompleteInteraction(InteractionId);
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
@@ -255,8 +252,7 @@ public class InteractionFileUploadStoreTests
         var (acceptedFileId, acceptedFilePath) = CreateEntry(fileUploadStore, "accepted.bin");
         var (lateFileId, lateFilePath) = fileUploadStore.CreateEntry("late.bin", InteractionId, InputName);
         fileUploadStore.CompleteUpload(InteractionId, acceptedFileId);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
-        _ = InteractionFileUploadStore.ValidateFileReferences(FileReferences(acceptedFileId), InputName, files);
+        ResolveValidateAndMarkFiles(fileUploadStore, FileReferences(acceptedFileId));
 
         fileUploadStore.CompleteUpload(InteractionId, lateFileId);
         fileUploadStore.CompleteInteraction(InteractionId);
@@ -299,7 +295,7 @@ public class InteractionFileUploadStoreTests
 
         Assert.NotEqual(maliciousFileName, filePath);
         Assert.NotEqual(expectedLeafName, Path.GetFileName(filePath));
-        Assert.Equal(expectedLeafName, Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
+        Assert.Equal(expectedLeafName, Assert.Single(fileUploadStore.GetCompletedFiles(InteractionId, InputName)).Name);
     }
 
     [Theory]
@@ -317,7 +313,7 @@ public class InteractionFileUploadStoreTests
 
         Assert.True(File.Exists(filePath));
         Assert.NotEqual(originalFileName, Path.GetFileName(filePath));
-        Assert.Equal(originalFileName, Assert.Single(fileUploadStore.GetFiles(InteractionId, InputName)).Name);
+        Assert.Equal(originalFileName, Assert.Single(fileUploadStore.GetCompletedFiles(InteractionId, InputName)).Name);
     }
 
     [Theory]
@@ -391,10 +387,7 @@ public class InteractionFileUploadStoreTests
         fileUploadStore.CompleteUpload(InteractionId, secondFileId);
         fileUploadStore.CompleteUpload(InteractionId, firstFileId);
 
-        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(
-            fileUploadStore,
-            InteractionId,
-            "CertInput");
+        IReadOnlyList<InteractionFileUpload>? resolvedFiles = fileUploadStore.GetCompletedFiles(InteractionId, "CertInput");
         resolvedFiles = InteractionFileUploadStore.ValidateFileReferences(
             FileReferences(secondFileId, firstFileId),
             "CertInput",
@@ -418,14 +411,14 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFiles_UsesStoredFileName()
+    public void GetCompletedFiles_UsesStoredFileName()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "../../../cert.pem", "CertInput");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        var resolvedFiles = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, "CertInput");
+        IReadOnlyList<InteractionFileUpload>? resolvedFiles = fileUploadStore.GetCompletedFiles(InteractionId, "CertInput");
         InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), "CertInput", resolvedFiles);
 
         var file = Assert.Single(resolvedFiles!);
@@ -441,7 +434,7 @@ public class InteractionFileUploadStoreTests
         var (secondFileId, _) = fileUploadStore.CreateEntry("second.txt", InteractionId, InputName);
         fileUploadStore.CompleteUpload(InteractionId, firstFileId);
         fileUploadStore.CompleteUpload(InteractionId, secondFileId);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(InteractionId, InputName);
         var mismatchedValues = new[]
         {
             "[]",
@@ -470,7 +463,7 @@ public class InteractionFileUploadStoreTests
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, "OtherFile");
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(InteractionId, "OtherFile");
         var exception = Assert.Throws<InvalidOperationException>(() =>
             InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), "OtherFile", files));
 
@@ -486,7 +479,7 @@ public class InteractionFileUploadStoreTests
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId + 1, InputName);
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(InteractionId + 1, InputName);
         var exception = Assert.Throws<InvalidOperationException>(() =>
             InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files));
 
@@ -500,7 +493,7 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var (fileId, _) = CreateEntry(fileUploadStore, "file.txt");
 
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(InteractionId, InputName);
         var exception = Assert.Throws<InvalidOperationException>(() =>
             InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files));
 
@@ -559,12 +552,18 @@ public class InteractionFileUploadStoreTests
     private static string FileReferences(params string[] fileIds) =>
         $"[{string.Join(',', fileIds.Select(fileId => $"{{\"Id\":\"{fileId}\"}}"))}]";
 
+    private static void ResolveValidateAndMarkFiles(InteractionFileUploadStore fileUploadStore, string jsonValue)
+    {
+        IReadOnlyList<InteractionFileUpload>? files = fileUploadStore.GetCompletedFiles(InteractionId, InputName);
+        files = InteractionFileUploadStore.ValidateFileReferences(jsonValue, InputName, files);
+        fileUploadStore.MarkFilesAccepted(InteractionId, InputName, files!.Select(file => file.Id).ToArray());
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference<InteractionFile> CompleteInteractionWithFile(InteractionFileUploadStore fileUploadStore, string fileId, string filePath)
     {
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
-        var files = InteractionFileUploadStore.ResolveFiles(fileUploadStore, InteractionId, InputName);
-        InteractionFileUploadStore.ValidateFileReferences(FileReferences(fileId), InputName, files);
+        ResolveValidateAndMarkFiles(fileUploadStore, FileReferences(fileId));
         fileUploadStore.CompleteInteraction(InteractionId);
         return new WeakReference<InteractionFile>(interactionFile);
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -19,13 +19,14 @@ public class InteractionFileUploadStoreTests
     public void CreateEntry_ValidFileName_ReturnsIdAndPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
         Assert.NotNull(fileId);
         Assert.NotEmpty(fileId);
-        Assert.Equal("test.txt", Path.GetFileName(filePath));
+        Assert.NotEqual("test.txt", Path.GetFileName(filePath));
+        Assert.Equal("test.txt", fileUploadStore.GetFileName(InteractionId, fileId));
         Assert.True(File.Exists(filePath));
     }
 
@@ -33,7 +34,7 @@ public class InteractionFileUploadStoreTests
     public void GetFilePath_ExistingEntry_ReturnsPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -45,7 +46,7 @@ public class InteractionFileUploadStoreTests
     public void GetFilePath_UploadInProgress_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -60,7 +61,7 @@ public class InteractionFileUploadStoreTests
     public void GetFilePath_NonexistentEntry_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         Assert.Null(fileUploadStore.GetFilePath("nonexistent", InteractionId, InputName));
     }
@@ -69,7 +70,7 @@ public class InteractionFileUploadStoreTests
     public void GetFileName_ExistingEntry_ReturnsFileName()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
@@ -80,7 +81,7 @@ public class InteractionFileUploadStoreTests
     public void RemoveEntry_ExistingEntry_DeletesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
@@ -95,7 +96,7 @@ public class InteractionFileUploadStoreTests
     public void RemoveEntry_LastFile_RemovesCompletedInteraction()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -104,7 +105,7 @@ public class InteractionFileUploadStoreTests
         Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
 
         fileUploadStore.RemoveEntry(InteractionId, fileId);
-        fileUploadStore.StartInteraction(InteractionId);
+        StartInteraction(fileUploadStore);
         var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.bin", InteractionId, InputName);
 
         Assert.True(File.Exists(replacementPath));
@@ -114,7 +115,7 @@ public class InteractionFileUploadStoreTests
     public void RemoveEntry_TerminalInteraction_RemainsUntilLastFileRemoved()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId1, filePath1) = CreateEntry(fileUploadStore, "file1.bin");
         var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
@@ -124,12 +125,12 @@ public class InteractionFileUploadStoreTests
 
         fileUploadStore.RemoveEntry(InteractionId, fileId1);
 
-        fileUploadStore.StartInteraction(InteractionId);
+        StartInteraction(fileUploadStore);
         Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
         Assert.Equal(filePath2, fileUploadStore.GetFilePath(fileId2, InteractionId, InputName));
 
         fileUploadStore.RemoveEntry(InteractionId, fileId2);
-        fileUploadStore.StartInteraction(InteractionId);
+        StartInteraction(fileUploadStore);
         var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.bin", InteractionId, InputName);
 
         Assert.True(File.Exists(replacementPath));
@@ -139,11 +140,11 @@ public class InteractionFileUploadStoreTests
     public void FileOperations_DifferentInteractionId_DoNotMutateEntry()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         var otherInteractionId = InteractionId + 1;
-        fileUploadStore.StartInteraction(otherInteractionId);
+        StartInteraction(fileUploadStore, otherInteractionId);
 
         Assert.Null(fileUploadStore.GetFileName(otherInteractionId, fileId));
         fileUploadStore.CompleteUpload(otherInteractionId, fileId);
@@ -163,7 +164,7 @@ public class InteractionFileUploadStoreTests
     public void CompleteInteraction_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId);
@@ -176,7 +177,7 @@ public class InteractionFileUploadStoreTests
     public void UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -189,7 +190,7 @@ public class InteractionFileUploadStoreTests
     public void CancelInteraction_UploadComplete_RemovesFileImmediately()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -204,7 +205,7 @@ public class InteractionFileUploadStoreTests
     public void CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
 
@@ -223,7 +224,7 @@ public class InteractionFileUploadStoreTests
     public void CompleteInteraction_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -237,7 +238,7 @@ public class InteractionFileUploadStoreTests
     public void CompleteInteraction_AfterInteractionFileCollected_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -258,12 +259,30 @@ public class InteractionFileUploadStoreTests
     public void CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
 
         Assert.NotEqual(maliciousFileName, filePath);
-        Assert.Equal(expectedLeafName, Path.GetFileName(filePath));
+        Assert.NotEqual(expectedLeafName, Path.GetFileName(filePath));
+        Assert.Equal(expectedLeafName, fileUploadStore.GetFileName(InteractionId, fileId));
+    }
+
+    [Theory]
+    [InlineData("bad*.txt")]
+    [InlineData("bad:name.txt")]
+    [InlineData("CON.txt")]
+    [InlineData("bad\0name.txt")]
+    public void CreateEntry_PlatformSensitiveFileName_UsesRandomDiskName(string originalFileName)
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, originalFileName);
+
+        Assert.True(File.Exists(filePath));
+        Assert.NotEqual(originalFileName, Path.GetFileName(filePath));
+        Assert.Equal(originalFileName, fileUploadStore.GetFileName(InteractionId, fileId));
     }
 
     [Theory]
@@ -273,7 +292,7 @@ public class InteractionFileUploadStoreTests
     public void CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, emptyFileName);
 
@@ -281,11 +300,56 @@ public class InteractionFileUploadStoreTests
         Assert.NotEmpty(Path.GetFileName(filePath));
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(InteractionHelpers.MaxFileCount)]
+    public void CreateEntry_ExceedsInputLimit_Throws(int maxFileCount)
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        StartInteraction(fileUploadStore, maxFileCount: maxFileCount);
+
+        for (var i = 0; i < maxFileCount; i++)
+        {
+            fileUploadStore.CreateEntry($"file-{i}.txt", InteractionId, InputName);
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("excess.txt", InteractionId, InputName));
+        var fileLabel = maxFileCount == 1 ? "file" : "files";
+        Assert.Equal($"File input '{InputName}' accepts at most {maxFileCount} {fileLabel}.", exception.Message);
+    }
+
+    [Fact]
+    public void CreateEntry_RemovedEntry_FreesInputCapacity()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        StartInteraction(fileUploadStore, maxFileCount: 1);
+        var (fileId, _) = fileUploadStore.CreateEntry("first.txt", InteractionId, InputName);
+
+        fileUploadStore.RemoveEntry(InteractionId, fileId);
+        var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", InteractionId, InputName);
+
+        Assert.True(File.Exists(replacementPath));
+    }
+
+    [Fact]
+    public void CreateEntry_UnregisteredInput_Throws()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
+        StartInteraction(fileUploadStore);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("file.txt", InteractionId, "OtherFile"));
+
+        Assert.Equal($"Interaction '{InteractionId}' is not accepting file uploads for input 'OtherFile'.", exception.Message);
+    }
+
     [Fact]
     public void ResolveFileReferences_ValidReference_ResolvesCorrectly()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
@@ -305,7 +369,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_DifferentInputName_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -319,7 +383,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -333,7 +397,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -345,7 +409,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -360,7 +424,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_MalformedReference_ReturnsNull(string json)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
@@ -371,7 +435,7 @@ public class InteractionFileUploadStoreTests
     public void ResolveFileReferences_EmptyValue_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
 
@@ -382,7 +446,7 @@ public class InteractionFileUploadStoreTests
     public void Dispose_CleansUpAllFiles()
     {
         using var fileSystemService = new TestFileSystemService();
-        var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var (_, filePath1) = CreateEntry(fileUploadStore, "file1.txt");
         var (_, filePath2) = CreateEntry(fileUploadStore, "file2.txt");
@@ -402,17 +466,29 @@ public class InteractionFileUploadStoreTests
     public void CreateEntry_UnknownInteraction_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = CreateFileUploadStore(fileSystemService);
 
         var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("temp.bin", InteractionId, InputName));
 
         Assert.Equal($"Interaction '{InteractionId}' is not accepting file uploads.", exception.Message);
     }
 
+    private static InteractionFileUploadStore CreateFileUploadStore(IFileSystemService fileSystemService) =>
+        new(fileSystemService, NullLogger<InteractionFileUploadStore>.Instance);
+
     private static (string FileId, string FilePath) CreateEntry(InteractionFileUploadStore fileUploadStore, string fileName, string inputName = InputName)
     {
-        fileUploadStore.StartInteraction(InteractionId);
+        StartInteraction(fileUploadStore, inputName: inputName);
         return fileUploadStore.CreateEntry(fileName, InteractionId, inputName);
+    }
+
+    private static void StartInteraction(
+        InteractionFileUploadStore fileUploadStore,
+        int interactionId = InteractionId,
+        string inputName = InputName,
+        int maxFileCount = InteractionHelpers.MaxFileCount)
+    {
+        fileUploadStore.StartInteraction(interactionId, [(inputName, maxFileCount)]);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1373,24 +1373,6 @@ public class InteractionServiceTests
     }
 
     [Fact]
-    public void InteractionInput_SetFiles_DoesNotDisposeExistingCollection()
-    {
-        var input = new InteractionInput { Name = "File", InputType = InputType.File };
-        var disposeCount = 0;
-        var originalFiles = new InteractionFileCollection([], () => disposeCount++);
-        var replacementFiles = new InteractionFileCollection([]);
-        input.SetFiles(originalFiles);
-
-        input.SetFiles(replacementFiles);
-
-        Assert.Equal(0, disposeCount);
-        Assert.Same(replacementFiles, input.GetFiles());
-
-        originalFiles.Dispose();
-        Assert.Equal(1, disposeCount);
-    }
-
-    [Fact]
     public async Task PromptInputsAsync_Canceled_CancelsFileUploads()
     {
         var fileUploadStore = new TestInteractionFileUploadStore();

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1506,6 +1506,51 @@ public class InteractionServiceTests
         Assert.Empty(input.ValidationErrors);
     }
 
+    [Theory]
+    [InlineData(false, 1, true)]
+    [InlineData(false, 2, false)]
+    [InlineData(true, InteractionHelpers.MaxFileCount, true)]
+    [InlineData(true, InteractionHelpers.MaxFileCount + 1, false)]
+    public async Task PromptInputsAsync_FileCount_ValidatesLimit(bool allowMultipleFiles, int fileCount, bool expectedValid)
+    {
+        var fileUploadStore = new TestInteractionFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
+        var input = new InteractionInput
+        {
+            Name = "File",
+            Label = "File",
+            InputType = InputType.File,
+            AllowMultipleFiles = allowMultipleFiles
+        };
+        _ = interactionService.PromptInputAsync("Select file", "please", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        var registeredFileInputs = Assert.Single(fileUploadStore.StartedFileInputs);
+        Assert.Equal((input.Name, InteractionHelpers.GetMaxFileCount(allowMultipleFiles)), Assert.Single(registeredFileInputs));
+        var files = Enumerable.Range(0, fileCount)
+            .Select(i => new InputFileDto($"file-{i}", $"file-{i}.txt", $"/tmp/file-{i}.txt"))
+            .ToArray();
+
+        await CompleteInteractionAsync(
+            interactionService,
+            interaction.InteractionId,
+            new InteractionCompletionState { Complete = true, State = new[] { input } },
+            inputs: [new InputDto("File", "files", InputType.File, files)]);
+
+        if (expectedValid)
+        {
+            Assert.True(interaction.CompletionTcs.Task.IsCompletedSuccessfully);
+            Assert.Empty(input.ValidationErrors);
+        }
+        else
+        {
+            var maxFileCount = allowMultipleFiles ? InteractionHelpers.MaxFileCount : 1;
+            Assert.False(interaction.CompletionTcs.Task.IsCompleted);
+            Assert.Collection(
+                input.ValidationErrors,
+                error => Assert.Equal($"File count exceeds the maximum of {maxFileCount}.", error));
+        }
+    }
+
     [Fact]
     public void InteractionInput_MaxFileSize_RejectsInvalidValues()
     {

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1368,7 +1368,26 @@ public class InteractionServiceTests
         Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.StartedInteractions));
         Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.CompletedInteractions));
         var resultInput = Assert.IsType<InteractionInput>(result.Data);
-        Assert.Single(resultInput.Files!);
+        using var files = resultInput.GetFiles();
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public void InteractionInput_SetFiles_DoesNotDisposeExistingCollection()
+    {
+        var input = new InteractionInput { Name = "File", InputType = InputType.File };
+        var disposeCount = 0;
+        var originalFiles = new InteractionFileCollection([], () => disposeCount++);
+        var replacementFiles = new InteractionFileCollection([]);
+        input.SetFiles(originalFiles);
+
+        input.SetFiles(replacementFiles);
+
+        Assert.Equal(0, disposeCount);
+        Assert.Same(replacementFiles, input.GetFiles());
+
+        originalFiles.Dispose();
+        Assert.Equal(1, disposeCount);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREPIPELINES001
 
+using System.Globalization;
 using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
@@ -641,6 +642,70 @@ public class PublishingActivityReporterTests
         var promptResult = await promptTask.DefaultTimeout();
         Assert.False(promptResult.Canceled);
         Assert.Equal("user-response", promptResult.Data?.Value);
+    }
+
+    [Fact]
+    public async Task CompleteInteractionAsync_MatchingFileResponse_UsesAuthoritativeMetadata()
+    {
+        var reporter = CreatePublishingReporter();
+        var input = new InteractionInput
+        {
+            Name = "artifact",
+            InputType = InputType.File,
+            Required = true
+        };
+        var promptTask = _interactionService.PromptInputAsync("Upload", "Select a file", input);
+        var activity = await reporter.ActivityItemUpdated.Reader.ReadAsync().DefaultTimeout();
+        var interactionId = int.Parse(activity.Data.Id, CultureInfo.InvariantCulture);
+        var (fileId, filePath) = _fileUploadStore.CreateEntry("artifact.zip", interactionId, input.Name);
+        _fileUploadStore.CompleteUpload(interactionId, fileId);
+
+        var responses = new[]
+        {
+            new PublishingPromptInputAnswer
+            {
+                Name = input.Name,
+                Value = $"[{{\"Id\":\"{fileId}\",\"Name\":\"spoofed.zip\"}}]"
+            }
+        };
+        await reporter.CompleteInteractionAsync(activity.Data.Id, responses, cancellationToken: CancellationToken.None).DefaultTimeout();
+
+        var result = await promptTask.DefaultTimeout();
+        Assert.False(result.Canceled);
+        var files = result.Data!.GetFiles();
+        var file = Assert.Single(files);
+        Assert.Equal(fileId, file.Id);
+        Assert.Equal("artifact.zip", file.Name);
+        Assert.Equal(filePath, file.FilePath);
+        Assert.Equal(filePath, _fileUploadStore.GetFilePath(fileId, interactionId, input.Name));
+
+        files.Dispose();
+
+        Assert.Null(_fileUploadStore.GetFilePath(fileId, interactionId, input.Name));
+    }
+
+    [Fact]
+    public async Task CompleteInteractionAsync_OmittedFileResponse_Throws()
+    {
+        var reporter = CreatePublishingReporter();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var input = new InteractionInput
+        {
+            Name = "artifact",
+            InputType = InputType.File
+        };
+        var promptTask = _interactionService.PromptInputAsync("Upload", "Select a file", input, cancellationToken: cancellationTokenSource.Token);
+        var activity = await reporter.ActivityItemUpdated.Reader.ReadAsync().DefaultTimeout();
+        var interactionId = int.Parse(activity.Data.Id, CultureInfo.InvariantCulture);
+        var (fileId, _) = _fileUploadStore.CreateEntry("artifact.zip", interactionId, input.Name);
+        _fileUploadStore.CompleteUpload(interactionId, fileId);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            reporter.CompleteInteractionAsync(activity.Data.Id, responses: null, cancellationToken: CancellationToken.None));
+
+        Assert.Equal("Submitted files for input 'artifact' do not match the completed uploads.", exception.Message);
+        await cancellationTokenSource.CancelAsync();
+        Assert.True((await promptTask).Canceled);
     }
 
     [Fact]

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -57,24 +57,45 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
         }
     }
 
-    public IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName)
+    public IReadOnlyList<InteractionFileUpload> GetCompletedFiles(int interactionId, string inputName)
     {
         var files = new List<InteractionFileUpload>();
         foreach (var (fileId, entry) in _files)
         {
             lock (entry)
             {
-                if (entry.State is FileEntryState.Uploaded or FileEntryState.Resolved &&
+                if (entry.State is FileEntryState.Uploaded or FileEntryState.Accepted &&
                     entry.InteractionId == interactionId &&
                     string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
                 {
-                    entry.State = FileEntryState.Resolved;
                     files.Add(new InteractionFileUpload(fileId, entry.OriginalFileName, entry.FilePath));
                 }
             }
         }
 
         return files;
+    }
+
+    public void MarkFilesAccepted(int interactionId, string inputName, IReadOnlyList<string> fileIds)
+    {
+        foreach (var fileId in fileIds)
+        {
+            if (!_files.TryGetValue(fileId, out var entry) || entry.InteractionId != interactionId)
+            {
+                throw new InvalidOperationException($"Submitted files for input '{inputName}' do not match the completed uploads.");
+            }
+
+            lock (entry)
+            {
+                if (entry.State is not (FileEntryState.Uploaded or FileEntryState.Accepted) ||
+                    !string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
+                {
+                    throw new InvalidOperationException($"Submitted files for input '{inputName}' do not match the completed uploads.");
+                }
+
+                entry.State = FileEntryState.Accepted;
+            }
+        }
     }
 
     public void RemoveEntry(int interactionId, string fileId)
@@ -124,7 +145,7 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
             lock (entry)
             {
                 removeEntry = entry.InteractionId == interactionId &&
-                    entry.State is FileEntryState.Uploaded or FileEntryState.Resolved;
+                    entry.State is FileEntryState.Uploaded or FileEntryState.Accepted;
                 if (entry.InteractionId == interactionId)
                 {
                     entry.State = FileEntryState.DiscardWhenComplete;
@@ -151,7 +172,7 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
     {
         Uploading,
         Uploaded,
-        Resolved,
+        Accepted,
         DiscardWhenComplete
     }
 }
@@ -160,7 +181,7 @@ internal static class InteractionFileUploadStoreTestExtensions
 {
     public static string? GetFilePath(this IInteractionFileUploadStore store, string fileId, int interactionId, string inputName)
     {
-        return store.GetFiles(interactionId, inputName).SingleOrDefault(file => file.Id == fileId)?.FilePath;
+        return store.GetCompletedFiles(interactionId, inputName).SingleOrDefault(file => file.Id == fileId)?.FilePath;
     }
 
 }

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -14,14 +14,16 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
 
     public ConcurrentQueue<int> StartedInteractions { get; } = new();
+    public ConcurrentQueue<IReadOnlyList<(string InputName, int MaxFileCount)>> StartedFileInputs { get; } = new();
     public ConcurrentQueue<int> CompletedInteractions { get; } = new();
     public ConcurrentQueue<int> CanceledInteractions { get; } = new();
     public Action<int>? CompleteInteractionCallback { get; set; }
     public Action<int>? CancelInteractionCallback { get; set; }
 
-    public void StartInteraction(int interactionId)
+    public void StartInteraction(int interactionId, IReadOnlyList<(string InputName, int MaxFileCount)> fileInputs)
     {
         StartedInteractions.Enqueue(interactionId);
+        StartedFileInputs.Enqueue(fileInputs.ToArray());
     }
 
     public (string FileId, string FilePath) CreateEntry(string originalFileName, int interactionId, string inputName)

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -38,20 +38,43 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
 
     public void CompleteUpload(int interactionId, string fileId)
     {
+        if (_files.TryGetValue(fileId, out var entry) && entry.InteractionId == interactionId)
+        {
+            bool removeEntry;
+            lock (entry)
+            {
+                removeEntry = entry.State == FileEntryState.DiscardWhenComplete;
+                if (entry.State == FileEntryState.Uploading)
+                {
+                    entry.State = FileEntryState.Uploaded;
+                }
+            }
+
+            if (removeEntry)
+            {
+                _files.TryRemove(fileId, out _);
+            }
+        }
     }
 
-    public string? GetFilePath(string fileId, int interactionId, string inputName)
+    public IReadOnlyList<InteractionFileUpload> GetFiles(int interactionId, string inputName)
     {
-        return _files.TryGetValue(fileId, out var entry) &&
-            entry.InteractionId == interactionId &&
-            string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
-                ? entry.FilePath
-                : null;
-    }
+        var files = new List<InteractionFileUpload>();
+        foreach (var (fileId, entry) in _files)
+        {
+            lock (entry)
+            {
+                if (entry.State is FileEntryState.Uploaded or FileEntryState.Resolved &&
+                    entry.InteractionId == interactionId &&
+                    string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName))
+                {
+                    entry.State = FileEntryState.Resolved;
+                    files.Add(new InteractionFileUpload(fileId, entry.OriginalFileName, entry.FilePath));
+                }
+            }
+        }
 
-    public string? GetFileName(int interactionId, string fileId)
-    {
-        return _files.TryGetValue(fileId, out var entry) && entry.InteractionId == interactionId ? entry.OriginalFileName : null;
+        return files;
     }
 
     public void RemoveEntry(int interactionId, string fileId)
@@ -66,6 +89,28 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
     {
         CompleteInteractionCallback?.Invoke(interactionId);
         CompletedInteractions.Enqueue(interactionId);
+
+        foreach (var (fileId, entry) in _files)
+        {
+            bool removeEntry;
+            lock (entry)
+            {
+                removeEntry = entry.InteractionId == interactionId && entry.State == FileEntryState.Uploaded;
+                if (entry.InteractionId == interactionId)
+                {
+                    entry.State = entry.State switch
+                    {
+                        FileEntryState.Uploading => FileEntryState.DiscardWhenComplete,
+                        _ => entry.State
+                    };
+                }
+            }
+
+            if (removeEntry)
+            {
+                _files.TryRemove(fileId, out _);
+            }
+        }
     }
 
     public void CancelInteraction(int interactionId)
@@ -75,12 +120,47 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
 
         foreach (var (fileId, entry) in _files)
         {
-            if (entry.InteractionId == interactionId)
+            bool removeEntry;
+            lock (entry)
+            {
+                removeEntry = entry.InteractionId == interactionId &&
+                    entry.State is FileEntryState.Uploaded or FileEntryState.Resolved;
+                if (entry.InteractionId == interactionId)
+                {
+                    entry.State = FileEntryState.DiscardWhenComplete;
+                }
+            }
+
+            if (removeEntry)
             {
                 _files.TryRemove(fileId, out _);
             }
         }
     }
 
-    private sealed record FileEntry(string FilePath, string OriginalFileName, int InteractionId, string InputName);
+    private sealed class FileEntry(string filePath, string originalFileName, int interactionId, string inputName)
+    {
+        public string FilePath { get; } = filePath;
+        public string OriginalFileName { get; } = originalFileName;
+        public int InteractionId { get; } = interactionId;
+        public string InputName { get; } = inputName;
+        public FileEntryState State { get; set; }
+    }
+
+    private enum FileEntryState
+    {
+        Uploading,
+        Uploaded,
+        Resolved,
+        DiscardWhenComplete
+    }
+}
+
+internal static class InteractionFileUploadStoreTestExtensions
+{
+    public static string? GetFilePath(this IInteractionFileUploadStore store, string fileId, int interactionId, string inputName)
+    {
+        return store.GetFiles(interactionId, inputName).SingleOrDefault(file => file.Id == fileId)?.FilePath;
+    }
+
 }


### PR DESCRIPTION
## Description

Interaction file uploads previously had inconsistent enforcement and lifetime management across clients:

- The Dashboard limited a single file-picker selection to 100 files, but the CLI and custom clients had no equivalent limit.
- The AppHost accepted unbounded uploads and did not enforce `AllowMultipleFiles` during upload or submission.
- Client-provided filenames were used when allocating temporary files.
- .NET callers had no deterministic way to release uploaded temporary files after processing them.

This PR makes upload validation and file ownership consistent across the Dashboard, CLI, custom clients, and the AppHost.

### File-count validation

- Adds a shared maximum of 100 files for inputs with `AllowMultipleFiles = true`.
- Limits single-file inputs to one file.
- Registers trusted per-input limits when an interaction starts.
- Enforces limits before Dashboard gRPC or CLI JSON-RPC upload content is written.
- Counts in-progress uploads as reserved slots so concurrent requests cannot exceed the limit.
- Rejects uploads for unknown interaction inputs.
- Revalidates the submitted file count as defense in depth.
- Uses the shared maximum in the Dashboard file picker.
- Documents that each client submits one file selection per input during an interaction; multi-file selections upload sequentially as part of that selection.

### Filename and temporary-file handling

- Always allocates uploaded content with an OS-generated temporary filename.
- Never uses the client-provided filename in the disk path.
- Retains only the separator-stripped leaf filename as authoritative display metadata and ignores client-supplied names during submission.
- Covers Unix and Windows traversal names, wildcard characters, ADS-like names, reserved Windows names, and embedded NUL characters.
- Keeps the existing per-file size limits and AppHost shutdown cleanup.

### Uploaded-file ownership

- Adds `InteractionInput.GetFiles()`.
- Adds `InteractionFileCollection`, which implements `IReadOnlyList<InteractionFile>` and `IDisposable`.
- Marks `InteractionInput.Files` obsolete in favor of `GetFiles()`.
- Disposing `InteractionFileCollection` removes its upload-store entries and deletes the temporary files from disk.
- Disposal is idempotent.
- After disposal, `InteractionFile.OpenRead()` and `ReadAllBytesAsync()` throw `ObjectDisposedException`.
- Assigning an `InteractionFileCollection` to an input does not implicitly dispose a previously assigned collection; ownership remains with the caller that received it.
- Migrates first-party Stress and Publishers AppHost samples to use and dispose `GetFiles()`.

### ATS / polyglot behavior

- Keeps the existing ATS file metadata projection for polyglot AppHosts.
- Excludes the .NET-only disposable collection API from ATS generation because it owns server-local files and implements `IDisposable`.
- Projects file metadata through a non-owning collection so ATS projection does not share or consume the .NET caller's cleanup ownership.

### User-facing usage

```csharp
using var files = input.GetFiles();
foreach (var file in files)
{
    var content = await file.ReadAllBytesAsync(cancellationToken);
    // Process content.
}
```

The uploaded temporary files are deleted when `files` is disposed. Attempts to read an `InteractionFile` after its owning collection is disposed throw `ObjectDisposedException`.

### Security considerations

File uploads contain untrusted names and content and are written to the operating system temporary directory. This change:

- Prevents client-provided filenames from being used in disk paths.
- Removes path components from retained filename metadata.
- Ignores client-supplied filename metadata during submission in favor of the trusted stored name.
- Rejects uploads for unknown inputs.
- Bounds file counts per input, including concurrent in-progress uploads.
- Preserves existing upload-size limits.
- Gives .NET callers deterministic cleanup ownership.

No formal threat model or security review has been completed.

### Validation

- `Aspire.Hosting.Tests`: 176 passed, including upload limits, malicious filenames, authoritative filename metadata, submission validation, disk reads, deletion on disposal, and post-disposal exceptions.
- `Aspire.Dashboard.Components.Tests`: 4 passed, including the 100/101 selection boundary.
- `Aspire.Dashboard.Tests`: 1,561 passed.
- `Aspire.Hosting.RemoteHost.Tests`: ATS file metadata projection passed.
- `Stress.AppHost`: build succeeded with no warnings or errors.
- `Publishers.AppHost`: build succeeded with no warnings or errors.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
