### PR TITLE
Replace JsonPatch.Net with local implementation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -117,7 +117,6 @@
     <PackageVersion Include="Hex1b.Tool" Version="0.165.0" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
-    <PackageVersion Include="JsonPatch.Net" Version="5.0.3" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -75,7 +75,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Polly.Core" />
-    <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />
     <PackageReference Include="Semver" />
     <PackageReference Include="System.IO.Hashing" />

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -17,7 +17,6 @@ using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Utils;
-using Json.Patch;
 using k8s;
 using k8s.Autorest;
 using k8s.Models;
@@ -1104,7 +1103,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
         var changed = JsonSerializer.SerializeToNode(copy);
 
-        var jsonPatch = current.CreatePatch(changed);
+        var jsonPatch = JsonPatch.Create(current, changed);
         return new V1Patch(jsonPatch, V1Patch.PatchType.JsonPatch);
     }
 

--- a/src/Aspire.Hosting/Dcp/JsonPatch.cs
+++ b/src/Aspire.Hosting/Dcp/JsonPatch.cs
@@ -1,0 +1,298 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Hosting.Dcp;
+
+/// <summary>
+/// Creates and applies the subset of RFC 6902 JSON Patch operations used by DCP resources.
+/// Paths use the JSON Pointer encoding defined by <see href="https://www.rfc-editor.org/rfc/rfc6901">RFC 6901</see>.
+/// </summary>
+internal static class JsonPatch
+{
+    internal static JsonArray Create(JsonNode? current, JsonNode? changed)
+    {
+        var operations = new JsonArray();
+        AddOperations(current, changed, string.Empty, operations);
+
+        return operations;
+    }
+
+    internal static JsonNode? Apply(JsonNode? current, JsonArray patch)
+    {
+        var result = current?.DeepClone();
+
+        foreach (var operationNode in patch)
+        {
+            if (operationNode is not JsonObject operation ||
+                operation["op"] is not JsonValue operationValue ||
+                operation["path"] is not JsonValue pathValue ||
+                !operationValue.TryGetValue<string>(out var operationName) ||
+                !pathValue.TryGetValue<string>(out var path))
+            {
+                throw new JsonException("A JSON Patch operation must contain string 'op' and 'path' properties.");
+            }
+
+            var segments = ParsePath(path);
+            var hasValue = operation.TryGetPropertyValue("value", out var value);
+            result = ApplyOperation(result, operationName, segments, hasValue, value);
+        }
+
+        return result;
+    }
+
+    private static void AddOperations(JsonNode? current, JsonNode? changed, string path, JsonArray operations)
+    {
+        if (JsonNode.DeepEquals(current, changed))
+        {
+            return;
+        }
+
+        if (current is JsonObject currentObject && changed is JsonObject changedObject)
+        {
+            foreach (var property in currentObject)
+            {
+                if (!changedObject.ContainsKey(property.Key))
+                {
+                    operations.Add(CreateOperation("remove", AppendPath(path, property.Key)));
+                }
+            }
+
+            foreach (var property in changedObject)
+            {
+                var propertyPath = AppendPath(path, property.Key);
+                if (currentObject.TryGetPropertyValue(property.Key, out var currentValue))
+                {
+                    AddOperations(currentValue, property.Value, propertyPath, operations);
+                }
+                else
+                {
+                    operations.Add(CreateOperation("add", propertyPath, property.Value));
+                }
+            }
+
+            return;
+        }
+
+        if (current is JsonArray currentArray && changed is JsonArray changedArray)
+        {
+            var commonLength = Math.Min(currentArray.Count, changedArray.Count);
+            for (var index = 0; index < commonLength; index++)
+            {
+                AddOperations(currentArray[index], changedArray[index], AppendPath(path, index), operations);
+            }
+
+            for (var index = currentArray.Count - 1; index >= changedArray.Count; index--)
+            {
+                operations.Add(CreateOperation("remove", AppendPath(path, index)));
+            }
+
+            for (var index = currentArray.Count; index < changedArray.Count; index++)
+            {
+                operations.Add(CreateOperation("add", AppendPath(path, index), changedArray[index]));
+            }
+
+            return;
+        }
+
+        operations.Add(CreateOperation("replace", path, changed));
+    }
+
+    private static JsonObject CreateOperation(string operation, string path, JsonNode? value = null)
+    {
+        var result = new JsonObject
+        {
+            ["op"] = operation,
+            ["path"] = path,
+        };
+
+        if (operation is not "remove")
+        {
+            result["value"] = value?.DeepClone();
+        }
+
+        return result;
+    }
+
+    private static string AppendPath(string path, string segment)
+    {
+        return $"{path}/{segment.Replace("~", "~0", StringComparison.Ordinal).Replace("/", "~1", StringComparison.Ordinal)}";
+    }
+
+    private static string AppendPath(string path, int index)
+    {
+        return $"{path}/{index.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    private static string[] ParsePath(string path)
+    {
+        if (path.Length == 0)
+        {
+            return [];
+        }
+
+        if (path[0] != '/')
+        {
+            throw new JsonException($"JSON Pointer path '{path}' must be empty or start with '/'.");
+        }
+
+        return path[1..].Split('/').Select(UnescapePathSegment).ToArray();
+    }
+
+    private static string UnescapePathSegment(string segment)
+    {
+        if (!segment.Contains('~', StringComparison.Ordinal))
+        {
+            return segment;
+        }
+
+        var result = new StringBuilder(segment.Length);
+        for (var index = 0; index < segment.Length; index++)
+        {
+            var character = segment[index];
+            if (character != '~')
+            {
+                result.Append(character);
+                continue;
+            }
+
+            if (++index >= segment.Length)
+            {
+                throw new JsonException($"JSON Pointer segment '{segment}' ends with an incomplete escape.");
+            }
+
+            result.Append(segment[index] switch
+            {
+                '0' => '~',
+                '1' => '/',
+                _ => throw new JsonException($"JSON Pointer segment '{segment}' contains an invalid escape."),
+            });
+        }
+
+        return result.ToString();
+    }
+
+    private static JsonNode? ApplyOperation(JsonNode? current, string operation, string[] segments, bool hasValue, JsonNode? value)
+    {
+        if (operation is not ("add" or "remove" or "replace"))
+        {
+            throw new JsonException($"JSON Patch operation '{operation}' is not supported.");
+        }
+
+        if (operation is not "remove" && !hasValue)
+        {
+            throw new JsonException($"JSON Patch operation '{operation}' requires a 'value' property.");
+        }
+
+        if (segments.Length == 0)
+        {
+            return operation switch
+            {
+                "remove" => null,
+                _ => value?.DeepClone(),
+            };
+        }
+
+        var parent = GetParent(current, segments);
+        var finalSegment = segments[^1];
+
+        switch (parent)
+        {
+            case JsonObject jsonObject:
+                ApplyToObject(jsonObject, operation, finalSegment, value);
+                break;
+            case JsonArray jsonArray:
+                ApplyToArray(jsonArray, operation, finalSegment, value);
+                break;
+            default:
+                throw new JsonException("A JSON Patch path can only traverse objects and arrays.");
+        }
+
+        return current;
+    }
+
+    private static JsonNode GetParent(JsonNode? current, string[] segments)
+    {
+        var parent = current ?? throw new JsonException("A JSON Patch path cannot traverse a null value.");
+
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            var segment = segments[index];
+            parent = parent switch
+            {
+                JsonObject jsonObject when jsonObject.TryGetPropertyValue(segment, out var child) && child is not null => child,
+                JsonArray jsonArray => jsonArray[ParseArrayIndex(segment, jsonArray.Count, allowEnd: false)]
+                    ?? throw new JsonException($"JSON Patch path segment '{segment}' refers to a null value."),
+                _ => throw new JsonException($"JSON Patch path segment '{segment}' does not exist."),
+            };
+        }
+
+        return parent;
+    }
+
+    private static void ApplyToObject(JsonObject target, string operation, string propertyName, JsonNode? value)
+    {
+        switch (operation)
+        {
+            case "add":
+                target[propertyName] = value?.DeepClone();
+                break;
+            case "remove":
+                if (!target.Remove(propertyName))
+                {
+                    throw new JsonException($"JSON Patch remove path refers to missing property '{propertyName}'.");
+                }
+                break;
+            case "replace":
+                if (!target.ContainsKey(propertyName))
+                {
+                    throw new JsonException($"JSON Patch replace path refers to missing property '{propertyName}'.");
+                }
+                target[propertyName] = value?.DeepClone();
+                break;
+        }
+    }
+
+    private static void ApplyToArray(JsonArray target, string operation, string indexText, JsonNode? value)
+    {
+        if (operation == "add" && indexText == "-")
+        {
+            target.Add(value?.DeepClone());
+            return;
+        }
+
+        var index = ParseArrayIndex(indexText, target.Count, allowEnd: operation == "add");
+        switch (operation)
+        {
+            case "add":
+                target.Insert(index, value?.DeepClone());
+                break;
+            case "remove":
+                target.RemoveAt(index);
+                break;
+            case "replace":
+                target[index] = value?.DeepClone();
+                break;
+        }
+    }
+
+    private static int ParseArrayIndex(string indexText, int count, bool allowEnd)
+    {
+        if (indexText.Length == 0 ||
+            (indexText.Length > 1 && indexText[0] == '0') ||
+            !indexText.All(char.IsAsciiDigit) ||
+            !int.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) ||
+            index < 0 ||
+            index > count ||
+            (!allowEnd && index == count))
+        {
+            throw new JsonException($"JSON Patch array index '{indexText}' is invalid for an array with {count} elements.");
+        }
+
+        return index;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/JsonPatchTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/JsonPatchTests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Hosting.Dcp;
+using k8s;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+[Trait("Partition", "4")]
+public sealed class JsonPatchTests
+{
+    [Fact]
+    public void Create_ObjectDifferences_CreatesAddRemoveAndReplaceOperations()
+    {
+        var current = JsonNode.Parse("""{"unchanged":1,"removed":2,"replaced":"before"}""");
+        var changed = JsonNode.Parse("""{"unchanged":1,"replaced":"after","added":true}""");
+
+        var patch = JsonPatch.Create(current, changed);
+
+        Assert.Equal(
+            """[{"op":"remove","path":"/removed"},{"op":"replace","path":"/replaced","value":"after"},{"op":"add","path":"/added","value":true}]""",
+            KubernetesJson.Serialize(patch, null));
+        Assert.True(JsonNode.DeepEquals(changed, JsonPatch.Apply(current, patch)));
+    }
+
+    [Fact]
+    public void Create_ScalarDifference_CreatesRootReplaceOperation()
+    {
+        var current = JsonValue.Create("before");
+        var changed = JsonValue.Create("after");
+
+        var patch = JsonPatch.Create(current, changed);
+
+        Assert.Equal(
+            """[{"op":"replace","path":"","value":"after"}]""",
+            KubernetesJson.Serialize(patch, null));
+        Assert.True(JsonNode.DeepEquals(changed, JsonPatch.Apply(current, patch)));
+    }
+
+    [Theory]
+    [InlineData(
+        """[1,2]""",
+        """[1,2,3,4]""",
+        """[{"op":"add","path":"/2","value":3},{"op":"add","path":"/3","value":4}]""")]
+    [InlineData(
+        """[1,2,3,4]""",
+        """[1,2]""",
+        """[{"op":"remove","path":"/3"},{"op":"remove","path":"/2"}]""")]
+    [InlineData(
+        """[{"value":"before"},2]""",
+        """[{"value":"after"},3]""",
+        """[{"op":"replace","path":"/0/value","value":"after"},{"op":"replace","path":"/1","value":3}]""")]
+    public void Create_ArrayDifferences_CreatesApplicableOperations(string currentJson, string changedJson, string expectedPatchJson)
+    {
+        var current = JsonNode.Parse(currentJson);
+        var changed = JsonNode.Parse(changedJson);
+
+        var patch = JsonPatch.Create(current, changed);
+
+        Assert.Equal(expectedPatchJson, KubernetesJson.Serialize(patch, null));
+        Assert.True(JsonNode.DeepEquals(changed, JsonPatch.Apply(current, patch)));
+    }
+
+    [Fact]
+    public void Create_PropertyNamesWithJsonPointerCharacters_EscapesPathSegments()
+    {
+        var current = JsonNode.Parse("""{"a/b":{"m~n":"before"}}""");
+        var changed = JsonNode.Parse("""{"a/b":{"m~n":"after"}}""");
+
+        var patch = JsonPatch.Create(current, changed);
+
+        Assert.Equal(
+            """[{"op":"replace","path":"/a~1b/m~0n","value":"after"}]""",
+            KubernetesJson.Serialize(patch, null));
+        Assert.True(JsonNode.DeepEquals(changed, JsonPatch.Apply(current, patch)));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -9,10 +9,10 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text;
 using k8s.Models;
 using k8s.Autorest;
-using Json.Patch;
 
 namespace Aspire.Hosting.Tests.Dcp;
 
@@ -335,7 +335,7 @@ internal sealed class TestKubernetesService : IKubernetesService
 
         if (patch.Type == V1Patch.PatchType.JsonPatch)
         {
-            Json.Patch.JsonPatch jsonPatch = (Json.Patch.JsonPatch)patch.Content;
+            var jsonPatch = (JsonArray)patch.Content;
 
             var res = CreatedResources.OfType<T>().FirstOrDefault(r =>
                 r.Metadata.Name == obj.Metadata.Name &&
@@ -346,7 +346,10 @@ internal sealed class TestKubernetesService : IKubernetesService
                 throw new ArgumentException($"Resource '{obj.Metadata.NamespaceProperty}/{obj.Metadata.Name}' not found");
             }
 
-            var result = jsonPatch.Apply<T, T>(res);
+            // Serialize against the runtime type because callers can patch through the CustomResource base type.
+            var resourceType = res.GetType();
+            var resultNode = JsonPatch.Apply(JsonSerializer.SerializeToNode(res, resourceType), jsonPatch);
+            var result = (T)JsonSerializer.Deserialize(resultNode, resourceType)!;
 
             // A patch changes the stored object, so it needs a new resource version. No watch event is
             // emitted here - tests push one themselves when they need it - but leaving the version behind


### PR DESCRIPTION
## Description

Removes the JsonPatch.Net dependency from Aspire.Hosting while preserving the JSON Patch behavior used to start and stop DCP resources and update container tunnel configuration.

The replacement is a focused internal implementation built on `System.Text.Json.Nodes`. It generates RFC 6902 `add`, `remove`, and `replace` operations for object, array, and scalar changes, encodes JSON Pointer path segments according to RFC 6901, and emits the JSON array wire shape expected by Kubernetes `V1Patch`. The test Kubernetes service applies the same limited operation set when emulating server behavior.

Added focused tests for object additions, removals, and replacements; scalar replacement; array growth, shrinkage, and element changes; escaped property names; patch application; and Kubernetes serialization.

Validation:

- `restore.cmd`
- Targeted Aspire.Hosting test run: 9 passed, including JSON Patch unit tests and DCP executable, container, and tunnel proxy patch flows
- `git diff --check`

Fixes #19493

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No