### PR TITLE
Remove pipeline-scoped Publish-Build-Assets group

### DIFF
--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -74,8 +74,8 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
-        # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+        # Pin Azure Identity explicitly so VSCE's transitive dependency graph
+        # remains stable across npm feed updates.
         npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
         vsce --version
       workingDirectory: '$(Build.SourcesDirectory)'

--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -74,7 +74,9 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        npm install -g @vscode/vsce@3.7.1
+        # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
+        # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+        npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
         vsce --version
       workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -226,7 +226,9 @@ extends:
                 inputs:
                   targetType: 'inline'
                   script: |
-                    npm install -g @vscode/vsce@3.7.1
+                    # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
+                    # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+                    npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
                     vsce --version
                   workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -226,8 +226,8 @@ extends:
                 inputs:
                   targetType: 'inline'
                   script: |
-                    # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
-                    # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+                    # Pin Azure Identity explicitly so VSCE's transitive dependency graph
+                    # remains stable across npm feed updates.
                     npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
                     vsce --version
                   workingDirectory: '$(Build.SourcesDirectory)'

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -505,13 +505,12 @@ extends:
           # not recognized."
           enableMicrobuild: true
           enablePublishUsingPipelines: true
-          # Asset_Registry_Publish (BAR publish) needs MaestroAccessToken from
-          # the Publish-Build-Assets variable group, which is only loaded on
-          # main / release / internal-release branches because of the AzDO
-          # ACL on that group. Skip the publish job entirely on contributor
-          # branches so jobs.yml does not inject Asset_Registry_Publish and
-          # fail at runtime for a missing token (and so the assemble stage
-          # does not trip an additional 1ES Branch control checkpoint).
+          # Asset_Registry_Publish (BAR publish) loads Publish-Build-Assets at
+          # job scope for MaestroAccessToken. The group has an AzDO ACL for
+          # main / release / internal-release branches, so skip the publish
+          # job entirely on contributor branches. This avoids injecting a job
+          # that cannot load its token and prevents another 1ES Branch control
+          # checkpoint on the assemble stage.
           ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}:
             enablePublishBuildAssets: true
             publishAssetsImmediately: true

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -32,7 +32,6 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     # SDL_Settings provides Guardian/SDL tooling credentials
     #
@@ -41,13 +40,11 @@ variables:
     # scope causes 1ES to inject a per-stage Branch control check that blocks
     # every stage on contributor branches before any work can start.
     #
-    # Only the BAR publish job (assemble stage's Asset_Registry_Publish) and
-    # helix telemetry actually need these tokens, and neither runs as a real
-    # publish on a contributor branch. Skip the group load when we're not on
-    # a branch the ACLs accept so manual / non-PR builds on ankj/* etc. can
-    # still validate the rest of the pipeline (including signing).
+    # Helix telemetry and Guardian/SDL tooling use these tokens. Skip the
+    # group load when we're not on a branch the ACLs accept so manual /
+    # non-PR builds on ankj/* etc. can still validate the rest of the
+    # pipeline (including signing).
     - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}:
-      - group: Publish-Build-Assets
       - group: DotNet-HelixApi-Access
       - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2178,9 +2178,8 @@ extends:
               - pwsh: |
                   $ErrorActionPreference = 'Stop'
 
-                  # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
-                  # available in dotnet-public-npm and requires Node 22. Remove this pin after
-                  # 1.0.0 is mirrored and this job is upgraded to Node 22.
+                  # Pin Azure Identity explicitly so VSCE's transitive dependency graph
+                  # remains stable across npm feed updates.
                   npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1 --registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
                   vsce --version
                 displayName: 'Install vsce'

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2178,7 +2178,9 @@ extends:
               - pwsh: |
                   $ErrorActionPreference = 'Stop'
 
-                  npm install -g @vscode/vsce@3.7.1 --registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+                  # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
+                  # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+                  npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1 --registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
                   vsce --version
                 displayName: 'Install vsce'
 

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -2179,7 +2179,8 @@ extends:
                   $ErrorActionPreference = 'Stop'
 
                   # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
-                  # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+                  # available in dotnet-public-npm and requires Node 22. Remove this pin after
+                  # 1.0.0 is mirrored and this job is upgraded to Node 22.
                   npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1 --registry https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
                   vsce --version
                 displayName: 'Install vsce'

--- a/eng/pipelines/templates/build_extension.yml
+++ b/eng/pipelines/templates/build_extension.yml
@@ -74,8 +74,8 @@ jobs:
           inputs:
             targetType: 'inline'
             script: |
-              # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
-              # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+              # Pin Azure Identity explicitly so VSCE's transitive dependency graph
+              # remains stable across npm feed updates.
               npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
               vsce --version
             workingDirectory: '$(Build.SourcesDirectory)'

--- a/eng/pipelines/templates/build_extension.yml
+++ b/eng/pipelines/templates/build_extension.yml
@@ -74,7 +74,9 @@ jobs:
           inputs:
             targetType: 'inline'
             script: |
-              npm install -g @vscode/vsce@3.7.1
+              # Azure Identity 4.13.2 depends on @azure/core-process, which is not yet
+              # available in dotnet-public-npm. Remove this pin after 1.0.0 is mirrored.
+              npm install -g @vscode/vsce@3.7.1 @azure/identity@4.13.1
               vsce --version
             workingDirectory: '$(Build.SourcesDirectory)'
 


### PR DESCRIPTION
## Description

Ports [internal PR 63710](https://dev.azure.com/dnceng/internal/_git/microsoft-aspire/pullrequest/63710) to `main`.

This removes the pipeline-scoped `Publish-Build-Assets` variable group. `Asset_Registry_Publish` already loads the group at job scope, so the credentials remain available where they are needed without being injected into every pipeline stage.

The internal npm mirror currently serves `@azure/identity` 4.13.2 without its quarantined `@azure/core-process` dependency. This also pins Azure Identity 4.13.1 explicitly at all four VSCE install sites so their transitive dependency graph remains stable across npm feed updates.

- Initial feed failures: [3052144](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052144), [3052233](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052233)
- Successful internal build: [3052356](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052356)

Build 3052356 completed every stage and job with no failed or canceled records. Its warning-only `partiallySucceeded` result matches the recent `main` control build. The final commit only clarifies comments and does not change the validated pipeline behavior.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No