### PR TITLE
Add Azure Front Door global entry point over regional stamps

### DIFF
--- a/docs/specs/deployment-stamps.md
+++ b/docs/specs/deployment-stamps.md
@@ -1,0 +1,199 @@
+# Deployment stamps
+
+This document describes how Aspire models a compute resource that is deployed to more than one compute
+environment, and how Azure Front Door acts as the global entry point in front of those deployments.
+
+## Motivation
+
+The Azure [deployment stamp pattern](https://learn.microsoft.com/azure/architecture/patterns/deployment-stamp)
+deploys identical copies of a workload to several regions and places a global routing layer in front of them.
+Before this feature Aspire could not express that topology: a compute resource was bound to exactly one
+compute environment, and Azure Front Door emitted a dedicated endpoint, origin group, origin, and route per
+backend, so each backend had its own hostname and there was nothing to fail over between.
+
+## Model
+
+A **stamp** is the pairing of a compute resource with one of the compute environments it is deployed to,
+represented by `Aspire.Hosting.ApplicationModel.ComputeStamp`:
+
+```csharp
+public sealed class ComputeStamp
+{
+    public IComputeEnvironmentResource Environment { get; }
+    public string Name { get; }
+    public bool QualifiesNames { get; }
+}
+```
+
+Binding is expressed with these APIs on any `IComputeResource`:
+
+| API | Behaviour |
+|---|---|
+| `WithComputeEnvironment(env)` | Binds to a single environment. Unchanged. |
+| `WithComputeEnvironments(env1, env2, …)` | Binds to several environments. The stamp name defaults to the environment's resource name. |
+| `WithStamp(env, stampName)` | Binds one stamp with an explicit short name. Repeatable. |
+
+Inspection helpers:
+
+| API | Returns |
+|---|---|
+| `GetComputeStamps()` | Every stamp, in declaration order. |
+| `GetComputeEnvironments()` | Every bound compute environment. |
+| `IsBoundToComputeEnvironment(env)` | Whether the resource is bound to a specific environment. |
+| `IsStamped()` | Whether the resource is bound to more than one environment. |
+| `GetStampQualifiedName(env)` | The infrastructure name to use for the resource in that environment. |
+| `GetDeploymentTargetAnnotations()` | Every deployment target, one per stamp. Never throws. |
+
+### Name stability
+
+`GetStampQualifiedName` returns the plain resource name whenever the resource is bound to a single compute
+environment and no explicit stamp name was supplied (`ComputeStamp.QualifiesNames` is `false`). This is a
+load-bearing invariant: every generated container app name, web site name, Bicep module path, Bicep
+parameter, and pipeline step name for a single-region application is byte-for-byte what earlier versions
+produced, so redeploying an existing application does not recreate its infrastructure.
+
+Adding a second compute environment to an existing resource *does* change its generated names, because the
+stamps must be distinguishable. Azure Container Apps caps app names at 32 characters, so use
+`WithStamp(env, "eus")` with short stamp names when the environment names are long.
+
+Every place that derives a name from a compute resource goes through `GetStampQualifiedName`:
+
+- `ContainerAppEnvironmentContext.CreateContainerAppAsync` — the `-containerapp` resource name
+- `BaseContainerAppContext.NormalizedContainerAppName` — the container app name and endpoint map
+- `AzureContainerAppEnvironmentResource.GetHostAddressExpression` — the regional hostname
+- `AzureAppServiceEnvironmentContext.CreateAppServiceAsync` — the `-website` resource name
+- `AzureAppServiceWebSiteResource.GetAppServiceWebsiteBaseNameAsync` and
+  `AzureAppServiceEnvironmentResource.GetHostAddressExpression` — the web site name and hostname
+- `AzurePublishingContext` — the Bicep module directory and file for each deployment target
+- `AzureContainerAppResource` / `AzureAppServiceWebSiteResource` — `deploy-{name}` and
+  `print-{name}-summary` pipeline step names
+
+## Regions
+
+`WithLocation` sets the Azure region of an individual Azure resource:
+
+```csharp
+var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+```
+
+It writes `AzureBicepResource.KnownParameters.Location` and records an `AzureResourceLocationAnnotation`. The
+annotation is what distinguishes an author's explicit choice from the location the provisioner infers from
+the Azure environment, because both end up in the same parameter slot.
+
+- **Deploy path**: already honoured. `BicepProvisioner.PopulateWellKnownParameters` only fills in the
+  environment location when the resource does not already carry one, and `GetEffectiveLocation` reads the
+  per-resource value.
+- **Publish path**: `AzurePublishingContext` now passes the resource's own location to the module when one is
+  configured, and skips the `location` entry in the parameter loop. Previously it added `location`
+  unconditionally and then re-added it from `resource.Parameters`, which threw on a duplicate key as soon as
+  a resource carried its own location.
+
+All stamps deploy into the application's single resource group. Azure allows a resource group to contain
+resources from any region, so multiple regions do not require multiple resource groups. Per-stamp resource
+groups are a possible follow-up: `AzureBicepResource.Scope` already supports per-module resource group
+scoping, but `main.bicep` emits exactly one `ResourceGroup` and `BicepProvisioner` resolves rather than
+creates scoped resource groups.
+
+## Deployment targets
+
+`DeploymentTargetAnnotation` already carried a `ComputeEnvironment`, so a stamped resource simply has one
+annotation per stamp. Each compute environment's `PrepareDeploymentTargetsAsync` now tests membership
+(`IsBoundToComputeEnvironment`) rather than equality, so a resource bound to several environments is
+processed by all of them.
+
+`GetDeploymentTargetAnnotation()` still throws when a resource has several deployment targets and no
+environment was supplied — that remains a useful guard against accidentally leaving a resource unbound in a
+model with two environments. For a resource that is intentionally stamped the message instead points at
+`GetDeploymentTargetAnnotations()`. Callers that must handle every stamp use the plural accessor.
+
+## Container registries
+
+A stamped resource's image is built and pushed **once**, and every stamp pulls that same image. All of a
+stamped resource's compute environments must therefore share one container registry. Each
+`AddAzureContainerAppEnvironment` provisions its own registry by default, so a stamped application has to
+point its environments at a shared one:
+
+```csharp
+var acr = builder.AddAzureContainerRegistry("acr");
+
+var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus").WithContainerRegistry(acr);
+var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope").WithContainerRegistry(acr);
+```
+
+`ResourceExtensions.GetContainerRegistry` fails with an actionable message when a stamped resource's stamps
+resolve to different registries. Without that check every stamp after the first would be emitted with an
+image reference into a registry the image was never pushed to, and whose managed identity has no pull
+rights — a guaranteed image-pull failure at deployment time rather than an error in the app model.
+
+Pushing one image to several registries is a possible follow-up; it would require resolving the image
+reference per deployment target rather than once per resource.
+
+## References between stamped resources
+
+References resolve **within the same stamp**. When `web` in `eastus` references `api`, and `api` is stamped to
+both `eastus` and `westeurope`, `web` gets the `eastus` copy of `api`, so traffic never leaves the region to
+reach a dependency that exists locally.
+
+`ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression` returns `false` — deferring to
+the publisher's local endpoint map, which is already per-environment — as soon as *any* of the target's
+environments is the environment currently being generated. `TryGetEffectiveComputeEnvironment` throws for a
+resource stamped across several environments, because there is no single environment to resolve; the message
+directs the caller to reference the resource through a global entry point instead.
+
+## Azure Front Door as the global entry point
+
+`WithOrigin(resource)` still produces one Front Door endpoint, origin group, and route per call, so each
+backend keeps its own `*.azurefd.net` hostname. What changed is that the origin group now contains **one
+origin per stamp**, each pointing at that stamp's regional hostname via its own compute environment's
+`GetHostAddressExpression`:
+
+```
+CdnProfile (Global)
+└── apiEndpoint                    ← one global hostname
+    ├── apiOriginGroup             ← health probe + load balancing
+    │   ├── api_aca_eastusOrigin   ← stamp 1
+    │   └── api_aca_westeuOrigin   ← stamp 2
+    └── apiRoute (dependsOn: every origin)
+output api_endpointUrl
+```
+
+`WithOriginGroup(resource, configure)` exposes the routing controls:
+
+- `WithRouting(FrontDoorOriginRouting)` — `LatencyBased` (default), `Failover`, `Weighted`
+- `WithStampPriority(env, priority)` / `WithStampWeight(env, weight)`
+- `WithHealthProbe(path, protocol, interval)`
+- `WithLoadBalancing(sampleSize, successfulSamplesRequired, additionalLatencyMilliseconds)`
+- `WithSessionAffinity(enabled)` / `WithTrafficRestorationTime(timeSpan)`
+- `WithCustomDomain(hostName)`
+
+`priority` and `weight` are only emitted when they carry information — an explicit per-stamp value, or
+`Failover` routing, which assigns ascending priorities in declaration order. That keeps the generated Bicep
+for a default single-stamp application identical to what earlier versions produced.
+
+Front Door itself is a global resource: it is deployed once and routes to the regional stamps of its origins.
+Binding an `AzureFrontDoorResource` to compute environments is rejected.
+
+### Custom domains and the module cycle
+
+An application cannot be told its own public Front Door hostname through the generated `*.azurefd.net` name.
+Front Door depends on the application's host address, so the reverse dependency would create a Bicep module
+cycle. A custom domain hostname is supplied by the author and therefore known before deployment, which makes
+`WithCustomDomain` the way to give an application its public address. The DNS TXT validation token needed to
+prove domain ownership is emitted as the `{origin}_customDomainValidationToken` output.
+
+For the same reason, locking origins down to Front Door traffic via the `X-Azure-FDID` header is not modelled:
+the Front Door ID is generated by the Front Door module, so injecting it into the origins would close the same
+cycle. It remains a manual post-deployment step.
+
+## Out of scope
+
+- **Per-stamp backing services.** Databases, caches, and storage are not replicated per stamp; every stamp
+  references the same instance. `ComputeStamp` carries the environment, so a future per-stamp backing service
+  feature can key off the same annotation.
+- **Per-stamp resource groups.** See "Regions" above.
+- **Kubernetes, Docker Compose, and Radius stamping.** The core model is publisher-agnostic, but only Azure
+  Container Apps and Azure App Service have stamp-aware name derivation. Kubernetes derives service names
+  from `resource.Name`, which would collide across stamps.
+- **Manifest publishing.** The manifest schema models a single deployment target per resource, so a stamped
+  resource is represented by its first stamp. Use the Azure publisher to emit infrastructure for every stamp.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -205,9 +205,11 @@ public class AzureContainerAppEnvironmentResource :
 
         foreach (var r in appModel.GetComputeResources())
         {
-            // Skip resources that are explicitly targeted to a different compute environment
-            var resourceComputeEnvironment = r.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            // Skip resources that are explicitly targeted to a different compute environment. A stamped
+            // resource is bound to several environments and must be processed by each of them, so the check
+            // is membership rather than equality.
+            var boundComputeEnvironments = r.GetComputeEnvironments();
+            if (boundComputeEnvironments.Count > 0 && !r.IsBoundToComputeEnvironment(this))
             {
                 continue;
             }
@@ -349,7 +351,10 @@ public class AzureContainerAppEnvironmentResource :
         var resource = endpointReference.Resource;
 
         var builder = new ReferenceExpressionBuilder();
-        builder.AppendLiteral(resource.Name.ToLowerInvariant());
+        // The container app name is stamp-qualified, so a resource deployed to several regions resolves to
+        // a distinct host in each of them. For a resource bound to a single environment this is just the
+        // resource name, keeping already deployed hostnames intact.
+        builder.AppendLiteral(resource.GetStampQualifiedName(this).ToLowerInvariant());
         if (!endpointReference.EndpointAnnotation.IsExternal)
         {
             builder.AppendLiteral(".internal");

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -30,40 +30,43 @@ public class AzureContainerAppResource : AzureProvisioningResource
         // Add pipeline step annotation for deploy
         Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
         {
-            // Get the deployment target annotation
-            var deploymentTargetAnnotation = targetResource.GetDeploymentTargetAnnotation();
+            // Get the deployment target annotation for this stamp. A stamped target resource has one
+            // deployment target per compute environment, so the environment has to narrow the lookup.
+            var deploymentTargetAnnotation = targetResource.GetDeploymentTargetAnnotation(ComputeEnvironment);
             if (deploymentTargetAnnotation is null)
             {
                 return [];
             }
 
+            var stampName = targetResource.GetStampQualifiedName(ComputeEnvironment);
+
             var steps = new List<PipelineStep>();
 
             var printResourceSummary = new PipelineStep
             {
-                Name = $"print-{targetResource.Name}-summary",
-                Description = $"Prints the deployment summary and URL for {targetResource.Name}.",
+                Name = $"print-{stampName}-summary",
+                Description = $"Prints the deployment summary and URL for {stampName}.",
                 Action = async ctx =>
                 {
                     var containerAppEnv = (AzureContainerAppEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
 
                     var domainValue = await containerAppEnv.ContainerAppDomain.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
-                    var portalLink = await ContainerAppUrls.GetPortalLinkAsync(containerAppEnv, targetResource.Name.ToLowerInvariant(), ctx.CancellationToken).ConfigureAwait(false);
+                    var portalLink = await ContainerAppUrls.GetPortalLinkAsync(containerAppEnv, stampName.ToLowerInvariant(), ctx.CancellationToken).ConfigureAwait(false);
 
                     if (targetResource.TryGetEndpoints(out var endpoints) && endpoints.Any(e => e.IsExternal))
                     {
-                        var endpoint = $"https://{targetResource.Name.ToLowerInvariant()}.{domainValue}";
+                        var endpoint = $"https://{stampName.ToLowerInvariant()}.{domainValue}";
                         var summaryValue = $"[{endpoint}]({endpoint}) ({portalLink})";
 
-                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to {summaryValue}"));
-                        ctx.Summary.Add(targetResource.Name, new MarkdownString(summaryValue));
+                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{stampName}** to {summaryValue}"));
+                        ctx.Summary.Add(stampName, new MarkdownString(summaryValue));
                     }
                     else
                     {
                         var summaryValue = $"No public endpoints ({portalLink})";
 
-                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to Azure Container Apps environment **{containerAppEnv.Name}**. {summaryValue}"));
-                        ctx.Summary.Add(targetResource.Name, new MarkdownString(summaryValue));
+                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{stampName}** to Azure Container Apps environment **{containerAppEnv.Name}**. {summaryValue}"));
+                        ctx.Summary.Add(stampName, new MarkdownString(summaryValue));
                     }
                 },
                 Tags = ["print-summary"],
@@ -72,8 +75,8 @@ public class AzureContainerAppResource : AzureProvisioningResource
 
             var deployStep = new PipelineStep
             {
-                Name = $"deploy-{targetResource.Name}",
-                Description = $"Aggregation step for deploying {targetResource.Name} to Azure Container Apps.",
+                Name = $"deploy-{stampName}",
+                Description = $"Aggregation step for deploying {stampName} to Azure Container Apps.",
                 Action = _ => Task.CompletedTask,
                 Tags = [WellKnownPipelineTags.DeployCompute]
             };
@@ -104,4 +107,14 @@ public class AzureContainerAppResource : AzureProvisioningResource
     /// Gets the target resource that this Azure Container App is being created for.
     /// </summary>
     public IResource TargetResource { get; }
+
+    /// <summary>
+    /// Gets the compute environment this container app is deployed to.
+    /// </summary>
+    /// <remarks>
+    /// A target resource deployed as several regional stamps produces one <see cref="AzureContainerAppResource"/>
+    /// per compute environment. This identifies which of those stamps this instance represents, so that
+    /// deployment-target lookups and generated names stay unambiguous.
+    /// </remarks>
+    public IComputeEnvironmentResource? ComputeEnvironment { get; init; }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -23,7 +23,7 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
     /// throughout the container app creation process for both the resource identifier 
     /// and endpoint mapping host names.
     /// </summary>
-    public string NormalizedContainerAppName => resource.Name.ToLowerInvariant();
+    public string NormalizedContainerAppName => resource.GetStampQualifiedName(_containerAppEnvironmentContext.Environment).ToLowerInvariant();
 
     protected record struct EndpointMapping(string Scheme, string Host, int Port, int? TargetPort, bool IsHttpIngress, bool External, bool TlsEnabled);
     protected readonly Dictionary<string, EndpointMapping> _endpointMapping = [];

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -77,10 +77,16 @@ internal sealed class ContainerAppEnvironmentContext(
             await context.ProcessResourceAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var provisioningResource = new AzureContainerAppResource(resource.Name + "-containerapp", context.BuildContainerApp, resource)
+        var provisioningResource = new AzureContainerAppResource(resource.GetStampQualifiedName(environment) + "-containerapp", context.BuildContainerApp, resource)
         {
-            ProvisioningBuildOptions = provisioningOptions.ProvisioningBuildOptions
+            ProvisioningBuildOptions = provisioningOptions.ProvisioningBuildOptions,
+            ComputeEnvironment = environment
         };
+
+        // A container app must be created in the same region as its managed environment, so the app inherits
+        // whatever region the environment was pinned to with WithLocation. Without this, every stamp of a
+        // multi-region application would be emitted into the application-wide region.
+        provisioningResource.InheritLocationFrom(environment);
 
         // Add references to any prerequisite resources to ensure they are provisioned first
         if (resource.TryGetAnnotationsOfType<DeploymentPrerequisitesAnnotation>(out var prereqs))

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContext.cs
@@ -77,10 +77,16 @@ internal sealed class AzureAppServiceEnvironmentContext(
             await context.ProcessAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var provisioningResource = new AzureAppServiceWebSiteResource(resource.Name + "-website", context.BuildWebSite, resource)
+        var provisioningResource = new AzureAppServiceWebSiteResource(resource.GetStampQualifiedName(Environment) + "-website", context.BuildWebSite, resource)
         {
-            ProvisioningBuildOptions = provisioningOptions.ProvisioningBuildOptions
+            ProvisioningBuildOptions = provisioningOptions.ProvisioningBuildOptions,
+            ComputeEnvironment = Environment
         };
+
+        // A web site must be created in the same region as its App Service plan, so the site inherits
+        // whatever region the environment was pinned to with WithLocation. Without this, every stamp of a
+        // multi-region application would be emitted into the application-wide region.
+        provisioningResource.InheritLocationFrom(Environment);
 
         // Add references to any prerequisite resources to ensure they are provisioned first
         if (resource.TryGetAnnotationsOfType<DeploymentPrerequisitesAnnotation>(out var prereqs))

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -217,9 +217,10 @@ public class AzureAppServiceEnvironmentResource :
                 continue;
             }
 
-            // Skip resources that are explicitly targeted to a different compute environment
-            var resourceComputeEnvironment = resource.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            // Skip resources that are explicitly targeted to a different compute environment. A stamped
+            // resource is bound to several environments and must be processed by each of them, so the check
+            // is membership rather than equality.
+            if (resource.GetComputeEnvironments().Count > 0 && !resource.IsBoundToComputeEnvironment(this))
             {
                 continue;
             }
@@ -508,7 +509,10 @@ public class AzureAppServiceEnvironmentResource :
     public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
     {
         var resource = endpointReference.Resource;
-        return ReferenceExpression.Create($"{resource.Name.ToLowerInvariant()}-{WebSiteSuffix}.azurewebsites.net");
+        // The web site name is stamp-qualified, so a resource deployed to several regions resolves to a
+        // distinct host in each of them. For a resource bound to a single environment this is just the
+        // resource name, keeping already deployed hostnames intact.
+        return ReferenceExpression.Create($"{resource.GetStampQualifiedName(this).ToLowerInvariant()}-{WebSiteSuffix}.azurewebsites.net");
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -30,19 +30,22 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
         // Add pipeline step annotation for deploy
         Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
         {
-            // Get the deployment target annotation
-            var deploymentTargetAnnotation = targetResource.GetDeploymentTargetAnnotation();
+            // Get the deployment target annotation for this stamp. A stamped target resource has one
+            // deployment target per compute environment, so the environment has to narrow the lookup.
+            var deploymentTargetAnnotation = targetResource.GetDeploymentTargetAnnotation(ComputeEnvironment);
             if (deploymentTargetAnnotation is null)
             {
                 return [];
             }
 
+            var stampName = targetResource.GetStampQualifiedName(ComputeEnvironment);
+
             var steps = new List<PipelineStep>();
 
             var printResourceSummary = new PipelineStep
             {
-                Name = $"print-{targetResource.Name}-summary",
-                Description = $"Prints the deployment summary and URL for {targetResource.Name}.",
+                Name = $"print-{stampName}-summary",
+                Description = $"Prints the deployment summary and URL for {stampName}.",
                 Action = async ctx =>
                 {
                     var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
@@ -70,8 +73,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
             var deployStep = new PipelineStep
             {
-                Name = $"deploy-{targetResource.Name}",
-                Description = $"Aggregation step for deploying {targetResource.Name} to Azure App Service.",
+                Name = $"deploy-{stampName}",
+                Description = $"Aggregation step for deploying {stampName} to Azure App Service.",
                 Action = _ => Task.CompletedTask,
                 Tags = [WellKnownPipelineTags.DeployCompute]
             };
@@ -104,15 +107,25 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     public IResource TargetResource { get; }
 
     /// <summary>
+    /// Gets the compute environment this web site is deployed to.
+    /// </summary>
+    /// <remarks>
+    /// A target resource deployed as several regional stamps produces one <see cref="AzureAppServiceWebSiteResource"/>
+    /// per compute environment. This identifies which of those stamps this instance represents, so that
+    /// deployment-target lookups and generated names stay unambiguous.
+    /// </remarks>
+    public IComputeEnvironmentResource? ComputeEnvironment { get; init; }
+
+    /// <summary>
     /// Gets the base Azure App Service website name without any deployment slot suffix.
     /// </summary>
     /// <param name="context">The pipeline step context.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the website name.</returns>
     private async Task<string> GetAppServiceWebsiteBaseNameAsync(PipelineStepContext context)
     {
-        var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
+        var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation(ComputeEnvironment)!.ComputeEnvironment!;
         var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-        return TruncateToMaxLength($"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}", 60);
+        return TruncateToMaxLength($"{TargetResource.GetStampQualifiedName(ComputeEnvironment).ToLowerInvariant()}-{websiteSuffix}", 60);
     }
 
     private static string GetAppServiceWebsiteName(string websiteName, string? deploymentSlot = null)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -35,9 +35,14 @@ internal sealed class AzureAppServiceWebsiteContext(
     public AzureResourceInfrastructure Infra => _infrastructure ?? throw new InvalidOperationException("Infra is not set");
 
     // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique name
-    // within the naming spec for the app service.
+    // within the naming spec for the app service. The name is stamp-qualified because every stamp of a
+    // resource deploys into the same resource group, so the uniqueString suffix is identical between them and
+    // would otherwise collide. This must stay in sync with
+    // AzureAppServiceEnvironmentResource.GetHostAddressExpression, which advertises this same hostname.
     private BicepValue<string> HostName => BicepFunction.Take(
-        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
+        BicepFunction.Interpolate($"{BicepFunction.ToLower(StampQualifiedResourceName)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
+
+    private string StampQualifiedResourceName => resource.GetStampQualifiedName(environmentContext.Environment);
 
     /// <summary>
     /// Gets the hostname for a deployment slot by appending the slot name to the base website name.
@@ -47,7 +52,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
     {
         var websitePrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLengthWithSlot);
+            BicepFunction.Interpolate($"{BicepFunction.ToLower(StampQualifiedResourceName)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLengthWithSlot);
 
         return BicepFunction.Take(
             BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLengthWithSlot);

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -35,7 +35,14 @@ public static class AzureFrontDoorExtensions
     /// and route, so each backend app is independently routable via its own <c>*.azurefd.net</c> hostname.
     /// </para>
     /// <para>
-    /// For advanced scenarios (shared origin groups, path-based routing, custom routes), use
+    /// When a backend is deployed as several regional stamps (see <c>WithComputeEnvironments</c>), its origin
+    /// group holds one origin per stamp, and Front Door health-probes and load-balances across all of them
+    /// behind that single hostname. That is what makes Front Door the global entry point of a multi-region
+    /// deployment. Use <see cref="WithOriginGroup"/> to control routing, health probes, and per-stamp
+    /// priorities or weights.
+    /// </para>
+    /// <para>
+    /// For advanced scenarios (path-based routing, rule sets, WAF policies), use
     /// <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}"/> to customize the
     /// generated infrastructure directly.
     /// </para>
@@ -49,6 +56,19 @@ public static class AzureFrontDoorExtensions
     /// var frontDoor = builder.AddAzureFrontDoor("frontdoor")
     ///     .WithOrigin(api)
     ///     .WithOrigin(web);
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Put one global entry point in front of an application deployed to two regions:
+    /// <code lang="C#">
+    /// var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+    /// var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+    ///
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///     .WithExternalHttpEndpoints()
+    ///     .WithComputeEnvironments(eastus, westeu);
+    ///
+    /// builder.AddAzureFrontDoor("frontdoor").WithOrigin(api);
     /// </code>
     /// </example>
     /// </remarks>
@@ -67,6 +87,15 @@ public static class AzureFrontDoorExtensions
         {
             var azureResource = (AzureFrontDoorResource)infrastructure.AspireResource;
 
+            // Front Door is a global resource: it is deployed once and fronts every region, so it must not
+            // itself be stamped.
+            if (azureResource.IsStamped())
+            {
+                throw new InvalidOperationException(
+                    $"Azure Front Door resource '{azureResource.Name}' is bound to multiple compute environments. " +
+                    "Front Door is a global resource that is deployed once and routes to the regional stamps of its origins, so it cannot be stamped itself.");
+            }
+
             // Create the CDN profile (Front Door)
             var profile = new CdnProfile(infrastructure.AspireResource.GetBicepIdentifier())
             {
@@ -76,79 +105,13 @@ public static class AzureFrontDoorExtensions
             };
             infrastructure.Add(profile);
 
-            // Create a separate endpoint → origin group → origin → route per WithOrigin call.
-            // This gives each backend app its own Front Door hostname.
+            // Create a separate endpoint → origin group → route per WithOrigin call, and one origin per
+            // regional stamp of that backend. Each backend app keeps its own Front Door hostname, and Front
+            // Door load-balances across the app's regions behind it.
             var originAnnotations = azureResource.Annotations.OfType<AzureFrontDoorOriginAnnotation>().ToList();
             foreach (var originAnnotation in originAnnotations)
             {
-                var originResource = originAnnotation.Resource;
-                var originBicepId = Infrastructure.NormalizeBicepIdentifier(originResource.Name);
-
-                var endpointReference = GetOriginEndpoint(originResource);
-
-                // Use health probe settings from the resource's probe annotations if available
-                var (probePath, probeProtocol) = GetProbeSettings(originResource);
-
-                // Resolve the hostname via the origin resource's compute environment
-                var computeEnv = GetEffectiveComputeEnvironment(originResource);
-                var hostExpression = computeEnv.GetHostAddressExpression(endpointReference);
-                var hostParam = hostExpression.AsProvisioningParameter(infrastructure, $"{originBicepId}_host");
-
-                // Endpoint
-                var endpoint = new FrontDoorEndpoint($"{originBicepId}Endpoint")
-                {
-                    Parent = profile,
-                    Location = new AzureLocation("Global")
-                };
-                infrastructure.Add(endpoint);
-
-                // Origin group — LoadBalancingSettings is required by ARM even with a single origin.
-                var originGroup = new FrontDoorOriginGroup($"{originBicepId}OriginGroup")
-                {
-                    Parent = profile,
-                    HealthProbeSettings = new HealthProbeSettings
-                    {
-                        ProbeProtocol = probeProtocol,
-                        ProbePath = probePath
-                    },
-                    LoadBalancingSettings = new LoadBalancingSettings()
-                    {
-                        SampleSize = 4,
-                        SuccessfulSamplesRequired = 3,
-                        AdditionalLatencyInMilliseconds = 50
-                    }
-                };
-                infrastructure.Add(originGroup);
-
-                // Origin
-                var origin = new FrontDoorOrigin($"{originBicepId}Origin")
-                {
-                    Parent = originGroup,
-                    HostName = hostParam,
-                    OriginHostHeader = hostParam
-                };
-                infrastructure.Add(origin);
-
-                // Route
-                var route = new FrontDoorRoute($"{originBicepId}Route")
-                {
-                    Parent = endpoint,
-                    OriginGroupId = originGroup.Id,
-                    PatternsToMatch = ["/*"],
-                    ForwardingProtocol = ForwardingProtocol.HttpsOnly,
-                    LinkToDefaultDomain = LinkToDefaultDomain.Enabled,
-                    HttpsRedirect = HttpsRedirect.Enabled
-                };
-                // Route must wait for origin to be created — without this, ARM deploys
-                // the route in parallel and fails because the origin group has no origins yet.
-                route.DependsOn.Add(origin);
-                infrastructure.Add(route);
-
-                // Output the endpoint URL for this origin
-                infrastructure.Add(new ProvisioningOutput($"{originBicepId}_endpointUrl", typeof(string))
-                {
-                    Value = BicepFunction.Interpolate($"https://{endpoint.HostName}")
-                });
+                AddOriginGroup(infrastructure, profile, originAnnotation);
             }
         };
 
@@ -170,6 +133,10 @@ public static class AzureFrontDoorExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
+    /// <para>
+    /// When <paramref name="resource"/> is deployed as several regional stamps, the origin group contains one
+    /// origin per stamp and Front Door routes each request to the closest healthy region.
+    /// </para>
     /// <example>
     /// Add multiple origins (each gets its own Front Door endpoint):
     /// <code lang="C#">
@@ -187,6 +154,65 @@ public static class AzureFrontDoorExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(resource);
 
+        return AddOriginAnnotation(builder, resource, new AzureFrontDoorOriginGroupBuilder());
+    }
+
+    /// <summary>
+    /// Adds an origin (backend) to the Azure Front Door resource and configures the origin group that fronts it.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource with endpoints.</typeparam>
+    /// <param name="builder">The Azure Front Door resource builder.</param>
+    /// <param name="resource">The resource to add as an origin (e.g., a project, container, or other compute resource with endpoints).</param>
+    /// <param name="configure">Callback that configures routing, health probes, session affinity, per-stamp priorities and weights, and an optional custom domain.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <example>
+    /// Route to the closest healthy region, probing a real health endpoint, and serve from a custom domain:
+    /// <code lang="C#">
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///     .WithExternalHttpEndpoints()
+    ///     .WithComputeEnvironments(eastus, westeu);
+    ///
+    /// builder.AddAzureFrontDoor("frontdoor")
+    ///     .WithOriginGroup(api, g =&gt; g
+    ///         .WithRouting(FrontDoorOriginRouting.LatencyBased)
+    ///         .WithHealthProbe("/health", FrontDoorHealthProbeProtocol.Https, TimeSpan.FromSeconds(30))
+    ///         .WithCustomDomain("www.contoso.com"));
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Run active/passive, preferring one region and failing over to another:
+    /// <code lang="C#">
+    /// builder.AddAzureFrontDoor("frontdoor")
+    ///     .WithOriginGroup(api, g =&gt; g
+    ///         .WithRouting(FrontDoorOriginRouting.Failover)
+    ///         .WithStampPriority(eastus, 1)
+    ///         .WithStampPriority(westeu, 2));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExport(RunSyncOnBackgroundThread = true)]
+    public static IResourceBuilder<AzureFrontDoorResource> WithOriginGroup<T>(
+        this IResourceBuilder<AzureFrontDoorResource> builder,
+        IResourceBuilder<T> resource,
+        Action<AzureFrontDoorOriginGroupBuilder> configure) where T : IComputeResource, IResourceWithEndpoints
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var settings = new AzureFrontDoorOriginGroupBuilder();
+        configure(settings);
+
+        return AddOriginAnnotation(builder, resource, settings);
+    }
+
+    private static IResourceBuilder<AzureFrontDoorResource> AddOriginAnnotation<T>(
+        IResourceBuilder<AzureFrontDoorResource> builder,
+        IResourceBuilder<T> resource,
+        AzureFrontDoorOriginGroupBuilder settings) where T : IComputeResource, IResourceWithEndpoints
+    {
         if (builder.Resource.Annotations
             .OfType<AzureFrontDoorOriginAnnotation>()
             .Any(a => a.Resource.Name == resource.Resource.Name))
@@ -196,7 +222,200 @@ public static class AzureFrontDoorExtensions
                 "Each origin can only be added once.");
         }
 
-        return builder.WithAnnotation(new AzureFrontDoorOriginAnnotation(resource.Resource));
+        return builder.WithAnnotation(new AzureFrontDoorOriginAnnotation(resource.Resource, settings));
+    }
+
+    private static void AddOriginGroup(
+        AzureResourceInfrastructure infrastructure,
+        CdnProfile profile,
+        AzureFrontDoorOriginAnnotation originAnnotation)
+    {
+        var originResource = originAnnotation.Resource;
+        var settings = originAnnotation.Settings;
+        var originBicepId = Infrastructure.NormalizeBicepIdentifier(originResource.Name);
+
+        var endpointReference = GetOriginEndpoint(originResource);
+
+        // Health probe settings come from the origin group configuration, falling back to the resource's own
+        // probe annotations.
+        var (probePath, probeProtocol) = GetProbeSettings(originResource, settings);
+
+        // Endpoint
+        var endpoint = new FrontDoorEndpoint($"{originBicepId}Endpoint")
+        {
+            Parent = profile,
+            Location = new AzureLocation("Global")
+        };
+        infrastructure.Add(endpoint);
+
+        var healthProbeSettings = new HealthProbeSettings
+        {
+            ProbeProtocol = probeProtocol,
+            ProbePath = probePath
+        };
+
+        if (settings.ProbeInterval is { } probeInterval)
+        {
+            healthProbeSettings.ProbeIntervalInSeconds = (int)probeInterval.TotalSeconds;
+        }
+
+        // Origin group — LoadBalancingSettings is required by ARM even with a single origin.
+        var originGroup = new FrontDoorOriginGroup($"{originBicepId}OriginGroup")
+        {
+            Parent = profile,
+            HealthProbeSettings = healthProbeSettings,
+            LoadBalancingSettings = new LoadBalancingSettings()
+            {
+                SampleSize = settings.SampleSize ?? 4,
+                SuccessfulSamplesRequired = settings.SuccessfulSamplesRequired ?? 3,
+                AdditionalLatencyInMilliseconds = settings.AdditionalLatencyMilliseconds ?? 50
+            }
+        };
+
+        if (settings.SessionAffinityEnabled is { } sessionAffinityEnabled)
+        {
+            originGroup.SessionAffinityState = sessionAffinityEnabled ? EnabledState.Enabled : EnabledState.Disabled;
+        }
+
+        if (settings.TrafficRestorationTime is { } trafficRestorationTime)
+        {
+            originGroup.TrafficRestorationTimeInMinutes = (int)trafficRestorationTime.TotalMinutes;
+        }
+
+        infrastructure.Add(originGroup);
+
+        // One origin per regional stamp of the backend. A backend bound to a single compute environment has
+        // exactly one stamp, which produces the same infrastructure as before stamping existed.
+        var stamps = GetOriginStamps(originResource);
+        var origins = new List<FrontDoorOrigin>(stamps.Count);
+
+        for (var i = 0; i < stamps.Count; i++)
+        {
+            var stamp = stamps[i];
+
+            // Resolve the hostname through the stamp's own compute environment so each origin points at the
+            // region that stamp is deployed to.
+            var hostExpression = stamp.Environment.GetHostAddressExpression(endpointReference);
+
+            // Suffix the bicep identifiers per stamp so the stamps do not collide. The single-stamp case
+            // keeps the original unsuffixed names, which is what keeps generated bicep stable for
+            // applications that are not stamped.
+            var stampSuffix = stamp.QualifiesNames ? $"_{Infrastructure.NormalizeBicepIdentifier(stamp.Name)}" : string.Empty;
+
+            var hostParam = hostExpression.AsProvisioningParameter(infrastructure, $"{originBicepId}{stampSuffix}_host");
+
+            var origin = new FrontDoorOrigin($"{originBicepId}{stampSuffix}Origin")
+            {
+                Parent = originGroup,
+                HostName = hostParam,
+                OriginHostHeader = hostParam
+            };
+
+            // Priority and weight are only emitted when they carry information. Leaving them unset for the
+            // default latency-based case keeps the generated bicep identical to what earlier versions
+            // produced, so redeploying an existing single-region application does not churn infrastructure.
+            if (GetOriginPriority(settings, stamp, i) is { } priority)
+            {
+                origin.Priority = priority;
+            }
+
+            if (settings.GetWeight(stamp.Environment) is { } weight)
+            {
+                origin.Weight = weight;
+            }
+
+            infrastructure.Add(origin);
+            origins.Add(origin);
+        }
+
+        FrontDoorCustomDomain? customDomain = null;
+        if (settings.CustomDomainHostName is { } customDomainHostName)
+        {
+            customDomain = new FrontDoorCustomDomain($"{originBicepId}CustomDomain")
+            {
+                Parent = profile,
+                HostName = customDomainHostName
+            };
+            infrastructure.Add(customDomain);
+        }
+
+        // Route
+        var route = new FrontDoorRoute($"{originBicepId}Route")
+        {
+            Parent = endpoint,
+            OriginGroupId = originGroup.Id,
+            PatternsToMatch = ["/*"],
+            ForwardingProtocol = ForwardingProtocol.HttpsOnly,
+            LinkToDefaultDomain = LinkToDefaultDomain.Enabled,
+            HttpsRedirect = HttpsRedirect.Enabled
+        };
+
+        if (customDomain is not null)
+        {
+            route.CustomDomains.Add(new FrontDoorActivatedResourceInfo { Id = customDomain.Id });
+        }
+
+        // Route must wait for the origins to be created — without this, ARM deploys
+        // the route in parallel and fails because the origin group has no origins yet.
+        foreach (var origin in origins)
+        {
+            route.DependsOn.Add(origin);
+        }
+
+        infrastructure.Add(route);
+
+        // Output the endpoint URL for this origin
+        infrastructure.Add(new ProvisioningOutput($"{originBicepId}_endpointUrl", typeof(string))
+        {
+            Value = BicepFunction.Interpolate($"https://{endpoint.HostName}")
+        });
+
+        if (customDomain is not null)
+        {
+            // A custom domain does not serve traffic until its ownership is proven, so surface the token that
+            // has to be published as a DNS TXT record.
+            infrastructure.Add(new ProvisioningOutput($"{originBicepId}_customDomainValidationToken", typeof(string))
+            {
+                Value = customDomain.ValidationProperties.ValidationToken
+            });
+        }
+    }
+
+    /// <summary>
+    /// Gets the regional stamps that become origins for the backend, or a single implicit stamp when the
+    /// backend is not explicitly bound to a compute environment.
+    /// </summary>
+    private static IReadOnlyList<ComputeStamp> GetOriginStamps(IResourceWithEndpoints originResource)
+    {
+        var stamps = originResource.GetComputeStamps();
+        if (stamps.Count > 0)
+        {
+            return stamps;
+        }
+
+        // Not explicitly bound: fall back to whichever environment the resource ended up deployed to.
+        return [new ComputeStamp(GetEffectiveComputeEnvironment(originResource), originResource.Name, qualifiesNames: false)];
+    }
+
+    /// <summary>
+    /// Gets the Front Door priority for a stamp, or <see langword="null"/> to leave the ARM default in place.
+    /// </summary>
+    private static int? GetOriginPriority(AzureFrontDoorOriginGroupBuilder settings, ComputeStamp stamp, int stampIndex)
+    {
+        if (settings.GetPriority(stamp.Environment) is { } explicitPriority)
+        {
+            return explicitPriority;
+        }
+
+        // Failover routing means "try the stamps in declaration order", which Front Door expresses as
+        // ascending priorities. Azure rejects priorities above 5, so the tail of a long stamp list shares
+        // the last usable priority rather than producing an invalid template.
+        if (settings.Routing == FrontDoorOriginRouting.Failover)
+        {
+            return Math.Min(stampIndex + 1, 5);
+        }
+
+        return null;
     }
 
     private static IComputeEnvironmentResource GetEffectiveComputeEnvironment(IResource resource)
@@ -228,8 +447,19 @@ public static class AzureFrontDoorExtensions
             "Call .WithExternalHttpEndpoints() on the resource before adding it as an origin.");
     }
 
-    private static (string Path, HealthProbeProtocol Protocol) GetProbeSettings(IResourceWithEndpoints resource)
+    private static (string Path, HealthProbeProtocol Protocol) GetProbeSettings(
+        IResourceWithEndpoints resource,
+        AzureFrontDoorOriginGroupBuilder settings)
     {
+        // An explicitly configured probe always wins.
+        if (settings.ProbePath is { } configuredPath)
+        {
+            var configuredProtocol = settings.ProbeProtocol == FrontDoorHealthProbeProtocol.Http
+                ? HealthProbeProtocol.Http
+                : HealthProbeProtocol.Https;
+            return (configuredPath, configuredProtocol);
+        }
+
         // Use settings from EndpointProbeAnnotation if available (set by WithHttpProbe).
         // Prefer liveness probes, matching the pattern used by App Service.
         var probeAnnotation = resource.Annotations

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorOriginAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorOriginAnnotation.cs
@@ -6,12 +6,18 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
-/// Represents an origin to be added to an Azure Front Door resource.
+/// Represents an origin group to be added to an Azure Front Door resource: one backend application, plus
+/// one origin per regional stamp of that application.
 /// </summary>
-internal sealed class AzureFrontDoorOriginAnnotation(IResourceWithEndpoints resource) : IResourceAnnotation
+internal sealed class AzureFrontDoorOriginAnnotation(IResourceWithEndpoints resource, AzureFrontDoorOriginGroupBuilder settings) : IResourceAnnotation
 {
     /// <summary>
-    /// Gets the resource for this origin.
+    /// Gets the resource for this origin group.
     /// </summary>
     public IResourceWithEndpoints Resource { get; } = resource ?? throw new ArgumentNullException(nameof(resource));
+
+    /// <summary>
+    /// Gets the origin group configuration, including routing, health probe, and per-stamp overrides.
+    /// </summary>
+    public AzureFrontDoorOriginGroupBuilder Settings { get; } = settings ?? throw new ArgumentNullException(nameof(settings));
 }

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorOriginGroupBuilder.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorOriginGroupBuilder.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Configures the Azure Front Door origin group that fronts one backend application, including how traffic
+/// is distributed across the application's regional stamps.
+/// </summary>
+/// <remarks>
+/// An origin group corresponds to one backend application. When that application is deployed as several
+/// regional stamps, the origin group holds one origin per stamp, and Front Door health-probes and
+/// load-balances across them behind a single global hostname.
+/// </remarks>
+[AspireExport(ExposeMethods = true)]
+public sealed class AzureFrontDoorOriginGroupBuilder
+{
+    private readonly Dictionary<string, int> _stampPriorities = [];
+    private readonly Dictionary<string, int> _stampWeights = [];
+
+    internal AzureFrontDoorOriginGroupBuilder()
+    {
+    }
+
+    internal FrontDoorOriginRouting Routing { get; private set; } = FrontDoorOriginRouting.LatencyBased;
+
+    internal string? ProbePath { get; private set; }
+
+    internal FrontDoorHealthProbeProtocol? ProbeProtocol { get; private set; }
+
+    internal TimeSpan? ProbeInterval { get; private set; }
+
+    internal int? SampleSize { get; private set; }
+
+    internal int? SuccessfulSamplesRequired { get; private set; }
+
+    internal int? AdditionalLatencyMilliseconds { get; private set; }
+
+    internal bool? SessionAffinityEnabled { get; private set; }
+
+    internal TimeSpan? TrafficRestorationTime { get; private set; }
+
+    internal string? CustomDomainHostName { get; private set; }
+
+    /// <summary>
+    /// Sets how traffic is distributed across the origins of this origin group.
+    /// </summary>
+    /// <param name="routing">The routing method.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// <example>
+    /// Serve every region simultaneously, closest-first:
+    /// <code lang="C#">
+    /// frontDoor.WithOriginGroup(api, g => g.WithRouting(FrontDoorOriginRouting.LatencyBased));
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithRouting(FrontDoorOriginRouting routing)
+    {
+        Routing = routing;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the routing priority of the stamp deployed to the specified compute environment.
+    /// </summary>
+    /// <param name="computeEnvironment">The compute environment identifying the stamp.</param>
+    /// <param name="priority">The priority, from 1 (most preferred) to 5.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// Front Door sends traffic to the healthy origins with the lowest priority number and treats higher
+    /// numbers as backups. Setting a priority implies <see cref="FrontDoorOriginRouting.Failover"/> semantics
+    /// for this origin group even when the routing method was not changed.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithStampPriority(IResourceBuilder<IComputeEnvironmentResource> computeEnvironment, int priority)
+    {
+        ArgumentNullException.ThrowIfNull(computeEnvironment);
+        // Azure rejects values outside this range, so fail in the app model rather than at deployment time.
+        ArgumentOutOfRangeException.ThrowIfLessThan(priority, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(priority, 5);
+
+        _stampPriorities[computeEnvironment.Resource.Name] = priority;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the routing weight of the stamp deployed to the specified compute environment.
+    /// </summary>
+    /// <param name="computeEnvironment">The compute environment identifying the stamp.</param>
+    /// <param name="weight">The weight, from 1 to 1000.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// Weights only apply between origins that share the same priority. Setting a weight implies
+    /// <see cref="FrontDoorOriginRouting.Weighted"/> semantics for this origin group even when the routing
+    /// method was not changed.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithStampWeight(IResourceBuilder<IComputeEnvironmentResource> computeEnvironment, int weight)
+    {
+        ArgumentNullException.ThrowIfNull(computeEnvironment);
+        ArgumentOutOfRangeException.ThrowIfLessThan(weight, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(weight, 1000);
+
+        _stampWeights[computeEnvironment.Resource.Name] = weight;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the health probe Front Door uses to decide whether each origin is healthy.
+    /// </summary>
+    /// <param name="path">The path to probe, for example <c>/health</c>.</param>
+    /// <param name="protocol">The protocol to probe with.</param>
+    /// <param name="interval">How often each origin is probed.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// When this is not called, the probe settings come from the origin resource's
+    /// <c>WithHttpProbe</c> annotation, falling back to an HTTPS probe of <c>/</c>.
+    /// Health probing is what makes regional failover work, so probe a path that reflects the health of the
+    /// whole stamp rather than one that always returns success.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithHealthProbe(string path, FrontDoorHealthProbeProtocol protocol, TimeSpan interval)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);
+
+        ProbePath = path;
+        ProbeProtocol = protocol;
+        ProbeInterval = interval;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures how Front Door samples origin latency when choosing between origins.
+    /// </summary>
+    /// <param name="sampleSize">The number of samples to consider for load balancing decisions.</param>
+    /// <param name="successfulSamplesRequired">The number of samples within the sample window that must succeed for an origin to be considered healthy.</param>
+    /// <param name="additionalLatencyMilliseconds">
+    /// The latency band, in milliseconds. Origins whose latency is within this many milliseconds of the
+    /// fastest origin are all considered equally close, and traffic is spread across them.
+    /// </param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// Widening <paramref name="additionalLatencyMilliseconds"/> spreads traffic across more regions;
+    /// narrowing it pins traffic to the closest region.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithLoadBalancing(int sampleSize, int successfulSamplesRequired, int additionalLatencyMilliseconds)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(sampleSize, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(successfulSamplesRequired, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(successfulSamplesRequired, sampleSize);
+        ArgumentOutOfRangeException.ThrowIfNegative(additionalLatencyMilliseconds);
+
+        SampleSize = sampleSize;
+        SuccessfulSamplesRequired = successfulSamplesRequired;
+        AdditionalLatencyMilliseconds = additionalLatencyMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables session affinity, which pins a client to the origin that served its first request.
+    /// </summary>
+    /// <param name="enabled"><see langword="true"/> to enable session affinity; otherwise <see langword="false"/>.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// Session affinity keeps a client in one regional stamp, which is useful for stateful backends but
+    /// works against latency-based routing when clients move between regions.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithSessionAffinity(bool enabled)
+    {
+        SessionAffinityEnabled = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets how gradually traffic is shifted back to an origin that has become healthy again.
+    /// </summary>
+    /// <param name="trafficRestorationTime">The restoration window, from 0 to 50 minutes.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// A non-zero window ramps traffic back up over time, so a region that has just recovered is not
+    /// immediately hit with its full share of load.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithTrafficRestorationTime(TimeSpan trafficRestorationTime)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(trafficRestorationTime, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(trafficRestorationTime, TimeSpan.FromMinutes(50));
+
+        TrafficRestorationTime = trafficRestorationTime;
+        return this;
+    }
+
+    /// <summary>
+    /// Serves this application from a custom domain in addition to the generated <c>*.azurefd.net</c> hostname.
+    /// </summary>
+    /// <param name="hostName">The fully qualified domain name, for example <c>www.contoso.com</c>.</param>
+    /// <returns>The origin group builder for chaining.</returns>
+    /// <ats-returns>The origin group builder.</ats-returns>
+    /// <remarks>
+    /// The domain must be validated by creating the DNS records Azure asks for; the required TXT validation
+    /// token is emitted as a Bicep output named <c>{origin}_customDomainValidationToken</c>.
+    /// A custom domain is the only public hostname known before deployment, so it is what backend
+    /// applications should be told about when they need to know their own public address. Referencing the
+    /// generated Front Door hostname from a backend would create a Bicep module cycle, because Front Door
+    /// already depends on the backend's host address.
+    /// </remarks>
+    public AzureFrontDoorOriginGroupBuilder WithCustomDomain(string hostName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(hostName);
+
+        CustomDomainHostName = hostName;
+        return this;
+    }
+
+    /// <summary>
+    /// Gets the priority configured for the stamp in the specified compute environment, if any.
+    /// </summary>
+    internal int? GetPriority(IComputeEnvironmentResource computeEnvironment) =>
+        _stampPriorities.TryGetValue(computeEnvironment.Name, out var priority) ? priority : null;
+
+    /// <summary>
+    /// Gets the weight configured for the stamp in the specified compute environment, if any.
+    /// </summary>
+    internal int? GetWeight(IComputeEnvironmentResource computeEnvironment) =>
+        _stampWeights.TryGetValue(computeEnvironment.Name, out var weight) ? weight : null;
+
+    /// <summary>
+    /// Gets a value indicating whether any per-stamp priority or weight was configured.
+    /// </summary>
+    internal bool HasStampOverrides => _stampPriorities.Count > 0 || _stampWeights.Count > 0;
+}

--- a/src/Aspire.Hosting.Azure.FrontDoor/FrontDoorOriginRouting.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/FrontDoorOriginRouting.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Determines how Azure Front Door distributes traffic across the origins of an origin group.
+/// </summary>
+/// <remarks>
+/// See <see href="https://learn.microsoft.com/azure/frontdoor/routing-methods"/> for the routing behaviour
+/// each of these produces.
+/// </remarks>
+public enum FrontDoorOriginRouting
+{
+    /// <summary>
+    /// Every origin is equally preferred and Front Door routes each request to the closest healthy origin,
+    /// measured by latency. This is the default and the usual choice for regional stamps of one application.
+    /// </summary>
+    LatencyBased,
+
+    /// <summary>
+    /// Origins are tried in declaration order: all traffic goes to the first origin while it is healthy, and
+    /// falls back to the next one when it is not. Use this for an active/passive topology.
+    /// </summary>
+    Failover,
+
+    /// <summary>
+    /// Traffic is split across all healthy origins in proportion to their weights. Use this to send a
+    /// deliberate share of traffic to each region, for example while validating a new region.
+    /// </summary>
+    Weighted
+}
+
+/// <summary>
+/// The protocol Azure Front Door uses to health-probe the origins of an origin group.
+/// </summary>
+public enum FrontDoorHealthProbeProtocol
+{
+    /// <summary>
+    /// Probe origins over HTTP.
+    /// </summary>
+    Http,
+
+    /// <summary>
+    /// Probe origins over HTTPS.
+    /// </summary>
+    Https
+}

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -40,6 +40,56 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
     .withOrigin(api);
 ```
 
+## Global entry point over regional stamps
+
+Deploy one application to several Azure regions and put a single global hostname in front of all of them.
+Bind the application to more than one compute environment with `WithComputeEnvironments`, and Front Door
+creates one origin per region inside a single origin group, health-probing and load-balancing across them:
+
+```csharp
+var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+var api = builder.AddProject<Projects.Api>("api")
+    .WithExternalHttpEndpoints()
+    .WithComputeEnvironments(eastus, westeu);
+
+builder.AddAzureFrontDoor("frontdoor")
+    .WithOrigin(api);
+```
+
+Use `WithOriginGroup` to control how traffic is distributed, how origins are health-probed, and which custom
+domain serves the application:
+
+```csharp
+builder.AddAzureFrontDoor("frontdoor")
+    .WithOriginGroup(api, g => g
+        .WithRouting(FrontDoorOriginRouting.LatencyBased)
+        .WithHealthProbe("/health", FrontDoorHealthProbeProtocol.Https, TimeSpan.FromSeconds(30))
+        .WithCustomDomain("www.contoso.com"));
+```
+
+For an active/passive topology, prefer one region and fail over to another:
+
+```csharp
+builder.AddAzureFrontDoor("frontdoor")
+    .WithOriginGroup(api, g => g
+        .WithRouting(FrontDoorOriginRouting.Failover)
+        .WithStampPriority(eastus, 1)
+        .WithStampPriority(westeu, 2));
+```
+
+Notes:
+
+* Health probing is what makes regional failover work. Probe a path that reflects the health of the whole
+  stamp rather than one that always returns success.
+* The generated `*.azurefd.net` hostname is not known until deployment completes, so an application cannot be
+  told its own public address through it — that would create a Bicep module cycle, because Front Door already
+  depends on the application's host address. Use `WithCustomDomain` when the application needs to know its
+  public hostname.
+* A custom domain does not serve traffic until ownership is proven. The required DNS TXT token is emitted as
+  the `{origin}_customDomainValidationToken` Bicep output.
+
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/

--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -1178,7 +1178,15 @@ internal sealed class AzureProvisioningController(
                 // Remove stale inferred parameters when the environment context changed. Leaving
                 // them in place would make a reset/reprovision keep deploying to the previous
                 // environment location.
-                bicepResource.Parameters.Remove(AzureBicepResource.KnownParameters.Location);
+                //
+                // A region the author pinned in the app model with WithLocation is not inferred state, so it
+                // must survive. Removing it would let the next provisioning pass refill the slot from the
+                // environment location and silently move the resource — which, for a stamped application,
+                // would collapse every region onto the same one.
+                if (bicepResource.GetConfiguredLocation() is null)
+                {
+                    bicepResource.Parameters.Remove(AzureBicepResource.KnownParameters.Location);
+                }
             }
 
             await ClearCachedDeploymentStateAsync(bicepResource, preserveOverrides, environmentLocation, currentLocationOverride, preserveInferredLocationOverrides, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -316,10 +316,25 @@ public sealed class AzurePublishingContext(
 
             var module = moduleMap[resource];
             module.Scope = GetScopeExpression(resource);
-            module.Parameters.Add("location", locationParam);
+
+            // A resource can pin itself to a specific Azure region with WithLocation, which is how one
+            // application spans multiple regions (the deployment stamp topology). Only an explicit
+            // override wins here: resource.Parameters can also hold a "location" value that the
+            // provisioner inferred from the Azure environment, and that must keep resolving to the
+            // shared environment parameter so publish output stays stable.
+            var configuredLocation = resource.GetConfiguredLocation();
+            module.Parameters.Add(
+                AzureBicepResource.KnownParameters.Location,
+                configuredLocation is null ? locationParam : ResolveValue(Eval(configuredLocation)));
 
             foreach (var parameter in resource.Parameters)
             {
+                // Location is mapped above. Adding it again would throw because the module already has it.
+                if (parameter.Key == AzureBicepResource.KnownParameters.Location)
+                {
+                    continue;
+                }
+
                 if (parameter.Key == AzureBicepResource.KnownParameters.UserPrincipalId && parameter.Value is null)
                 {
                     module.Parameters.Add(parameter.Key, principalId);
@@ -373,9 +388,16 @@ public sealed class AzurePublishingContext(
         // These include DeploymentTarget resources and any other resources that have parameters that reference bicep outputs.
         foreach (var resource in model.Resources)
         {
-            if (resource.GetDeploymentTargetAnnotation() is { } annotation && annotation.DeploymentTarget is AzureBicepResource br)
+            // A stamped resource has one deployment target per compute environment, and each of those is a
+            // separate Bicep module, so every stamp has to be visited.
+            var bicepDeploymentTargets = resource.GetDeploymentTargetAnnotations()
+                .Where(a => a.DeploymentTarget is AzureBicepResource)
+                .ToList();
+
+            if (bicepDeploymentTargets.Count > 0)
             {
-                // Materialize Dockerfile factory if present
+                // Materialize Dockerfile factory if present. The image is built once and shared by every
+                // stamp, so this is done per resource rather than per deployment target.
                 if (resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var dockerfileBuildAnnotation) &&
                     dockerfileBuildAnnotation.DockerfileFactory is not null)
                 {
@@ -391,26 +413,36 @@ public sealed class AzurePublishingContext(
                     await dockerfileBuildAnnotation.EmitDockerfileArtifactsAsync(context, resourceDockerfilePath).ConfigureAwait(false);
                 }
 
-                var task = await step.CreateTaskAsync(
-                    $"Processing deployment target {resource.Name}",
-                    cancellationToken: default
-                )
-                .ConfigureAwait(false);
+                foreach (var annotation in bicepDeploymentTargets)
+                {
+                    var br = (AzureBicepResource)annotation.DeploymentTarget;
 
-                var moduleDirectory = outputDirectory.CreateSubdirectory(resource.Name);
+                    // The module directory is stamp-qualified so the stamps of one resource do not overwrite
+                    // each other. For a resource bound to a single compute environment this is the plain
+                    // resource name, which keeps existing publish output paths unchanged.
+                    var moduleName = resource.GetStampQualifiedName(annotation.ComputeEnvironment);
 
-                var modulePath = Path.Combine(moduleDirectory.FullName, $"{resource.Name}.bicep");
+                    var task = await step.CreateTaskAsync(
+                        $"Processing deployment target {moduleName}",
+                        cancellationToken: default
+                    )
+                    .ConfigureAwait(false);
 
-                var file = br.GetBicepTemplateFile(tempDirectory);
+                    var moduleDirectory = outputDirectory.CreateSubdirectory(moduleName);
 
-                File.Copy(file.Path, modulePath, true);
+                    var modulePath = Path.Combine(moduleDirectory.FullName, $"{moduleName}.bicep");
 
-                CaptureBicepOutputsFromParameters(br);
+                    var file = br.GetBicepTemplateFile(tempDirectory);
 
-                await task.SucceedAsync(
-                    $"Wrote bicep module for deployment target {resource.Name} to {modulePath}",
-                    cancellationToken: default
-                ).ConfigureAwait(false);
+                    File.Copy(file.Path, modulePath, true);
+
+                    CaptureBicepOutputsFromParameters(br);
+
+                    await task.SucceedAsync(
+                        $"Wrote bicep module for deployment target {moduleName} to {modulePath}",
+                        cancellationToken: default
+                    ).ConfigureAwait(false);
+                }
             }
             else if (resource is IResourceWithParameters rwp && !bicepResourcesToPublish.Contains(resource))
             {

--- a/src/Aspire.Hosting.Azure/AzureResourceLocationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceLocationAnnotation.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Records an explicit Azure region for a single Azure resource, set via <c>WithLocation</c>.
+/// </summary>
+/// <remarks>
+/// The location itself lives in <see cref="AzureBicepResource.Parameters"/> under
+/// <see cref="AzureBicepResource.KnownParameters.Location"/>, but the provisioner writes an inferred
+/// environment location into that same slot during deployment. This annotation is what lets publish-time
+/// code distinguish an author's explicit choice from an inferred value.
+/// </remarks>
+/// <param name="location">The location value, either a <see cref="string"/> or a <see cref="ParameterResource"/>.</param>
+internal sealed class AzureResourceLocationAnnotation(object location) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the configured location, which is either a <see cref="string"/> or a <see cref="ParameterResource"/>.
+    /// </summary>
+    public object Location { get; } = location ?? throw new ArgumentNullException(nameof(location));
+}

--- a/src/Aspire.Hosting.Azure/AzureResourceLocationExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceLocationExtensions.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods for controlling the Azure region that an individual Azure resource is deployed to.
+/// </summary>
+/// <remarks>
+/// By default every Azure resource in an Aspire application is deployed to the location configured on the
+/// <see cref="AzureEnvironmentResource"/>. Setting a location on an individual resource makes it possible to
+/// spread a single application across multiple Azure regions, which is the basis of the regional stamp
+/// (deployment stamp) topology. See <see href="https://learn.microsoft.com/azure/architecture/patterns/deployment-stamp"/>.
+/// </remarks>
+public static class AzureResourceLocationExtensions
+{
+    /// <summary>
+    /// Sets the Azure region that this resource is deployed to.
+    /// </summary>
+    /// <typeparam name="T">The type of the Azure resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="location">The Azure region name, for example <c>eastus</c>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// The location overrides the region configured on the <see cref="AzureEnvironmentResource"/> for this
+    /// resource only. Resources of different regions can coexist in a single resource group, so no additional
+    /// resource group configuration is required.
+    /// </para>
+    /// <example>
+    /// Deploy two Azure Container Apps environments to different regions:
+    /// <code lang="C#">
+    /// var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+    /// var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Use the polyglot withLocation export that accepts string or ParameterResource values instead.")]
+    public static IResourceBuilder<T> WithLocation<T>(this IResourceBuilder<T> builder, string location)
+        where T : AzureBicepResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(location);
+
+        return WithLocationCore(builder, location);
+    }
+
+    /// <summary>
+    /// Sets the Azure region that this resource is deployed to using a parameter.
+    /// </summary>
+    /// <typeparam name="T">The type of the Azure resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="location">A parameter that supplies the Azure region name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <example>
+    /// Deploy a Container Apps environment to a region supplied at deployment time:
+    /// <code lang="C#">
+    /// var region = builder.AddParameter("primary-region");
+    /// var aca = builder.AddAzureContainerAppEnvironment("aca").WithLocation(region);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Use the polyglot withLocation export that accepts string or ParameterResource values instead.")]
+    public static IResourceBuilder<T> WithLocation<T>(this IResourceBuilder<T> builder, IResourceBuilder<ParameterResource> location)
+        where T : AzureBicepResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(location);
+
+        return WithLocationCore(builder, location.Resource);
+    }
+
+    /// <summary>
+    /// Sets the Azure region that this resource is deployed to.
+    /// </summary>
+    /// <typeparam name="T">The type of the Azure resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="location">The Azure region name as a string or parameter resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExport("withAzureResourceLocation", MethodName = "withLocation")]
+    internal static IResourceBuilder<T> WithLocationForPolyglot<T>(
+        this IResourceBuilder<T> builder,
+        [AspireUnion(typeof(string), typeof(ParameterResource))] object location)
+        where T : AzureBicepResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(location);
+
+        if (location is not (string or ParameterResource))
+        {
+            throw new ArgumentException(
+                $"The location must be a string or a {nameof(ParameterResource)}, but was '{location.GetType()}'.",
+                nameof(location));
+        }
+
+        if (location is string { Length: 0 })
+        {
+            throw new ArgumentException("The location must not be empty.", nameof(location));
+        }
+
+        return WithLocationCore(builder, location);
+    }
+
+    /// <summary>
+    /// Gets the location explicitly configured for the resource, or <see langword="null"/> when the resource
+    /// uses the location of the <see cref="AzureEnvironmentResource"/>.
+    /// </summary>
+    /// <param name="resource">The Azure resource.</param>
+    /// <returns>The configured location value, which is either a <see cref="string"/> or a <see cref="ParameterResource"/>.</returns>
+    internal static object? GetConfiguredLocation(this AzureBicepResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        // Only a location placed there by WithLocation counts as configured. The provisioner also writes
+        // the environment location into this same slot during deployment (BicepProvisioner
+        // PopulateWellKnownParameters), so the annotation is what distinguishes an author's intent from
+        // an inferred value.
+        return resource.Annotations.OfType<AzureResourceLocationAnnotation>().LastOrDefault()?.Location;
+    }
+
+    /// <summary>
+    /// Copies the Azure region configured on <paramref name="source"/> onto <paramref name="target"/>, if any.
+    /// </summary>
+    /// <param name="target">The resource that should adopt the region.</param>
+    /// <param name="source">The resource whose configured region is copied.</param>
+    /// <remarks>
+    /// <para>
+    /// Compute environments use this to place the infrastructure they generate — container apps, web sites —
+    /// in the same region as the environment itself. Azure requires it: a container app must live in the
+    /// region of its managed environment, and a web site in the region of its App Service plan. Without it,
+    /// every stamp of an application deployed to several regions would be emitted into the
+    /// application-wide region.
+    /// </para>
+    /// <para>
+    /// Only a region set with <c>WithLocation</c> is copied. A region that the provisioner inferred from the
+    /// Azure environment is left alone, so that the target keeps resolving to the shared environment region.
+    /// </para>
+    /// <example>
+    /// Propagate the environment's region onto a generated deployment target:
+    /// <code lang="C#">
+    /// var containerApp = new AzureContainerAppResource(name, configure, resource);
+    /// containerApp.InheritLocationFrom(environment);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Infrastructure-generation helper for compute environment authors — not part of the ATS surface.")]
+    public static void InheritLocationFrom(this AzureBicepResource target, AzureBicepResource source)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (source.GetConfiguredLocation() is { } location)
+        {
+            target.Parameters[AzureBicepResource.KnownParameters.Location] = location;
+            target.Annotations.Add(new AzureResourceLocationAnnotation(location));
+        }
+    }
+
+    private static IResourceBuilder<T> WithLocationCore<T>(IResourceBuilder<T> builder, object location)
+        where T : AzureBicepResource
+    {
+        builder.Resource.Parameters[AzureBicepResource.KnownParameters.Location] = location;
+
+        // Track the override separately from the parameter so later code can tell an explicit choice apart
+        // from the location the provisioner infers from the Azure environment. Repeated calls append, and
+        // readers take the last annotation, so the most recent call wins.
+        builder.Resource.Annotations.Add(new AzureResourceLocationAnnotation(location));
+
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -44,7 +44,18 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
         Annotations.Add(new PipelineStepAnnotation(async (ctx) =>
         {
             List<PipelineStep> steps = [];
-            var deploymentAnnotation = Target.GetDeploymentTargetAnnotation() ?? throw new InvalidOperationException($"Deployment target annotation is required on resource '{Target.Name}' to deploy as hosted agent.");
+            // Hosted agents deploy to a single Foundry project, so a target deployed as several regional
+            // stamps cannot be expressed here. Report that directly rather than surfacing the generic
+            // deployment-target ambiguity error.
+            var deploymentAnnotations = Target.GetDeploymentTargetAnnotations();
+            if (deploymentAnnotations.Count > 1)
+            {
+                throw new InvalidOperationException($"Resource '{Target.Name}' is deployed as multiple stamps and cannot be deployed as a hosted agent. Bind it to a single compute environment.");
+            }
+
+            var deploymentAnnotation = deploymentAnnotations.Count == 1
+                ? deploymentAnnotations[0]
+                : throw new InvalidOperationException($"Deployment target annotation is required on resource '{Target.Name}' to deploy as hosted agent.");
             var project = deploymentAnnotation.ComputeEnvironment as AzureCognitiveServicesProjectResource
                 ?? throw new InvalidOperationException($"Compute environment for resource '{Target.Name}' must be an AzureCognitiveServicesProjectResource to deploy as hosted agent.");
 

--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -3,7 +3,17 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
+internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment, string? stampName = null) : IResourceAnnotation
 {
     public IComputeEnvironmentResource ComputeEnvironment { get; } = computeEnvironment;
+
+    /// <summary>
+    /// Gets the explicitly configured stamp name, or <see langword="null"/> when the stamp name is derived
+    /// from <see cref="ComputeEnvironment"/>.
+    /// </summary>
+    /// <remarks>
+    /// An explicit stamp name also forces infrastructure-name qualification even for a resource bound to a
+    /// single compute environment, because asking for a stamp name is an explicit request for distinct names.
+    /// </remarks>
+    public string? StampName { get; } = stampName;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ComputeStamp.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeStamp.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a single regional copy ("stamp") of a compute resource: the pairing of the resource with
+/// one of the compute environments it is deployed to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A compute resource bound to several compute environments is deployed once per environment. Each of
+/// those deployments is a stamp, and each stamp gets its own infrastructure names and its own host address.
+/// This mirrors the Azure deployment stamp pattern, where identical copies of a workload are deployed to
+/// multiple regions behind a single global entry point.
+/// See <see href="https://learn.microsoft.com/azure/architecture/patterns/deployment-stamp"/>.
+/// </para>
+/// <para>
+/// Use <see cref="ResourceExtensions.GetComputeStamps(IResource)"/> to enumerate the stamps of a resource.
+/// </para>
+/// </remarks>
+public sealed class ComputeStamp
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComputeStamp"/> class.
+    /// </summary>
+    /// <param name="environment">The compute environment this stamp is deployed to.</param>
+    /// <param name="name">The name of the stamp.</param>
+    /// <param name="qualifiesNames">Whether infrastructure names generated for this stamp are suffixed with <paramref name="name"/>.</param>
+    /// <remarks>
+    /// Integration authors normally obtain stamps from <see cref="ResourceExtensions.GetComputeStamps(IResource)"/>.
+    /// This constructor exists so an integration can synthesize a single implicit stamp for a resource that
+    /// is not explicitly bound to a compute environment.
+    /// </remarks>
+    public ComputeStamp(IComputeEnvironmentResource environment, string name, bool qualifiesNames)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        Environment = environment;
+        Name = name;
+        QualifiesNames = qualifiesNames;
+    }
+
+    /// <summary>
+    /// Gets the compute environment this stamp is deployed to.
+    /// </summary>
+    public IComputeEnvironmentResource Environment { get; }
+
+    /// <summary>
+    /// Gets the name of the stamp. Defaults to the name of <see cref="Environment"/>.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether infrastructure names generated for this stamp are suffixed with
+    /// <see cref="Name"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is <see langword="false"/> for the common case of a resource bound to exactly one compute
+    /// environment without an explicit stamp name, so that names generated for single-region applications
+    /// are unchanged and already deployed infrastructure is not recreated.
+    /// </remarks>
+    public bool QualifiesNames { get; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1036,6 +1036,11 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to get the compute environment for.</param>
     /// <returns>The compute environment the resource is bound to, or <c>null</c> if the resource is not bound to any specific compute environment.</returns>
+    /// <remarks>
+    /// A resource deployed as several regional stamps is bound to more than one compute environment, and this
+    /// method returns only the last of them. Use <see cref="GetComputeEnvironments(IResource)"/> or
+    /// <see cref="GetComputeStamps(IResource)"/> to handle stamped resources.
+    /// </remarks>
     [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
     public static IComputeEnvironmentResource? GetComputeEnvironment(this IResource resource)
     {
@@ -1047,6 +1052,156 @@ public static class ResourceExtensions
     }
 
     /// <summary>
+    /// Gets every compute environment that the resource is explicitly bound to, in declaration order.
+    /// </summary>
+    /// <param name="resource">The resource to get the compute environments for.</param>
+    /// <returns>The compute environments the resource is bound to. Empty if the resource is not bound to any specific compute environment.</returns>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static IReadOnlyList<IComputeEnvironmentResource> GetComputeEnvironments(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return [.. resource.Annotations.OfType<ComputeEnvironmentAnnotation>().Select(a => a.ComputeEnvironment).Distinct()];
+    }
+
+    /// <summary>
+    /// Determines whether the resource is bound to the specified compute environment.
+    /// </summary>
+    /// <param name="resource">The resource to check.</param>
+    /// <param name="computeEnvironment">The compute environment to look for.</param>
+    /// <returns><see langword="true"/> if the resource is explicitly bound to <paramref name="computeEnvironment"/>; otherwise <see langword="false"/>.</returns>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static bool IsBoundToComputeEnvironment(this IResource resource, IComputeEnvironmentResource computeEnvironment)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(computeEnvironment);
+
+        return resource.Annotations.OfType<ComputeEnvironmentAnnotation>().Any(a => a.ComputeEnvironment == computeEnvironment);
+    }
+
+    /// <summary>
+    /// Gets the regional stamps of the resource: one entry per compute environment the resource is deployed to.
+    /// </summary>
+    /// <param name="resource">The resource to get the stamps for.</param>
+    /// <returns>
+    /// The stamps of the resource in declaration order. Empty if the resource is not bound to any specific
+    /// compute environment.
+    /// </returns>
+    /// <remarks>
+    /// Infrastructure names are only stamp-qualified when the resource is bound to more than one compute
+    /// environment, or when an explicit stamp name was supplied. This keeps names for single-region
+    /// applications unchanged.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static IReadOnlyList<ComputeStamp> GetComputeStamps(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        // De-duplicate by environment. Annotations can repeat — the singular WithComputeEnvironment appends,
+        // and auto-binding adds one directly — and counting duplicates would flip name qualification on and
+        // silently rename already deployed infrastructure. This must agree with IsStamped.
+        var annotations = new List<ComputeEnvironmentAnnotation>();
+        var seen = new HashSet<IComputeEnvironmentResource>();
+        foreach (var annotation in resource.Annotations.OfType<ComputeEnvironmentAnnotation>())
+        {
+            if (seen.Add(annotation.ComputeEnvironment))
+            {
+                annotations.Add(annotation);
+            }
+        }
+
+        if (annotations.Count == 0)
+        {
+            return [];
+        }
+
+        var qualifiesNames = annotations.Count > 1;
+
+        var stamps = new List<ComputeStamp>(annotations.Count);
+        foreach (var annotation in annotations)
+        {
+            stamps.Add(new ComputeStamp(
+                annotation.ComputeEnvironment,
+                annotation.StampName ?? annotation.ComputeEnvironment.Name,
+                qualifiesNames || annotation.StampName is not null));
+        }
+
+        return stamps;
+    }
+
+    /// <summary>
+    /// Determines whether the resource is deployed as more than one regional stamp.
+    /// </summary>
+    /// <param name="resource">The resource to check.</param>
+    /// <returns><see langword="true"/> if the resource is bound to more than one compute environment; otherwise <see langword="false"/>.</returns>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static bool IsStamped(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return resource.Annotations.OfType<ComputeEnvironmentAnnotation>().Select(a => a.ComputeEnvironment).Distinct().Count() > 1;
+    }
+
+    /// <summary>
+    /// Gets the infrastructure name to use for the resource within the specified compute environment.
+    /// </summary>
+    /// <param name="resource">The resource whose name is being qualified.</param>
+    /// <param name="computeEnvironment">The compute environment the name is being generated for, or <see langword="null"/> when no environment is in scope.</param>
+    /// <returns>
+    /// The resource name suffixed with the stamp name when the resource is stamped; otherwise the resource
+    /// name unchanged.
+    /// </returns>
+    /// <remarks>
+    /// Every name derived from a compute resource — container app names, web site names, Bicep module paths,
+    /// pipeline step names — must go through this helper so that the stamps of one resource do not collide.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static string GetStampQualifiedName(this IResource resource, IComputeEnvironmentResource? computeEnvironment)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (computeEnvironment is null)
+        {
+            return resource.Name;
+        }
+
+        foreach (var stamp in resource.GetComputeStamps())
+        {
+            if (stamp.Environment == computeEnvironment)
+            {
+                return stamp.QualifiesNames ? $"{resource.Name}-{stamp.Name}" : resource.Name;
+            }
+        }
+
+        return resource.Name;
+    }
+
+    /// <summary>
+    /// Gets every deployment target of the resource, one per compute environment it is deployed to.
+    /// </summary>
+    /// <param name="resource">The resource to get the deployment targets for.</param>
+    /// <returns>The deployment targets of the resource. Empty if the resource has none.</returns>
+    /// <remarks>
+    /// Unlike <see cref="GetDeploymentTargetAnnotation(IResource, IComputeEnvironmentResource?)"/> this never
+    /// throws on ambiguity, so it is the accessor to use for a resource deployed as several regional stamps.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Deployment target inspection helper — not part of the ATS surface.")]
+    public static IReadOnlyList<DeploymentTargetAnnotation> GetDeploymentTargetAnnotations(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var boundEnvironments = resource.GetComputeEnvironments();
+        var annotations = resource.Annotations.OfType<DeploymentTargetAnnotation>();
+
+        // When the resource is explicitly bound, only report targets for those environments. A compute
+        // environment that the resource is not bound to may still have produced a target if it ran before
+        // the binding was applied.
+        return boundEnvironments.Count == 0
+            ? [.. annotations]
+            : [.. annotations.Where(a => a.ComputeEnvironment is null || boundEnvironments.Contains(a.ComputeEnvironment))];
+    }
+
+    /// <summary>
     /// Gets the deployment target for the specified resource, if any. Throws an exception if
     /// there are multiple compute environments and a compute environment is not explicitly specified.
     /// </summary>
@@ -1054,17 +1209,20 @@ public static class ResourceExtensions
     public static DeploymentTargetAnnotation? GetDeploymentTargetAnnotation(this IResource resource, IComputeEnvironmentResource? targetComputeEnvironment = null)
     {
         IComputeEnvironmentResource? selectedComputeEnvironment = null;
-        if (resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation))
+        var boundComputeEnvironments = resource.GetComputeEnvironments();
+        if (boundComputeEnvironments.Count > 0)
         {
             // If you have a ComputeEnvironmentAnnotation, it means the resource is bound to a specific compute environment.
             // Skip the annotation if it doesn't match the specified targetComputeEnvironment.
-            if (targetComputeEnvironment is not null && targetComputeEnvironment != computeEnvironmentAnnotation.ComputeEnvironment)
+            if (targetComputeEnvironment is not null && !boundComputeEnvironments.Contains(targetComputeEnvironment))
             {
                 return null;
             }
 
-            // If the resource is bound to a specific compute environment, use that one.
-            selectedComputeEnvironment = computeEnvironmentAnnotation.ComputeEnvironment;
+            // A stamped resource is bound to several environments, so it can only be narrowed by an explicit
+            // target. Leaving the selection null lets the ambiguity check below produce the error.
+            selectedComputeEnvironment = targetComputeEnvironment
+                ?? (boundComputeEnvironments.Count == 1 ? boundComputeEnvironments[0] : null);
         }
 
         if (resource.TryGetAnnotationsOfType<DeploymentTargetAnnotation>(out var deploymentTargetAnnotations))
@@ -1079,7 +1237,9 @@ public static class ResourceExtensions
             if (annotations.Length > 1)
             {
                 var computeEnvironmentNames = string.Join(", ", annotations.Select(a => a.ComputeEnvironment?.Name));
-                throw new InvalidOperationException($"Resource '{resource.Name}' has multiple compute environments - '{computeEnvironmentNames}'. Please specify a single compute environment using 'WithComputeEnvironment'.");
+                throw new InvalidOperationException(resource.IsStamped()
+                    ? $"Resource '{resource.Name}' is deployed as multiple stamps across compute environments - '{computeEnvironmentNames}'. Use 'GetDeploymentTargetAnnotations' to enumerate every stamp, or pass the compute environment to select one."
+                    : $"Resource '{resource.Name}' has multiple compute environments - '{computeEnvironmentNames}'. Please specify a single compute environment using 'WithComputeEnvironment'.");
             }
 
             var deploymentTargetAnnotation = annotations[0];
@@ -1366,11 +1526,29 @@ public static class ResourceExtensions
             return registryAnnotation.Registry;
         }
 
-        // Try to get the container registry from DeploymentTargetAnnotation first
-        var deploymentTarget = resource.GetDeploymentTargetAnnotation();
-        if (deploymentTarget?.ContainerRegistry is not null)
+        // Try to get the container registry from DeploymentTargetAnnotation first. A stamped resource has one
+        // deployment target per compute environment, and the image is built and pushed once. If the stamps
+        // resolved to different registries, every stamp after the first would be wired to an image that was
+        // never pushed to its registry — and whose managed identity has no pull rights — so fail with an
+        // actionable message instead of producing a deployment that cannot pull its image.
+        var registries = resource.GetDeploymentTargetAnnotations()
+            .Select(a => a.ContainerRegistry)
+            .Where(r => r is not null)
+            .Distinct()
+            .ToArray();
+
+        if (registries.Length > 1)
         {
-            return deploymentTarget.ContainerRegistry;
+            var deploymentTargetRegistryNames = string.Join(", ", registries.Select(r => r is IResource res ? res.Name : r!.ToString()));
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' is deployed as multiple stamps whose compute environments use different container registries - '{deploymentTargetRegistryNames}'. " +
+                $"A stamped resource is built once and pulled by every stamp, so all of its compute environments must share one registry. " +
+                $"Point them at the same registry with '.WithContainerRegistry(registryBuilder)' on each compute environment.");
+        }
+
+        if (registries.Length == 1)
+        {
+            return registries[0]!;
         }
 
         // Fall back to RegistryTargetAnnotation (added automatically via BeforeStartEvent)

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -266,9 +266,11 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                         continue;
                     }
 
-                    // Skip if resource has a deployment target with a ContainerRegistry set
-                    var deploymentTargetAnnotation = resource.GetDeploymentTargetAnnotation();
-                    if (deploymentTargetAnnotation?.ContainerRegistry is not null)
+                    // Skip if any deployment target has a ContainerRegistry set. A stamped resource has one
+                    // deployment target per compute environment, and each of those supplies its own registry,
+                    // so the singular accessor would throw on the ambiguity.
+                    var deploymentTargetAnnotations = resource.GetDeploymentTargetAnnotations();
+                    if (deploymentTargetAnnotations.Any(a => a.ContainerRegistry is not null))
                     {
                         continue;
                     }
@@ -396,6 +398,10 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
         var unboundResources = model.Resources
             .OfType<IComputeResource>()
+            // Resources that are never deployed cannot target a compute environment, so requiring a binding
+            // for them would be a false positive. This matters now that multi-environment models are normal
+            // for regional stamps rather than an edge case.
+            .Where(resource => !resource.IsExcludedFromPublish() && !resource.IsBuildOnlyContainer())
             .Where(resource => resource.GetComputeEnvironment() is null)
             .ToList();
 
@@ -408,7 +414,8 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         var environmentNames = string.Join("', '", computeEnvironments.Select(environment => environment.Name));
         throw new InvalidOperationException(
             $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
-            $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
+            $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder, " +
+            $"or deploy a resource to several environments as regional stamps by calling 'WithComputeEnvironments'.");
     }
 
     private static void ValidateBuildOnlyContainerReferences(DistributedApplicationModel model)

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -181,7 +181,11 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
         var relativePathToProjectFile = GetManifestRelativePath(metadata.ProjectPath);
 
-        var deploymentTarget = project.GetDeploymentTargetAnnotation();
+        // The manifest schema has room for a single deployment target per resource, so a resource deployed
+        // as several regional stamps is represented by its first stamp. Use the Azure publisher to emit
+        // infrastructure for every stamp.
+        var projectDeploymentTargets = project.GetDeploymentTargetAnnotations();
+        var deploymentTarget = projectDeploymentTargets.Count > 0 ? projectDeploymentTargets[0] : null;
         if (deploymentTarget is not null)
         {
             Writer.WriteString("type", "project.v1");
@@ -314,7 +318,9 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     /// <exception cref="DistributedApplicationException">Thrown if the container resource does not contain a <see cref="ContainerImageAnnotation"/>.</exception>
     public async Task WriteContainerAsync(ContainerResource container)
     {
-        var deploymentTarget = container.GetDeploymentTargetAnnotation();
+        // See WriteProjectAsync: the manifest represents only the first stamp of a stamped resource.
+        var containerDeploymentTargets = container.GetDeploymentTargetAnnotations();
+        var deploymentTarget = containerDeploymentTargets.Count > 0 ? containerDeploymentTargets[0] : null;
 
         if (container.Annotations.OfType<DockerfileBuildAnnotation>().Any())
         {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4756,8 +4756,124 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(computeEnvironmentResource);
 
-        builder.WithAnnotation(new ComputeEnvironmentAnnotation(computeEnvironmentResource.Resource));
+        // Replace rather than append so repeated calls keep meaning "last one wins", which is what this
+        // method did before a resource could be bound to several environments. Appending would turn a second
+        // call into a second stamp, which both doubles the deployment and renames the first one.
+        builder.WithAnnotation(new ComputeEnvironmentAnnotation(computeEnvironmentResource.Resource), ResourceAnnotationMutationBehavior.Replace);
         return builder;
+    }
+
+    /// <summary>
+    /// Deploys the compute resource to every one of the specified compute environments, as a regional stamp per environment.
+    /// </summary>
+    /// <param name="builder">The compute resource builder.</param>
+    /// <param name="computeEnvironmentResources">The compute environments to deploy the resource to.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// Each compute environment produces an independent deployment of the resource, with its own
+    /// infrastructure names and its own host address. This is the deployment stamp topology: identical
+    /// copies of a workload deployed to several regions behind a single global entry point such as Azure
+    /// Front Door. See <see href="https://learn.microsoft.com/azure/architecture/patterns/deployment-stamp"/>.
+    /// </para>
+    /// <para>
+    /// Infrastructure names are suffixed with the stamp name, which defaults to the compute environment's
+    /// resource name. Use <see cref="WithStamp{T}(IResourceBuilder{T}, IResourceBuilder{IComputeEnvironmentResource}, string)"/>
+    /// to choose a shorter suffix when the generated names would exceed a platform's length limits.
+    /// </para>
+    /// <para>
+    /// References between stamped resources resolve within the same stamp, so a resource never crosses a
+    /// region boundary to reach a dependency that is present in its own stamp.
+    /// </para>
+    /// <example>
+    /// Deploy one API to two Azure regions behind a single Front Door hostname:
+    /// <code lang="C#">
+    /// var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+    /// var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+    ///
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///     .WithExternalHttpEndpoints()
+    ///     .WithComputeEnvironments(eastus, westeu);
+    ///
+    /// builder.AddAzureFrontDoor("frontdoor").WithOrigin(api);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExport]
+    public static IResourceBuilder<T> WithComputeEnvironments<T>(this IResourceBuilder<T> builder, params IResourceBuilder<IComputeEnvironmentResource>[] computeEnvironmentResources)
+        where T : IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(computeEnvironmentResources);
+
+        if (computeEnvironmentResources.Length == 0)
+        {
+            throw new ArgumentException("At least one compute environment must be specified.", nameof(computeEnvironmentResources));
+        }
+
+        foreach (var computeEnvironmentResource in computeEnvironmentResources)
+        {
+            ArgumentNullException.ThrowIfNull(computeEnvironmentResource, nameof(computeEnvironmentResources));
+
+            AddComputeEnvironmentAnnotation(builder, computeEnvironmentResource.Resource, stampName: null);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Deploys the compute resource to the specified compute environment as a named regional stamp.
+    /// </summary>
+    /// <param name="builder">The compute resource builder.</param>
+    /// <param name="computeEnvironmentResource">The compute environment to deploy this stamp to.</param>
+    /// <param name="stampName">
+    /// The name of the stamp. It is appended to infrastructure names generated for this stamp, so prefer a
+    /// short value such as a region abbreviation.
+    /// </param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// <para>
+    /// Call this method once per stamp. Unlike
+    /// <see cref="WithComputeEnvironments{T}(IResourceBuilder{T}, IResourceBuilder{IComputeEnvironmentResource}[])"/>,
+    /// supplying a stamp name always qualifies the generated infrastructure names, even for a single stamp.
+    /// </para>
+    /// <example>
+    /// Use short stamp names to stay within platform name-length limits:
+    /// <code lang="C#">
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///     .WithExternalHttpEndpoints()
+    ///     .WithStamp(eastus, "eus")
+    ///     .WithStamp(westeu, "weu");
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AspireExport]
+    public static IResourceBuilder<T> WithStamp<T>(this IResourceBuilder<T> builder, IResourceBuilder<IComputeEnvironmentResource> computeEnvironmentResource, string stampName)
+        where T : IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(computeEnvironmentResource);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stampName);
+
+        AddComputeEnvironmentAnnotation(builder, computeEnvironmentResource.Resource, stampName);
+
+        return builder;
+    }
+
+    private static void AddComputeEnvironmentAnnotation<T>(IResourceBuilder<T> builder, IComputeEnvironmentResource computeEnvironment, string? stampName)
+        where T : IComputeResource
+    {
+        // Binding the same environment twice would generate two identical stamps, which collide on every
+        // derived infrastructure name. Fail early with a message that names the resource.
+        if (builder.Resource.IsBoundToComputeEnvironment(computeEnvironment))
+        {
+            throw new InvalidOperationException(
+                $"Resource '{builder.Resource.Name}' is already bound to compute environment '{computeEnvironment.Name}'. Each compute environment can only be specified once.");
+        }
+
+        builder.WithAnnotation(new ComputeEnvironmentAnnotation(computeEnvironment, stampName));
     }
 
     /// <summary>

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -83,6 +83,21 @@ internal static class ComputeEnvironmentEndpointResolver
 
         var owningResource = endpointReferenceExpression.Endpoint.Resource;
 
+        // A stamped resource is deployed to several compute environments. When one of them is the
+        // environment currently being generated, the reference must stay inside that stamp so traffic
+        // never crosses a region boundary to reach a dependency that exists locally. The local endpoint
+        // map already resolves to the local stamp, so leave it alone.
+        foreach (var owned in owningResource.GetComputeEnvironments())
+        {
+            foreach (var current in currentComputeEnvironments)
+            {
+                if (ReferenceEquals(current, owned))
+                {
+                    return false;
+                }
+            }
+        }
+
         // Resolve the compute environment the owning resource deploys to. A plain resource that is
         // not deployed anywhere has none, so there is nothing to delegate to and the local lookup
         // handles it.
@@ -121,17 +136,40 @@ internal static class ComputeEnvironmentEndpointResolver
     /// <returns>
     /// <see langword="true"/> if a compute environment was resolved; otherwise <see langword="false"/>.
     /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the resource is deployed as several regional stamps, because there is no single
+    /// environment to resolve. Callers that can handle stamps should use
+    /// <see cref="ResourceExtensions.GetComputeStamps"/> instead.
+    /// </exception>
     public static bool TryGetEffectiveComputeEnvironment(
         IResource resource,
         [NotNullWhen(true)] out IComputeEnvironmentResource? computeEnvironment)
     {
         ArgumentNullException.ThrowIfNull(resource);
 
+        var boundComputeEnvironments = resource.GetComputeEnvironments();
+        if (boundComputeEnvironments.Count > 1)
+        {
+            var names = string.Join("', '", boundComputeEnvironments.Select(e => e.Name));
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' is deployed as multiple stamps across compute environments '{names}', so a single endpoint cannot be resolved. " +
+                "Reference the resource from within one of those environments, or route to it through a global entry point such as Azure Front Door.");
+        }
+
         // Prefer an explicit compute environment binding, then fall back to the deployment target's
         // compute environment. This matches how endpoint references are resolved elsewhere
         // (Azure Front Door origins, Foundry hosted agents) so all call sites agree on "where is
         // this resource deployed".
-        computeEnvironment = resource.GetComputeEnvironment() ?? resource.GetDeploymentTargetAnnotation()?.ComputeEnvironment;
+        if (boundComputeEnvironments.Count == 1)
+        {
+            computeEnvironment = boundComputeEnvironments[0];
+            return true;
+        }
+
+        // No explicit binding. The singular accessor still throws when the resource has several deployment
+        // targets, because an unbound resource with more than one target is genuinely ambiguous — silently
+        // picking one would resolve the endpoint to an arbitrary environment.
+        computeEnvironment = resource.GetDeploymentTargetAnnotation()?.ComputeEnvironment;
         return computeEnvironment is not null;
     }
 }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
@@ -28,6 +28,223 @@ public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
         await DeployReactTemplateWithFrontDoorCore(cancellationToken);
     }
 
+    /// <summary>
+    /// Deploys one application to two Azure regions as regional stamps, behind a single Front Door hostname.
+    /// </summary>
+    /// <remarks>
+    /// This is the global entry point topology: two Azure Container Apps environments in different regions,
+    /// the server project stamped across both, and one Front Door origin group holding an origin per stamp.
+    /// The verification checks that both regional Container Apps are reachable directly, which is what proves
+    /// each stamp landed in its own region and is healthy enough for Front Door to route to.
+    /// </remarks>
+    [Fact]
+    public async Task DeployMultiRegionTemplateWithFrontDoor()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployMultiRegionTemplateWithFrontDoorCore(cancellationToken);
+    }
+
+    private async Task DeployMultiRegionTemplateWithFrontDoorCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("fdmultiregion");
+        var projectName = "FrontDoorMultiRegionApp";
+
+        output.WriteLine($"Test: {nameof(DeployMultiRegionTemplateWithFrontDoor)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
+                await auto.SourceAspireCliEnvironmentAsync(counter);
+            }
+
+            output.WriteLine("Step 3: Creating React + ASP.NET Core project...");
+            await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.JsReact, useRedisCache: false);
+
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // See DeployReactTemplateWithFrontDoorCore for why WaitForAspireAddCompletionAsync is used here.
+            output.WriteLine("Step 5: Adding Azure Container Apps hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
+
+            output.WriteLine("Step 5b: Adding Azure Front Door hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.FrontDoor");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
+
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            // With more than one compute environment in the model every compute resource must be bound
+            // explicitly, so webfrontend is pinned to the primary region while server is stamped across both.
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = """
+// Two regional Azure Container App Environments
+var acaEastUs = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+var acaWestUs = builder.AddAzureContainerAppEnvironment("aca-westus").WithLocation("westus3");
+
+// Deploy the server to both regions as regional stamps
+server.WithComputeEnvironments(acaEastUs, acaWestUs);
+webfrontend.WithComputeEnvironment(acaEastUs);
+
+// One global entry point in front of both stamps
+builder.AddAzureFrontDoor("frontdoor")
+    .WithOriginGroup(server, g => g
+        .WithRouting(FrontDoorOriginRouting.LatencyBased)
+        .WithHealthProbe("/health", FrontDoorHealthProbeProtocol.Https, TimeSpan.FromSeconds(30)));
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+            File.WriteAllText(appHostFilePath, content);
+
+            output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
+
+            output.WriteLine("Step 7: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // AZURE__LOCATION still sets the region of the resource group and of any resource that is not
+            // pinned with WithLocation. The two Container Apps environments override it per stamp.
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 9: Starting multi-region Azure deployment with Front Door...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync(ConsoleActivityLoggerStrings.PipelineSucceeded, timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Verify that two Container Apps environments were created, one per region, and that the stamped
+            // server produced a container app in each of them. Front Door itself is covered by the successful
+            // deployment: querying it with `az afd` would trigger an interactive `cdn` extension install, and
+            // its DNS takes 5-15 minutes to propagate.
+            output.WriteLine("Step 10: Verifying both regional stamps...");
+            await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+                  "echo \"Resource group: $RG_NAME\" && " +
+                  "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
+                  // Two managed environments, one per region.
+                  "envs=$(az containerapp env list -g \"$RG_NAME\" --query \"[].location\" -o tsv 2>/dev/null | sort -u) && " +
+                  "env_count=$(echo \"$envs\" | grep -c . ) && " +
+                  "echo \"Container Apps environment regions: $envs\" && " +
+                  "if [ \"$env_count\" -lt 2 ]; then echo \"❌ Expected 2 regions, found $env_count\"; exit 1; fi && " +
+                  // Two stamps of the server, one per environment.
+                  "stamps=$(az containerapp list -g \"$RG_NAME\" --query \"[?starts_with(name, 'server')].name\" -o tsv 2>/dev/null) && " +
+                  "stamp_count=$(echo \"$stamps\" | grep -c . ) && " +
+                  "echo \"Server stamps: $stamps\" && " +
+                  "if [ \"$stamp_count\" -lt 2 ]; then echo \"❌ Expected 2 server stamps, found $stamp_count\"; exit 1; fi && " +
+                  "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                  "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
+                  "failed=0 && " +
+                  // A single shared deadline keeps the loop bounded regardless of how many endpoints exist.
+                  "deadline=$(( $(date +%s) + 660 )) && " +
+                  "for url in $urls; do " +
+                  "echo \"Checking ACA https://$url...\"; " +
+                  "success=0; " +
+                  "while true; do " +
+                  "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 30 2>/dev/null); " +
+                  "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS\"; success=1; break; fi; " +
+                  "if [ \"$(date +%s)\" -ge \"$deadline\" ]; then break; fi; " +
+                  "echo \"  $STATUS, retrying in 10s...\"; sleep 10; " +
+                  "done; " +
+                  "if [ \"$success\" -eq 0 ]; then echo \"  ❌ $url not reachable before deadline\"; failed=1; fi; " +
+                  "done && " +
+                  "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi");
+            await auto.EnterAsync();
+            // Must exceed the in-terminal deadline plus the final in-flight `curl --max-time 30`; see
+            // DeployReactTemplateWithFrontDoorCore for the full rationale.
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(15));
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployMultiRegionTemplateWithFrontDoor),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployMultiRegionTemplateWithFrontDoor),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
     private async Task DeployReactTemplateWithFrontDoorCore(CancellationToken cancellationToken)
     {
         // Validate prerequisites

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
@@ -249,6 +249,267 @@ public class AzureFrontDoorTests
         Assert.Contains("has already been added", exception.Message);
     }
 
+    [Fact]
+    public async Task AddAzureFrontDoorWithStampedOriginGeneratesOneOriginPerStamp()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironments(eastus, westeu);
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAzureFrontDoorWithFailoverRoutingAssignsAscendingPriorities()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironments(eastus, westeu);
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOriginGroup(api, g => g.WithRouting(FrontDoorOriginRouting.Failover));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAzureFrontDoorWithWeightedRoutingAndCustomDomainGeneratesBicep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironments(eastus, westeu);
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOriginGroup(api, g => g
+                .WithRouting(FrontDoorOriginRouting.Weighted)
+                .WithStampWeight(eastus, 900)
+                .WithStampWeight(westeu, 100)
+                .WithHealthProbe("/health", FrontDoorHealthProbeProtocol.Https, TimeSpan.FromSeconds(30))
+                .WithLoadBalancing(sampleSize: 8, successfulSamplesRequired: 5, additionalLatencyMilliseconds: 100)
+                .WithSessionAffinity(true)
+                .WithTrafficRestorationTime(TimeSpan.FromMinutes(10))
+                .WithCustomDomain("www.contoso.com"));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task StampedOriginsUseShortStampNamesFromWithStamp()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithStamp(eastus, "eus")
+            .WithStamp(westeu, "weu");
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        Assert.Contains("param api_eus_host string", bicep);
+        Assert.Contains("param api_weu_host string", bicep);
+        Assert.Contains("api_eusOrigin", bicep);
+        Assert.Contains("api_weuOrigin", bicep);
+    }
+
+    [Fact]
+    public async Task StampedOriginsShareASingleEndpointAndOriginGroup()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironments(eastus, westeu);
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        // One global entry point: a single endpoint, origin group, and route fronting both regions.
+        Assert.Equal(1, CountOccurrences(bicep, "'Microsoft.Cdn/profiles/afdEndpoints@"));
+        Assert.Equal(1, CountOccurrences(bicep, "'Microsoft.Cdn/profiles/originGroups@"));
+        Assert.Equal(1, CountOccurrences(bicep, "'Microsoft.Cdn/profiles/afdEndpoints/routes@"));
+        Assert.Equal(2, CountOccurrences(bicep, "'Microsoft.Cdn/profiles/originGroups/origins@"));
+        Assert.Equal(1, CountOccurrences(bicep, "output api_endpointUrl string"));
+    }
+
+    [Fact]
+    public void WithStampPriorityRejectsOutOfRangeValues()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus");
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            frontDoor.WithOriginGroup(api, g => g.WithStampPriority(eastus, 0)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            frontDoor.WithOriginGroup(api, g => g.WithStampPriority(eastus, 6)));
+    }
+
+    [Fact]
+    public void WithStampWeightRejectsOutOfRangeValues()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus");
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            frontDoor.WithOriginGroup(api, g => g.WithStampWeight(eastus, 0)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            frontDoor.WithOriginGroup(api, g => g.WithStampWeight(eastus, 1001)));
+    }
+
+    [Fact]
+    public void WithOriginGroupThrowsOnNullConfigure()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor");
+
+        Assert.Throws<ArgumentNullException>(() => frontDoor.WithOriginGroup(api, null!));
+    }
+
+    [Fact]
+    public async Task EachStampIsDeployedToItsOwnComputeEnvironmentRegion()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
+        var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironments(eastus, westeu);
+
+        builder.AddAzureFrontDoor("frontdoor").WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        // Azure requires a container app to live in the region of its managed environment, so each stamp's
+        // deployment target must carry its own environment's region rather than the app-wide one.
+        var targets = api.Resource.GetDeploymentTargetAnnotations();
+        Assert.Equal(2, targets.Count);
+
+        var locations = targets
+            .Select(t => ((AzureBicepResource)t.DeploymentTarget).Parameters[AzureBicepResource.KnownParameters.Location])
+            .ToArray();
+
+        Assert.Equal(["eastus", "westeurope"], locations);
+    }
+
+    [Fact]
+    public async Task SingleEnvironmentDeploymentTargetDoesNotPinALocation()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints();
+
+        builder.AddAzureFrontDoor("frontdoor").WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        // Without an explicit WithLocation the deployment target must keep resolving to the shared Azure
+        // environment region, so no location is pinned on it.
+        var target = Assert.Single(api.Resource.GetDeploymentTargetAnnotations());
+        Assert.DoesNotContain(
+            AzureBicepResource.KnownParameters.Location,
+            ((AzureBicepResource)target.DeploymentTarget).Parameters.Keys);
+    }
+
+    private static int CountOccurrences(string value, string substring)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(substring, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += substring.Length;
+        }
+
+        return count;
+    }
+
     private sealed class Project : IProjectMetadata
     {
         public string ProjectPath => "project";

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithFailoverRoutingAssignsAscendingPriorities.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithFailoverRoutingAssignsAscendingPriorities.verified.bicep
@@ -1,0 +1,81 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param api_aca_eastus_host string
+
+param api_aca_westeu_host string
+
+resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+  tags: {
+    'aspire-resource-name': 'frontdoor'
+  }
+}
+
+resource apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
+  name: take('apiEndpoint-${uniqueString(resourceGroup().id)}', 46)
+  location: 'Global'
+  parent: frontdoor
+}
+
+resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
+  name: take('apiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    healthProbeSettings: {
+      probePath: '/'
+      probeProtocol: 'Https'
+    }
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+  }
+  parent: frontdoor
+}
+
+resource api_aca_eastusOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacaeastusOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_eastus_host
+    originHostHeader: api_aca_eastus_host
+    priority: 1
+  }
+  parent: apiOriginGroup
+}
+
+resource api_aca_westeuOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacawesteuOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_westeu_host
+    originHostHeader: api_aca_westeu_host
+    priority: 2
+  }
+  parent: apiOriginGroup
+}
+
+resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
+  name: take('apiRoute-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    forwardingProtocol: 'HttpsOnly'
+    httpsRedirect: 'Enabled'
+    linkToDefaultDomain: 'Enabled'
+    originGroup: {
+      id: apiOriginGroup.id
+    }
+    patternsToMatch: [
+      '/*'
+    ]
+  }
+  parent: apiEndpoint
+  dependsOn: [
+    api_aca_eastusOrigin
+    api_aca_westeuOrigin
+  ]
+}
+
+output api_endpointUrl string = 'https://${apiEndpoint.properties.hostName}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithStampedOriginGeneratesOneOriginPerStamp.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithStampedOriginGeneratesOneOriginPerStamp.verified.bicep
@@ -1,0 +1,79 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param api_aca_eastus_host string
+
+param api_aca_westeu_host string
+
+resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+  tags: {
+    'aspire-resource-name': 'frontdoor'
+  }
+}
+
+resource apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
+  name: take('apiEndpoint-${uniqueString(resourceGroup().id)}', 46)
+  location: 'Global'
+  parent: frontdoor
+}
+
+resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
+  name: take('apiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    healthProbeSettings: {
+      probePath: '/'
+      probeProtocol: 'Https'
+    }
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+  }
+  parent: frontdoor
+}
+
+resource api_aca_eastusOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacaeastusOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_eastus_host
+    originHostHeader: api_aca_eastus_host
+  }
+  parent: apiOriginGroup
+}
+
+resource api_aca_westeuOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacawesteuOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_westeu_host
+    originHostHeader: api_aca_westeu_host
+  }
+  parent: apiOriginGroup
+}
+
+resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
+  name: take('apiRoute-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    forwardingProtocol: 'HttpsOnly'
+    httpsRedirect: 'Enabled'
+    linkToDefaultDomain: 'Enabled'
+    originGroup: {
+      id: apiOriginGroup.id
+    }
+    patternsToMatch: [
+      '/*'
+    ]
+  }
+  parent: apiEndpoint
+  dependsOn: [
+    api_aca_eastusOrigin
+    api_aca_westeuOrigin
+  ]
+}
+
+output api_endpointUrl string = 'https://${apiEndpoint.properties.hostName}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithWeightedRoutingAndCustomDomainGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithWeightedRoutingAndCustomDomainGeneratesBicep.verified.bicep
@@ -1,0 +1,99 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param api_aca_eastus_host string
+
+param api_aca_westeu_host string
+
+resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+  tags: {
+    'aspire-resource-name': 'frontdoor'
+  }
+}
+
+resource apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
+  name: take('apiEndpoint-${uniqueString(resourceGroup().id)}', 46)
+  location: 'Global'
+  parent: frontdoor
+}
+
+resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
+  name: take('apiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    healthProbeSettings: {
+      probePath: '/health'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 30
+    }
+    loadBalancingSettings: {
+      sampleSize: 8
+      successfulSamplesRequired: 5
+      additionalLatencyInMilliseconds: 100
+    }
+    sessionAffinityState: 'Enabled'
+    trafficRestorationTimeToHealedOrNewEndpointsInMinutes: 10
+  }
+  parent: frontdoor
+}
+
+resource api_aca_eastusOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacaeastusOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_eastus_host
+    originHostHeader: api_aca_eastus_host
+    weight: 900
+  }
+  parent: apiOriginGroup
+}
+
+resource api_aca_westeuOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiacawesteuOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    hostName: api_aca_westeu_host
+    originHostHeader: api_aca_westeu_host
+    weight: 100
+  }
+  parent: apiOriginGroup
+}
+
+resource apiCustomDomain 'Microsoft.Cdn/profiles/customDomains@2025-06-01' = {
+  name: take('apicustomdomain${uniqueString(resourceGroup().id)}', 24)
+  properties: {
+    hostName: 'www.contoso.com'
+  }
+  parent: frontdoor
+}
+
+resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
+  name: take('apiRoute-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    customDomains: [
+      {
+        id: apiCustomDomain.id
+      }
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    httpsRedirect: 'Enabled'
+    linkToDefaultDomain: 'Enabled'
+    originGroup: {
+      id: apiOriginGroup.id
+    }
+    patternsToMatch: [
+      '/*'
+    ]
+  }
+  parent: apiEndpoint
+  dependsOn: [
+    api_aca_eastusOrigin
+    api_aca_westeuOrigin
+  ]
+}
+
+output api_endpointUrl string = 'https://${apiEndpoint.properties.hostName}'
+
+output api_customDomainValidationToken string = apiCustomDomain.properties.validationProperties.validationToken

--- a/tests/Aspire.Hosting.Tests/ComputeStampTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeStampTests.cs
@@ -1,0 +1,312 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Aspire.Hosting.Tests;
+
+/// <summary>
+/// Tests for deploying a single compute resource to several compute environments as regional stamps.
+/// </summary>
+[Trait("Partition", "6")]
+public class ComputeStampTests
+{
+    [Fact]
+    public void UnboundResourceHasNoStamps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var api = builder.AddResource(new TestComputeResource("api"));
+
+        Assert.Empty(api.Resource.GetComputeStamps());
+        Assert.False(api.Resource.IsStamped());
+    }
+
+    [Fact]
+    public void SingleComputeEnvironmentProducesOneStampThatDoesNotQualifyNames()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env);
+
+        var stamp = Assert.Single(api.Resource.GetComputeStamps());
+
+        Assert.Same(env.Resource, stamp.Environment);
+        Assert.Equal("env1", stamp.Name);
+        Assert.False(stamp.QualifiesNames);
+        Assert.False(api.Resource.IsStamped());
+
+        // The load-bearing invariant: a single-environment resource keeps its plain name so already
+        // deployed infrastructure is never renamed.
+        Assert.Equal("api", api.Resource.GetStampQualifiedName(env.Resource));
+    }
+
+    [Fact]
+    public void WithComputeEnvironmentsProducesOneStampPerEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        Assert.True(api.Resource.IsStamped());
+
+        Assert.Collection(
+            api.Resource.GetComputeStamps(),
+            stamp =>
+            {
+                Assert.Same(env1.Resource, stamp.Environment);
+                Assert.Equal("env1", stamp.Name);
+                Assert.True(stamp.QualifiesNames);
+            },
+            stamp =>
+            {
+                Assert.Same(env2.Resource, stamp.Environment);
+                Assert.Equal("env2", stamp.Name);
+                Assert.True(stamp.QualifiesNames);
+            });
+
+        Assert.Equal("api-env1", api.Resource.GetStampQualifiedName(env1.Resource));
+        Assert.Equal("api-env2", api.Resource.GetStampQualifiedName(env2.Resource));
+    }
+
+    [Fact]
+    public void WithStampUsesTheSuppliedStampNameAndAlwaysQualifiesNames()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("aca-eastus"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithStamp(env1, "eus");
+
+        var stamp = Assert.Single(api.Resource.GetComputeStamps());
+
+        Assert.Equal("eus", stamp.Name);
+        Assert.True(stamp.QualifiesNames);
+        Assert.Equal("api-eus", api.Resource.GetStampQualifiedName(env1.Resource));
+    }
+
+    [Fact]
+    public void GetStampQualifiedNameReturnsResourceNameForUnknownEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env1);
+
+        Assert.Equal("api", api.Resource.GetStampQualifiedName(env2.Resource));
+        Assert.Equal("api", api.Resource.GetStampQualifiedName(null));
+    }
+
+    [Fact]
+    public void BindingTheSameComputeEnvironmentTwiceThrows()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => api.WithComputeEnvironments(env1));
+
+        Assert.Contains("'api'", ex.Message);
+        Assert.Contains("'env1'", ex.Message);
+    }
+
+    [Fact]
+    public void RepeatingTheSingularWithComputeEnvironmentKeepsOneUnqualifiedStamp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env1)
+            .WithComputeEnvironment(env1);
+
+        // Repeating the singular binding must not look like two stamps, otherwise generated names would gain
+        // a suffix and already deployed infrastructure would be recreated.
+        var stamp = Assert.Single(api.Resource.GetComputeStamps());
+        Assert.Same(env1.Resource, stamp.Environment);
+        Assert.False(stamp.QualifiesNames);
+        Assert.False(api.Resource.IsStamped());
+        Assert.Equal("api", api.Resource.GetStampQualifiedName(env1.Resource));
+    }
+
+    [Fact]
+    public void SingularWithComputeEnvironmentIsLastOneWins()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env1)
+            .WithComputeEnvironment(env2);
+
+        // The singular API meant "last one wins" before stamping existed. Turning a second call into a second
+        // stamp would silently double the deployment and rename the first one.
+        var stamp = Assert.Single(api.Resource.GetComputeStamps());
+        Assert.Same(env2.Resource, stamp.Environment);
+        Assert.False(api.Resource.IsStamped());
+        Assert.False(api.Resource.IsBoundToComputeEnvironment(env1.Resource));
+        Assert.True(api.Resource.IsBoundToComputeEnvironment(env2.Resource));
+        Assert.Equal("api", api.Resource.GetStampQualifiedName(env2.Resource));
+    }
+
+    [Fact]
+    public void GetContainerRegistryThrowsWhenStampsUseDifferentRegistries()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t1"))
+        {
+            ComputeEnvironment = env1.Resource,
+            ContainerRegistry = new TestContainerRegistry("acr1")
+        });
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t2"))
+        {
+            ComputeEnvironment = env2.Resource,
+            ContainerRegistry = new TestContainerRegistry("acr2")
+        });
+
+        // The image is built and pushed once, so every stamp has to be able to pull it from the same
+        // registry. Otherwise every stamp after the first cannot pull its image.
+        var ex = Assert.Throws<InvalidOperationException>(api.Resource.GetContainerRegistry);
+
+        Assert.Contains("'api'", ex.Message);
+        Assert.Contains("acr1", ex.Message);
+        Assert.Contains("acr2", ex.Message);
+        Assert.Contains("WithContainerRegistry", ex.Message);
+    }
+
+    [Fact]
+    public void GetContainerRegistryReturnsTheSharedRegistryAcrossStamps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        var shared = new TestContainerRegistry("shared-acr");
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t1")) { ComputeEnvironment = env1.Resource, ContainerRegistry = shared });
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t2")) { ComputeEnvironment = env2.Resource, ContainerRegistry = shared });
+
+        Assert.Same(shared, api.Resource.GetContainerRegistry());
+    }
+
+    [Fact]
+    public void WithComputeEnvironmentsRequiresAtLeastOneEnvironment()
+    {        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var api = builder.AddResource(new TestComputeResource("api"));
+
+        Assert.Throws<ArgumentException>(() => api.WithComputeEnvironments());
+    }
+
+    [Fact]
+    public void IsBoundToComputeEnvironmentMatchesEveryStamp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var env3 = builder.AddResource(new TestComputeEnvironmentResource("env3"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        Assert.True(api.Resource.IsBoundToComputeEnvironment(env1.Resource));
+        Assert.True(api.Resource.IsBoundToComputeEnvironment(env2.Resource));
+        Assert.False(api.Resource.IsBoundToComputeEnvironment(env3.Resource));
+    }
+
+    [Fact]
+    public async Task StampedResourceSatisfiesTheMultipleComputeEnvironmentValidation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+    }
+
+    [Fact]
+    public void GetDeploymentTargetAnnotationsReturnsEveryStampTarget()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("api-env1-target")) { ComputeEnvironment = env1.Resource });
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("api-env2-target")) { ComputeEnvironment = env2.Resource });
+
+        Assert.Equal(2, api.Resource.GetDeploymentTargetAnnotations().Count);
+
+        // Narrowing by environment picks exactly one stamp.
+        Assert.Equal("api-env1-target", api.Resource.GetDeploymentTargetAnnotation(env1.Resource)!.DeploymentTarget.Name);
+        Assert.Equal("api-env2-target", api.Resource.GetDeploymentTargetAnnotation(env2.Resource)!.DeploymentTarget.Name);
+    }
+
+    [Fact]
+    public void GetDeploymentTargetAnnotationThrowsForAStampedResourceWithoutAnEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments(env1, env2);
+
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t1")) { ComputeEnvironment = env1.Resource });
+        api.Resource.Annotations.Add(new DeploymentTargetAnnotation(new TestComputeResource("t2")) { ComputeEnvironment = env2.Resource });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => api.Resource.GetDeploymentTargetAnnotation());
+
+        Assert.Contains("deployed as multiple stamps", ex.Message);
+        Assert.Contains("GetDeploymentTargetAnnotations", ex.Message);
+    }
+
+    private sealed class TestContainerRegistry : Resource, IContainerRegistry
+    {
+        public TestContainerRegistry(string registryName) : base(registryName)
+        {
+        }
+
+        ReferenceExpression IContainerRegistry.Name => ReferenceExpression.Create($"{Name}");
+
+        public ReferenceExpression Endpoint => ReferenceExpression.Create($"{Name}.azurecr.io");
+    }
+
+    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+#pragma warning disable ASPIRECOMPUTE002
+        public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
+            ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
+#pragma warning restore ASPIRECOMPUTE002
+    }
+
+    private sealed class TestComputeResource(string name) : Resource(name), IComputeResource, IResourceWithEndpoints
+    {
+    }
+}


### PR DESCRIPTION
## Description

Azure Front Door shipped as a *per-app front end*: every `WithOrigin` call emitted a dedicated endpoint → origin group → origin → route, so each backend got its own `*.azurefd.net` hostname and there was nothing to fail over between. There was also no way to deploy one application to several regions, because a compute resource was bound to exactly one compute environment (`GetDeploymentTargetAnnotation()` threw on more than one).

This adds **regional stamps** and makes Front Door the **global entry point** in front of them.

```csharp
var eastus = builder.AddAzureContainerAppEnvironment("aca-eastus").WithLocation("eastus");
var westeu = builder.AddAzureContainerAppEnvironment("aca-westeu").WithLocation("westeurope");

var api = builder.AddProject<Projects.Api>("api")
    .WithExternalHttpEndpoints()
    .WithComputeEnvironments(eastus, westeu);   // one app, two regional stamps

builder.AddAzureFrontDoor("frontdoor")
    .WithOrigin(api);                            // one global hostname, two origins
```

```
CdnProfile (Global)
└── apiEndpoint                    ← one global hostname
    ├── apiOriginGroup             ← health probe + load balancing
    │   ├── api_aca_eastusOrigin   ← stamp 1
    │   └── api_aca_westeuOrigin   ← stamp 2
    └── apiRoute (dependsOn: every origin)
```

### What changed

- **Stamping model** — a `ComputeStamp` is a `(compute resource, compute environment)` pair. `WithComputeEnvironments(...)` / `WithStamp(env, "eus")` bind a resource to several environments; `GetComputeStamps`, `GetComputeEnvironments`, `IsStamped`, `IsBoundToComputeEnvironment`, `GetStampQualifiedName`, and `GetDeploymentTargetAnnotations` inspect them.
- **Regions** — `WithLocation` pins an individual Azure resource to a region. Deployment targets inherit their compute environment's region via `InheritLocationFrom`, which Azure requires (a container app must live in its managed environment's region).
- **Front Door** — the origin group now holds one origin per stamp. `WithOriginGroup(resource, configure)` adds routing (`LatencyBased` / `Failover` / `Weighted`), per-stamp priority and weight, health probes, load balancing, session affinity, traffic restoration, and custom domains.
- **Stamp-local references** — a reference from `web`@eastus to a stamped `api` resolves to the `eastus` copy, so traffic never leaves the region to reach a dependency that exists locally.

### Load-bearing invariant

A resource bound to **one** compute environment produces **byte-for-byte identical** output to before — same generated names, Bicep module paths, Bicep parameters, and pipeline step names — so existing deployments are not recreated. The two pre-existing Front Door snapshots are unchanged, and `ComputeStampTests` asserts this directly.

### Bugs found and fixed along the way

- `AzurePublishingContext` added the `location` module parameter unconditionally and then re-added it from `resource.Parameters` — a duplicate-key throw the moment any resource carried its own location.
- The App Service web site *name producer* (`AzureAppServiceWebsiteContext.HostName`) was not stamp-qualified, so stamps would collide on a globally-unique site name and the advertised hostname would not match the site Bicep creates.
- `WithComputeEnvironment` (singular) appended, so calling it twice silently renamed infrastructure and a second call turned into a second deployment. It now replaces, preserving "last one wins".
- A stamped resource whose environments used different container registries would emit every stamp after the first with an image reference into a registry the image was never pushed to. This now fails fast with an actionable message (see `docs/specs/deployment-stamps.md` for the shared-registry requirement).
- `AzureProvisioningController` reset dropped an explicit `WithLocation` along with inferred locations, silently moving the resource on the next provisioning pass.

## Local verification

Full `./build.sh` is clean — **0 warnings, 0 errors**.

| Test project | Result |
|---|---|
| `Aspire.Hosting.Tests` | 3361 total, 3354 passed, 5 skipped |
| `Aspire.Hosting.Azure.Tests` | 1701 total, 1695 passed, 5 skipped |
| `Aspire.Hosting.Docker.Tests` | 100 passed, 1 skipped |
| `Aspire.Hosting.Kubernetes.Tests` | 284 passed |
| `Aspire.Hosting.Radius.Tests` | 464 passed |

All run with `--filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`. Three tests failed only when two heavy suites ran concurrently (`AzureSignalREmulatorFunctionalTest`, `AzureStorageEmulatorFunctionalTests.AzureStorageEmulator_WithPersistentLifetime_ReusesContainersAndPorts`, `WithProcessCommandTests`) and each passes in isolation — container/process contention, not related to this change.

Three new Bicep snapshots were reviewed before acceptance (stamped origins, failover priorities, weighted + custom domain). `Aspire.Deployment.EndToEnd.Tests` builds; the new two-region deployment test requires an Azure subscription and has not been run.

## Deferred

- **Per-stamp resource groups.** All stamps deploy into the app's single resource group; Azure permits resources of many regions in one group. `AzureBicepResource.Scope` already supports per-module RG scoping, but `main.bicep` emits one `ResourceGroup` and `BicepProvisioner` resolves rather than creates scoped groups.
- **Per-stamp backing services.** Databases, caches, and storage stay shared. `ComputeStamp` carries the environment so this can be layered on.
- **Pushing one image to several registries.** Would require resolving the image reference per deployment target.
- **`X-Azure-FDID` origin lock-down.** Injecting the Front Door ID into origins closes a Bicep module cycle, since Front Door already depends on the origins' host addresses. Same reason a backend cannot be told its generated `*.azurefd.net` name — use `WithCustomDomain` instead.
- **Kubernetes / Docker Compose / Radius stamping.** The core model is publisher-agnostic, but only ACA and App Service have stamp-aware name derivation.
- **ATS baseline.** All new capabilities are additive, so no suppressions are needed. The checked-in `*.ats.txt` files are the release baseline, updated by the scheduled `generate-ats-diffs.yml` workflow rather than in a PR.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

> **API review needed** across three packages: `WithComputeEnvironments`, `WithStamp`, `ComputeStamp`, `GetComputeStamps` / `GetComputeEnvironments` / `IsStamped` / `IsBoundToComputeEnvironment` / `GetStampQualifiedName` / `GetDeploymentTargetAnnotations` (`Aspire.Hosting`); `WithLocation`, `InheritLocationFrom` (`Aspire.Hosting.Azure`); `WithOriginGroup`, `AzureFrontDoorOriginGroupBuilder`, `FrontDoorOriginRouting`, `FrontDoorHealthProbeProtocol` (`Aspire.Hosting.Azure.FrontDoor`).