### PR TITLE
Make AppHost tree E2E startup deterministic under CI contention

### DIFF
--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -5,7 +5,9 @@ import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { cancelActiveInput, cancelAppHostsSectionTextTransition, clickTreeItem, executeCommandFromPalette, getNotificationMessages, openAspireView, startAppHostsSectionTextTransition, waitForAppHostsSectionTextAfterTransition, waitForChildTreeItem, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchText } from './helpers/vscode';
 
 suite('Aspire AppHost tree E2E', function () {
-    this.timeout(240000);
+    // The first real AppHost launch pays for an isolated CLI bundle extraction and cold build.
+    // Leave the CLI's full startup budget plus another budget for the scenario and its cleanup.
+    this.timeout(600000);
 
     teardown(async () => {
         await runE2eTeardown([
@@ -185,14 +187,16 @@ suite('Aspire AppHost tree E2E', function () {
         await openAspireView();
         await waitForRepositoryIdle();
         const discovered = await waitForWorkspaceAppHost();
+        const appHostPath = discovered.state.workspaceAppHostPath ?? getPrimaryAppHostProjectPath();
         const appHostLabel = getTreeAppHostLabel(discovered.state);
-        const section = await openAspireView();
+        await openAspireView();
 
-        const idleItem = await waitForTreeItem(section, appHostLabel);
-        await idleItem.expand();
-        await clickTreeItem(section, 'Run AppHost');
-        await waitForCommandOutcome('aspire-vscode.runAppHost', 'success');
-        const running = await waitForRunningAppHost();
+        const runInvocationBefore = getCommandInvocationCount('aspire-vscode.runAppHost');
+        await executeE2eControlCommand({ name: 'runAppHost', appHostPath }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.runAppHost', 'success', 60000, runInvocationBefore);
+        // Match the E2E runner's CLI startup budget so CI contention cannot make the test abandon a
+        // launch that the CLI still legitimately considers in progress.
+        const running = await waitForRunningAppHost(300000);
         const runningAppHost = findRunningAppHost(running.state);
         assert.ok(runningAppHost);
         const authoritativeSnapshotAppHostPid = runningAppHost.appHostPid + 1_000_000;

--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -4,10 +4,12 @@ import { assertClipboardMatchesLastExpectationForE2E, captureWorkspaceAppHostPat
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { cancelActiveInput, cancelAppHostsSectionTextTransition, clickTreeItem, executeCommandFromPalette, getNotificationMessages, openAspireView, startAppHostsSectionTextTransition, waitForAppHostsSectionTextAfterTransition, waitForChildTreeItem, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchText } from './helpers/vscode';
 
+const cliStartupTimeoutMs = getCliStartupTimeoutMs();
+
 suite('Aspire AppHost tree E2E', function () {
     // The first real AppHost launch pays for an isolated CLI bundle extraction and cold build.
     // Leave the CLI's full startup budget plus another budget for the scenario and its cleanup.
-    this.timeout(600000);
+    this.timeout(cliStartupTimeoutMs * 2);
 
     teardown(async () => {
         await runE2eTeardown([
@@ -196,7 +198,7 @@ suite('Aspire AppHost tree E2E', function () {
         await waitForCommandOutcome('aspire-vscode.runAppHost', 'success', 60000, runInvocationBefore);
         // Match the E2E runner's CLI startup budget so CI contention cannot make the test abandon a
         // launch that the CLI still legitimately considers in progress.
-        const running = await waitForRunningAppHost(300000);
+        const running = await waitForRunningAppHost(cliStartupTimeoutMs);
         const runningAppHost = findRunningAppHost(running.state);
         assert.ok(runningAppHost);
         const authoritativeSnapshotAppHostPid = runningAppHost.appHostPid + 1_000_000;
@@ -381,5 +383,15 @@ suite('Aspire AppHost tree E2E', function () {
         await openAspireView();
         await waitForNoRunningAppHost(120000, appHostPath);
     });
-
 });
+
+function getCliStartupTimeoutMs(): number {
+    // run-e2e.js forwards the effective CLI timeout as a positive integer number of seconds,
+    // for example ASPIRE_CLI_START_TIMEOUT=300.
+    const configuredSeconds = Number(process.env.ASPIRE_CLI_START_TIMEOUT);
+    if (!Number.isInteger(configuredSeconds) || configuredSeconds <= 0) {
+        throw new Error(`ASPIRE_CLI_START_TIMEOUT must be a positive integer for AppHost tree E2E tests. Got '${process.env.ASPIRE_CLI_START_TIMEOUT ?? '<unset>'}'.`);
+    }
+
+    return configuredSeconds * 1000;
+}

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -899,32 +899,19 @@ suite('E2E launch profile', () => {
         assert.ok(cleanup.includes('() => cancelAppHostsSectionTextTransition()'), 'The transition tracker must be disposed even when the E2E fails before observing the rendered row.');
     });
 
-    test('keeps AppHost tree cold-start budgets above the CLI startup budget', () => {
+    test('derives AppHost tree cold-start budgets from the effective CLI startup timeout', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');
-        const assertions = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'assertions.ts'), 'utf8');
         const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
         const runningBeforeDiscoveryTest = getTestBlock(appHostTree, 'running AppHosts appear before slow discovery results');
-        const cliStartupTimeout = /ASPIRE_CLI_START_TIMEOUT:\s*process\.env\.ASPIRE_EXTENSION_E2E_CLI_START_TIMEOUT\s*\|\|\s*'([\d_]+)'/.exec(runner);
-        const defaultRunningWait = /waitForRunningAppHost\(timeoutMs = ([\d_]+)\)/.exec(assertions);
-        const explicitRunningWait = /waitForRunningAppHost\(([\d_]+)\)/.exec(runningBeforeDiscoveryTest);
-        const suiteTimeout = /this\.timeout\(([\d_]+)\);/.exec(appHostTree);
 
-        assert.ok(cliStartupTimeout, 'Expected the E2E runner to configure the CLI startup timeout.');
-        assert.ok(defaultRunningWait, 'Expected waitForRunningAppHost to declare its default timeout.');
-        assert.ok(suiteTimeout, 'Expected the AppHost tree suite to declare its timeout.');
-
-        const parseNumericLiteral = (value: string) => Number(value.replaceAll('_', ''));
-        const cliStartupTimeoutMs = parseNumericLiteral(cliStartupTimeout[1]) * 1000;
-        const runningWaitMs = parseNumericLiteral((explicitRunningWait ?? defaultRunningWait)[1]);
-        const suiteTimeoutMs = parseNumericLiteral(suiteTimeout[1]);
-
-        assert.ok(
-            runningWaitMs >= cliStartupTimeoutMs,
-            `The running AppHost wait (${runningWaitMs}ms) must not expire before the CLI startup budget (${cliStartupTimeoutMs}ms).`);
-        assert.ok(
-            suiteTimeoutMs >= runningWaitMs + cliStartupTimeoutMs,
-            `The AppHost tree suite timeout (${suiteTimeoutMs}ms) must leave one CLI startup budget after the running wait for the scenario assertions and cleanup.`);
+        assert.ok(runner.includes("ASPIRE_CLI_START_TIMEOUT: process.env.ASPIRE_EXTENSION_E2E_CLI_START_TIMEOUT || '300'"));
+        assert.ok(appHostTree.includes('const cliStartupTimeoutMs = getCliStartupTimeoutMs();'));
+        assert.ok(appHostTree.includes('const configuredSeconds = Number(process.env.ASPIRE_CLI_START_TIMEOUT);'));
+        assert.ok(appHostTree.includes('this.timeout(cliStartupTimeoutMs * 2);'));
+        assert.ok(runningBeforeDiscoveryTest.includes('waitForRunningAppHost(cliStartupTimeoutMs)'));
+        assert.ok(!appHostTree.includes('this.timeout(600000);'));
+        assert.ok(!runningBeforeDiscoveryTest.includes('waitForRunningAppHost(300000)'));
     });
 
     test('starts the running-before-discovery scenario through the deterministic control bridge', () => {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -899,6 +899,48 @@ suite('E2E launch profile', () => {
         assert.ok(cleanup.includes('() => cancelAppHostsSectionTextTransition()'), 'The transition tracker must be disposed even when the E2E fails before observing the rendered row.');
     });
 
+    test('keeps AppHost tree cold-start budgets above the CLI startup budget', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');
+        const assertions = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'assertions.ts'), 'utf8');
+        const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
+        const runningBeforeDiscoveryTest = getTestBlock(appHostTree, 'running AppHosts appear before slow discovery results');
+        const cliStartupTimeout = /ASPIRE_CLI_START_TIMEOUT:\s*process\.env\.ASPIRE_EXTENSION_E2E_CLI_START_TIMEOUT\s*\|\|\s*'([\d_]+)'/.exec(runner);
+        const defaultRunningWait = /waitForRunningAppHost\(timeoutMs = ([\d_]+)\)/.exec(assertions);
+        const explicitRunningWait = /waitForRunningAppHost\(([\d_]+)\)/.exec(runningBeforeDiscoveryTest);
+        const suiteTimeout = /this\.timeout\(([\d_]+)\);/.exec(appHostTree);
+
+        assert.ok(cliStartupTimeout, 'Expected the E2E runner to configure the CLI startup timeout.');
+        assert.ok(defaultRunningWait, 'Expected waitForRunningAppHost to declare its default timeout.');
+        assert.ok(suiteTimeout, 'Expected the AppHost tree suite to declare its timeout.');
+
+        const parseNumericLiteral = (value: string) => Number(value.replaceAll('_', ''));
+        const cliStartupTimeoutMs = parseNumericLiteral(cliStartupTimeout[1]) * 1000;
+        const runningWaitMs = parseNumericLiteral((explicitRunningWait ?? defaultRunningWait)[1]);
+        const suiteTimeoutMs = parseNumericLiteral(suiteTimeout[1]);
+
+        assert.ok(
+            runningWaitMs >= cliStartupTimeoutMs,
+            `The running AppHost wait (${runningWaitMs}ms) must not expire before the CLI startup budget (${cliStartupTimeoutMs}ms).`);
+        assert.ok(
+            suiteTimeoutMs >= runningWaitMs + cliStartupTimeoutMs,
+            `The AppHost tree suite timeout (${suiteTimeoutMs}ms) must leave one CLI startup budget after the running wait for the scenario assertions and cleanup.`);
+    });
+
+    test('starts the running-before-discovery scenario through the deterministic control bridge', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
+        const runningBeforeDiscoveryTest = getTestBlock(appHostTree, 'running AppHosts appear before slow discovery results');
+
+        assert.ok(runningBeforeDiscoveryTest.includes('const appHostPath = discovered.state.workspaceAppHostPath ?? getPrimaryAppHostProjectPath();'));
+        assert.ok(runningBeforeDiscoveryTest.includes("const runInvocationBefore = getCommandInvocationCount('aspire-vscode.runAppHost');"));
+        assert.ok(runningBeforeDiscoveryTest.includes("await executeE2eControlCommand({ name: 'runAppHost', appHostPath }, { waitFor: 'started' });"));
+        assert.ok(runningBeforeDiscoveryTest.includes("await waitForCommandOutcome('aspire-vscode.runAppHost', 'success', 60000, runInvocationBefore);"));
+        assert.ok(!runningBeforeDiscoveryTest.includes('waitForTreeItem('));
+        assert.ok(!runningBeforeDiscoveryTest.includes('.expand()'));
+        assert.ok(!runningBeforeDiscoveryTest.includes('clickTreeItem('));
+    });
+
     test('patches ExTester launch arguments without version-specific assumptions or replacement-token expansion', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');


### PR DESCRIPTION
## Description

The AppHost tree E2E could fail before exercising the refresh behavior it is intended to verify:

- A cold first launch had a 180-second harness wait even though the E2E runner gives the CLI a 300-second startup budget. The reported failure spent about 105 seconds extracting the isolated CLI bundle and building before AppHost startup.
- The scenario redundantly started the AppHost through virtualized tree rows. The E2E health ledger recorded this exact test timing out while waiting for a tree item 9 times across 4 PRs.

This change aligns the scenario's startup wait with the CLI budget, gives the suite enough time for the cold-start path and cleanup, and starts the AppHost through the deterministic E2E control bridge with sequence-gated command tracking. Separate AppHost tree tests continue to cover the `Run AppHost` UI action.

Two unit contracts were added test-first:

- The timeout-budget contract failed with `180000ms < 300000ms` before the fix.
- The control-bridge contract failed while the scenario still used `waitForTreeItem` / `clickTreeItem`.

Validation:

- `corepack yarn unit-test --run out/test/e2eLaunchProfile.test.js` - 66 passed
- `corepack yarn compile-e2e`
- `corepack yarn eslint src/test/e2eLaunchProfile.test.ts src/test-e2e/appHostTree.e2e.test.ts`

The full scenario was not treated as locally verified because this host is Windows ARM64 and its Extension Host failed to reopen the generated workspace before reaching the target test. The PR's Windows and Linux x64 E2E jobs provide the authoritative scenario validation.

Related to #19485
Related to #19282

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
