### PR TITLE
[release/13.5] Preserve TypeSystem compatibility with older CLIs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -248,14 +248,13 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
     /// <inheritdoc />
     public RuntimeSpec GetRuntimeSpec()
     {
-        return new RuntimeSpec
+        var runtimeSpec = new RuntimeSpec
         {
             Language = LanguageId,
             DisplayName = LanguageDisplayName,
             CodeGenLanguage = CodeGenTarget,
             DetectionPatterns = s_detectionPatterns,
             ExtensionLaunchCapability = "node",
-            CertificateBundleEnvironmentVariable = CertificateBundleEnvironmentVariable,
             InstallDependencies = new CommandSpec
             {
                 Command = "npm",
@@ -293,5 +292,25 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                 [AppHostTsConfigFileName] = s_appHostTsConfigContent
             }
         };
+
+        SetCertificateBundleEnvironmentVariableIfSupported(runtimeSpec, CertificateBundleEnvironmentVariable);
+
+        return runtimeSpec;
+    }
+
+    /// <summary>
+    /// Sets the certificate bundle environment variable when the runtime contract supports it.
+    /// </summary>
+    internal static void SetCertificateBundleEnvironmentVariableIfSupported(
+        object runtimeSpec,
+        string environmentVariableName)
+    {
+        // Aspire.TypeSystem is force-shared from the installed CLI. A newer codegen assembly can
+        // therefore run against an older RuntimeSpec that has the same assembly identity but does not
+        // expose this additive property. Probe by name so the new certificate feature is skipped while
+        // the rest of code generation remains compatible.
+        runtimeSpec.GetType()
+            .GetProperty(nameof(RuntimeSpec.CertificateBundleEnvironmentVariable))
+            ?.SetValue(runtimeSpec, environmentVariableName);
     }
 }

--- a/src/Aspire.TypeSystem/Aspire.TypeSystem.csproj
+++ b/src/Aspire.TypeSystem/Aspire.TypeSystem.csproj
@@ -59,6 +59,12 @@
       package baseline validation), which flags any change to the shipped surface, forcing a
       deliberate decision about whether the change is additive (no bump) or breaking (bump).
 
+      An additive member is not automatically safe for SDK-side codegen that can run against an
+      older CLI bundle with the same frozen identity. Newer codegen must capability-probe the
+      member before invoking it; otherwise the older force-shared contract binds successfully and
+      the direct member call fails with MissingMethodException. See
+      https://github.com/microsoft/aspire/issues/19503.
+
       Only AssemblyVersion is frozen; FileVersion, InformationalVersion, and the NuGet package
       version remain build-derived so diagnostics keep real build identities. Aspire.TypeSystem is
       consumed only via ProjectReference (no PackageReference consumers), so the frozen

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -265,6 +265,18 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
     }
 
     [Fact]
+    public void SetCertificateBundleEnvironmentVariableIfSupported_IgnoresLegacyRuntimeSpec()
+    {
+        var legacyRuntimeSpec = new LegacyRuntimeSpec();
+
+        TypeScriptLanguageSupport.SetCertificateBundleEnvironmentVariableIfSupported(
+            legacyRuntimeSpec,
+            "NODE_EXTRA_CA_CERTS");
+
+        Assert.NotNull(legacyRuntimeSpec);
+    }
+
+    [Fact]
     public void Scaffold_EmitsScaffoldedEslintConfigVerbatim()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -312,5 +324,9 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
     {
         Assert.InRange(port, minInclusive, maxExclusive - 1);
         Assert.True(port < WindowsEphemeralPortMin, $"Expected port {port} to be below the Windows ephemeral range.");
+    }
+
+    private sealed class LegacyRuntimeSpec
+    {
     }
 }


### PR DESCRIPTION
Backport of #19506 to release/13.5

/cc @joperezr

## Customer Impact

TypeScript AppHosts using the 13.5 SDK/codegen fail to start under CLI 13.4.6 with a `MissingMethodException`, even though this CLI/SDK version skew is intended to remain compatible.

## Testing

`Aspire.Hosting.CodeGeneration.TypeScript.Tests` passed 100/100 on `release/13.5`. The source PR also validated physical CLI 13.4.6 and current CLI scenarios, confirming older CLIs omit `NODE_EXTRA_CA_CERTS` while current CLIs still populate it.

## Risk

Low. The change is localized to capability-probing one additive TypeSystem property; current CLIs retain existing behavior and older CLIs skip only the unsupported certificate metadata. The source PR's Java follow-up is not applicable because `release/13.5` does not contain the `CommandSpec.UpToDateCheck` feature.

## Regression?

Yes — introduced in 13.5 by #19365.
