### PR TITLE
Preserve TypeSystem compatibility with older CLIs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.Java;
@@ -185,7 +187,7 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
     internal const string CompileStampFileName = ".aspire-compile-stamp";
 
     /// <summary>
-    /// Builds the up-to-date check that lets an unchanged AppHost skip <c>javac</c> entirely.
+    /// Sets the up-to-date check that lets an unchanged AppHost skip <c>javac</c> entirely when supported.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -205,28 +207,80 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
     /// solution do not give back the time this saves.
     /// </para>
     /// </remarks>
+    /// <param name="commandSpec">The compile command to update.</param>
     /// <param name="classOutputDirectory">Directory javac writes classes to, which is where the stamp lives.</param>
-    internal static CommandUpToDateCheck CreateCompileUpToDateCheck(string classOutputDirectory)
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The installed CLI roots the force-shared contract when this property exists.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "The installed CLI roots the force-shared contract when this property exists.")]
+    internal static void SetCompileUpToDateCheckIfSupported(object commandSpec, string classOutputDirectory)
     {
-        return new CommandUpToDateCheck
+        // Aspire.TypeSystem is force-shared from the installed CLI. A newer codegen assembly can
+        // therefore run against an older CommandSpec that has the same assembly identity but does not
+        // expose this additive property. Probe by name so the optimization is skipped and the older CLI
+        // compiles on every launch rather than failing to load the Java language support.
+        var upToDateCheckProperty = commandSpec.GetType().GetProperty(nameof(CommandSpec.UpToDateCheck));
+
+        if (upToDateCheckProperty is null)
         {
-            Inputs =
-            [
-                "{appHostFile}",
-                "./**",
-                $"{GeneratedSourcesDirectory}/**",
-                "src/main/java/**"
-            ],
-            // Only sources are inputs. Without this the .class files javac writes beside the sources in
-            // the flat layout would invalidate the very check they were produced under.
-            FileExtensions = [".java"],
-            StampFile = Path.Combine(classOutputDirectory, CompileStampFileName)
-        };
+            return;
+        }
+
+        var expectedTypeName = $"{typeof(CommandSpec).Namespace}.{nameof(CommandUpToDateCheck)}";
+        var upToDateCheckType = upToDateCheckProperty.PropertyType;
+        var inputsProperty = upToDateCheckType.GetProperty(nameof(CommandUpToDateCheck.Inputs));
+        var fileExtensionsProperty = upToDateCheckType.GetProperty(nameof(CommandUpToDateCheck.FileExtensions));
+        var stampFileProperty = upToDateCheckType.GetProperty(nameof(CommandUpToDateCheck.StampFile));
+
+        if (upToDateCheckProperty.SetMethod is null ||
+            !upToDateCheckProperty.SetMethod.IsPublic ||
+            upToDateCheckType.Assembly != typeof(CommandSpec).Assembly ||
+            upToDateCheckType.FullName != expectedTypeName ||
+            upToDateCheckType.IsAbstract ||
+            upToDateCheckType.GetConstructor(Type.EmptyTypes) is null ||
+            inputsProperty?.PropertyType != typeof(string[]) ||
+            inputsProperty.SetMethod is null ||
+            !inputsProperty.SetMethod.IsPublic ||
+            fileExtensionsProperty?.PropertyType != typeof(string[]) ||
+            fileExtensionsProperty.SetMethod is null ||
+            !fileExtensionsProperty.SetMethod.IsPublic ||
+            stampFileProperty?.PropertyType != typeof(string) ||
+            stampFileProperty.SetMethod is null ||
+            !stampFileProperty.SetMethod.IsPublic)
+        {
+            throw new MissingMemberException(
+                $"The runtime {nameof(CommandSpec.UpToDateCheck)} contract does not match {expectedTypeName}.");
+        }
+
+        var upToDateCheck = Activator.CreateInstance(upToDateCheckType)
+            ?? throw new MissingMemberException($"The runtime type {expectedTypeName} could not be created.");
+
+        inputsProperty.SetValue(upToDateCheck, new[]
+        {
+            "{appHostFile}",
+            "./**",
+            $"{GeneratedSourcesDirectory}/**",
+            "src/main/java/**"
+        });
+        // Only sources are inputs. Without this the .class files javac writes beside the sources in
+        // the flat layout would invalidate the very check they were produced under.
+        fileExtensionsProperty.SetValue(upToDateCheck, new[] { ".java" });
+        stampFileProperty.SetValue(upToDateCheck, Path.Combine(classOutputDirectory, CompileStampFileName));
+        upToDateCheckProperty.SetValue(commandSpec, upToDateCheck);
     }
 
     /// <inheritdoc />
     public RuntimeSpec GetRuntimeSpec()
     {
+        var compile = new CommandSpec
+        {
+            // No shell. javac creates the destination directory itself, so there is nothing
+            // left that needed one, and running without a shell means arguments are not
+            // re-split: a project under a path such as "C:\My Projects" works unchanged, on
+            // Windows and Unix alike, from a single spec.
+            Command = "javac",
+            Args = [.. s_javacOptions, "-d", BuildOutputDirectory, $"@{GeneratedSourcesListPath}", "{appHostFile}"]
+        };
+        SetCompileUpToDateCheckIfSupported(compile, BuildOutputDirectory);
+
         return new RuntimeSpec
         {
             Language = LanguageId,
@@ -238,19 +292,7 @@ internal sealed class JavaLanguageSupport : ILanguageSupport
             // would otherwise start a shell), and it lets --no-build skip the compile.
             // A Maven or Gradle AppHost replaces both commands via JavaAppHostToolchainResolver.
             InstallDependencies = null,
-            PreExecute =
-            [
-                new CommandSpec
-                {
-                    // No shell. javac creates the destination directory itself, so there is nothing
-                    // left that needed one, and running without a shell means arguments are not
-                    // re-split: a project under a path such as "C:\My Projects" works unchanged, on
-                    // Windows and Unix alike, from a single spec.
-                    Command = "javac",
-                    Args = [.. s_javacOptions, "-d", BuildOutputDirectory, $"@{GeneratedSourcesListPath}", "{appHostFile}"],
-                    UpToDateCheck = CreateCompileUpToDateCheck(BuildOutputDirectory)
-                }
-            ],
+            PreExecute = [compile],
             // Debugging the AppHost itself goes through the same Java debug adapter the resources use.
             // The CLI only takes this path when the extension reports the capability, so a CLI-only
             // run is unaffected.

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -248,14 +248,13 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
     /// <inheritdoc />
     public RuntimeSpec GetRuntimeSpec()
     {
-        return new RuntimeSpec
+        var runtimeSpec = new RuntimeSpec
         {
             Language = LanguageId,
             DisplayName = LanguageDisplayName,
             CodeGenLanguage = CodeGenTarget,
             DetectionPatterns = s_detectionPatterns,
             ExtensionLaunchCapability = "node",
-            CertificateBundleEnvironmentVariable = CertificateBundleEnvironmentVariable,
             InstallDependencies = new CommandSpec
             {
                 Command = "npm",
@@ -293,5 +292,25 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                 [AppHostTsConfigFileName] = s_appHostTsConfigContent
             }
         };
+
+        SetCertificateBundleEnvironmentVariableIfSupported(runtimeSpec, CertificateBundleEnvironmentVariable);
+
+        return runtimeSpec;
+    }
+
+    /// <summary>
+    /// Sets the certificate bundle environment variable when the runtime contract supports it.
+    /// </summary>
+    internal static void SetCertificateBundleEnvironmentVariableIfSupported(
+        object runtimeSpec,
+        string environmentVariableName)
+    {
+        // Aspire.TypeSystem is force-shared from the installed CLI. A newer codegen assembly can
+        // therefore run against an older RuntimeSpec that has the same assembly identity but does not
+        // expose this additive property. Probe by name so the new certificate feature is skipped while
+        // the rest of code generation remains compatible.
+        runtimeSpec.GetType()
+            .GetProperty(nameof(RuntimeSpec.CertificateBundleEnvironmentVariable))
+            ?.SetValue(runtimeSpec, environmentVariableName);
     }
 }

--- a/src/Aspire.TypeSystem/Aspire.TypeSystem.csproj
+++ b/src/Aspire.TypeSystem/Aspire.TypeSystem.csproj
@@ -59,6 +59,12 @@
       package baseline validation), which flags any change to the shipped surface, forcing a
       deliberate decision about whether the change is additive (no bump) or breaking (bump).
 
+      An additive member is not automatically safe for SDK-side codegen that can run against an
+      older CLI bundle with the same frozen identity. Newer codegen must capability-probe the
+      member before invoking it; otherwise the older force-shared contract binds successfully and
+      the direct member call fails with MissingMethodException. See
+      https://github.com/microsoft/aspire/issues/19503.
+
       Only AssemblyVersion is frozen; FileVersion, InformationalVersion, and the NuGet package
       version remain build-derived so diagnostics keep real build identities. Aspire.TypeSystem is
       consumed only via ProjectReference (no PackageReference consumers), so the frozen

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/JavaLanguageSupportTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TypeSystem;
+
+namespace Aspire.Hosting.CodeGeneration.Java.Tests;
+
+public class JavaLanguageSupportTests
+{
+    [Fact]
+    public void GetRuntimeSpec_SetsCompileUpToDateCheckWhenSupported()
+    {
+        var runtimeSpec = new JavaLanguageSupport().GetRuntimeSpec();
+        var compile = Assert.Single(runtimeSpec.PreExecute!);
+
+        AssertCompileUpToDateCheck(compile);
+    }
+
+    [Fact]
+    public void SetCompileUpToDateCheckIfSupported_PopulatesCompileUpToDateCheckOnCommandSpec()
+    {
+        var compile = new CommandSpec
+        {
+            Command = "javac",
+            Args = ["--release", "25", "-d", ".java-build", "@.aspire/modules/sources.txt", "{appHostFile}"]
+        };
+
+        JavaLanguageSupport.SetCompileUpToDateCheckIfSupported(compile, ".java-build");
+
+        AssertCompileUpToDateCheck(compile);
+    }
+
+    [Fact]
+    public void SetCompileUpToDateCheckIfSupported_IgnoresLegacyCommandSpec()
+    {
+        var exception = Record.Exception(() =>
+            JavaLanguageSupport.SetCompileUpToDateCheckIfSupported(
+                new LegacyCommandSpec(),
+                ".java-build"));
+
+        Assert.Null(exception);
+    }
+
+    private sealed class LegacyCommandSpec
+    {
+    }
+
+    private static void AssertCompileUpToDateCheck(CommandSpec compile)
+    {
+        var check = Assert.IsType<CommandUpToDateCheck>(compile.UpToDateCheck);
+
+        Assert.Equal(["{appHostFile}", "./**", ".aspire/modules/**", "src/main/java/**"], check.Inputs);
+        Assert.Equal([".java"], check.FileExtensions!);
+        Assert.Equal(Path.Combine(".java-build", ".aspire-compile-stamp"), check.StampFile);
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -265,6 +265,18 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
     }
 
     [Fact]
+    public void SetCertificateBundleEnvironmentVariableIfSupported_IgnoresLegacyRuntimeSpec()
+    {
+        var legacyRuntimeSpec = new LegacyRuntimeSpec();
+
+        TypeScriptLanguageSupport.SetCertificateBundleEnvironmentVariableIfSupported(
+            legacyRuntimeSpec,
+            "NODE_EXTRA_CA_CERTS");
+
+        Assert.NotNull(legacyRuntimeSpec);
+    }
+
+    [Fact]
     public void Scaffold_EmitsScaffoldedEslintConfigVerbatim()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -312,5 +324,9 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
     {
         Assert.InRange(port, minInclusive, maxExclusive - 1);
         Assert.True(port < WindowsEphemeralPortMin, $"Expected port {port} to be below the Windows ephemeral range.");
+    }
+
+    private sealed class LegacyRuntimeSpec
+    {
     }
 }


### PR DESCRIPTION
## Description

A TypeScript AppHost using SDK/codegen 13.5 fails under CLI 13.4.6 because the CLI force-shares its older `Aspire.TypeSystem` contract. The assembly identity still binds, but the newer codegen directly calls a `RuntimeSpec.CertificateBundleEnvironmentVariable` setter that does not exist in the older contract.

Java codegen has the same compatibility boundary for `CommandSpec.UpToDateCheck`; CLI 13.4.6 is missing both the property and the `CommandUpToDateCheck` type.

This probes the additive properties before using them. Current CLIs still pass `NODE_EXTRA_CA_CERTS` and retain Java's incremental compile check. Older CLIs skip those unsupported capabilities while the rest of code generation continues.

Validation:

- `TypeScriptLanguageSupportTests`: 14 passed
- `Aspire.Hosting.CodeGeneration.Java.Tests`: 45 passed
- `Aspire.Hosting.CodeGeneration.TypeScript`, `Aspire.Hosting.CodeGeneration.Java`, and `Aspire.Hosting.RemoteHost`: built with 0 warnings and 0 errors
- Physical CLI 13.4.6 with locally built 13.5 TypeScript SDK/codegen: AppHost started without `MissingMethodException`; `NODE_EXTRA_CA_CERTS` was omitted
- Locally built current CLI with the same TypeScript SDK/codegen: AppHost started with `NODE_EXTRA_CA_CERTS` populated
- Physical CLI 13.4.6 with the previous Java codegen: failed with `Could not load type 'Aspire.TypeSystem.CommandUpToDateCheck'`
- Physical CLI 13.4.6 with the fixed Java codegen: AppHost and dashboard started successfully

Fixes #19503

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No