### PR TITLE
Fix dashboard resource subscription race

### DIFF
--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -558,6 +558,7 @@ internal sealed class DashboardClient : IDashboardClient
         await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             List<ResourceViewModelChange>? changes = null;
+            ImmutableHashSet<Channel<IReadOnlyList<ResourceViewModelChange>>> resourceChannels = [];
             var shouldUpdateConnectionState = false;
 
             lock (_lock)
@@ -652,6 +653,10 @@ internal sealed class DashboardClient : IDashboardClient
                     var resolvedNames = _resourceByName.Values
                         .Select(r => ResourceViewModel.GetResourceName(r, _resourceByName));
                     ColorGenerator.Instance.ResolveAll(resolvedNames);
+
+                    // Capture subscribers atomically with the model transition. A subscriber added after this
+                    // point receives the updated model in its initial snapshot and must not also receive this change.
+                    resourceChannels = _outgoingResourceChannels;
                 }
             }
 
@@ -664,7 +669,7 @@ internal sealed class DashboardClient : IDashboardClient
 
             if (changes is not null)
             {
-                foreach (var channel in _outgoingResourceChannels)
+                foreach (var channel in resourceChannels)
                 {
                     // Channel is unbound so TryWrite always succeeds.
                     channel.Writer.TryWrite(changes);


### PR DESCRIPTION
## Description

Fixes a race between applying a resource update and notifying dashboard resource subscribers. A subscriber could register after the updated model was available but before the notification recipients were enumerated, causing it to receive both the updated initial snapshot and the stale in-flight change.

Capture the subscriber set under the same lock as the model transition, then notify that captured set after releasing the lock. Subscribers now observe each transition through either their initial snapshot or a subsequent change notification, but not both.

Validated with:

```text
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-method "*.SubscribeResources_ReplicaStoppedAtChanged_EmitsParentChange" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No