### PR TITLE
[automated] Enable WinGet publishing by default in release pipeline

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -120,7 +120,7 @@ Before starting a release:
    | `SkipNpmRidPublish` | Set `true` if npm RID packages published but the pointer package did not. | `false` |
    | `SkipNpmPointerPublish` | Set `true` if the pointer package published but a later validation or promotion step failed. Registry validation still runs. | `false` |
    | `SkipChannelPromotion` | Set `true` if re-running after darc success. | `false` |
-   | `SkipWinGetPublish` | Set `true` if re-running after WinGet success. | `true` |
+   | `SkipWinGetPublish` | Set `true` if re-running after WinGet success. | `false` |
    | `SkipGitHubTasks` | Set `true` to skip dispatching the GH workflow. | `false` |
    | `SkipReleaseAssets` | Set `true` to skip uploading `aspire-cli-*` assets to the GitHub release. | `false` |
    | `SkipNixPackageUpdate` | Set `true` if the Nix flake update was already added to the baseline version PR. Stable releases dispatch the updater with checksums from the source build; prereleases skip it. | `false` |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -120,7 +120,7 @@ Before starting a release:
    | `SkipNpmRidPublish` | Set `true` if npm RID packages published but the pointer package did not. | `false` |
    | `SkipNpmPointerPublish` | Set `true` if the pointer package published but a later validation or promotion step failed. Registry validation still runs. | `false` |
    | `SkipChannelPromotion` | Set `true` if re-running after darc success. | `false` |
-   | `SkipWinGetPublish` | Set `true` if re-running after WinGet success. | `false` |
+   | `SkipWinGetPublish` | Set `true` if re-running a stable release after WinGet success. Prerelease releases skip WinGet automatically. | `false` |
    | `SkipGitHubTasks` | Set `true` to skip dispatching the GH workflow. | `false` |
    | `SkipReleaseAssets` | Set `true` to skip uploading `aspire-cli-*` assets to the GitHub release. | `false` |
    | `SkipNixPackageUpdate` | Set `true` if the Nix flake update was already added to the baseline version PR. Stable releases dispatch the updater with checksums from the source build; prereleases skip it. | `false` |

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -77,7 +77,7 @@ parameters:
   - name: SkipWinGetPublish
     displayName: '[Advanced] Skip WinGet Publishing (re-run after success)'
     type: boolean
-    default: true
+    default: false
 
   - name: SkipGitHubTasks
     displayName: '[Advanced] Skip GitHub Tasks dispatch (re-run after success)'

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -239,7 +239,7 @@ extends:
                   displayName: 'Publish npm Signature Sidecars'
                   targetPath: '$(Pipeline.Workspace)/npm/signatures'
                   artifactName: 'NpmSignatureArtifacts'
-                - ${{ if eq(parameters.SkipWinGetPublish, false) }}:
+                - ${{ if and(eq(parameters.SkipWinGetPublish, false), eq(parameters.IsPrerelease, false)) }}:
                   - output: pipelineArtifact
                     displayName: 'Publish WinGet Manifests'
                     targetPath: '$(Pipeline.Workspace)/installers/winget-manifests-stable'
@@ -419,7 +419,7 @@ extends:
                     downloadPath: '$(Pipeline.Workspace)/aspire-build'
                     checkDownloadedFiles: true
 
-              - ${{ if eq(parameters.SkipWinGetPublish, false) }}:
+              - ${{ if and(eq(parameters.SkipWinGetPublish, false), eq(parameters.IsPrerelease, false)) }}:
                 - download: aspire-build
                   displayName: 'Download WinGet Manifests from Source Build'
                   artifact: winget-manifests-stable
@@ -2099,7 +2099,14 @@ extends:
                   } else {
                     Write-Host " (EXECUTED)"
                   }
-                  Write-Host "║ WinGet:         (runs in parallel after this job)"
+                  Write-Host "║ WinGet:         ${{ parameters.SkipWinGetPublish }}" -NoNewline
+                  if ("${{ parameters.SkipWinGetPublish }}" -eq "true") {
+                    Write-Host " (SKIPPED)"
+                  } elseif ("${{ parameters.IsPrerelease }}" -eq "true") {
+                    Write-Host " (SKIPPED - prerelease)"
+                  } else {
+                    Write-Host " (runs in parallel after this job)"
+                  }
                   Write-Host "║ GitHub Tasks:   ${{ parameters.SkipGitHubTasks }}" -NoNewline
                   if ("${{ parameters.SkipGitHubTasks }}" -eq "true") {
                     Write-Host " (SKIPPED)"
@@ -2312,7 +2319,8 @@ extends:
             condition: |
               and(
                 in(dependencies.ReleaseJob.result, 'Succeeded', 'SucceededWithIssues'),
-                eq('${{ parameters.SkipWinGetPublish }}', 'false')
+                eq('${{ parameters.SkipWinGetPublish }}', 'false'),
+                eq('${{ parameters.IsPrerelease }}', 'false')
               )
             timeoutInMinutes: 30
             pool:

--- a/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ReleasePublishNugetPipelineTests.cs
@@ -546,6 +546,36 @@ public sealed class ReleasePublishNugetPipelineTests
     }
 
     [Fact]
+    public async Task WinGetPublishingRunsOnlyForStableReleases()
+    {
+        var pipeline = await ReadRepoFileAsync("eng/pipelines/release-publish-nuget.yml");
+
+        Assert.Equal("false", FindYamlParameterDefault(pipeline, "SkipWinGetPublish"));
+
+        const string stableReleaseGate = "${{ if and(eq(parameters.SkipWinGetPublish, false), eq(parameters.IsPrerelease, false)) }}:";
+        Assert.Equal(2, pipeline.Split(stableReleaseGate, StringSplitOptions.None).Length - 1);
+
+        var winGetJob = ExtractSection(
+            pipeline,
+            "# ===== WINGET PUBLISHING =====",
+            "# ===== STAGE 3: GITHUB TASKS =====");
+        Assert.Contains("eq('${{ parameters.SkipWinGetPublish }}', 'false')", winGetJob);
+        Assert.Contains("eq('${{ parameters.IsPrerelease }}', 'false')", winGetJob);
+
+        var releaseSummary = ExtractSection(
+            pipeline,
+            "# ===== SUMMARY =====",
+            "# ===== VS CODE EXTENSION PUBLISHING =====");
+        var winGetSummary = ExtractSection(
+            releaseSummary,
+            """Write-Host "║ WinGet:""",
+            """Write-Host "║ GitHub Tasks:""");
+        Assert.Contains("""if ("${{ parameters.SkipWinGetPublish }}" -eq "true")""", winGetSummary);
+        Assert.Contains("""elseif ("${{ parameters.IsPrerelease }}" -eq "true")""", winGetSummary);
+        Assert.Contains("Write-Host \" (SKIPPED - prerelease)\"", winGetSummary);
+    }
+
+    [Fact]
     public async Task VSCodeExtensionPublishUsesAzureCredential()
     {
         var pipeline = await ReadRepoFileAsync("eng/pipelines/release-publish-nuget.yml");


### PR DESCRIPTION
## Description

[automated] WinGet publishing is currently skipped by default in the release pipeline:

```yaml
SkipWinGetPublish: true
```

This changes the default to `false` so normal release runs publish WinGet packages. The parameter remains available to skip WinGet publishing when rerunning a release after that step has already succeeded.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
