### PR TITLE
Remove flaky duplicate child log path test

### DIFF
--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1002,22 +1002,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("123", message, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public void GenerateChildLogFilePath_UsesDetachChildNamingWithoutProcessId()
-    {
-        var logsDirectory = Path.Combine(Path.GetTempPath(), "aspire-cli-tests");
-        var now = new DateTimeOffset(2026, 02, 12, 18, 00, 00, TimeSpan.Zero);
-        var timeProvider = new FixedTimeProvider(now);
-
-        var path = AppHostLauncher.GenerateChildLogFilePath(logsDirectory, timeProvider);
-        var fileName = Path.GetFileName(path);
-
-        Assert.StartsWith(logsDirectory, path, StringComparison.OrdinalIgnoreCase);
-        Assert.StartsWith("cli_20260212T180000000_detach-child_", fileName, StringComparison.Ordinal);
-        Assert.EndsWith(".log", fileName, StringComparison.Ordinal);
-        Assert.DoesNotContain($"_{Environment.ProcessId}", fileName, StringComparison.Ordinal);
-    }
-
     private sealed class ProjectFileDoesNotExistLocator : Aspire.Cli.Projects.IProjectLocator
     {
         public Task<List<AppHostProjectCandidate>> FindAppHostProjectsAsync(DirectoryInfo searchDirectory, AppHostDiscoveryScope scope, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description

The child log path test in `RunCommandTests` could fail randomly when the generated GUID began with the decimal process ID. Decimal process ID digits are valid hexadecimal digits, so searching the complete filename for `_{Environment.ProcessId}` did not reliably prove that the filename contained no process ID segment.

Remove the stale duplicate test. The owner-local `AppHostLauncherTests.GenerateChildLogFilePath_UsesDetachChildNamingWithoutProcessId` test already verifies the complete filename shape with an exact regular expression, including the 32-character hexadecimal identifier.

Validation:

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.GenerateChildLogFilePath_UsesDetachChildNamingWithoutProcessId" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (1 passed)
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (5,262 passed, 52 skipped, 0 failed)

Fixes #17243

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
