### PR TITLE
[release/13.5] fix(release): Restore WinGet publication with .NET 9 wingetcreate

### DIFF
--- a/eng/pipelines/templates/prepare-winget-manifest.yml
+++ b/eng/pipelines/templates/prepare-winget-manifest.yml
@@ -50,6 +50,26 @@ steps:
       Write-Host "##vso[task.setvariable variable=WinGetIsPrereleaseInStablePackage]$isPrereleaseInStablePackage"
     displayName: 🟣Set version ${{ parameters.version }}
 
+  # The standalone wingetcreate executable is framework-dependent. Exercise it
+  # in regular builds so an upstream target-framework change is caught before
+  # the release pipeline attempts a public submission.
+  - task: UseDotNet@2
+    displayName: '🟣Install .NET 9 runtime for wingetcreate'
+    inputs:
+      packageType: 'runtime'
+      version: '9.0.x'
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+
+      Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile "$(Build.StagingDirectory)/wingetcreate.exe"
+      & "$(Build.StagingDirectory)/wingetcreate.exe" info
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "wingetcreate info failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+      }
+    displayName: '🟣Verify wingetcreate'
+
   - pwsh: |
       # Probe-only: do not attempt to install/repair winget here. The 1ES `1es-windows-2022`
       # pool blocks outbound access to cdn.winget.microsoft.com, so

--- a/eng/pipelines/templates/publish-winget.yml
+++ b/eng/pipelines/templates/publish-winget.yml
@@ -181,16 +181,35 @@ steps:
     # Same gate as the installer-URL validation above and the Submit step below.
     condition: |
       and(
-        succeeded(),
-        eq('${{ parameters.dryRun }}', 'false'),
-        eq(variables['_IsProductionBranch'], 'true')
+         succeeded(),
+         eq('${{ parameters.dryRun }}', 'false'),
+         eq(variables['_IsProductionBranch'], 'true')
+      )
+
+  # The latest standalone wingetcreate executable targets .NET 9 and is not
+  # self-contained, so the release agent must provide a compatible runtime.
+  - task: UseDotNet@2
+    displayName: '🟣Install .NET 9 runtime for wingetcreate'
+    inputs:
+      packageType: 'runtime'
+      version: '9.0.x'
+    condition: |
+      and(
+       succeeded(),
+       eq('${{ parameters.dryRun }}', 'false'),
+       eq(variables['_IsProductionBranch'], 'true')
       )
 
   - powershell: |
       $ErrorActionPreference = 'Stop'
       Write-Host "Downloading wingetcreate..."
       Invoke-WebRequest -Uri "https://aka.ms/wingetcreate/latest" -OutFile "$(Build.StagingDirectory)/wingetcreate.exe"
-      Write-Host "wingetcreate downloaded successfully"
+      & "$(Build.StagingDirectory)/wingetcreate.exe" info
+      if ($LASTEXITCODE -ne 0) {
+        Write-Error "wingetcreate info failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+      }
+      Write-Host "wingetcreate downloaded and verified successfully"
     displayName: '🟣Install wingetcreate'
     # Skip when no Submit step will run. wingetcreate is only used to submit to
     # the upstream winget-pkgs repo, so dry-run and non-production-branch builds

--- a/eng/pipelines/templates/publish-winget.yml
+++ b/eng/pipelines/templates/publish-winget.yml
@@ -181,24 +181,20 @@ steps:
     # Same gate as the installer-URL validation above and the Submit step below.
     condition: |
       and(
-         succeeded(),
-         eq('${{ parameters.dryRun }}', 'false'),
-         eq(variables['_IsProductionBranch'], 'true')
+        succeeded(),
+        eq('${{ parameters.dryRun }}', 'false'),
+        eq(variables['_IsProductionBranch'], 'true')
       )
 
   # The latest standalone wingetcreate executable targets .NET 9 and is not
-  # self-contained, so the release agent must provide a compatible runtime.
+  # self-contained. Install its runtime whenever the WinGet job is selected so
+  # dry-run and non-production builds also verify that the CLI can start.
   - task: UseDotNet@2
     displayName: '🟣Install .NET 9 runtime for wingetcreate'
     inputs:
       packageType: 'runtime'
       version: '9.0.x'
-    condition: |
-      and(
-       succeeded(),
-       eq('${{ parameters.dryRun }}', 'false'),
-       eq(variables['_IsProductionBranch'], 'true')
-      )
+    condition: succeeded()
 
   - powershell: |
       $ErrorActionPreference = 'Stop'
@@ -211,16 +207,8 @@ steps:
       }
       Write-Host "wingetcreate downloaded and verified successfully"
     displayName: '🟣Install wingetcreate'
-    # Skip when no Submit step will run. wingetcreate is only used to submit to
-    # the upstream winget-pkgs repo, so dry-run and non-production-branch builds
-    # gain nothing from downloading it and instead pick up an aka.ms-redirect
-    # failure surface for free.
-    condition: |
-      and(
-        succeeded(),
-        eq('${{ parameters.dryRun }}', 'false'),
-        eq(variables['_IsProductionBranch'], 'true')
-      )
+    # This is side-effect free; the Submit step below retains the production gate.
+    condition: succeeded()
 
   - powershell: |
       $ErrorActionPreference = 'Stop'

--- a/eng/winget/README.md
+++ b/eng/winget/README.md
@@ -59,7 +59,9 @@ The Azure DevOps prepare stage also installs the .NET 9 runtime, downloads the
 latest standalone `wingetcreate`, and runs `wingetcreate info`. This
 side-effect-free smoke catches runtime compatibility changes before the release
 pipeline attempts a public submission; it does not exercise credentials or
-submission.
+submission. The release WinGet job repeats the same startup check whenever that
+job is selected, including dry-run and non-production-branch builds, while the
+submission step remains limited to non-dry-run production builds.
 
 ## Validation model
 

--- a/eng/winget/README.md
+++ b/eng/winget/README.md
@@ -55,6 +55,11 @@ Where arch is `x64` or `arm64`.
 | `release-publish-nuget.yml` (release) | —                                               | Stable manifests only |
 
 Publishing submits a PR to `microsoft/winget-pkgs` using `wingetcreate submit`.
+The Azure DevOps prepare stage also installs the .NET 9 runtime, downloads the
+latest standalone `wingetcreate`, and runs `wingetcreate info`. This
+side-effect-free smoke catches runtime compatibility changes before the release
+pipeline attempts a public submission; it does not exercise credentials or
+submission.
 
 ## Validation model
 

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -598,17 +598,23 @@ public sealed class ReleasePublishNugetPipelineTests
     }
 
     [Fact]
-    public async Task WinGetSubmissionInstallsRequiredDotNetRuntime()
+    public async Task WinGetJobVerifiesWingetCreateBeforeConditionalSubmission()
     {
         var template = await ReadRepoFileAsync("eng/pipelines/templates/publish-winget.yml");
         var runtimeInstallIndex = FindRequiredText(template, "- task: UseDotNet@2");
-        var wingetCreateInstallIndex = FindRequiredText(template, "displayName: '🟣Install wingetcreate'");
+        var wingetCreateInstallIndex = FindRequiredText(template, "Write-Host \"Downloading wingetcreate...\"");
+        var submitIndex = FindRequiredText(template, "Write-Host \"Submitting WinGet manifests");
         var runtimeInstall = template[runtimeInstallIndex..wingetCreateInstallIndex];
+        var wingetCreateInstall = template[wingetCreateInstallIndex..submitIndex];
+        var submission = template[submitIndex..];
 
         Assert.Contains("packageType: 'runtime'", runtimeInstall);
         Assert.Contains("version: '9.0.x'", runtimeInstall);
-        Assert.Contains("eq('${{ parameters.dryRun }}', 'false')", runtimeInstall);
-        Assert.Contains("eq(variables['_IsProductionBranch'], 'true')", runtimeInstall);
+        Assert.Contains("condition: succeeded()", runtimeInstall);
+        Assert.Contains("wingetcreate.exe\" info", wingetCreateInstall);
+        Assert.Contains("condition: succeeded()", wingetCreateInstall);
+        Assert.Contains("eq('${{ parameters.dryRun }}', 'false')", submission);
+        Assert.Contains("eq(variables['_IsProductionBranch'], 'true')", submission);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -598,6 +598,32 @@ public sealed class ReleasePublishNugetPipelineTests
     }
 
     [Fact]
+    public async Task WinGetSubmissionInstallsRequiredDotNetRuntime()
+    {
+        var template = await ReadRepoFileAsync("eng/pipelines/templates/publish-winget.yml");
+        var runtimeInstallIndex = FindRequiredText(template, "- task: UseDotNet@2");
+        var wingetCreateInstallIndex = FindRequiredText(template, "displayName: '🟣Install wingetcreate'");
+        var runtimeInstall = template[runtimeInstallIndex..wingetCreateInstallIndex];
+
+        Assert.Contains("packageType: 'runtime'", runtimeInstall);
+        Assert.Contains("version: '9.0.x'", runtimeInstall);
+        Assert.Contains("eq('${{ parameters.dryRun }}', 'false')", runtimeInstall);
+        Assert.Contains("eq(variables['_IsProductionBranch'], 'true')", runtimeInstall);
+    }
+
+    [Fact]
+    public async Task WinGetPreparationExercisesWingetCreate()
+    {
+        var template = await ReadRepoFileAsync("eng/pipelines/templates/prepare-winget-manifest.yml");
+
+        Assert.Contains("- task: UseDotNet@2", template);
+        Assert.Contains("packageType: 'runtime'", template);
+        Assert.Contains("version: '9.0.x'", template);
+        Assert.Contains("https://aka.ms/wingetcreate/latest", template);
+        Assert.Contains("wingetcreate.exe\" info", template);
+    }
+
+    [Fact]
     public async Task MarketplacePublishingDocumentationKeepsIdentityDetailsInternalAndRetiresPat()
     {
         var documentation = await ReadRepoFileAsync("docs/release-process.md");


### PR DESCRIPTION
## Description

**Aspire 13.5 WinGet publication failed before opening the upstream PR:**

```text
wingetcreate.exe : You must install or update .NET to run this application.
```

The latest framework-dependent `wingetcreate` targets .NET 9, but the release agent did not have a compatible runtime. This installs the .NET 9 runtime before launching `wingetcreate` and runs `wingetcreate info` in regular preparation and selected release jobs so future runtime incompatibilities fail before a live submission.

The actual `wingetcreate submit` step remains restricted to non-dry-run production-branch runs.

Validation:

- `ReleasePublishNugetPipelineTests`: 32 passed, 0 failed.
- Azure DevOps run 3052264 installed .NET runtime 9.0.19 and successfully ran `wingetcreate v1.12.13.0 info`; submission remained skipped.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
