### PR TITLE
Add global Azure Front Door support for regional app stamps

### DIFF
--- a/docs/specs/manifest-spec.md
+++ b/docs/specs/manifest-spec.md
@@ -106,3 +106,44 @@ When ```dotnet run --publisher manifest``` is called on the AppHost project cont
     }
 }
 ```
+
+## Compute resource deployments
+
+Projects and containers without a deployment target use `project.v0` and `container.v0`.
+When a compute resource has one deployment target, it uses `project.v1` or `container.v1`
+and writes that target to the `deployment` property.
+
+A compute resource deployed to more than one compute environment uses `project.v2` or
+`container.v2`. Its `deployments` object is keyed by compute-environment resource name so
+publishers can preserve the environment associated with each target:
+
+```json
+{
+  "resources": {
+    "api": {
+      "type": "project.v2",
+      "path": "api/api.csproj",
+      "deployments": {
+        "east": {
+          "type": "azure.bicep.v0",
+          "path": "api-east-containerapp.module.bicep"
+        },
+        "west": {
+          "type": "azure.bicep.v0",
+          "path": "api-west-containerapp.module.bicep"
+        }
+      }
+    }
+  }
+}
+```
+
+The v2 shape requires at least two entries. Publishers must not emit a singular
+`deployment` fallback for a v2 resource because a consumer could otherwise deploy only
+one target without reporting that the topology was incomplete.
+
+## Azure Bicep scopes
+
+An `azure.bicep.v1` resource can specify a resource group, subscription, or tenant in its
+`scope` object. The value `"current"` in `scope.subscription` selects the current Azure
+subscription. Similarly, `"current"` is the only supported value for `scope.tenant`.

--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)AzureDeclaredLocation.cs" LinkBase="Shared\AzureDeclaredLocation.cs" />
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)BicepFormattingHelpers.cs" LinkBase="Shared\BicepFormattingHelpers.cs" />
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIRECOMPUTE004 // Multi-target compute environments are experimental.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -23,7 +24,7 @@ namespace Aspire.Hosting.Azure.AppContainers;
 /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete
 public class AzureContainerAppEnvironmentResource :
-    AzureProvisioningResource, IAzureComputeEnvironmentResource, IAzureContainerRegistry, IAzureDelegatedSubnetResource
+    AzureProvisioningResource, IAzureComputeEnvironmentResource, IAzureContainerRegistry, IAzureDelegatedSubnetResource, IMultiTargetComputeEnvironmentResource
 #pragma warning restore CS0618 // Type or member is obsolete
 {
     /// <inheritdoc />
@@ -206,11 +207,13 @@ public class AzureContainerAppEnvironmentResource :
         foreach (var r in appModel.GetComputeResources())
         {
             // Skip resources that are explicitly targeted to a different compute environment
-            var resourceComputeEnvironment = r.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            var resourceComputeEnvironments = r.GetComputeEnvironments();
+            if (resourceComputeEnvironments.Count > 0 && !resourceComputeEnvironments.Contains(this))
             {
                 continue;
             }
+
+            ValidateMultiTargetRegistry(r, resourceComputeEnvironments);
 
             // This step is reachable from two pipeline executions: it is RequiredBy "before-start"
             // (so it runs during AppHost startup) and it is also part of the publish/deploy DAG.
@@ -239,11 +242,67 @@ public class AzureContainerAppEnvironmentResource :
         containerAppEnvironmentContext.LogHttpsUpgradeIfNeeded();
     }
 
+    private static void ValidateMultiTargetRegistry(IResource resource, IReadOnlyList<IComputeEnvironmentResource> computeEnvironments)
+    {
+        if (computeEnvironments.Count <= 1)
+        {
+            return;
+        }
+
+        if (!resource.TryGetAnnotationsIncludingAncestorsOfType<ContainerRegistryReferenceAnnotation>(out var resourceRegistryAnnotations) ||
+            resourceRegistryAnnotations.LastOrDefault() is not { } resourceRegistry)
+        {
+            throw new DistributedApplicationException(
+                $"Resource '{resource.Name}' targets multiple Azure Container Apps environments and must select one shared registry with '.WithContainerRegistry(registryBuilder)'.");
+        }
+
+        foreach (var environment in computeEnvironments.OfType<AzureContainerAppEnvironmentResource>())
+        {
+            if (!environment.TryGetLastAnnotation<ContainerRegistryReferenceAnnotation>(out var environmentRegistry) ||
+                !ReferenceEquals(environmentRegistry.Registry, resourceRegistry.Registry))
+            {
+                throw new DistributedApplicationException(
+                    $"Resource '{resource.Name}' targets multiple Azure Container Apps environments, but environment '{environment.Name}' does not use the same explicitly configured registry. " +
+                    "Call '.WithAzureContainerRegistry(registryBuilder)' on every environment.");
+            }
+        }
+
+        var resourceGroupScopes = computeEnvironments
+            .OfType<AzureContainerAppEnvironmentResource>()
+            .Select(static environment => environment.Scope is { HasResourceGroup: true } scope
+                ? scope.ResourceGroup switch
+                {
+                    string literal => $"literal:{literal}",
+                    IManifestExpressionProvider expression => expression.ValueExpression,
+                    _ => null
+                }
+                : null)
+            .ToArray();
+        if (resourceGroupScopes.Length != computeEnvironments.Count ||
+            resourceGroupScopes.Any(static scope => scope is null) ||
+            resourceGroupScopes.Distinct(StringComparer.Ordinal).Count() != resourceGroupScopes.Length)
+        {
+            throw new DistributedApplicationException(
+                $"Resource '{resource.Name}' targets multiple Azure Container Apps environments whose container apps would share a physical name. " +
+                "Call '.WithResourceGroup(resourceGroupBuilder)' on every environment and use a distinct resource group for each.");
+        }
+    }
+
     internal bool UseAzdNamingConvention { get; set; }
 
     internal bool UseCompactResourceNaming { get; set; }
 
     internal bool UseUniqueResourceNaming { get; set; }
+
+    internal object? DeclaredLocationValue =>
+        AzureDeclaredLocation.IsSet(this)
+            ? Parameters[KnownParameters.Location]
+            : null;
+
+    internal void SetDeclaredLocation(object location)
+    {
+        AzureDeclaredLocation.Set(this, location);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether the Aspire dashboard should be included in the container app environment.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -917,6 +917,68 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
+    /// Configures the Azure location for the Container Apps environment.
+    /// </summary>
+    /// <param name="builder">The Container Apps environment builder.</param>
+    /// <param name="location">The Azure location.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// The declared location is used during publish and deploy and cannot be changed by the
+    /// development-time Azure resource command.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal withLocation dispatcher export.")]
+    [Experimental("ASPIREAZURERG001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithLocation(
+        this IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
+        string location)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(location);
+        return WithLocationCore(builder, location);
+    }
+
+    /// <summary>
+    /// Configures the Azure location for the Container Apps environment.
+    /// </summary>
+    /// <param name="builder">The Container Apps environment builder.</param>
+    /// <param name="location">The parameter containing the Azure location.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// The declared location is used during publish and deploy and cannot be changed by the
+    /// development-time Azure resource command.
+    /// </remarks>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal withLocation dispatcher export.")]
+    [Experimental("ASPIREAZURERG001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithLocation(
+        this IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
+        IResourceBuilder<ParameterResource> location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        if (!ReferenceEquals(builder.ApplicationBuilder, location.ApplicationBuilder))
+        {
+            throw new ArgumentException(
+                $"Location parameter '{location.Resource.Name}' belongs to a different distributed application builder.",
+                nameof(location));
+        }
+
+        return WithLocationCore(builder, location.Resource);
+    }
+
+    /// <summary>
+    /// Configures the Azure location for the Container Apps environment.
+    /// </summary>
+    [AspireExport("withContainerAppEnvironmentLocation", MethodName = "withLocation")]
+    [Experimental("ASPIREAZURERG001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    internal static IResourceBuilder<AzureContainerAppEnvironmentResource> WithLocationForPolyglot(
+        this IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object location) =>
+        location switch
+        {
+            string literal => builder.WithLocation(literal),
+            IResourceBuilder<ParameterResource> parameter => builder.WithLocation(parameter),
+            _ => throw new ArgumentException("Location must be a string or parameter resource builder.", nameof(location))
+        };
+
+    /// <summary>
     /// Configures the container app environment to use compact resource naming that maximally preserves
     /// the <c>uniqueString</c> suffix for length-constrained Azure resources such as storage accounts.
     /// </summary>
@@ -1194,6 +1256,7 @@ public static class AzureContainerAppExtensions
                             new StringLiteralExpression("-"),
                             new StringLiteralExpression(""));
                     }
+
                 });
         };
 
@@ -1203,5 +1266,15 @@ public static class AzureContainerAppExtensions
             builder.AddResource(resource).WithIconName("Archive");
         }
         return resource;
+    }
+
+    private static IResourceBuilder<AzureContainerAppEnvironmentResource> WithLocationCore(
+        IResourceBuilder<AzureContainerAppEnvironmentResource> builder,
+        object location)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Resource.SetDeclaredLocation(location);
+        return builder;
     }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -23,15 +23,29 @@ public class AzureContainerAppResource : AzureProvisioningResource
     /// <param name="configureInfrastructure">Callback to configure the Azure resources.</param>
     /// <param name="targetResource">The target compute resource that this Azure Container App is being created for.</param>
     public AzureContainerAppResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure, IResource targetResource)
+        : this(name, configureInfrastructure, targetResource, computeEnvironment: null)
+    {
+    }
+
+    internal AzureContainerAppResource(
+        string name,
+        Action<AzureResourceInfrastructure> configureInfrastructure,
+        IResource targetResource,
+        AzureContainerAppEnvironmentResource? computeEnvironment)
         : base(name, configureInfrastructure)
     {
         TargetResource = targetResource;
+        ComputeEnvironment = computeEnvironment;
+        var isMultiTarget = targetResource.GetComputeEnvironments().Count > 1;
+        var pipelineTargetName = isMultiTarget ? name : targetResource.Name;
 
         // Add pipeline step annotation for deploy
         Annotations.Add(new PipelineStepAnnotation((factoryContext) =>
         {
             // Get the deployment target annotation
-            var deploymentTargetAnnotation = targetResource.GetDeploymentTargetAnnotation();
+            var deploymentTargetAnnotation = computeEnvironment is null
+                ? targetResource.GetDeploymentTargetAnnotation()
+                : targetResource.GetDeploymentTargetAnnotation(computeEnvironment);
             if (deploymentTargetAnnotation is null)
             {
                 return [];
@@ -41,11 +55,16 @@ public class AzureContainerAppResource : AzureProvisioningResource
 
             var printResourceSummary = new PipelineStep
             {
-                Name = $"print-{targetResource.Name}-summary",
-                Description = $"Prints the deployment summary and URL for {targetResource.Name}.",
+                Name = $"print-{pipelineTargetName}-summary",
+                Description = isMultiTarget
+                    ? $"Prints the deployment summary and URL for {targetResource.Name} in {deploymentTargetAnnotation.ComputeEnvironment?.Name}."
+                    : $"Prints the deployment summary and URL for {targetResource.Name}.",
                 Action = async ctx =>
                 {
                     var containerAppEnv = (AzureContainerAppEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    var summaryKey = isMultiTarget
+                        ? $"{targetResource.Name} ({containerAppEnv.Name})"
+                        : targetResource.Name;
 
                     var domainValue = await containerAppEnv.ContainerAppDomain.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
                     var portalLink = await ContainerAppUrls.GetPortalLinkAsync(containerAppEnv, targetResource.Name.ToLowerInvariant(), ctx.CancellationToken).ConfigureAwait(false);
@@ -56,14 +75,14 @@ public class AzureContainerAppResource : AzureProvisioningResource
                         var summaryValue = $"[{endpoint}]({endpoint}) ({portalLink})";
 
                         ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to {summaryValue}"));
-                        ctx.Summary.Add(targetResource.Name, new MarkdownString(summaryValue));
+                        ctx.Summary.Add(summaryKey, new MarkdownString(summaryValue));
                     }
                     else
                     {
                         var summaryValue = $"No public endpoints ({portalLink})";
 
                         ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to Azure Container Apps environment **{containerAppEnv.Name}**. {summaryValue}"));
-                        ctx.Summary.Add(targetResource.Name, new MarkdownString(summaryValue));
+                        ctx.Summary.Add(summaryKey, new MarkdownString(summaryValue));
                     }
                 },
                 Tags = ["print-summary"],
@@ -72,8 +91,10 @@ public class AzureContainerAppResource : AzureProvisioningResource
 
             var deployStep = new PipelineStep
             {
-                Name = $"deploy-{targetResource.Name}",
-                Description = $"Aggregation step for deploying {targetResource.Name} to Azure Container Apps.",
+                Name = $"deploy-{pipelineTargetName}",
+                Description = isMultiTarget
+                    ? $"Aggregation step for deploying {targetResource.Name} to Azure Container Apps environment {deploymentTargetAnnotation.ComputeEnvironment?.Name}."
+                    : $"Aggregation step for deploying {targetResource.Name} to Azure Container Apps.",
                 Action = _ => Task.CompletedTask,
                 Tags = [WellKnownPipelineTags.DeployCompute]
             };
@@ -104,4 +125,15 @@ public class AzureContainerAppResource : AzureProvisioningResource
     /// Gets the target resource that this Azure Container App is being created for.
     /// </summary>
     public IResource TargetResource { get; }
+
+    internal AzureContainerAppEnvironmentResource? ComputeEnvironment { get; }
+
+    internal void ApplyEnvironmentSettings(AzureContainerAppEnvironmentResource environment)
+    {
+        Scope = environment.Scope;
+        if (environment.DeclaredLocationValue is { } declaredLocation)
+        {
+            AzureDeclaredLocation.Set(this, declaredLocation);
+        }
+    }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -4,11 +4,12 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.AppContainers;
+using Aspire.Hosting.Azure.Utils;
 using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Resources;
-using Aspire.Hosting.Azure.Utils;
 
 namespace Aspire.Hosting.Azure;
 
@@ -222,6 +223,8 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReference ep)
         {
+            ValidateRemoteInternalContainerAppEndpoint(ep);
+
             // The referenced endpoint may belong to a resource deployed to a different compute
             // environment (for example a Foundry hosted agent). In that case delegate to the owning
             // compute environment instead of looking it up in this environment's local endpoint map.
@@ -283,6 +286,8 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
 
         if (value is EndpointReferenceExpression epExpr)
         {
+            ValidateRemoteInternalContainerAppEndpoint(epExpr.Endpoint);
+
             if (ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
                 epExpr, [_containerAppEnvironmentContext.Environment], out var crossExpr))
             {
@@ -382,6 +387,24 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
         }
 
         throw new NotSupportedException("Unsupported value type " + value.GetType());
+    }
+
+    private void ValidateRemoteInternalContainerAppEndpoint(EndpointReference endpointReference)
+    {
+        if (endpointReference.EndpointAnnotation.IsExternal)
+        {
+            return;
+        }
+
+        var owningEnvironments = ComputeEnvironmentEndpointResolver.GetEffectiveComputeEnvironments(endpointReference.Resource);
+        if (owningEnvironments.OfType<AzureContainerAppEnvironmentResource>().Any() &&
+            !owningEnvironments.Contains(_containerAppEnvironmentContext.Environment))
+        {
+            throw new InvalidOperationException(
+                $"Internal endpoint '{endpointReference.EndpointName}' on resource '{endpointReference.Resource.Name}' " +
+                $"is not reachable from Azure Container Apps environment '{_containerAppEnvironmentContext.Environment.Name}'. " +
+                "Deploy the referenced resource to the same environment or expose an external endpoint.");
+        }
     }
 
     private BicepValue<string> AllocateKeyVaultSecretUriReference(IAzureKeyVaultSecretReference secretOutputReference)

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -77,10 +77,18 @@ internal sealed class ContainerAppEnvironmentContext(
             await context.ProcessResourceAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var provisioningResource = new AzureContainerAppResource(resource.Name + "-containerapp", context.BuildContainerApp, resource)
+        var deploymentTargetName = resource.GetComputeEnvironments().Count > 1
+            ? $"{resource.Name}-{Environment.Name}-containerapp"
+            : $"{resource.Name}-containerapp";
+        var provisioningResource = new AzureContainerAppResource(
+            deploymentTargetName,
+            context.BuildContainerApp,
+            resource,
+            Environment)
         {
             ProvisioningBuildOptions = provisioningOptions.ProvisioningBuildOptions
         };
+        provisioningResource.ApplyEnvironmentSettings(Environment);
 
         // Add references to any prerequisite resources to ensure they are provisioned first
         if (resource.TryGetAnnotationsOfType<DeploymentPrerequisitesAnnotation>(out var prereqs))

--- a/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
+++ b/src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)AzureDeclaredLocation.cs" LinkBase="Shared\AzureDeclaredLocation.cs" />
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)BicepFormattingHelpers.cs" LinkBase="Shared\BicepFormattingHelpers.cs" />
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -218,8 +218,8 @@ public class AzureAppServiceEnvironmentResource :
             }
 
             // Skip resources that are explicitly targeted to a different compute environment
-            var resourceComputeEnvironment = resource.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            var resourceComputeEnvironments = resource.GetComputeEnvironments();
+            if (resourceComputeEnvironments.Count > 0 && !resourceComputeEnvironments.Contains(this))
             {
                 continue;
             }

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryResource.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryResource.cs
@@ -91,6 +91,14 @@ public class AzureContainerRegistryResource : AzureProvisioningResource, IAzureC
             store))
         {
             store.Name = NameOutputReference.AsProvisioningParameter(infra);
+            if (infra.AspireResource.Scope is not null &&
+                (Scope is null || !ScopeEquals(Scope, infra.AspireResource.Scope)))
+            {
+                var registryScope = Scope ??
+                    throw new InvalidOperationException(
+                        $"Azure Container Registry '{Name}' cannot be referenced from another resource group because its Azure scope is unavailable.");
+                SetScopeProperty(store, CreateScopeExpression(registryScope, infra));
+            }
         }
 
         infra.Add(store);

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -76,8 +76,9 @@ public static class AzureFrontDoorExtensions
             };
             infrastructure.Add(profile);
 
-            // Create a separate endpoint → origin group → origin → route per WithOrigin call.
-            // This gives each backend app its own Front Door hostname.
+            // Create a separate endpoint → origin group → route per WithOrigin call.
+            // A logical resource deployed to multiple environments contributes one origin per
+            // environment to the shared group, giving the app one global Front Door hostname.
             var originAnnotations = azureResource.Annotations.OfType<AzureFrontDoorOriginAnnotation>().ToList();
             foreach (var originAnnotation in originAnnotations)
             {
@@ -89,10 +90,7 @@ public static class AzureFrontDoorExtensions
                 // Use health probe settings from the resource's probe annotations if available
                 var (probePath, probeProtocol) = GetProbeSettings(originResource);
 
-                // Resolve the hostname via the origin resource's compute environment
-                var computeEnv = GetEffectiveComputeEnvironment(originResource);
-                var hostExpression = computeEnv.GetHostAddressExpression(endpointReference);
-                var hostParam = hostExpression.AsProvisioningParameter(infrastructure, $"{originBicepId}_host");
+                var computeEnvironments = GetEffectiveComputeEnvironments(originResource);
 
                 // Endpoint
                 var endpoint = new FrontDoorEndpoint($"{originBicepId}Endpoint")
@@ -120,14 +118,34 @@ public static class AzureFrontDoorExtensions
                 };
                 infrastructure.Add(originGroup);
 
-                // Origin
-                var origin = new FrontDoorOrigin($"{originBicepId}Origin")
+                var origins = new List<FrontDoorOrigin>(computeEnvironments.Count);
+                foreach (var computeEnvironment in computeEnvironments)
                 {
-                    Parent = originGroup,
-                    HostName = hostParam,
-                    OriginHostHeader = hostParam
-                };
-                infrastructure.Add(origin);
+                    var environmentBicepId = Infrastructure.NormalizeBicepIdentifier(computeEnvironment.Name);
+                    var hostParameterName = computeEnvironments.Count == 1
+                        ? $"{originBicepId}_host"
+                        : $"{originBicepId}_{environmentBicepId}_host";
+                    var originIdentifier = computeEnvironments.Count == 1
+                        ? $"{originBicepId}Origin"
+                        : $"{originBicepId}_{environmentBicepId}Origin";
+                    var hostExpression = computeEnvironment.GetHostAddressExpression(endpointReference);
+                    var hostParameter = hostExpression.AsProvisioningParameter(infrastructure, hostParameterName);
+
+                    var origin = new FrontDoorOrigin(originIdentifier)
+                    {
+                        Parent = originGroup,
+                        HostName = hostParameter,
+                        OriginHostHeader = hostParameter
+                    };
+                    if (computeEnvironments.Count > 1)
+                    {
+                        origin.EnabledState = EnabledState.Enabled;
+                        origin.Priority = 1;
+                        origin.Weight = 1000;
+                    }
+                    infrastructure.Add(origin);
+                    origins.Add(origin);
+                }
 
                 // Route
                 var route = new FrontDoorRoute($"{originBicepId}Route")
@@ -139,9 +157,12 @@ public static class AzureFrontDoorExtensions
                     LinkToDefaultDomain = LinkToDefaultDomain.Enabled,
                     HttpsRedirect = HttpsRedirect.Enabled
                 };
-                // Route must wait for origin to be created — without this, ARM deploys
-                // the route in parallel and fails because the origin group has no origins yet.
-                route.DependsOn.Add(origin);
+                // Route must wait for every origin to be created — without this, ARM can deploy
+                // the route in parallel and fail because the origin group has no origins yet.
+                foreach (var origin in origins)
+                {
+                    route.DependsOn.Add(origin);
+                }
                 infrastructure.Add(route);
 
                 // Output the endpoint URL for this origin
@@ -160,9 +181,10 @@ public static class AzureFrontDoorExtensions
     }
 
     /// <summary>
-    /// Adds an origin (backend) to the Azure Front Door resource.
-    /// Each origin gets its own Front Door endpoint with a distinct <c>*.azurefd.net</c> hostname,
-    /// its own origin group, and a default route.
+    /// Adds a logical origin (backend) to the Azure Front Door resource.
+    /// Each logical origin gets its own Front Door endpoint with a distinct <c>*.azurefd.net</c>
+    /// hostname, origin group, and default route. When the resource targets multiple compute
+    /// environments, the origin group contains one equal-priority, equal-weight origin per environment.
     /// </summary>
     /// <typeparam name="T">The type of the resource with endpoints.</typeparam>
     /// <param name="builder">The Azure Front Door resource builder.</param>
@@ -199,11 +221,12 @@ public static class AzureFrontDoorExtensions
         return builder.WithAnnotation(new AzureFrontDoorOriginAnnotation(resource.Resource));
     }
 
-    private static IComputeEnvironmentResource GetEffectiveComputeEnvironment(IResource resource)
+    private static IReadOnlyList<IComputeEnvironmentResource> GetEffectiveComputeEnvironments(IResource resource)
     {
-        if (ComputeEnvironmentEndpointResolver.TryGetEffectiveComputeEnvironment(resource, out var computeEnvironment))
+        var computeEnvironments = ComputeEnvironmentEndpointResolver.GetEffectiveComputeEnvironments(resource);
+        if (computeEnvironments.Count > 0)
         {
-            return computeEnvironment;
+            return computeEnvironments;
         }
 
         throw new InvalidOperationException(

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorResource.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorResource.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Azure.Provisioning;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+
+#pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREPIPELINES003
 
 namespace Aspire.Hosting.Azure;
 
@@ -13,11 +18,46 @@ namespace Aspire.Hosting.Azure;
 /// fast, secure, and widely scalable web applications. It provides load balancing, SSL offloading,
 /// and application acceleration for your web applications.
 /// </remarks>
-/// <param name="name">The name of the resource.</param>
-/// <param name="configureInfrastructure">Callback to configure the Azure resources.</param>
-public class AzureFrontDoorResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
-    : AzureProvisioningResource(name, configureInfrastructure)
+public class AzureFrontDoorResource : AzureProvisioningResource
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureFrontDoorResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="configureInfrastructure">Callback to configure the Azure resources.</param>
+    public AzureFrontDoorResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
+        : base(name, configureInfrastructure)
+    {
+        Annotations.Add(new PipelineStepAnnotation(_ =>
+        {
+            var summaryStep = new PipelineStep
+            {
+                Name = $"print-frontdoor-url-{name}",
+                Description = $"Prints the Azure Front Door endpoints for {name}.",
+                Action = PrintEndpointUrlsAsync,
+                Tags = ["print-summary"],
+                RequiredBySteps = [WellKnownPipelineSteps.Deploy],
+                Resource = this
+            };
+            return summaryStep;
+        }));
+        Annotations.Add(new PipelineConfigurationAnnotation(context =>
+        {
+            var frontDoorProvisionSteps = context.GetSteps(this, WellKnownPipelineTags.ProvisionInfrastructure);
+            context.GetSteps(this, "print-summary").DependsOn(frontDoorProvisionSteps);
+
+            foreach (var deploymentTarget in Annotations
+                .OfType<AzureFrontDoorOriginAnnotation>()
+                .SelectMany(static origin => origin.Resource.GetDeploymentTargetAnnotations())
+                .Select(static annotation => annotation.DeploymentTarget)
+                .OfType<AzureBicepResource>())
+            {
+                frontDoorProvisionSteps.DependsOn(
+                    context.GetSteps(deploymentTarget, WellKnownPipelineTags.ProvisionInfrastructure));
+            }
+        }));
+    }
+
     /// <summary>
     /// Gets the endpoint URL output reference for a specific origin by its resource name.
     /// </summary>
@@ -31,5 +71,24 @@ public class AzureFrontDoorResource(string name, Action<AzureResourceInfrastruct
     {
         var normalizedName = Infrastructure.NormalizeBicepIdentifier(originResourceName);
         return new($"{normalizedName}_endpointUrl", this);
+    }
+
+    private async Task PrintEndpointUrlsAsync(PipelineStepContext context)
+    {
+        foreach (var origin in Annotations.OfType<AzureFrontDoorOriginAnnotation>())
+        {
+            var endpointUrl = await GetEndpointUrl(origin.Resource.Name)
+                .GetValueAsync(context.CancellationToken)
+                .ConfigureAwait(false) ??
+                throw new InvalidOperationException($"Azure Front Door did not produce an endpoint for origin '{origin.Resource.Name}'.");
+            context.Summary.Add(
+                $"🌐 {origin.Resource.Name}",
+                new MarkdownString($"[{endpointUrl}]({endpointUrl})"));
+        }
+
+        await context.ReportingStep.CompleteAsync(
+            "Azure Front Door endpoints are available.",
+            CompletionState.Completed,
+            context.CancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting.Azure.FrontDoor/README.md
+++ b/src/Aspire.Hosting.Azure.FrontDoor/README.md
@@ -40,6 +40,77 @@ const frontDoor = await builder.addAzureFrontDoor("frontdoor")
     .withOrigin(api);
 ```
 
+### Active-active regional deployment
+
+One logical compute resource can be deployed to several Azure Container Apps environments and
+exposed through one Front Door endpoint. The environments must use one explicitly shared Azure
+Container Registry. Add the `Aspire.Hosting.Azure.AppContainers` and
+`Aspire.Hosting.Azure.ContainerRegistry` integrations before using this scenario.
+
+**C#**
+
+```csharp
+#pragma warning disable ASPIRECOMPUTE003
+#pragma warning disable ASPIRECOMPUTE004
+#pragma warning disable ASPIREAZURERG001
+
+var registry = builder.AddAzureContainerRegistry("registry");
+
+var eastGroup = builder.AddAzureResourceGroup("app-east-rg", "eastus2");
+var westGroup = builder.AddAzureResourceGroup("app-west-rg", "westus3");
+
+var east = builder.AddAzureContainerAppEnvironment("east")
+    .WithLocation("eastus2")
+    .WithResourceGroup(eastGroup)
+    .WithAzureContainerRegistry(registry);
+
+var west = builder.AddAzureContainerAppEnvironment("west")
+    .WithLocation("westus3")
+    .WithResourceGroup(westGroup)
+    .WithAzureContainerRegistry(registry);
+
+var api = builder.AddProject<Projects.Api>("api")
+    .WithExternalHttpEndpoints()
+    .WithContainerRegistry(registry)
+    .WithComputeEnvironments([east, west]);
+
+var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+    .WithOrigin(api);
+```
+
+**TypeScript**
+
+```typescript
+const registry = await builder.addAzureContainerRegistry("registry");
+
+const eastGroup = await builder.addAzureResourceGroup("app-east-rg", "eastus2");
+const westGroup = await builder.addAzureResourceGroup("app-west-rg", "westus3");
+
+const east = await builder.addAzureContainerAppEnvironment("east")
+    .withLocation("eastus2")
+    .withResourceGroup(eastGroup)
+    .withAzureContainerRegistry(registry);
+
+const west = await builder.addAzureContainerAppEnvironment("west")
+    .withLocation("westus3")
+    .withResourceGroup(westGroup)
+    .withAzureContainerRegistry(registry);
+
+const api = await builder.addNodeApp("api", "../api", "server.js")
+    .withExternalHttpEndpoints()
+    .withContainerRegistry(registry)
+    .withComputeEnvironments([east, west]);
+
+const frontDoor = await builder.addAzureFrontDoor("frontdoor")
+    .withOrigin(api);
+```
+
+The app runs once during local development and is replicated only during publish and deploy.
+Each regional resource group is owned by Aspire and removed by `aspire destroy`. The regional
+Container Apps endpoints remain publicly reachable and can bypass Front Door. This integration
+does not automatically configure Front Door-only ingress, WAF policies, custom domains, or
+Azure Container Registry geo-replication.
+
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -59,10 +59,10 @@ public partial class AzureKubernetesEnvironmentResource
 
         foreach (var r in appModel.GetComputeResources())
         {
-            var resourceComputeEnvironment = r.GetComputeEnvironment();
+            var resourceComputeEnvironments = r.GetComputeEnvironments();
 
             // Check if this resource targets THIS AKS environment
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            if (resourceComputeEnvironments.Count > 0 && !resourceComputeEnvironments.Contains(this))
             {
                 continue;
             }

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Process\ProcessSpec.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Process\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Process\ProcessUtil.cs" />
+    <Compile Include="$(SharedDir)AzureDeclaredLocation.cs" Link="AzureDeclaredLocation.cs" />
     <Compile Include="$(SharedDir)AzurePortalUrls.cs" Link="AzurePortalUrls.cs" />
     <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="Utils\CustomResourceSnapshotExtensions.cs" />
     <Compile Include="$(SharedDir)ExceptionUtils.cs" Link="Utils\ExceptionUtils.cs" />

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -89,6 +89,14 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         {
             ProcessAzureReferences(azureReferences, parameter.Value);
         }
+        if (Scope is { } scope)
+        {
+            if (scope.HasResourceGroup)
+            {
+                ProcessAzureReferences(azureReferences, scope.ResourceGroup);
+            }
+            ProcessAzureReferences(azureReferences, scope.Subscription);
+        }
 
         return azureReferences;
     }
@@ -286,6 +294,10 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                 WriteScopeValue(context, "resourceGroup", Scope.ResourceGroup);
             }
             WriteScopeValue(context, "subscription", Scope.Subscription);
+            if (Scope.IsSubscriptionScope && Scope.Subscription is null)
+            {
+                context.Writer.WriteString("subscription", "current");
+            }
             if (Scope.IsTenantScope)
             {
                 context.Writer.WriteString("tenant", "current");

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -35,12 +35,19 @@ public sealed class AzureBicepResourceScope
 
     private AzureBicepResourceScope(ScopeKind scopeKind)
     {
-        if (scopeKind is not ScopeKind.Tenant)
+        if (scopeKind is ScopeKind.Tenant)
         {
-            throw new ArgumentOutOfRangeException(nameof(scopeKind));
+            IsTenantScope = true;
+            return;
         }
 
-        IsTenantScope = true;
+        if (scopeKind is ScopeKind.Subscription)
+        {
+            IsSubscriptionScope = true;
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(scopeKind));
     }
 
     private AzureBicepResourceScope(ScopeKind scopeKind, object subscription)
@@ -53,6 +60,16 @@ public sealed class AzureBicepResourceScope
         ArgumentNullException.ThrowIfNull(subscription);
 
         Subscription = subscription;
+        IsSubscriptionScope = true;
+    }
+
+    /// <summary>
+    /// Creates a scope for subscription-level resources in the current subscription.
+    /// </summary>
+    /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the current subscription.</returns>
+    public static AzureBicepResourceScope CreateForSubscription()
+    {
+        return new AzureBicepResourceScope(ScopeKind.Subscription);
     }
 
     /// <summary>
@@ -91,6 +108,11 @@ public sealed class AzureBicepResourceScope
     /// Gets a value indicating whether the scope targets the current tenant.
     /// </summary>
     public bool IsTenantScope { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the scope targets a subscription.
+    /// </summary>
+    public bool IsSubscriptionScope { get; }
 
     /// <summary>
     /// Gets a value indicating whether the scope targets a resource group.

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -226,13 +226,9 @@ public sealed class AzureEnvironmentResource : Resource
         var tokenCredentialProvider = context.Services.GetRequiredService<ITokenCredentialProvider>();
         var armClientProvider = context.Services.GetRequiredService<IArmClientProvider>();
 
-        // Read deployment state to find the resource group
         var azureStateSection = await deploymentStateManager.AcquireSectionAsync("Azure", context.CancellationToken).ConfigureAwait(false);
-
-        var resourceGroupName = azureStateSection.Data["ResourceGroup"]?.ToString();
         var subscriptionId = azureStateSection.Data["SubscriptionId"]?.ToString();
-
-        if (string.IsNullOrEmpty(resourceGroupName) || string.IsNullOrEmpty(subscriptionId))
+        if (string.IsNullOrEmpty(subscriptionId))
         {
             await context.ReportingStep.CompleteAsync(
                 "No Azure deployment state found. Nothing to destroy.",
@@ -241,7 +237,6 @@ public sealed class AzureEnvironmentResource : Resource
             return;
         }
 
-        // Fail fast in non-interactive mode without --yes before doing any Azure work
         var options = context.Services.GetRequiredService<IOptions<PipelineOptions>>();
         if (!options.Value.SkipConfirmation)
         {
@@ -253,86 +248,129 @@ public sealed class AzureEnvironmentResource : Resource
             }
         }
 
-        var credential = tokenCredentialProvider.TokenCredential;
-        var armClient = armClientProvider.GetArmClient(credential, subscriptionId);
-        var (subscription, _) = await armClient.GetSubscriptionAndTenantAsync(context.CancellationToken).ConfigureAwait(false);
-
-        var resourceGroups = subscription.GetResourceGroups();
-
-        IResourceGroupResource resourceGroup;
-        try
+        var resourceGroupNames = new HashSet<string>(StringComparers.AzureResourceGroupName);
+        if (azureStateSection.Data["ResourceGroup"]?.ToString() is { Length: > 0 } primaryResourceGroupName)
         {
-            var rgResponse = await resourceGroups.GetAsync(resourceGroupName, context.CancellationToken).ConfigureAwait(false);
-            resourceGroup = rgResponse.Value;
+            resourceGroupNames.Add(primaryResourceGroupName);
         }
-        catch (RequestFailedException ex) when (ex.Status == 404)
+
+        foreach (var ownedResourceGroup in context.Model.Resources.OfType<AzureResourceGroupResource>())
         {
-            // Resource group already deleted
+            var stateSection = await deploymentStateManager
+                .AcquireSectionAsync($"Azure:Deployments:{ownedResourceGroup.Name}", context.CancellationToken)
+                .ConfigureAwait(false);
+            var outputsJson = stateSection.Data[BicepUtilities.DeploymentStateOutputsKey]?.GetValue<string>();
+            var resourceGroupName = outputsJson is null
+                ? null
+                : AzureProvisioningJsonHelpers.ParseDeploymentStateJson(outputsJson)?["name"]?["value"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(resourceGroupName))
+            {
+                resourceGroupName = ownedResourceGroup.ResourceGroupName switch
+                {
+                    string literal => literal,
+                    IValueProvider valueProvider => await valueProvider.GetValueAsync(context.CancellationToken).ConfigureAwait(false),
+                    _ => null
+                };
+            }
+            if (!string.IsNullOrWhiteSpace(resourceGroupName))
+            {
+                resourceGroupNames.Add(resourceGroupName);
+            }
+            else
+            {
+                context.Logger.LogWarning(
+                    "Azure resource group {ResourceName} has no deployment output or resolvable configured name and cannot be destroyed automatically.",
+                    ownedResourceGroup.Name);
+            }
+        }
+
+        if (resourceGroupNames.Count == 0)
+        {
             await context.ReportingStep.CompleteAsync(
-                new MarkdownString($"Resource group **{resourceGroupName}** not found (already deleted)"),
+                "No Azure deployment state found. Nothing to destroy.",
                 CompletionState.Completed,
                 context.CancellationToken).ConfigureAwait(false);
             return;
         }
 
-        // Enumerate resources in the resource group so the user can see what will be destroyed
-        var resources = new List<(string Name, string ResourceType)>();
-
+        var credential = tokenCredentialProvider.TokenCredential;
+        var armClient = armClientProvider.GetArmClient(credential, subscriptionId);
+        var (subscription, _) = await armClient.GetSubscriptionAndTenantAsync(context.CancellationToken).ConfigureAwait(false);
+        var resourceGroups = subscription.GetResourceGroups();
+        var groupsToDelete = new List<(string Name, IResourceGroupResource Resource, List<(string Name, string ResourceType)> Resources)>();
+        foreach (var resourceGroupName in resourceGroupNames.Order(StringComparers.AzureResourceGroupName))
         {
+            IResourceGroupResource resourceGroup;
+            try
+            {
+                var response = await resourceGroups.GetAsync(resourceGroupName, context.CancellationToken).ConfigureAwait(false);
+                resourceGroup = response.Value;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                context.Logger.LogInformation("Resource group {ResourceGroupName} was already deleted.", resourceGroupName);
+                continue;
+            }
+
+            var resources = new List<(string Name, string ResourceType)>();
             var discoveryTask = await context.ReportingStep.CreateTaskAsync(
                 new MarkdownString($"Discovering resources in **{resourceGroupName}**"),
                 context.CancellationToken).ConfigureAwait(false);
-            await using var _ = discoveryTask.ConfigureAwait(false);
-
-            try
+            await using (discoveryTask.ConfigureAwait(false))
             {
-                await foreach (var resource in resourceGroup.GetResourcesAsync(context.CancellationToken).ConfigureAwait(false))
+                try
                 {
-                    resources.Add(resource);
-                }
+                    await foreach (var resource in resourceGroup.GetResourcesAsync(context.CancellationToken).ConfigureAwait(false))
+                    {
+                        resources.Add(resource);
+                    }
 
-                if (resources.Count == 0)
-                {
-                    await discoveryTask.CompleteAsync(
-                        new MarkdownString($"Resource group **{resourceGroupName}** is empty"),
-                        CompletionState.Completed,
-                        context.CancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
                     foreach (var (name, type) in resources)
                     {
                         var shortType = type.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase)
                             ? type["Microsoft.".Length..]
                             : type;
-                        context.Logger.LogInformation("  {Type}: {Name}", shortType, name);
+                        context.Logger.LogInformation("  {ResourceGroup}: {Type}: {Name}", resourceGroupName, shortType, name);
                     }
 
+                    var discoveryMessage = resources.Count == 0
+                        ? new MarkdownString($"Resource group **{resourceGroupName}** is empty")
+                        : new MarkdownString($"Found **{resources.Count}** resource(s) in **{resourceGroupName}**");
                     await discoveryTask.CompleteAsync(
-                        new MarkdownString($"Found **{resources.Count}** resource(s) in **{resourceGroupName}**"),
+                        discoveryMessage,
                         CompletionState.Completed,
                         context.CancellationToken).ConfigureAwait(false);
                 }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    context.Logger.LogWarning(ex, "Failed to enumerate resources in resource group {ResourceGroupName}; deletion will still be attempted.", resourceGroupName);
+                    await discoveryTask.CompleteAsync(
+                        new MarkdownString($"Could not enumerate resources in **{resourceGroupName}**; deletion will still be attempted."),
+                        CompletionState.CompletedWithWarning,
+                        context.CancellationToken).ConfigureAwait(false);
+                }
             }
-            catch (Exception ex)
-            {
-                // Non-fatal — proceed with deletion even if enumeration fails
-                context.Logger.LogWarning(ex, "Failed to enumerate resources in resource group '{ResourceGroupName}'", resourceGroupName);
-                await discoveryTask.CompleteAsync(
-                    "Could not enumerate resources (will proceed with deletion)",
-                    CompletionState.Completed,
-                    context.CancellationToken).ConfigureAwait(false);
-            }
+
+            groupsToDelete.Add((resourceGroupName, resourceGroup, resources));
         }
 
-        // Confirm destruction with the user (unless --yes was specified)
+        if (groupsToDelete.Count == 0)
+        {
+            await context.ReportingStep.CompleteAsync(
+                "All Azure resource groups were already absent.",
+                CompletionState.Completed,
+                context.CancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         if (!options.Value.SkipConfirmation)
         {
             var interactionService = context.Services.GetRequiredService<IInteractionService>();
-
-            var confirmMessage = resources.Count > 0
-                ? $"Delete resource group '{resourceGroupName}' with {resources.Count} resource(s)? This action cannot be undone."
-                : $"Delete resource group '{resourceGroupName}'? This action cannot be undone.";
+            var groupList = string.Join("', '", groupsToDelete.Select(static group => group.Name));
+            var resourceCount = groupsToDelete.Sum(static group => group.Resources.Count);
+            var confirmMessage = resourceCount > 0
+                ? $"Delete resource groups '{groupList}' with {resourceCount} resource(s) in total? This action cannot be undone."
+                : $"Delete resource groups '{groupList}'? This action cannot be undone.";
 
             var result = await interactionService.PromptNotificationAsync(
                 "Destroy Azure resources",
@@ -354,33 +392,41 @@ public sealed class AzureEnvironmentResource : Resource
             }
         }
 
-        // Delete the resource group
-        var deleteTask = await context.ReportingStep.CreateTaskAsync(
-            new MarkdownString($"Deleting resource group **{resourceGroupName}** ({resources.Count} resource(s))"),
-            context.CancellationToken).ConfigureAwait(false);
-        await using var __ = deleteTask.ConfigureAwait(false);
-
-        try
+        var deleteFailures = new List<Exception>();
+        foreach (var (resourceGroupName, resourceGroup, resources) in groupsToDelete)
         {
-            await resourceGroup.DeleteAsync(WaitUntil.Started, context.CancellationToken).ConfigureAwait(false);
-
-            var portalUrl = AzurePortalUrls.GetResourceGroupUrl(subscriptionId, resourceGroupName, subscription.TenantId);
-            context.Summary.Add("🗑️ Resource Group", new MarkdownString($"[{resourceGroupName}]({portalUrl})"));
-            context.Summary.Add("🔑 Subscription", subscriptionId);
-            context.Summary.Add("⏳ Status", new MarkdownString($"Deletion in progress. Monitor [here]({portalUrl})"));
-
-            await deleteTask.CompleteAsync(
-                new MarkdownString($"Resource group **{resourceGroupName}** deletion in progress. Monitor in the [Azure portal]({portalUrl})."),
-                CompletionState.Completed,
+            var deleteTask = await context.ReportingStep.CreateTaskAsync(
+                new MarkdownString($"Deleting resource group **{resourceGroupName}** ({resources.Count} resource(s))"),
                 context.CancellationToken).ConfigureAwait(false);
+            await using (deleteTask.ConfigureAwait(false))
+            {
+                try
+                {
+                    await resourceGroup.DeleteAsync(WaitUntil.Started, context.CancellationToken).ConfigureAwait(false);
+
+                    var portalUrl = AzurePortalUrls.GetResourceGroupUrl(subscriptionId, resourceGroupName, subscription.TenantId);
+                    context.Summary.Add($"🗑️ Resource Group {resourceGroupName}", new MarkdownString($"[{resourceGroupName}]({portalUrl})"));
+                    await deleteTask.CompleteAsync(
+                        new MarkdownString($"Resource group **{resourceGroupName}** deletion in progress. Monitor in the [Azure portal]({portalUrl})."),
+                        CompletionState.Completed,
+                        context.CancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    await deleteTask.CompleteAsync(
+                        $"Failed to delete resource group '{resourceGroupName}': {ex.Message}",
+                        CompletionState.CompletedWithError,
+                        context.CancellationToken).ConfigureAwait(false);
+                    deleteFailures.Add(new InvalidOperationException($"Failed to delete Azure resource group '{resourceGroupName}'.", ex));
+                }
+            }
         }
-        catch (Exception ex)
+
+        context.Summary.Add("🔑 Subscription", subscriptionId);
+        context.Summary.Add("⏳ Status", "Resource-group deletions are in progress.");
+        if (deleteFailures.Count > 0)
         {
-            await deleteTask.CompleteAsync(
-                $"Failed to delete resource group '{resourceGroupName}': {ex.Message}",
-                CompletionState.CompletedWithError,
-                context.CancellationToken).ConfigureAwait(false);
-            throw;
+            throw new AggregateException("One or more Azure resource groups could not be deleted.", deleteFailures);
         }
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -656,6 +656,7 @@ internal sealed class AzureProvisioningController(
         ArgumentNullException.ThrowIfNull(model);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
 
+        ThrowIfLocationFixedByApplicationModel(model, resourceName);
         ThrowIfKeyVaultLocationChangeTarget(model, resourceName);
 
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
@@ -718,6 +719,7 @@ internal sealed class AzureProvisioningController(
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
         ArgumentException.ThrowIfNullOrWhiteSpace(location);
 
+        ThrowIfLocationFixedByApplicationModel(model, resourceName);
         ThrowIfKeyVaultLocationChangeTarget(model, resourceName);
 
         location = NormalizeLocation(location, await GetLocationOptionsAsync(cancellationToken).ConfigureAwait(false));
@@ -934,8 +936,9 @@ internal sealed class AzureProvisioningController(
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
         ArgumentNullException.ThrowIfNull(context);
 
+        var model = context.Services.GetRequiredService<DistributedApplicationModel>();
         if (command == AzureResourceCommand.ChangeLocation &&
-            IsKeyVaultTarget(context.Services.GetRequiredService<DistributedApplicationModel>(), resourceName))
+            (IsKeyVaultTarget(model, resourceName) || IsLocationFixedByApplicationModel(model, resourceName)))
         {
             return ResourceCommandState.Hidden;
         }
@@ -1163,11 +1166,17 @@ internal sealed class AzureProvisioningController(
                 continue;
             }
 
-            var currentLocationOverride = preserveOverrides && preserveInferredLocationOverrides
-                ? TryGetCurrentResourceLocationOverride(bicepResource, environmentLocation)
-                : null;
+            var currentLocationOverride = !AzureDeclaredLocation.IsSet(bicepResource) &&
+                preserveOverrides &&
+                preserveInferredLocationOverrides
+                    ? TryGetCurrentResourceLocationOverride(bicepResource, environmentLocation)
+                    : null;
 
-            if (currentLocationOverride is not null)
+            if (AzureDeclaredLocation.IsSet(bicepResource))
+            {
+                // The application model owns this value; reset must preserve it.
+            }
+            else if (currentLocationOverride is not null)
             {
                 // Apply the override before clearing cached state so the next provisioning pass
                 // emits Bicep with the desired per-resource location.
@@ -1331,6 +1340,21 @@ internal sealed class AzureProvisioningController(
     {
         return GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: false)
             .Any(static resource => resource.AzureResource is IAzureKeyVaultResource);
+    }
+
+    private static bool IsLocationFixedByApplicationModel(DistributedApplicationModel model, string resourceName)
+    {
+        return GetTargetAzureResources(model, resourceName, includeAnnotationParentRelationships: false)
+            .Any(static resource => resource.AzureResource is AzureBicepResource bicepResource && AzureDeclaredLocation.IsSet(bicepResource));
+    }
+
+    private static void ThrowIfLocationFixedByApplicationModel(DistributedApplicationModel model, string resourceName)
+    {
+        if (IsLocationFixedByApplicationModel(model, resourceName))
+        {
+            throw new InvalidOperationException(
+                $"Azure resource '{resourceName}' has a location declared by the application model and cannot be moved with the change-location command.");
+        }
     }
 
     private static void ThrowIfKeyVaultLocationChangeTarget(DistributedApplicationModel model, string resourceName)
@@ -2737,6 +2761,11 @@ internal sealed class AzureProvisioningController(
     private async Task ApplyResourceOverridesAsync(IAzureResource azureResource, CancellationToken cancellationToken)
     {
         if (azureResource is not AzureBicepResource bicepResource)
+        {
+            return;
+        }
+
+        if (AzureDeclaredLocation.IsSet(bicepResource))
         {
             return;
         }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -18,6 +18,8 @@ namespace Aspire.Hosting.Azure;
 public class AzureProvisioningResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
     : AzureBicepResource(name, templateFile: $"{name}.module.bicep")
 {
+    internal virtual bool IsSubscriptionScopedInfrastructure => false;
+
     /// <summary>
     /// Callback for configuring the Azure resources.
     /// </summary>
@@ -195,13 +197,14 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
         return true;
     }
 
-    private static bool ScopeEquals(AzureBicepResourceScope expected, AzureBicepResourceScope? actual)
+    internal static bool ScopeEquals(AzureBicepResourceScope expected, AzureBicepResourceScope? actual)
     {
         return actual is not null &&
             expected.HasResourceGroup == actual.HasResourceGroup &&
             (!expected.HasResourceGroup || ScopeValueEquals(expected.ResourceGroup, actual.ResourceGroup)) &&
             ScopeValueEquals(expected.Subscription, actual.Subscription) &&
-            expected.IsTenantScope == actual.IsTenantScope;
+            expected.IsTenantScope == actual.IsTenantScope &&
+            expected.IsSubscriptionScope == actual.IsSubscriptionScope;
     }
 
     private static bool ScopeValueEquals(object? left, object? right)
@@ -214,49 +217,53 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
         return left.GetType() == right.GetType() && left.Equals(right);
     }
 
-    private static BicepValue<string> CreateScopeExpression(AzureBicepResourceScope scope, AzureResourceInfrastructure infra)
+    internal static BicepValue<string> CreateScopeExpression(AzureBicepResourceScope scope, AzureResourceInfrastructure infra)
     {
+        static BicepValue<string> GetScopeValue(object value, AzureResourceInfrastructure infrastructure) =>
+            value switch
+            {
+                string literal => literal,
+                ParameterResource parameter => parameter.AsProvisioningParameter(infrastructure),
+                BicepOutputReference output => output.AsProvisioningParameter(infrastructure),
+                _ => throw new NotSupportedException($"Scope value type '{value.GetType()}' is not supported.")
+            };
+
         if (scope.IsTenantScope)
         {
             return new FunctionCallExpression(new IdentifierExpression("tenant"));
         }
 
+        if (scope.IsSubscriptionScope && scope.Subscription is null)
+        {
+            return new FunctionCallExpression(new IdentifierExpression("subscription"));
+        }
+
         if (scope.HasResourceGroup && scope.Subscription is not null)
         {
-            return (scope.Subscription, scope.ResourceGroup) switch
-            {
-                (string subscription, string resourceGroup) => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), new StringLiteralExpression(subscription), new StringLiteralExpression(resourceGroup)),
-                (string subscription, ParameterResource resourceGroup) => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), new StringLiteralExpression(subscription), resourceGroup.AsProvisioningParameter(infra).Value.Compile()),
-                (ParameterResource subscription, string resourceGroup) => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), subscription.AsProvisioningParameter(infra).Value.Compile(), new StringLiteralExpression(resourceGroup)),
-                (ParameterResource subscription, ParameterResource resourceGroup) => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), subscription.AsProvisioningParameter(infra).Value.Compile(), resourceGroup.AsProvisioningParameter(infra).Value.Compile()),
-                _ => throw new NotSupportedException($"Scope value types '{scope.Subscription.GetType()}' and '{scope.ResourceGroup.GetType()}' are not supported.")
-            };
+            return new FunctionCallExpression(
+                new IdentifierExpression("resourceGroup"),
+                GetScopeValue(scope.Subscription, infra).Compile(),
+                GetScopeValue(scope.ResourceGroup, infra).Compile());
         }
 
         if (scope.HasResourceGroup)
         {
-            return scope.ResourceGroup switch
-            {
-                string resourceGroup => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), new StringLiteralExpression(resourceGroup)),
-                ParameterResource resourceGroup => new FunctionCallExpression(new IdentifierExpression("resourceGroup"), resourceGroup.AsProvisioningParameter(infra).Value.Compile()),
-                _ => throw new NotSupportedException($"Resource group type '{scope.ResourceGroup.GetType()}' is not supported.")
-            };
+            return new FunctionCallExpression(
+                new IdentifierExpression("resourceGroup"),
+                GetScopeValue(scope.ResourceGroup, infra).Compile());
         }
 
         if (scope.Subscription is not null)
         {
-            return scope.Subscription switch
-            {
-                string subscription => new FunctionCallExpression(new IdentifierExpression("subscription"), new StringLiteralExpression(subscription)),
-                ParameterResource subscription => new FunctionCallExpression(new IdentifierExpression("subscription"), subscription.AsProvisioningParameter(infra).Value.Compile()),
-                _ => throw new NotSupportedException($"Subscription type '{scope.Subscription.GetType()}' is not supported.")
-            };
+            return new FunctionCallExpression(
+                new IdentifierExpression("subscription"),
+                GetScopeValue(scope.Subscription, infra).Compile());
         }
 
         throw new InvalidOperationException("The Azure Bicep resource scope must specify a resource group, subscription, or tenant scope.");
     }
 
-    private static void SetScopeProperty(ProvisionableResource provisionableResource, BicepValue<string> scope)
+    internal static void SetScopeProperty(ProvisionableResource provisionableResource, BicepValue<string> scope)
     {
         // HACK: This is a dance we do to set extra properties using Azure.Provisioning
         // will be resolved if we ever get https://github.com/Azure/azure-sdk-for-net/issues/47980

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -267,10 +267,19 @@ public sealed class AzurePublishingContext(
             }
 
             var scope = resource.Scope;
+            if (scope.HasResourceGroup && ReferenceEquals(scope.ResourceGroup, environment.ResourceGroupName))
+            {
+                return new IdentifierExpression(rg.BicepIdentifier);
+            }
 
             if (scope.IsTenantScope)
             {
                 return new FunctionCallExpression(new IdentifierExpression("tenant"));
+            }
+
+            if (scope.IsSubscriptionScope && scope.Subscription is null)
+            {
+                return new FunctionCallExpression(new IdentifierExpression("subscription"));
             }
 
             if (scope.HasResourceGroup && scope.Subscription is not null)
@@ -316,10 +325,19 @@ public sealed class AzurePublishingContext(
 
             var module = moduleMap[resource];
             module.Scope = GetScopeExpression(resource);
-            module.Parameters.Add("location", locationParam);
+            var configuredLocation = resource.Parameters.GetValueOrDefault(AzureBicepResource.KnownParameters.Location);
+            var moduleLocation = configuredLocation is not null
+                    ? ResolveValue(Eval(configuredLocation))
+                    : locationParam;
+            module.Parameters.Add(AzureBicepResource.KnownParameters.Location, moduleLocation);
 
             foreach (var parameter in resource.Parameters)
             {
+                if (parameter.Key == AzureBicepResource.KnownParameters.Location)
+                {
+                    continue;
+                }
+
                 if (parameter.Key == AzureBicepResource.KnownParameters.UserPrincipalId && parameter.Value is null)
                 {
                     module.Parameters.Add(parameter.Key, principalId);
@@ -373,7 +391,11 @@ public sealed class AzurePublishingContext(
         // These include DeploymentTarget resources and any other resources that have parameters that reference bicep outputs.
         foreach (var resource in model.Resources)
         {
-            if (resource.GetDeploymentTargetAnnotation() is { } annotation && annotation.DeploymentTarget is AzureBicepResource br)
+            var deploymentTargets = resource.GetDeploymentTargetAnnotations()
+                .Select(static annotation => annotation.DeploymentTarget)
+                .OfType<AzureBicepResource>()
+                .ToArray();
+            if (deploymentTargets.Length > 0)
             {
                 // Materialize Dockerfile factory if present
                 if (resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var dockerfileBuildAnnotation) &&
@@ -391,26 +413,27 @@ public sealed class AzurePublishingContext(
                     await dockerfileBuildAnnotation.EmitDockerfileArtifactsAsync(context, resourceDockerfilePath).ConfigureAwait(false);
                 }
 
-                var task = await step.CreateTaskAsync(
-                    $"Processing deployment target {resource.Name}",
-                    cancellationToken: default
-                )
-                .ConfigureAwait(false);
+                foreach (var deploymentTarget in deploymentTargets)
+                {
+                    var task = await step.CreateTaskAsync(
+                        $"Processing deployment target {deploymentTarget.Name}",
+                        cancellationToken: default
+                    )
+                    .ConfigureAwait(false);
 
-                var moduleDirectory = outputDirectory.CreateSubdirectory(resource.Name);
+                    var artifactName = deploymentTargets.Length == 1 ? resource.Name : deploymentTarget.Name;
+                    var moduleDirectory = outputDirectory.CreateSubdirectory(artifactName);
+                    var modulePath = Path.Combine(moduleDirectory.FullName, $"{artifactName}.bicep");
+                    var file = deploymentTarget.GetBicepTemplateFile(tempDirectory);
 
-                var modulePath = Path.Combine(moduleDirectory.FullName, $"{resource.Name}.bicep");
+                    File.Copy(file.Path, modulePath, true);
+                    CaptureBicepOutputsFromParameters(deploymentTarget);
 
-                var file = br.GetBicepTemplateFile(tempDirectory);
-
-                File.Copy(file.Path, modulePath, true);
-
-                CaptureBicepOutputsFromParameters(br);
-
-                await task.SucceedAsync(
-                    $"Wrote bicep module for deployment target {resource.Name} to {modulePath}",
-                    cancellationToken: default
-                ).ConfigureAwait(false);
+                    await task.SucceedAsync(
+                        $"Wrote bicep module for deployment target {deploymentTarget.Name} to {modulePath}",
+                        cancellationToken: default
+                    ).ConfigureAwait(false);
+                }
             }
             else if (resource is IResourceWithParameters rwp && !bicepResourcesToPublish.Contains(resource))
             {

--- a/src/Aspire.Hosting.Azure/AzureResourceGroupExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceGroupExtensions.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE001 // Azure environment APIs are experimental.
+#pragma warning disable ASPIREAZURERG001 // Owned Azure resource groups are experimental.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for Azure resource groups.
+/// </summary>
+[Experimental("ASPIREAZURERG001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public static class AzureResourceGroupExtensions
+{
+    /// <summary>
+    /// Adds an Azure resource group owned by the distributed application.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the resource and the default physical resource-group name.</param>
+    /// <param name="location">The Azure location for the resource group.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal addAzureResourceGroup dispatcher export.")]
+    public static IResourceBuilder<AzureResourceGroupResource> AddAzureResourceGroup(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        string location)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(location);
+        return AddAzureResourceGroupCore(builder, name, location);
+    }
+
+    /// <summary>
+    /// Adds an Azure resource group owned by the distributed application.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the resource and the default physical resource-group name.</param>
+    /// <param name="location">The parameter containing the Azure location for the resource group.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal addAzureResourceGroup dispatcher export.")]
+    public static IResourceBuilder<AzureResourceGroupResource> AddAzureResourceGroup(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        IResourceBuilder<ParameterResource> location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        return AddAzureResourceGroupCore(builder, name, location.Resource);
+    }
+
+    /// <summary>
+    /// Adds an Azure resource group owned by the distributed application.
+    /// </summary>
+    [AspireExport("addAzureResourceGroup")]
+    internal static IResourceBuilder<AzureResourceGroupResource> AddAzureResourceGroupForPolyglot(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object location) =>
+        location switch
+        {
+            string literal => builder.AddAzureResourceGroup(name, literal),
+            IResourceBuilder<ParameterResource> parameter => builder.AddAzureResourceGroup(name, parameter),
+            _ => throw new ArgumentException("Location must be a string or parameter resource builder.", nameof(location))
+        };
+
+    /// <summary>
+    /// Configures the physical name of the Azure resource group.
+    /// </summary>
+    /// <param name="builder">The Azure resource-group builder.</param>
+    /// <param name="resourceGroupName">The physical resource-group name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal withResourceGroupName dispatcher export.")]
+    public static IResourceBuilder<AzureResourceGroupResource> WithResourceGroupName(
+        this IResourceBuilder<AzureResourceGroupResource> builder,
+        string resourceGroupName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(resourceGroupName);
+
+        ThrowIfResourceGroupAlreadyReferenced(builder.Resource);
+        builder.Resource.ResourceGroupName = resourceGroupName;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the physical name of the Azure resource group.
+    /// </summary>
+    /// <param name="builder">The Azure resource-group builder.</param>
+    /// <param name="resourceGroupName">The parameter containing the physical resource-group name.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExportIgnore(Reason = "Polyglot AppHosts use the internal withResourceGroupName dispatcher export.")]
+    public static IResourceBuilder<AzureResourceGroupResource> WithResourceGroupName(
+        this IResourceBuilder<AzureResourceGroupResource> builder,
+        IResourceBuilder<ParameterResource> resourceGroupName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resourceGroupName);
+
+        ThrowIfResourceGroupAlreadyReferenced(builder.Resource);
+        builder.Resource.ResourceGroupName = resourceGroupName.Resource;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the physical name of the Azure resource group.
+    /// </summary>
+    [AspireExport("withResourceGroupName")]
+    internal static IResourceBuilder<AzureResourceGroupResource> WithResourceGroupNameForPolyglot(
+        this IResourceBuilder<AzureResourceGroupResource> builder,
+        [AspireUnion(typeof(string), typeof(IResourceBuilder<ParameterResource>))] object resourceGroupName) =>
+        resourceGroupName switch
+        {
+            string literal => builder.WithResourceGroupName(literal),
+            IResourceBuilder<ParameterResource> parameter => builder.WithResourceGroupName(parameter),
+            _ => throw new ArgumentException("Resource-group name must be a string or parameter resource builder.", nameof(resourceGroupName))
+        };
+
+    /// <summary>
+    /// Configures an Azure Bicep resource to deploy into an Aspire-owned resource group.
+    /// </summary>
+    /// <typeparam name="T">The Azure Bicep resource type.</typeparam>
+    /// <param name="builder">The Azure Bicep resource builder.</param>
+    /// <param name="resourceGroup">The owned Azure resource group.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    [AspireExport("withOwnedAzureResourceGroup", MethodName = "withResourceGroup")]
+    public static IResourceBuilder<T> WithResourceGroup<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureResourceGroupResource> resourceGroup)
+        where T : AzureBicepResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resourceGroup);
+
+        if (!ReferenceEquals(builder.ApplicationBuilder, resourceGroup.ApplicationBuilder))
+        {
+            throw new ArgumentException(
+                $"Azure resource group '{resourceGroup.Resource.Name}' belongs to a different distributed application builder.",
+                nameof(resourceGroup));
+        }
+
+        if (builder.Resource.Scope is not null ||
+            builder.Resource.HasAnnotationOfType<ExistingAzureResourceAnnotation>())
+        {
+            throw new InvalidOperationException(
+                $"Azure resource '{builder.Resource.Name}' already has an explicit scope. Configure either the existing scope or the owned resource group, but not both.");
+        }
+
+        builder.Resource.Scope = new AzureBicepResourceScope(resourceGroup.Resource.ResourceGroupName);
+        builder.Resource.References.Add(resourceGroup.Resource);
+        resourceGroup.Resource.AddDependentResource(builder.Resource);
+        var dependencyParameterName = Infrastructure.NormalizeBicepIdentifier(
+            $"{resourceGroup.Resource.Name}_resourceGroupDependency");
+        builder.Resource.Parameters[dependencyParameterName] = resourceGroup.Resource.NameOutputReference;
+        if (!AzureDeclaredLocation.IsSet(builder.Resource))
+        {
+            AzureDeclaredLocation.Set(builder.Resource, resourceGroup.Resource.LocationOutputReference);
+        }
+        return builder;
+    }
+
+    private static IResourceBuilder<AzureResourceGroupResource> AddAzureResourceGroupCore(
+        IDistributedApplicationBuilder builder,
+        string name,
+        object location)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        builder.AddAzureProvisioning();
+        var resource = location switch
+        {
+            string literal => new AzureResourceGroupResource(name, literal),
+            ParameterResource parameter => new AzureResourceGroupResource(name, parameter),
+            _ => throw new ArgumentException($"Location type '{location.GetType()}' is not supported.", nameof(location))
+        };
+        var azureEnvironment = builder.Resources.OfType<AzureEnvironmentResource>().Single();
+        resource.ResourceGroupName = ReferenceExpression.Create($"{azureEnvironment.ResourceGroupName}-{name}");
+        return builder.ExecutionContext.IsRunMode
+            ? builder.CreateResourceBuilder(resource)
+            : builder.AddResource(resource);
+    }
+
+    private static void ThrowIfResourceGroupAlreadyReferenced(AzureResourceGroupResource resource)
+    {
+        if (resource.HasDependentResources)
+        {
+            throw new InvalidOperationException(
+                $"Azure resource group '{resource.Name}' is already referenced by another resource. " +
+                $"Configure its physical name with '{nameof(WithResourceGroupName)}' before calling '{nameof(WithResourceGroup)}'.");
+        }
+    }
+}

--- a/src/Aspire.Hosting.Azure/AzureResourceGroupResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceGroupResource.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning;
+using Azure.Provisioning.Resources;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an Azure resource group owned by the distributed application.
+/// </summary>
+/// <remarks>
+/// Use this resource to place Azure resources in a resource group other than the primary
+/// resource group used by the Azure deployment.
+/// </remarks>
+[Experimental("ASPIREAZURERG001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class AzureResourceGroupResource : AzureProvisioningResource
+{
+    private readonly HashSet<IResource> _dependentResources = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureResourceGroupResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="location">The Azure location for the resource group.</param>
+    public AzureResourceGroupResource(string name, string location)
+        : this(name, (object)location)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(location);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureResourceGroupResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="location">The parameter containing the Azure location for the resource group.</param>
+    public AzureResourceGroupResource(string name, ParameterResource location)
+        : this(name, (object)location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+    }
+
+    private AzureResourceGroupResource(string name, object location)
+        : base(name, ConfigureResourceGroupInfrastructure)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(location);
+
+        ResourceGroupName = name;
+        Location = location;
+        AzureDeclaredLocation.Set(this, location);
+        Scope = AzureBicepResourceScope.CreateForSubscription();
+    }
+
+    internal override bool IsSubscriptionScopedInfrastructure => true;
+
+    internal object ResourceGroupName { get; set; }
+
+    internal object Location { get; set; }
+
+    internal bool HasDependentResources => _dependentResources.Count > 0;
+
+    internal void AddDependentResource(IResource resource) => _dependentResources.Add(resource);
+
+    /// <summary>
+    /// Gets a reference to the provisioned resource-group name.
+    /// </summary>
+    public BicepOutputReference NameOutputReference => new("name", this);
+
+    /// <summary>
+    /// Gets a reference to the provisioned resource-group identifier.
+    /// </summary>
+    public BicepOutputReference Id => new("id", this);
+
+    /// <summary>
+    /// Gets a reference to the provisioned resource-group location.
+    /// </summary>
+    public BicepOutputReference LocationOutputReference => new("location", this);
+
+    private static void ConfigureResourceGroupInfrastructure(AzureResourceInfrastructure infrastructure)
+    {
+        var resource = (AzureResourceGroupResource)infrastructure.AspireResource;
+        var location = ToParameter(resource.Location, infrastructure, KnownParameters.Location);
+        var resourceGroupName = ToValue(resource.ResourceGroupName, infrastructure, "resourceGroupName");
+
+        var resourceGroup = new ResourceGroup(resource.GetBicepIdentifier())
+        {
+            Name = resourceGroupName,
+            Location = location
+        };
+        infrastructure.Add(resourceGroup);
+
+        infrastructure.Add(new ProvisioningOutput("name", typeof(string))
+        {
+            Value = resourceGroup.Name.ToBicepExpression()
+        });
+        infrastructure.Add(new ProvisioningOutput("id", typeof(string))
+        {
+            Value = resourceGroup.Id.ToBicepExpression()
+        });
+        infrastructure.Add(new ProvisioningOutput("location", typeof(string))
+        {
+            Value = resourceGroup.Location.ToBicepExpression()
+        });
+    }
+
+    private static BicepValue<string> ToValue(object value, AzureResourceInfrastructure infrastructure, string parameterName) =>
+        value switch
+        {
+            string literal => literal,
+            ParameterResource parameter => parameter.AsProvisioningParameter(infrastructure, parameterName),
+            IManifestExpressionProvider expression => expression.AsProvisioningParameter(infrastructure, parameterName),
+            _ => throw new NotSupportedException($"Azure resource group value type '{value.GetType()}' is not supported.")
+        };
+
+    private static ProvisioningParameter ToParameter(object value, AzureResourceInfrastructure infrastructure, string parameterName)
+    {
+        var parameter = infrastructure.GetParameters().Single(candidate => candidate.BicepIdentifier == parameterName);
+        switch (value)
+        {
+            case string literal:
+                parameter.Value = literal;
+                break;
+            case ParameterResource parameterResource:
+                parameter = parameterResource.AsProvisioningParameter(infrastructure, parameterName);
+                break;
+            default:
+                throw new NotSupportedException($"Azure resource group value type '{value.GetType()}' is not supported.");
+        }
+
+        return parameter;
+    }
+}

--- a/src/Aspire.Hosting.Azure/AzureResourceInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceInfrastructure.cs
@@ -3,6 +3,7 @@
 
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
 
 namespace Aspire.Hosting.Azure;
 
@@ -17,14 +18,23 @@ public sealed class AzureResourceInfrastructure : Infrastructure
     {
         AspireResource = resource;
 
+        if (resource.IsSubscriptionScopedInfrastructure)
+        {
+            TargetScope = DeploymentScope.Subscription;
+        }
+
         // Always add a default location parameter.
         // azd assumes there will be a location parameter for every module.
         // The Infrastructure location resolver will resolve unset Location properties to this parameter.
-        Add(new ProvisioningParameter("location", typeof(string))
+        var location = new ProvisioningParameter("location", typeof(string))
         {
-            Description = "The location for the resource(s) to be deployed.",
-            Value = BicepFunction.GetResourceGroup().Location
-        });
+            Description = "The location for the resource(s) to be deployed."
+        };
+        if (!resource.IsSubscriptionScopedInfrastructure)
+        {
+            location.Value = BicepFunction.GetResourceGroup().Location;
+        }
+        Add(location);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -581,7 +581,11 @@ internal sealed class AzureResourcePreparer(
 
     private static void ApplyExistingResourceScope(AzureBicepResource roleAssignmentResource, AzureProvisioningResource targetResource)
     {
-        if (targetResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation) &&
+        if (targetResource.Scope is { } configuredScope)
+        {
+            roleAssignmentResource.Scope = configuredScope;
+        }
+        else if (targetResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation) &&
             AzureBicepResourceScope.FromExistingResourceAnnotation(existingAnnotation) is { } scope)
         {
             roleAssignmentResource.Scope = scope;

--- a/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
@@ -91,6 +91,10 @@ internal static class BicepUtilities
             await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
         }
         await SetScopeValueAsync(scope, "subscription", targetScope.Subscription, cancellationToken).ConfigureAwait(false);
+        if (targetScope.IsSubscriptionScope && targetScope.Subscription is null)
+        {
+            scope["subscription"] = "current";
+        }
         if (targetScope.IsTenantScope)
         {
             scope["tenant"] = "current";

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -510,8 +510,7 @@ internal sealed class BicepProvisioner(
         var resourceLogger = loggerService.GetLogger(resource);
         var targetScope = BicepUtilities.GetExistingResourceScope(resource);
         var isTenantScoped = targetScope?.IsTenantScope == true;
-        var isSubscriptionScoped = !isTenantScoped &&
-            targetScope is { Subscription: not null, HasResourceGroup: false };
+        var isSubscriptionScoped = !isTenantScoped && targetScope?.IsSubscriptionScope == true;
 
         if (targetScope?.Subscription is { } existingSubscription)
         {

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -321,8 +321,8 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
         foreach (var r in appModel.GetComputeResources())
         {
             // Skip resources that are explicitly targeted to a different compute environment
-            var resourceComputeEnvironment = r.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null && resourceComputeEnvironment != this)
+            var resourceComputeEnvironments = r.GetComputeEnvironments();
+            if (resourceComputeEnvironments.Count > 0 && !resourceComputeEnvironments.Contains(this))
             {
                 continue;
             }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -460,10 +460,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             // Skip resources that are explicitly targeted to a different compute environment.
             // Also match if the resource targets a parent compute environment (e.g., AKS)
             // that owns this Kubernetes environment.
-            var resourceComputeEnvironment = r.GetComputeEnvironment();
-            if (resourceComputeEnvironment is not null &&
-                resourceComputeEnvironment != this &&
-                resourceComputeEnvironment != OwningComputeEnvironment)
+            var resourceComputeEnvironments = r.GetComputeEnvironments();
+            if (resourceComputeEnvironments.Count > 0 &&
+                !resourceComputeEnvironments.Any(environment => environment == this || environment == OwningComputeEnvironment))
             {
                 continue;
             }
@@ -471,7 +470,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             // Use the resource's actual compute environment (which may be a parent
             // like AzureKubernetesEnvironmentResource) so that GetDeploymentTargetAnnotation
             // can match it correctly during publish.
-            var computeEnvForAnnotation = resourceComputeEnvironment ?? targetComputeEnvironment;
+            var computeEnvForAnnotation = resourceComputeEnvironments
+                .SingleOrDefault(environment => environment == this || environment == OwningComputeEnvironment) ??
+                targetComputeEnvironment;
 
             // This step is reachable from two pipeline executions: it is RequiredBy
             // "before-start" (so it runs during AppHost startup) and it is also part of the

--- a/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
@@ -128,7 +128,7 @@ public sealed class RadiusEnvironmentResource : Resource, IComputeEnvironmentRes
         // Fall back to this environment's namespace when the target resolves to no Radius
         // environment: the single-environment and AKS-wrap cases share this environment's
         // namespace, so the fallback is correct there.
-        var targetNamespace = (resource.GetComputeEnvironment() as RadiusEnvironmentResource)?.Namespace ?? Namespace;
+        var targetNamespace = resource.GetComputeEnvironments().OfType<RadiusEnvironmentResource>().SingleOrDefault()?.Namespace ?? Namespace;
 
         // The Radius Kubernetes container recipe names the ClusterIP Service `{name}-{name}` (see
         // RadiusServiceDiscovery), not the bare resource name, so service discovery must address

--- a/src/Aspire.Hosting.Radius/RadiusInfrastructure.cs
+++ b/src/Aspire.Hosting.Radius/RadiusInfrastructure.cs
@@ -70,15 +70,14 @@ internal static class RadiusInfrastructure
 
         foreach (var resource in context.Model.GetComputeResources())
         {
-            var resourceComputeEnvironment = resource.GetComputeEnvironment();
+            var resourceComputeEnvironments = resource.GetComputeEnvironments();
 
             // Skip resources that are explicitly targeted to a different compute environment.
             // ValidateComputeEnvironments (a DependsOn for this step) already fails-fast on
             // untargeted resources when multiple compute environments exist, so a null value
             // here means there's exactly one compute environment in the model — which is us.
-            if (resourceComputeEnvironment is not null &&
-                resourceComputeEnvironment != environment &&
-                resourceComputeEnvironment != environment.OwningComputeEnvironment)
+            if (resourceComputeEnvironments.Count > 0 &&
+                !resourceComputeEnvironments.Any(target => target == environment || target == environment.OwningComputeEnvironment))
             {
                 continue;
             }
@@ -89,7 +88,9 @@ internal static class RadiusInfrastructure
             // matches the DeploymentTargetAnnotation by the resource's ComputeEnvironmentAnnotation,
             // so using the parent here would cause an explicitly-targeted resource to look
             // untargeted. This mirrors KubernetesEnvironmentResource's computeEnvForAnnotation.
-            var computeEnvForAnnotation = resourceComputeEnvironment ?? targetComputeEnvironment;
+            var computeEnvForAnnotation = resourceComputeEnvironments
+                .SingleOrDefault(target => target == environment || target == environment.OwningComputeEnvironment) ??
+                targetComputeEnvironment;
 
             // Skip if a target annotation for this environment already exists. Prepare steps
             // are idempotent so re-execution (e.g. during test composition) does not duplicate.

--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
+internal sealed class ComputeEnvironmentAnnotation(IReadOnlyList<IComputeEnvironmentResource> computeEnvironments) : IResourceAnnotation
 {
-    public IComputeEnvironmentResource ComputeEnvironment { get; } = computeEnvironment;
+    public IReadOnlyList<IComputeEnvironmentResource> ComputeEnvironments { get; } = computeEnvironments;
 }

--- a/src/Aspire.Hosting/ApplicationModel/IMultiTargetComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IMultiTargetComputeEnvironmentResource.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Identifies a compute environment that can deploy the same logical compute resource alongside
+/// other compute environments.
+/// </summary>
+/// <remarks>
+/// Implementations must create an environment-specific deployment target and resolve endpoint
+/// references in the context of that environment.
+/// </remarks>
+[Experimental("ASPIRECOMPUTE004", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public interface IMultiTargetComputeEnvironmentResource : IComputeEnvironmentResource
+{
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1032,6 +1032,21 @@ public static class ResourceExtensions
     }
 
     /// <summary>
+    /// Gets the compute environments that the resource is explicitly bound to.
+    /// </summary>
+    /// <param name="resource">The resource to get the compute environments for.</param>
+    /// <returns>The explicitly selected compute environments, or an empty list when the resource is unbound.</returns>
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    public static IReadOnlyList<IComputeEnvironmentResource> GetComputeEnvironments(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation)
+            ? computeEnvironmentAnnotation.ComputeEnvironments
+            : [];
+    }
+
+    /// <summary>
     /// Gets the compute environment that the resource is explicitly bound to, if any.
     /// </summary>
     /// <param name="resource">The resource to get the compute environment for.</param>
@@ -1039,11 +1054,23 @@ public static class ResourceExtensions
     [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
     public static IComputeEnvironmentResource? GetComputeEnvironment(this IResource resource)
     {
-        if (resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation))
-        {
-            return computeEnvironmentAnnotation.ComputeEnvironment;
-        }
-        return null;
+        var computeEnvironments = resource.GetComputeEnvironments();
+        return computeEnvironments.Count == 1 ? computeEnvironments[0] : null;
+    }
+
+    /// <summary>
+    /// Gets all deployment targets associated with the resource.
+    /// </summary>
+    /// <param name="resource">The resource to get deployment targets for.</param>
+    /// <returns>The deployment target annotations associated with the resource.</returns>
+    [AspireExportIgnore(Reason = "Deployment-target inspection helper — not part of the ATS surface.")]
+    public static IReadOnlyList<DeploymentTargetAnnotation> GetDeploymentTargetAnnotations(this IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return resource.TryGetAnnotationsOfType<DeploymentTargetAnnotation>(out var annotations)
+            ? annotations.ToArray()
+            : [];
     }
 
     /// <summary>
@@ -1053,47 +1080,38 @@ public static class ResourceExtensions
     [AspireExportIgnore(Reason = "Deployment target inspection helper — not part of the ATS surface.")]
     public static DeploymentTargetAnnotation? GetDeploymentTargetAnnotation(this IResource resource, IComputeEnvironmentResource? targetComputeEnvironment = null)
     {
-        IComputeEnvironmentResource? selectedComputeEnvironment = null;
-        if (resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation))
-        {
-            // If you have a ComputeEnvironmentAnnotation, it means the resource is bound to a specific compute environment.
-            // Skip the annotation if it doesn't match the specified targetComputeEnvironment.
-            if (targetComputeEnvironment is not null && targetComputeEnvironment != computeEnvironmentAnnotation.ComputeEnvironment)
-            {
-                return null;
-            }
+        ArgumentNullException.ThrowIfNull(resource);
 
-            // If the resource is bound to a specific compute environment, use that one.
-            selectedComputeEnvironment = computeEnvironmentAnnotation.ComputeEnvironment;
+        var computeEnvironments = resource.GetComputeEnvironments();
+        if (targetComputeEnvironment is not null &&
+            computeEnvironments.Count > 0 &&
+            !computeEnvironments.Contains(targetComputeEnvironment))
+        {
+            return null;
         }
 
-        if (resource.TryGetAnnotationsOfType<DeploymentTargetAnnotation>(out var deploymentTargetAnnotations))
+        var deploymentTargetAnnotations = resource.GetDeploymentTargetAnnotations();
+        if (targetComputeEnvironment is not null)
         {
-            var annotations = deploymentTargetAnnotations.ToArray();
-
-            if (selectedComputeEnvironment is not null)
-            {
-                return annotations.SingleOrDefault(a => a.ComputeEnvironment == selectedComputeEnvironment);
-            }
-
-            if (annotations.Length > 1)
-            {
-                var computeEnvironmentNames = string.Join(", ", annotations.Select(a => a.ComputeEnvironment?.Name));
-                throw new InvalidOperationException($"Resource '{resource.Name}' has multiple compute environments - '{computeEnvironmentNames}'. Please specify a single compute environment using 'WithComputeEnvironment'.");
-            }
-
-            var deploymentTargetAnnotation = annotations[0];
-
-            // If you have a DeploymentTargetAnnotation, it means the resource is bound to a specific compute environment.
-            // Skip the annotation if it doesn't match the specified targetComputeEnvironment.
-            if (targetComputeEnvironment is not null && targetComputeEnvironment != deploymentTargetAnnotation.ComputeEnvironment)
-            {
-                return null;
-            }
-
-            return deploymentTargetAnnotation;
+            return deploymentTargetAnnotations.SingleOrDefault(annotation => annotation.ComputeEnvironment == targetComputeEnvironment);
         }
-        return null;
+
+        if (computeEnvironments.Count == 1)
+        {
+            return deploymentTargetAnnotations.SingleOrDefault(annotation => annotation.ComputeEnvironment == computeEnvironments[0]);
+        }
+
+        if (computeEnvironments.Count > 1 || deploymentTargetAnnotations.Count > 1)
+        {
+            var names = computeEnvironments.Count > 1
+                ? computeEnvironments.Select(static environment => environment.Name)
+                : deploymentTargetAnnotations.Select(static annotation => annotation.ComputeEnvironment?.Name ?? "<unknown>");
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' has multiple compute environments ('{string.Join("', '", names)}'). " +
+                "Specify the compute environment when retrieving its deployment target.");
+        }
+
+        return deploymentTargetAnnotations.SingleOrDefault();
     }
 
     /// <summary>
@@ -1366,11 +1384,22 @@ public static class ResourceExtensions
             return registryAnnotation.Registry;
         }
 
-        // Try to get the container registry from DeploymentTargetAnnotation first
-        var deploymentTarget = resource.GetDeploymentTargetAnnotation();
-        if (deploymentTarget?.ContainerRegistry is not null)
+        // Try to get a common container registry from deployment targets.
+        var deploymentTargetRegistries = resource.GetDeploymentTargetAnnotations()
+            .Select(static annotation => annotation.ContainerRegistry)
+            .OfType<IContainerRegistry>()
+            .Distinct()
+            .ToArray();
+        if (deploymentTargetRegistries.Length == 1)
         {
-            return deploymentTarget.ContainerRegistry;
+            return deploymentTargetRegistries[0];
+        }
+        if (deploymentTargetRegistries.Length > 1)
+        {
+            var names = string.Join(", ", deploymentTargetRegistries.Select(static registry => registry is IResource resource ? resource.Name : registry.ToString()));
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' has deployment targets that use different container registries - '{names}'. " +
+                $"Please specify one registry with '.WithContainerRegistry(registryBuilder)'.");
         }
 
         // Fall back to RegistryTargetAnnotation (added automatically via BeforeStartEvent)

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -749,9 +749,9 @@ public class DistributedApplication : IHost, IAsyncDisposable
             {
                 // Skip resources that already have an explicit compute environment binding so we
                 // never override a developer's intentional choice.
-                if (computeResource.GetComputeEnvironment() is null)
+                if (computeResource.GetComputeEnvironments().Count == 0)
                 {
-                    computeResource.Annotations.Add(new ComputeEnvironmentAnnotation(environment));
+                    computeResource.Annotations.Add(new ComputeEnvironmentAnnotation([environment]));
                 }
             }
         }

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -266,11 +266,22 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                         continue;
                     }
 
-                    // Skip if resource has a deployment target with a ContainerRegistry set
-                    var deploymentTargetAnnotation = resource.GetDeploymentTargetAnnotation();
-                    if (deploymentTargetAnnotation?.ContainerRegistry is not null)
+                    // Skip if every deployment target that declares a registry resolves to the same registry.
+                    var deploymentTargetRegistries = resource.GetDeploymentTargetAnnotations()
+                        .Select(static annotation => annotation.ContainerRegistry)
+                        .OfType<IContainerRegistry>()
+                        .Distinct()
+                        .ToArray();
+                    if (deploymentTargetRegistries.Length == 1)
                     {
                         continue;
+                    }
+                    if (deploymentTargetRegistries.Length > 1)
+                    {
+                        var names = string.Join(", ", deploymentTargetRegistries.Select(static registry => registry is IResource resource ? resource.Name : registry.ToString()));
+                        throw new InvalidOperationException(
+                            $"Resource '{resource.Name}' has deployment targets that use different container registries - '{names}'. " +
+                            $"Please specify one registry with '.WithContainerRegistry(registryBuilder)'.");
                     }
 
                     // Check for RegistryTargetAnnotations (automatically added via BeforeStartEvent)
@@ -396,7 +407,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
         var unboundResources = model.Resources
             .OfType<IComputeResource>()
-            .Where(resource => resource.GetComputeEnvironment() is null)
+            .Where(resource => resource.GetComputeEnvironments().Count == 0)
             .ToList();
 
         if (unboundResources.Count == 0)
@@ -408,7 +419,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         var environmentNames = string.Join("', '", computeEnvironments.Select(environment => environment.Name));
         throw new InvalidOperationException(
             $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
-            $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
+            $"Specify which environment or environments each resource should target by calling 'WithComputeEnvironment' or 'WithComputeEnvironments' on the resource builder.");
     }
 
     private static void ValidateBuildOnlyContainerReferences(DistributedApplicationModel model)

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -181,21 +181,25 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
         var relativePathToProjectFile = GetManifestRelativePath(metadata.ProjectPath);
 
-        var deploymentTarget = project.GetDeploymentTargetAnnotation();
-        if (deploymentTarget is not null)
+        var deploymentTargets = project.GetDeploymentTargetAnnotations();
+        var manifestDeploymentTargets = deploymentTargets.Where(HasManifestPublishingCallback).ToArray();
+        Writer.WriteString("type", manifestDeploymentTargets.Length switch
         {
-            Writer.WriteString("type", "project.v1");
-        }
-        else
-        {
-            Writer.WriteString("type", "project.v0");
-        }
+            0 when deploymentTargets.Count == 0 => "project.v0",
+            0 => "project.v1",
+            1 => "project.v1",
+            _ => "project.v2"
+        });
 
         Writer.WriteString("path", relativePathToProjectFile);
 
-        if (deploymentTarget is not null)
+        if (manifestDeploymentTargets.Length == 1)
         {
-            await WriteDeploymentTarget(deploymentTarget).ConfigureAwait(false);
+            await WriteDeploymentTarget("deployment", manifestDeploymentTargets[0]).ConfigureAwait(false);
+        }
+        else if (manifestDeploymentTargets.Length > 1)
+        {
+            await WriteDeploymentTargets(manifestDeploymentTargets).ConfigureAwait(false);
         }
 
         WriteContainerFilesDestination(project);
@@ -207,16 +211,42 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
         WriteBindings(project);
     }
 
-    private async Task WriteDeploymentTarget(DeploymentTargetAnnotation deploymentTarget)
+    private async Task WriteDeploymentTarget(string propertyName, DeploymentTargetAnnotation deploymentTarget)
     {
-        if (deploymentTarget.DeploymentTarget.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var manifestPublishingCallbackAnnotation) &&
-            manifestPublishingCallbackAnnotation.Callback is not null)
+        Writer.WriteStartObject(propertyName);
+        await WriteDeploymentTargetBody(deploymentTarget).ConfigureAwait(false);
+        Writer.WriteEndObject();
+    }
+
+    private async Task WriteDeploymentTargets(IReadOnlyList<DeploymentTargetAnnotation> deploymentTargets)
+    {
+        Writer.WriteStartObject("deployments");
+        foreach (var deploymentTarget in deploymentTargets.OrderBy(
+            static target => target.ComputeEnvironment?.Name,
+            StringComparers.ResourceName))
         {
-            Writer.WriteStartObject("deployment");
-            await manifestPublishingCallbackAnnotation.Callback(this).ConfigureAwait(false);
+            var computeEnvironment = deploymentTarget.ComputeEnvironment ??
+                throw new InvalidOperationException("A resource with multiple deployment targets must associate each target with a compute environment.");
+            Writer.WriteStartObject(computeEnvironment.Name);
+            await WriteDeploymentTargetBody(deploymentTarget).ConfigureAwait(false);
             Writer.WriteEndObject();
         }
+        Writer.WriteEndObject();
     }
+
+    private async Task WriteDeploymentTargetBody(DeploymentTargetAnnotation deploymentTarget)
+    {
+        var manifestPublishingCallbackAnnotation = deploymentTarget.DeploymentTarget
+            .Annotations
+            .OfType<ManifestPublishingCallbackAnnotation>()
+            .Last(static annotation => annotation.Callback is not null);
+        await manifestPublishingCallbackAnnotation.Callback!(this).ConfigureAwait(false);
+    }
+
+    private static bool HasManifestPublishingCallback(DeploymentTargetAnnotation deploymentTarget) =>
+        deploymentTarget.DeploymentTarget.Annotations
+            .OfType<ManifestPublishingCallbackAnnotation>()
+            .Any(static annotation => annotation.Callback is not null);
 
     private void WriteContainerFilesDestination(IResource resource)
     {
@@ -314,11 +344,12 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     /// <exception cref="DistributedApplicationException">Thrown if the container resource does not contain a <see cref="ContainerImageAnnotation"/>.</exception>
     public async Task WriteContainerAsync(ContainerResource container)
     {
-        var deploymentTarget = container.GetDeploymentTargetAnnotation();
+        var deploymentTargets = container.GetDeploymentTargetAnnotations();
+        var manifestDeploymentTargets = deploymentTargets.Where(HasManifestPublishingCallback).ToArray();
 
         if (container.Annotations.OfType<DockerfileBuildAnnotation>().Any())
         {
-            Writer.WriteString("type", "container.v1");
+            Writer.WriteString("type", manifestDeploymentTargets.Length > 1 ? "container.v2" : "container.v1");
             WriteConnectionString(container);
             await WriteBuildContextAsync(container).ConfigureAwait(false);
         }
@@ -329,7 +360,11 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 throw new DistributedApplicationException($"Could not get the container image name for resource '{container.Name}'.");
             }
 
-            if (deploymentTarget is not null)
+            if (manifestDeploymentTargets.Length > 1)
+            {
+                Writer.WriteString("type", "container.v2");
+            }
+            else if (deploymentTargets.Count > 0)
             {
                 Writer.WriteString("type", "container.v1");
             }
@@ -342,9 +377,13 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
             Writer.WriteString("image", image);
         }
 
-        if (deploymentTarget is not null)
+        if (manifestDeploymentTargets.Length == 1)
         {
-            await WriteDeploymentTarget(deploymentTarget).ConfigureAwait(false);
+            await WriteDeploymentTarget("deployment", manifestDeploymentTargets[0]).ConfigureAwait(false);
+        }
+        else if (manifestDeploymentTargets.Length > 1)
+        {
+            await WriteDeploymentTargets(manifestDeploymentTargets).ConfigureAwait(false);
         }
 
         if (container.Entrypoint is not null)

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4756,8 +4756,102 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(computeEnvironmentResource);
 
-        builder.WithAnnotation(new ComputeEnvironmentAnnotation(computeEnvironmentResource.Resource));
-        return builder;
+        ValidateComputeEnvironmentBuilder(builder, computeEnvironmentResource, nameof(computeEnvironmentResource));
+
+        return builder.WithAnnotation(
+            new ComputeEnvironmentAnnotation([computeEnvironmentResource.Resource]),
+            ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
+    /// Configures the compute environments that deploy the compute resource.
+    /// </summary>
+    /// <typeparam name="T">The type of compute resource.</typeparam>
+    /// <param name="builder">The compute resource builder.</param>
+    /// <param name="computeEnvironmentResources">The compute environments that deploy the resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// The resource runs once during local development. The selected environments create separate
+    /// deployment targets during publish and deploy.
+    /// </remarks>
+    /// <example>
+    /// Deploy a project to two compute environments:
+    /// <code>
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///     .WithComputeEnvironments([east, west]);
+    /// </code>
+    /// </example>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder"/> or <paramref name="computeEnvironmentResources"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no compute environments are supplied, an environment is repeated, or an environment belongs to another application builder.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when any selected environment does not support multi-target compute resources.
+    /// </exception>
+    [AspireExport]
+    [Experimental("ASPIRECOMPUTE004", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static IResourceBuilder<T> WithComputeEnvironments<T>(
+        this IResourceBuilder<T> builder,
+        IReadOnlyList<IResourceBuilder<IComputeEnvironmentResource>> computeEnvironmentResources)
+        where T : IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(computeEnvironmentResources);
+
+        if (computeEnvironmentResources.Count == 0)
+        {
+            throw new ArgumentException("At least one compute environment must be specified.", nameof(computeEnvironmentResources));
+        }
+
+        var environments = new List<IComputeEnvironmentResource>(computeEnvironmentResources.Count);
+        var environmentNames = new HashSet<string>(StringComparers.ResourceName);
+
+        foreach (var computeEnvironmentResource in computeEnvironmentResources)
+        {
+            if (computeEnvironmentResource is null)
+            {
+                throw new ArgumentException("The compute environment list cannot contain null entries.", nameof(computeEnvironmentResources));
+            }
+
+            ValidateComputeEnvironmentBuilder(builder, computeEnvironmentResource, nameof(computeEnvironmentResources));
+
+            if (!environmentNames.Add(computeEnvironmentResource.Resource.Name))
+            {
+                throw new ArgumentException(
+                    $"Compute environment '{computeEnvironmentResource.Resource.Name}' was specified more than once.",
+                    nameof(computeEnvironmentResources));
+            }
+
+            environments.Add(computeEnvironmentResource.Resource);
+        }
+
+        if (environments.Count > 1 &&
+            environments.FirstOrDefault(static environment => environment is not IMultiTargetComputeEnvironmentResource) is { } unsupportedEnvironment)
+        {
+            throw new NotSupportedException(
+                $"Compute environment '{unsupportedEnvironment.Name}' does not support deploying a resource to multiple compute environments.");
+        }
+
+        return builder.WithAnnotation(
+            new ComputeEnvironmentAnnotation(environments),
+            ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    private static void ValidateComputeEnvironmentBuilder<T>(
+        IResourceBuilder<T> builder,
+        IResourceBuilder<IComputeEnvironmentResource> computeEnvironmentResource,
+        string parameterName)
+        where T : IComputeResource
+    {
+        if (!ReferenceEquals(builder.ApplicationBuilder, computeEnvironmentResource.ApplicationBuilder))
+        {
+            throw new ArgumentException(
+                $"Compute environment '{computeEnvironmentResource.Resource.Name}' belongs to a different distributed application builder.",
+                parameterName);
+        }
     }
 
     /// <summary>

--- a/src/Schema/aspire-8.0.json
+++ b/src/Schema/aspire-8.0.json
@@ -117,7 +117,7 @@
             ],
             "properties": {
               "type": {
-                "const": "container.v1"
+                "enum": [ "container.v1", "container.v2" ]
               },
               "image": {
                 "type": "string",
@@ -136,6 +136,21 @@
                     "$ref": "#/definitions/resource.azure.bicep.v1"
                   }
                 ]
+              },
+              "deployments": {
+                "type": "object",
+                "description": "Deployment targets keyed by compute-environment resource name.",
+                "minProperties": 2,
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/resource.azure.bicep.v0"
+                    },
+                    {
+                      "$ref": "#/definitions/resource.azure.bicep.v1"
+                    }
+                  ]
+                }
               },
               "args": {
                 "$ref": "#/definitions/args"
@@ -180,6 +195,37 @@
                 "$ref": "#/definitions/volumes"
               }
             },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "container.v2"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [ "deployments" ],
+                  "not": {
+                    "required": [ "deployment" ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "container.v1"
+                    }
+                  }
+                },
+                "then": {
+                  "not": {
+                    "required": [ "deployments" ]
+                  }
+                }
+              }
+            ],
             "additionalProperties": false
           },
           {
@@ -233,7 +279,7 @@
             "required": [ "type", "path" ],
             "properties": {
               "type": {
-                "const": "project.v1"
+                "enum": [ "project.v1", "project.v2" ]
               },
               "path": {
                 "type": "string",
@@ -248,6 +294,21 @@
                     "$ref": "#/definitions/resource.azure.bicep.v1"
                   }
                 ]
+              },
+              "deployments": {
+                "type": "object",
+                "description": "Deployment targets keyed by compute-environment resource name.",
+                "minProperties": 2,
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/resource.azure.bicep.v0"
+                    },
+                    {
+                      "$ref": "#/definitions/resource.azure.bicep.v1"
+                    }
+                  ]
+                }
               },
               "containerFiles": {
                 "type": "object",
@@ -280,6 +341,37 @@
                 "$ref": "#/definitions/bindings"
               }
             },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "project.v2"
+                    }
+                  }
+                },
+                "then": {
+                  "required": [ "deployments" ],
+                  "not": {
+                    "required": [ "deployment" ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "project.v1"
+                    }
+                  }
+                },
+                "then": {
+                  "not": {
+                    "required": [ "deployments" ]
+                  }
+                }
+              }
+            ],
             "additionalProperties": false
           },
           {
@@ -583,9 +675,11 @@
                     "annotated.string",
                     "container.v0",
                     "container.v1",
+                    "container.v2",
                     "dockerfile.v0",
                     "project.v0",
                     "project.v1",
+                    "project.v2",
                     "value.v0",
                     "executable.v0",
                     "azure.bicep.v0",
@@ -677,7 +771,7 @@
             },
             "subscription": {
               "type": "string",
-              "description": "The subscription identifier to deploy the resource to."
+              "description": "The subscription identifier to deploy the resource to, or \"current\" for the current subscription."
             },
             "tenant": {
               "type": "string",

--- a/src/Shared/AzureDeclaredLocation.cs
+++ b/src/Shared/AzureDeclaredLocation.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Tracks locations declared by the application model separately from mutable provisioning overrides.
+/// </summary>
+internal static class AzureDeclaredLocation
+{
+    public static bool IsSet(AzureBicepResource resource) =>
+        resource.HasAnnotationOfType<AzureDeclaredLocationAnnotation>();
+
+    public static void Set(AzureBicepResource resource, object location)
+    {
+        resource.Parameters[AzureBicepResource.KnownParameters.Location] = location;
+        resource.Annotations.Add(new AzureDeclaredLocationAnnotation());
+    }
+
+    private sealed class AzureDeclaredLocationAnnotation : IResourceAnnotation;
+}

--- a/src/Shared/ComputeEnvironmentEndpointResolver.cs
+++ b/src/Shared/ComputeEnvironmentEndpointResolver.cs
@@ -83,27 +83,27 @@ internal static class ComputeEnvironmentEndpointResolver
 
         var owningResource = endpointReferenceExpression.Endpoint.Resource;
 
-        // Resolve the compute environment the owning resource deploys to. A plain resource that is
-        // not deployed anywhere has none, so there is nothing to delegate to and the local lookup
-        // handles it.
-        if (!TryGetEffectiveComputeEnvironment(owningResource, out var owningComputeEnvironment))
+        var owningComputeEnvironments = GetEffectiveComputeEnvironments(owningResource);
+        if (owningComputeEnvironments.Count == 0)
         {
             return false;
         }
 
-        // If the owning resource deploys to one of the current publisher's compute environments, the
-        // endpoint lives in the local endpoint map. Leave resolution to the existing local lookup so
-        // generated artifacts (bicep parameters, helm values, etc.) are unchanged.
-        foreach (var current in currentComputeEnvironments)
+        if (owningComputeEnvironments.Any(owning => currentComputeEnvironments.Any(current => ReferenceEquals(current, owning))))
         {
-            if (ReferenceEquals(current, owningComputeEnvironment))
-            {
-                return false;
-            }
+            return false;
+        }
+
+        if (owningComputeEnvironments.Count > 1)
+        {
+            var names = string.Join("', '", owningComputeEnvironments.Select(static environment => environment.Name));
+            throw new InvalidOperationException(
+                $"Endpoint resource '{owningResource.Name}' targets multiple remote compute environments ('{names}'). " +
+                "The endpoint cannot be resolved without a target compute-environment context.");
         }
 
 #pragma warning disable ASPIRECOMPUTE002 // Experimental: compute environment endpoint expression
-        expression = owningComputeEnvironment.GetEndpointPropertyExpression(endpointReferenceExpression);
+        expression = owningComputeEnvironments[0].GetEndpointPropertyExpression(endpointReferenceExpression);
 #pragma warning restore ASPIRECOMPUTE002
 
         return true;
@@ -127,11 +127,39 @@ internal static class ComputeEnvironmentEndpointResolver
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        // Prefer an explicit compute environment binding, then fall back to the deployment target's
-        // compute environment. This matches how endpoint references are resolved elsewhere
-        // (Azure Front Door origins, Foundry hosted agents) so all call sites agree on "where is
-        // this resource deployed".
-        computeEnvironment = resource.GetComputeEnvironment() ?? resource.GetDeploymentTargetAnnotation()?.ComputeEnvironment;
+        var computeEnvironments = GetEffectiveComputeEnvironments(resource);
+        if (computeEnvironments.Count > 1)
+        {
+            computeEnvironment = null;
+            return false;
+        }
+
+        computeEnvironment = computeEnvironments.SingleOrDefault();
         return computeEnvironment is not null;
+    }
+
+    /// <summary>
+    /// Gets the compute environments that deploy a resource.
+    /// </summary>
+    public static IReadOnlyList<IComputeEnvironmentResource> GetEffectiveComputeEnvironments(IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var explicitlySelected = resource.GetComputeEnvironments();
+        if (explicitlySelected.Count > 0)
+        {
+            return explicitlySelected;
+        }
+
+        var environments = new List<IComputeEnvironmentResource>();
+        foreach (var environment in resource.GetDeploymentTargetAnnotations().Select(static annotation => annotation.ComputeEnvironment).OfType<IComputeEnvironmentResource>())
+        {
+            if (!environments.Any(existing => ReferenceEquals(existing, environment)))
+            {
+                environments.Add(environment);
+            }
+        }
+
+        return environments;
     }
 }

--- a/src/Shared/CrossScopeAcrPullIdentityPreparer.cs
+++ b/src/Shared/CrossScopeAcrPullIdentityPreparer.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
 #pragma warning disable ASPIREAZURE003
+#pragma warning disable ASPIREAZURERG001
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
@@ -46,7 +47,13 @@ internal static class CrossScopeAcrPullIdentityPreparer
     {
         builder.WithAnnotation(new PipelineStepAnnotation(context =>
         {
-            if (!ShouldPrepareIdentity(context.PipelineContext.ExecutionContext, builder.Resource))
+            if (!context.PipelineContext.ExecutionContext.IsPublishMode)
+            {
+                return [];
+            }
+
+            PrepareRegistryScope(builder);
+            if (!ShouldPrepareIdentity(context.PipelineContext.ExecutionContext, builder))
             {
                 return [];
             }
@@ -72,9 +79,11 @@ internal static class CrossScopeAcrPullIdentityPreparer
 
     private static bool ShouldPrepareIdentity<TEnvironment>(
         DistributedApplicationExecutionContext executionContext,
-        TEnvironment environment)
+        IResourceBuilder<TEnvironment> builder)
         where TEnvironment : IResource, IAzureComputeEnvironmentResource
     {
+        var environment = builder.Resource;
+
         // Run mode does not emit the environment Bicep that contains the problematic role assignment.
         // Adding a standalone Azure identity there would unnecessarily change the local application model.
         if (!executionContext.IsPublishMode)
@@ -89,15 +98,21 @@ internal static class CrossScopeAcrPullIdentityPreparer
         }
 
         // ContainerRegistry is evaluated late so registry replacement APIs have already selected the final registry.
-        if (environment.ContainerRegistry is not AzureContainerRegistryResource registry ||
-            !registry.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingRegistry))
+        if (environment.ContainerRegistry is not AzureContainerRegistryResource registry)
         {
             return false;
         }
 
-        // An existing registry without an explicit scope resolves in the deployment's resource group and
-        // subscription, where the current inline identity and role assignment remain valid.
-        return existingRegistry.ResourceGroup is not null || existingRegistry.Subscription is not null;
+        // An environment module in an explicit resource group cannot emit an inline role assignment
+        // against the primary-group registry. Promote the identity so a separately scoped module can
+        // create the assignment.
+        if (environment is AzureBicepResource { Scope: not null })
+        {
+            return true;
+        }
+
+        return registry.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingRegistry) &&
+            (existingRegistry.ResourceGroup is not null || existingRegistry.Subscription is not null);
     }
 
     private static void PrepareIdentity<TEnvironment>(
@@ -107,7 +122,8 @@ internal static class CrossScopeAcrPullIdentityPreparer
         Action<IResourceBuilder<AzureUserAssignedIdentityResource>>? configureIdentity)
         where TEnvironment : IResource, IAzureComputeEnvironmentResource
     {
-        if (!ShouldPrepareIdentity(context.ExecutionContext, builder.Resource) ||
+        PrepareRegistryScope(builder);
+        if (!ShouldPrepareIdentity(context.ExecutionContext, builder) ||
             builder.Resource.ContainerRegistry is not AzureContainerRegistryResource registry)
         {
             return;
@@ -124,6 +140,24 @@ internal static class CrossScopeAcrPullIdentityPreparer
         }
 
         var identity = new AzureUserAssignedIdentityResource(identityName);
+        if (builder.Resource is AzureBicepResource environmentResource)
+        {
+            identity.Scope = environmentResource.Scope;
+            foreach (var parameter in environmentResource.Parameters.Where(static parameter =>
+                parameter.Value is BicepOutputReference { Resource: AzureResourceGroupResource }))
+            {
+                identity.Parameters[parameter.Key] = parameter.Value;
+            }
+            foreach (var resourceGroup in environmentResource.References.OfType<AzureResourceGroupResource>())
+            {
+                identity.References.Add(resourceGroup);
+            }
+            if (environmentResource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.Location, out var location) &&
+                location is not null)
+            {
+                AzureDeclaredLocation.Set(identity, location);
+            }
+        }
         var identityBuilder = builder.ApplicationBuilder.CreateResourceBuilder(identity);
         identityBuilder.ConfigureInfrastructure(infrastructure =>
         {
@@ -149,5 +183,22 @@ internal static class CrossScopeAcrPullIdentityPreparer
         {
             environment.References.Add(identity);
         }
+    }
+
+    private static void PrepareRegistryScope<TEnvironment>(IResourceBuilder<TEnvironment> builder)
+        where TEnvironment : IResource, IAzureComputeEnvironmentResource
+    {
+        if (builder.Resource is not AzureBicepResource { Scope: not null } ||
+            builder.Resource.ContainerRegistry is not AzureContainerRegistryResource registry ||
+            registry.HasAnnotationOfType<ExistingAzureResourceAnnotation>() ||
+            registry.Scope is not null)
+        {
+            return;
+        }
+
+        var azureEnvironment = builder.ApplicationBuilder.Resources.OfType<AzureEnvironmentResource>().FirstOrDefault() ??
+            throw new DistributedApplicationException(
+                $"Cannot configure cross-resource-group access to Azure Container Registry '{registry.Name}' because the application model does not contain an Azure environment.");
+        registry.Scope = new AzureBicepResourceScope(azureEnvironment.ResourceGroupName);
     }
 }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
@@ -13,22 +13,21 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// </summary>
 public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
 {
-    // Timeout set to 40 minutes to allow for Azure Front Door and ACA provisioning.
-    // Full deployments can take up to 30 minutes if Azure infrastructure is backed up.
-    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+    // Two regional ACA environments plus Front Door can take longer to converge under Azure load.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(90);
 
     [Fact]
-    public async Task DeployReactTemplateWithFrontDoor()
+    public async Task DeployReactTemplateWithRegionalFrontDoor()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cts.Token, TestContext.Current.CancellationToken);
         var cancellationToken = linkedCts.Token;
 
-        await DeployReactTemplateWithFrontDoorCore(cancellationToken);
+        await DeployReactTemplateWithRegionalFrontDoorCore(cancellationToken);
     }
 
-    private async Task DeployReactTemplateWithFrontDoorCore(CancellationToken cancellationToken)
+    private async Task DeployReactTemplateWithRegionalFrontDoorCore(CancellationToken cancellationToken)
     {
         // Validate prerequisites
         var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
@@ -53,9 +52,11 @@ public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
         var startTime = DateTime.UtcNow;
         var deploymentUrls = new Dictionary<string, string>();
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("frontdoor");
+        var eastResourceGroupName = $"{resourceGroupName}-east";
+        var westResourceGroupName = $"{resourceGroupName}-west";
         var projectName = "FrontDoorApp";
 
-        output.WriteLine($"Test: {nameof(DeployReactTemplateWithFrontDoor)}");
+        output.WriteLine($"Test: {nameof(DeployReactTemplateWithRegionalFrontDoor)}");
         output.WriteLine($"Project Name: {projectName}");
         output.WriteLine($"Resource Group: {resourceGroupName}");
         output.WriteLine($"Subscription: {subscriptionId[..8]}...");
@@ -106,7 +107,12 @@ public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
 
-            // Step 6: Modify AppHost.cs to add Azure Container App Environment and Front Door
+            output.WriteLine("Step 5c: Adding Azure Container Registry hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.ContainerRegistry");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Step 6: Modify AppHost.cs to add two regional environments and one global Front Door endpoint.
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
             var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
             var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
@@ -117,11 +123,26 @@ public sealed class FrontDoorDeploymentTests(ITestOutputHelper output)
 
             // Insert Azure infrastructure before builder.Build().Run();
             var buildRunPattern = "builder.Build().Run();";
-            var replacement = """
-// Add Azure Container App Environment for deployment
-builder.AddAzureContainerAppEnvironment("aca");
+            var replacement = $$"""
+var registry = builder.AddAzureContainerRegistry("registry");
 
-// Add Azure Front Door in front of the server
+var eastGroup = builder.AddAzureResourceGroup("east-rg", "eastus2")
+    .WithResourceGroupName("{{eastResourceGroupName}}");
+var westGroup = builder.AddAzureResourceGroup("west-rg", "westus3")
+    .WithResourceGroupName("{{westResourceGroupName}}");
+
+var east = builder.AddAzureContainerAppEnvironment("east")
+    .WithLocation("eastus2")
+    .WithResourceGroup(eastGroup)
+    .WithAzureContainerRegistry(registry);
+var west = builder.AddAzureContainerAppEnvironment("west")
+    .WithLocation("westus3")
+    .WithResourceGroup(westGroup)
+    .WithAzureContainerRegistry(registry);
+
+server.WithContainerRegistry(registry)
+    .WithComputeEnvironments([east, west]);
+
 builder.AddAzureFrontDoor("frontdoor")
     .WithOrigin(server);
 
@@ -129,6 +150,7 @@ builder.Build().Run();
 """;
 
             content = content.Replace(buildRunPattern, replacement);
+            content = "#pragma warning disable ASPIRECOMPUTE003\n#pragma warning disable ASPIRECOMPUTE004\n#pragma warning disable ASPIREAZURERG001\n" + content;
             File.WriteAllText(appHostFilePath, content);
 
             output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
@@ -148,25 +170,19 @@ builder.Build().Run();
             output.WriteLine("Step 9: Starting Azure deployment with Front Door...");
             await auto.TypeAsync("aspire deploy --clear-cache");
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync(ConsoleActivityLoggerStrings.PipelineSucceeded, timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitUntilTextAsync(ConsoleActivityLoggerStrings.PipelineSucceeded, timeout: TimeSpan.FromMinutes(45));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
-            // Front Door provisioning is covered by the successful deployment above. Do not query it
-            // through `az afd` here: recent Azure CLI versions dynamically install the `cdn` extension,
-            // which can block this interactive terminal waiting for installation confirmation. Front Door
-            // HTTP checks are also intentionally skipped because DNS propagation can take 5-15 minutes.
-            output.WriteLine("Step 10: Verifying deployed ACA endpoints...");
-            await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
-                  "echo \"Resource group: $RG_NAME\" && " +
-                  "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
-                  // Check ACA endpoints (exclude internal endpoints)
-                  "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
-                  "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
+            // Use generic `az resource` queries rather than `az afd`; the latter may block while
+            // dynamically installing the CDN extension in the interactive test terminal.
+            output.WriteLine("Step 10: Verifying regional ACA endpoints and global Front Door...");
+            await auto.TypeAsync($"PRIMARY_RG=\"{resourceGroupName}\" && EAST_RG=\"{eastResourceGroupName}\" && WEST_RG=\"{westResourceGroupName}\" && " +
+                  "for rg in \"$PRIMARY_RG\" \"$EAST_RG\" \"$WEST_RG\"; do if ! az group show -n \"$rg\" &>/dev/null; then echo \"❌ Resource group $rg not found\"; exit 1; fi; done && " +
                   "failed=0 && " +
-                  // Share a single deadline across every endpoint (see the rationale comment below the
-                  // command) so the whole loop stays bounded no matter how many endpoints are returned.
                   "deadline=$(( $(date +%s) + 660 )) && " +
-                  // Verify ACA endpoints
+                  "for rg in \"$EAST_RG\" \"$WEST_RG\"; do " +
+                  "urls=$(az containerapp list -g \"$rg\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                  "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found in $rg\"; exit 1; fi; " +
                   "for url in $urls; do " +
                   "echo \"Checking ACA https://$url...\"; " +
                   "success=0; " +
@@ -177,21 +193,26 @@ builder.Build().Run();
                   "echo \"  $STATUS, retrying in 10s...\"; sleep 10; " +
                   "done; " +
                   "if [ \"$success\" -eq 0 ]; then echo \"  ❌ $url not reachable before deadline\"; failed=1; fi; " +
-                  "done && " +
-                  "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi");
+                  "done; done && " +
+                  "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more regional endpoint checks failed\"; exit 1; fi && " +
+                  "origin_count=$(az resource list -g \"$PRIMARY_RG\" --resource-type \"Microsoft.Cdn/profiles/originGroups/origins\" --query \"length(@)\" -o tsv) && " +
+                  "if [ \"$origin_count\" -lt 2 ]; then echo \"❌ Expected two Front Door origins, found $origin_count\"; exit 1; fi && " +
+                  "fd_host=$(az resource list -g \"$PRIMARY_RG\" --resource-type \"Microsoft.Cdn/profiles/afdEndpoints\" --query \"[0].properties.hostName\" -o tsv) && " +
+                  "if [ -z \"$fd_host\" ]; then echo \"❌ Front Door endpoint not found\"; exit 1; fi && " +
+                  "echo \"Checking Front Door https://$fd_host...\" && success=0 && deadline=$(( $(date +%s) + 900 )) && " +
+                  "while true; do STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$fd_host\" --max-time 30 2>/dev/null); " +
+                  "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS\"; success=1; break; fi; " +
+                  "if [ \"$(date +%s)\" -ge \"$deadline\" ]; then break; fi; echo \"  $STATUS, retrying in 15s...\"; sleep 15; done && " +
+                  "if [ \"$success\" -eq 0 ]; then echo \"❌ Front Door endpoint did not become healthy\"; exit 1; fi");
             await auto.EnterAsync();
-            // The in-terminal verification loop above checks every external ACA endpoint, retrying each
-            // with `curl --max-time 30` + `sleep 10`. `urls` can contain more than one endpoint (for
-            // example the workload plus the Aspire dashboard), and the endpoints are checked
-            // sequentially, so a per-endpoint retry budget would let the total runtime grow with the
-            // number of endpoints. Instead the loop shares a single ~11-minute deadline across all
-            // endpoints (each still gets at least one attempt), which keeps the worst case bounded.
-            // The outer success-prompt wait must exceed that deadline plus the final in-flight
-            // `curl --max-time 30`, so 15 minutes covers it; a shorter wait would abandon a
-            // still-running (and often eventually-successful) loop and fail an otherwise healthy deploy.
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(15));
+            // Regional checks share an 11-minute deadline, then Front Door gets a separate 15-minute
+            // DNS/probe convergence budget. The outer wait covers both bounded phases.
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(30));
 
-            // Step 11: Exit terminal
+            // Step 11: Verify Aspire-owned primary and regional groups are all cleaned up.
+            await auto.AspireDestroyAsync(counter);
+
+            // Step 12: Exit terminal
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 
@@ -201,7 +222,7 @@ builder.Build().Run();
             output.WriteLine($"Deployment completed in {duration}");
 
             DeploymentReporter.ReportDeploymentSuccess(
-                nameof(DeployReactTemplateWithFrontDoor),
+                nameof(DeployReactTemplateWithRegionalFrontDoor),
                 resourceGroupName,
                 deploymentUrls,
                 duration);
@@ -214,7 +235,7 @@ builder.Build().Run();
             output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
 
             DeploymentReporter.ReportDeploymentFailure(
-                nameof(DeployReactTemplateWithFrontDoor),
+                nameof(DeployReactTemplateWithRegionalFrontDoor),
                 resourceGroupName,
                 ex.Message,
                 ex.StackTrace);
@@ -225,6 +246,8 @@ builder.Build().Run();
         {
             output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
             TriggerCleanupResourceGroup(resourceGroupName, output);
+            TriggerCleanupResourceGroup(eastResourceGroupName, output);
+            TriggerCleanupResourceGroup(westResourceGroupName, output);
             DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
         }
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
@@ -24,6 +24,16 @@ public class AzureBicepResourceScopeTests
     }
 
     [Fact]
+    public void CurrentSubscriptionScopeHasNoExplicitSubscription()
+    {
+        var scope = AzureBicepResourceScope.CreateForSubscription();
+
+        Assert.True(scope.IsSubscriptionScope);
+        Assert.Null(scope.Subscription);
+        Assert.False(scope.HasResourceGroup);
+    }
+
+    [Fact]
     public void ResourceGroupThrowsForTenantScope()
     {
         var scope = AzureBicepResourceScope.CreateForTenant();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECOMPUTE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIRECOMPUTE003 // Container registry targeting is experimental.
+#pragma warning disable ASPIRECOMPUTE004 // Multi-target compute environments are experimental.
+#pragma warning disable ASPIREAZURE003 // Azure role-assignment resources are experimental.
+#pragma warning disable ASPIREAZURERG001 // Owned Azure resource groups are experimental.
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREACANAMING001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -165,6 +169,33 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task InternalEndpointCannotBeReferencedAcrossContainerAppEnvironments()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var east = builder.AddAzureContainerAppEnvironment("east");
+        var west = builder.AddAzureContainerAppEnvironment("west");
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithComputeEnvironment(east);
+        var web = builder.AddProject<Project>("web", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithComputeEnvironment(west)
+            .WithReference(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var target = Assert.IsAssignableFrom<AzureProvisioningResource>(
+            web.Resource.GetDeploymentTargetAnnotation(west.Resource)?.DeploymentTarget);
+        var exception = Assert.Throws<InvalidOperationException>(target.GetBicepTemplateString);
+
+        Assert.Contains("Internal endpoint 'http' on resource 'api'", exception.Message);
+        Assert.Contains("not reachable from Azure Container Apps environment 'west'", exception.Message);
     }
 
     private static void SetFoundryProjectOutputs(AzureCognitiveServicesProjectResource project)
@@ -1888,6 +1919,239 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         await app.RunAsync();
 
         await VerifyFile(Path.Combine(workspace.Path, "aspire-manifest.json"));
+    }
+
+    [Fact]
+    public async Task LocationAndOwnedResourceGroupPropagateToContainerAppTarget()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var resourceGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var environment = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation("eastus2")
+            .WithResourceGroup(resourceGroup);
+        var api = builder.AddContainer("api", "myimage")
+            .WithComputeEnvironment(environment);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        Assert.Equal("eastus2", environment.Resource.Parameters[AzureBicepResource.KnownParameters.Location]);
+        Assert.Same(resourceGroup.Resource.ResourceGroupName, environment.Resource.Scope?.ResourceGroup);
+
+        var annotation = Assert.IsType<DeploymentTargetAnnotation>(api.Resource.GetDeploymentTargetAnnotation(environment.Resource));
+        var target = Assert.IsType<AzureContainerAppResource>(annotation.DeploymentTarget);
+        Assert.Equal("eastus2", target.Parameters[AzureBicepResource.KnownParameters.Location]);
+        Assert.Same(resourceGroup.Resource.ResourceGroupName, target.Scope?.ResourceGroup);
+    }
+
+    [Fact]
+    public async Task OwnedResourceGroupLocationIsTheDefaultContainerAppLocation()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var resourceGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var environment = builder.AddAzureContainerAppEnvironment("east")
+            .WithResourceGroup(resourceGroup);
+        var api = builder.AddContainer("api", "myimage")
+            .WithComputeEnvironment(environment);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var environmentLocation = Assert.IsType<BicepOutputReference>(
+            environment.Resource.Parameters[AzureBicepResource.KnownParameters.Location]);
+        Assert.Same(resourceGroup.Resource, environmentLocation.Resource);
+
+        var target = Assert.IsType<AzureContainerAppResource>(
+            api.Resource.GetDeploymentTargetAnnotation(environment.Resource)?.DeploymentTarget);
+        var targetLocation = Assert.IsType<BicepOutputReference>(
+            target.Parameters[AzureBicepResource.KnownParameters.Location]);
+        Assert.Same(resourceGroup.Resource, targetLocation.Resource);
+    }
+
+    [Fact]
+    public async Task OneLogicalResourceCreatesContainerAppTargetPerEnvironment()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var eastGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var westGroup = builder.AddAzureResourceGroup("west-rg", "westus3");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation("eastus2")
+            .WithResourceGroup(eastGroup)
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithLocation("westus3")
+            .WithResourceGroup(westGroup)
+            .WithAzureContainerRegistry(registry);
+        var api = builder.AddContainer("api", "myimage")
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var annotations = api.Resource.GetDeploymentTargetAnnotations();
+        Assert.Equal(2, annotations.Count);
+
+        var eastTarget = Assert.IsType<AzureContainerAppResource>(
+            Assert.Single(annotations, annotation => annotation.ComputeEnvironment == east.Resource).DeploymentTarget);
+        var westTarget = Assert.IsType<AzureContainerAppResource>(
+            Assert.Single(annotations, annotation => annotation.ComputeEnvironment == west.Resource).DeploymentTarget);
+
+        Assert.Equal("api-east-containerapp", eastTarget.Name);
+        Assert.Equal("api-west-containerapp", westTarget.Name);
+        Assert.Equal("eastus2", eastTarget.Parameters[AzureBicepResource.KnownParameters.Location]);
+        Assert.Equal("westus3", westTarget.Parameters[AzureBicepResource.KnownParameters.Location]);
+
+        var eastBicep = eastTarget.GetBicepTemplateString();
+        var westBicep = westTarget.GetBicepTemplateString();
+        Assert.Contains("name: 'api'", eastBicep);
+        Assert.Contains("name: 'api'", westBicep);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var eastIdentity = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>(), identity => identity.Name == "east-mi");
+        var westIdentity = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>(), identity => identity.Name == "west-mi");
+        Assert.Same(eastGroup.Resource.ResourceGroupName, eastIdentity.Scope?.ResourceGroup);
+        Assert.Same(westGroup.Resource.ResourceGroupName, westIdentity.Scope?.ResourceGroup);
+        Assert.Contains(model.Resources.OfType<AzureRoleAssignmentResource>(), roleAssignment => roleAssignment.Name == "east-mi-roles-registry");
+        Assert.Contains(model.Resources.OfType<AzureRoleAssignmentResource>(), roleAssignment => roleAssignment.Name == "west-mi-roles-registry");
+
+        var eastEnvironmentBicep = east.Resource.GetBicepTemplateString();
+        Assert.Contains("param resourceGroupName string", eastEnvironmentBicep);
+        Assert.Contains("scope: resourceGroup(resourceGroupName)", eastEnvironmentBicep);
+
+        var manifest = await ManifestUtils.GetManifest(api.Resource);
+        Assert.Equal("container.v2", manifest["type"]!.GetValue<string>());
+        var deployments = Assert.IsType<JsonObject>(manifest["deployments"]);
+        Assert.Equal("api-east-containerapp.module.bicep", deployments["east"]!["path"]!.GetValue<string>());
+        Assert.Equal("api-west-containerapp.module.bicep", deployments["west"]!["path"]!.GetValue<string>());
+        Assert.Null(manifest["deployment"]);
+    }
+
+    [Fact]
+    public async Task MultiEnvironmentResourceRequiresExplicitSharedRegistry()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var east = builder.AddAzureContainerAppEnvironment("east");
+        var west = builder.AddAzureContainerAppEnvironment("west");
+        builder.AddContainer("api", "myimage")
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => ExecuteBeforeStartHooksAsync(app, default));
+
+        Assert.Contains("must select one shared registry", exception.Message);
+    }
+
+    [Fact]
+    public async Task MultiEnvironmentResourceRejectsDifferentEnvironmentRegistry()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var otherRegistry = builder.AddAzureContainerRegistry("other-registry");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithAzureContainerRegistry(otherRegistry);
+        builder.AddContainer("api", "myimage")
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => ExecuteBeforeStartHooksAsync(app, default));
+
+        Assert.Contains("environment 'west' does not use the same explicitly configured registry", exception.Message);
+    }
+
+    [Fact]
+    public async Task MultiEnvironmentResourceRequiresDistinctResourceGroups()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithAzureContainerRegistry(registry);
+        builder.AddContainer("api", "myimage")
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => ExecuteBeforeStartHooksAsync(app, default));
+
+        Assert.Contains("use a distinct resource group for each", exception.Message);
+    }
+
+    [Fact]
+    public async Task ProjectWithMultipleEnvironmentTargetsUsesProjectV2Manifest()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var eastGroup = builder.AddAzureResourceGroup("project-east-rg", "eastus2");
+        var westGroup = builder.AddAzureResourceGroup("project-west-rg", "westus3");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithResourceGroup(eastGroup)
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithResourceGroup(westGroup)
+            .WithAzureContainerRegistry(registry);
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var manifest = await ManifestUtils.GetManifest(api.Resource);
+        Assert.Equal("project.v2", manifest["type"]!.GetValue<string>());
+        var deployments = Assert.IsType<JsonObject>(manifest["deployments"]);
+        Assert.Equal(2, deployments.Count);
+        Assert.NotNull(deployments["east"]);
+        Assert.NotNull(deployments["west"]);
+    }
+
+    [Fact]
+    public void WithLocationSupportsParameterResource()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var location = builder.AddParameter("east-location");
+        var environment = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation(location);
+
+        Assert.Same(location.Resource, environment.Resource.Parameters[AzureBicepResource.KnownParameters.Location]);
+    }
+
+    [Fact]
+    public async Task DeclaredLocationCannotBeChangedByProvisioningCommand()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation("eastus2");
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var controller = app.Services.GetRequiredService<AzureProvisioningController>();
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => controller.ChangeResourceLocationAsync(model, environment.Resource.Name));
+
+        Assert.Contains("location declared by the application model", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -8,6 +8,7 @@
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIRECONTAINERRUNTIME001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREAZURERG001 // Owned Azure resource groups are experimental.
 
 using System.Text.Json.Nodes;
 using Azure.Core;
@@ -2005,6 +2006,73 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Verify the resource group was actually deleted via ARM
         Assert.True(testResourceGroup.WasDeleteCalled, "DeleteAsync should have been called on the resource group");
         Assert.True(testResourceGroup.WasGetResourcesCalled, "GetResourcesAsync should have been called to enumerate resources before deletion");
+    }
+
+    [Fact]
+    public async Task DestroyAsync_WithOwnedRegionalResourceGroup_DeletesAllResourceGroups()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Destroy);
+        var stateManager = new InMemoryDeploymentStateManager();
+        stateManager.SetSection("Azure", new JsonObject
+        {
+            ["ResourceGroup"] = "rg-test-destroy",
+            ["SubscriptionId"] = "12345678-1234-1234-1234-123456789012",
+            ["Location"] = "westus2"
+        });
+        stateManager.SetSection("Azure:Deployments:regional-rg", new JsonObject
+        {
+            [BicepUtilities.DeploymentStateOutputsKey] = """{"name":{"value":"rg-test-regional"}}"""
+        });
+
+        var testResourceGroup = new TestResourceGroupResource("rg-test-destroy");
+        var armClientProvider = new TestArmClientProvider(testResourceGroup);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
+        ConfigureTestServices(
+            builder,
+            bicepProvisioner: new NoOpBicepProvisioner(),
+            armClientProvider: armClientProvider,
+            activityReporter: mockActivityReporter,
+            deploymentStateManager: stateManager,
+            setDefaultProvisioningOptions: false);
+        builder.Services.Configure<PipelineOptions>(options => options.SkipConfirmation = true);
+
+        builder.AddAzureResourceGroup("regional-rg", "eastus2");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        Assert.Equal(2, testResourceGroup.DeleteCallCount);
+    }
+
+    [Fact]
+    public async Task DestroyAsync_WithConfiguredRegionalResourceGroupName_DoesNotRequireDeploymentOutput()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Destroy);
+        var stateManager = new InMemoryDeploymentStateManager();
+        stateManager.SetSection("Azure", new JsonObject
+        {
+            ["ResourceGroup"] = "rg-test-destroy",
+            ["SubscriptionId"] = "12345678-1234-1234-1234-123456789012",
+            ["Location"] = "westus2"
+        });
+
+        var testResourceGroup = new TestResourceGroupResource("rg-test-destroy");
+        var armClientProvider = new TestArmClientProvider(testResourceGroup);
+        ConfigureTestServices(
+            builder,
+            bicepProvisioner: new NoOpBicepProvisioner(),
+            armClientProvider: armClientProvider,
+            deploymentStateManager: stateManager,
+            setDefaultProvisioningOptions: false);
+        builder.Services.Configure<PipelineOptions>(options => options.SkipConfirmation = true);
+
+        builder.AddAzureResourceGroup("regional-rg", "eastus2")
+            .WithResourceGroupName("rg-test-regional");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        Assert.Equal(2, testResourceGroup.DeleteCallCount);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIRECOMPUTE003 // Container registry targeting is experimental.
+#pragma warning disable ASPIRECOMPUTE004 // Multi-target compute environments are experimental.
+#pragma warning disable ASPIREAZURERG001 // Owned Azure resource groups are experimental.
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
@@ -43,6 +46,43 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
             .AppendContentAsFile(envBicep, "bicep");
 
         workspace.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void MultiEnvironmentTargetWritesUniqueDeploymentModules()
+    {
+        using var workspace = TemporaryWorkspace.Create(output);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var eastGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var westGroup = builder.AddAzureResourceGroup("west-rg", "westus3");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation("eastus2")
+            .WithResourceGroup(eastGroup)
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithLocation("westus3")
+            .WithResourceGroup(westGroup)
+            .WithAzureContainerRegistry(registry);
+        builder.AddContainer("api", "my-api-image:latest")
+            .WithContainerRegistry(registry)
+            .WithHttpEndpoint()
+            .WithComputeEnvironments([east, west]);
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.True(File.Exists(Path.Combine(workspace.Path, "api-east-containerapp", "api-east-containerapp.bicep")));
+        Assert.True(File.Exists(Path.Combine(workspace.Path, "api-west-containerapp", "api-west-containerapp.bicep")));
+
+        var mainBicep = File.ReadAllText(Path.Combine(workspace.Path, "main.bicep"));
+        Assert.Contains("module east_rg 'east-rg/east-rg.bicep'", mainBicep);
+        Assert.Contains("module west_rg 'west-rg/west-rg.bicep'", mainBicep);
+        Assert.Contains("scope: resourceGroup('${resourceGroupName}-east-rg')", mainBicep);
+        Assert.Contains("scope: resourceGroup('${resourceGroupName}-west-rg')", mainBicep);
+        Assert.Contains("east_rg_resourceGroupDependency: east_rg.outputs.name", mainBicep);
+        Assert.Contains("west_rg_resourceGroupDependency: west_rg.outputs.name", mainBicep);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFrontDoorTests.cs
@@ -2,10 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECOMPUTE002
+#pragma warning disable ASPIRECOMPUTE003
+#pragma warning disable ASPIRECOMPUTE004
+#pragma warning disable ASPIREAZURERG001
 #pragma warning disable ASPIREPROBES001
+#pragma warning disable ASPIREPIPELINES001
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -109,6 +115,102 @@ public class AzureFrontDoorTests
         var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
 
         await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAzureFrontDoorWithReplicatedOriginGeneratesBicep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var eastGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var westGroup = builder.AddAzureResourceGroup("west-rg", "westus3");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithLocation("eastus2")
+            .WithResourceGroup(eastGroup)
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithLocation("westus3")
+            .WithResourceGroup(westGroup)
+            .WithAzureContainerRegistry(registry);
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOrigin(api);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(frontDoor.Resource);
+
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task ReplicatedOriginMakesFrontDoorProvisioningDependOnEveryTarget()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry");
+        var eastGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var westGroup = builder.AddAzureResourceGroup("west-rg", "westus3");
+        var east = builder.AddAzureContainerAppEnvironment("east")
+            .WithResourceGroup(eastGroup)
+            .WithAzureContainerRegistry(registry);
+        var west = builder.AddAzureContainerAppEnvironment("west")
+            .WithResourceGroup(westGroup)
+            .WithAzureContainerRegistry(registry);
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpsEndpoint()
+            .WithExternalHttpEndpoints()
+            .WithContainerRegistry(registry)
+            .WithComputeEnvironments([east, west]);
+        var frontDoor = builder.AddAzureFrontDoor("frontdoor")
+            .WithOrigin(api);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var targets = api.Resource.GetDeploymentTargetAnnotations()
+            .Select(static annotation => Assert.IsAssignableFrom<AzureBicepResource>(annotation.DeploymentTarget))
+            .ToArray();
+        var frontDoorProvision = CreateProvisionStep("provision-frontdoor", frontDoor.Resource);
+        var eastProvision = CreateProvisionStep("provision-api-east", targets[0]);
+        var westProvision = CreateProvisionStep("provision-api-west", targets[1]);
+        var summary = new PipelineStep
+        {
+            Name = "print-frontdoor",
+            Resource = frontDoor.Resource,
+            Tags = ["print-summary"],
+            Action = static _ => Task.CompletedTask
+        };
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var context = new PipelineConfigurationContext
+        {
+            Services = app.Services,
+            Model = model,
+            Steps = [frontDoorProvision, eastProvision, westProvision, summary]
+        };
+
+        foreach (var annotation in frontDoor.Resource.Annotations.OfType<PipelineConfigurationAnnotation>())
+        {
+            await annotation.Callback(context);
+        }
+
+        Assert.Contains(eastProvision.Name, frontDoorProvision.DependsOnSteps);
+        Assert.Contains(westProvision.Name, frontDoorProvision.DependsOnSteps);
+
+        static PipelineStep CreateProvisionStep(string name, IResource resource) => new()
+        {
+            Name = name,
+            Resource = resource,
+            Tags = [WellKnownPipelineTags.ProvisionInfrastructure],
+            Action = static _ => Task.CompletedTask
+        };
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceGroupTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceGroupTests.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURERG001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using static Aspire.Hosting.Utils.AzureManifestUtils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureResourceGroupTests
+{
+    [Fact]
+    public async Task AddAzureResourceGroupGeneratesSubscriptionScopedBicep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var resourceGroup = builder.AddAzureResourceGroup("app-east-rg", "eastus2");
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await GetManifestWithBicep(resourceGroup.Resource);
+
+        Assert.Contains("targetScope = 'subscription'", bicep);
+        Assert.Contains("param location string = 'eastus2'", bicep);
+        Assert.Contains("param resourceGroupName string", bicep);
+        Assert.Contains("resource app_east_rg 'Microsoft.Resources/resourceGroups@", bicep);
+        Assert.Contains("name: resourceGroupName", bicep);
+        Assert.Contains("location: location", bicep);
+        Assert.Contains("output name string = app_east_rg.name", bicep);
+        Assert.Contains("output id string = app_east_rg.id", bicep);
+        Assert.True(resourceGroup.Resource.Scope?.IsSubscriptionScope);
+        var physicalName = Assert.IsType<ReferenceExpression>(resourceGroup.Resource.ResourceGroupName);
+        Assert.EndsWith("-app-east-rg", physicalName.ValueExpression, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithResourceGroupNameUsesParameter()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var name = builder.AddParameter("east-resource-group-name");
+        var resourceGroup = builder.AddAzureResourceGroup("east-group", "eastus2")
+            .WithResourceGroupName(name);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resourceGroup.Resource);
+
+        Assert.Equal("{east-resource-group-name.value}", manifest["params"]!["resourceGroupName"]!.GetValue<string>());
+        Assert.Contains("param resourceGroupName string", bicep);
+        Assert.Contains("name: resourceGroupName", bicep);
+    }
+
+    [Fact]
+    public void WithResourceGroupRejectsAnotherApplicationBuilder()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var otherBuilder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var resourceGroup = otherBuilder.AddAzureResourceGroup("other-rg", "eastus2");
+        var storage = builder.AddAzureStorage("storage");
+
+        Assert.Throws<ArgumentException>(() => storage.WithResourceGroup(resourceGroup));
+    }
+
+    [Fact]
+    public void WithResourceGroupRejectsAnExistingExplicitScope()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var first = builder.AddAzureResourceGroup("first-rg", "eastus2");
+        var second = builder.AddAzureResourceGroup("second-rg", "westus3");
+        var storage = builder.AddAzureStorage("storage")
+            .WithResourceGroup(first);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => storage.WithResourceGroup(second));
+
+        Assert.Contains("already has an explicit scope", exception.Message);
+    }
+
+    [Fact]
+    public void WithResourceGroupNameRejectsMutationAfterResourceGroupIsReferenced()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var resourceGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        builder.AddAzureStorage("storage")
+            .WithResourceGroup(resourceGroup);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => resourceGroup.WithResourceGroupName("new-east-rg"));
+
+        Assert.Contains("already referenced", exception.Message);
+        Assert.Contains("before calling 'WithResourceGroup'", exception.Message);
+    }
+
+    [Fact]
+    public void AddAzureResourceGroupDoesNotAddResourceInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var resourceGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+
+        Assert.DoesNotContain(resourceGroup.Resource, builder.Resources);
+    }
+
+    [Fact]
+    public void WithResourceGroupRejectsExistingResourceConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var resourceGroup = builder.AddAzureResourceGroup("east-rg", "eastus2");
+        var storage = builder.AddAzureStorage("storage")
+            .PublishAsExisting("existing-storage", "existing-rg");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => storage.WithResourceGroup(resourceGroup));
+
+        Assert.Contains("already has an explicit scope", exception.Message);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithReplicatedOriginGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithReplicatedOriginGeneratesBicep.verified.bicep
@@ -1,0 +1,85 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param api_east_host string
+
+param api_west_host string
+
+resource frontdoor 'Microsoft.Cdn/profiles@2025-06-01' = {
+  name: take('frontdoor-${uniqueString(resourceGroup().id)}', 260)
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+  tags: {
+    'aspire-resource-name': 'frontdoor'
+  }
+}
+
+resource apiEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2025-06-01' = {
+  name: take('apiEndpoint-${uniqueString(resourceGroup().id)}', 46)
+  location: 'Global'
+  parent: frontdoor
+}
+
+resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
+  name: take('apiOriginGroup-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    healthProbeSettings: {
+      probePath: '/'
+      probeProtocol: 'Https'
+    }
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+  }
+  parent: frontdoor
+}
+
+resource api_eastOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apieastOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    enabledState: 'Enabled'
+    hostName: api_east_host
+    originHostHeader: api_east_host
+    priority: 1
+    weight: 1000
+  }
+  parent: apiOriginGroup
+}
+
+resource api_westOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
+  name: take('apiwestOrigin-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    enabledState: 'Enabled'
+    hostName: api_west_host
+    originHostHeader: api_west_host
+    priority: 1
+    weight: 1000
+  }
+  parent: apiOriginGroup
+}
+
+resource apiRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2025-06-01' = {
+  name: take('apiRoute-${uniqueString(resourceGroup().id)}', 90)
+  properties: {
+    forwardingProtocol: 'HttpsOnly'
+    httpsRedirect: 'Enabled'
+    linkToDefaultDomain: 'Enabled'
+    originGroup: {
+      id: apiOriginGroup.id
+    }
+    patternsToMatch: [
+      '/*'
+    ]
+  }
+  parent: apiEndpoint
+  dependsOn: [
+    api_eastOrigin
+    api_westOrigin
+  ]
+}
+
+output api_endpointUrl string = 'https://${apiEndpoint.properties.hostName}'

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -1445,6 +1445,7 @@ type Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource interface {
 	WithChildRelationship(child Resource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithConfig(config *TestConfigDto) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource
@@ -2026,6 +2027,18 @@ func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithComputeEnv
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) Aspire_Hosting_CodeGeneration_Go_TestsTestVaultResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -3670,6 +3683,7 @@ type CSharpAppResource interface {
 	WithChildRelationship(child Resource) CSharpAppResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) CSharpAppResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) CSharpAppResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) CSharpAppResource
 	WithConfig(config *TestConfigDto) CSharpAppResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) CSharpAppResource
 	WithContainerRegistry(registry Resource) CSharpAppResource
@@ -4210,6 +4224,18 @@ func (s *cSharpAppResource) WithComputeEnvironment(computeEnvironmentResource Co
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *cSharpAppResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) CSharpAppResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -7549,6 +7575,7 @@ type ContainerResource interface {
 	WithChildRelationship(child Resource) ContainerResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ContainerResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ContainerResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ContainerResource
 	WithConfig(config *TestConfigDto) ContainerResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ContainerResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) ContainerResource
@@ -8129,6 +8156,18 @@ func (s *containerResource) WithComputeEnvironment(computeEnvironmentResource Co
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *containerResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ContainerResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -11215,6 +11254,7 @@ type DotnetToolResource interface {
 	WithChildRelationship(child Resource) DotnetToolResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) DotnetToolResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) DotnetToolResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) DotnetToolResource
 	WithConfig(config *TestConfigDto) DotnetToolResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) DotnetToolResource
 	WithContainerRegistry(registry Resource) DotnetToolResource
@@ -11729,6 +11769,18 @@ func (s *dotnetToolResource) WithComputeEnvironment(computeEnvironmentResource C
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *dotnetToolResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) DotnetToolResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -14017,6 +14069,7 @@ type ExecutableResource interface {
 	WithChildRelationship(child Resource) ExecutableResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ExecutableResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ExecutableResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ExecutableResource
 	WithConfig(config *TestConfigDto) ExecutableResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ExecutableResource
 	WithContainerRegistry(registry Resource) ExecutableResource
@@ -14525,6 +14578,18 @@ func (s *executableResource) WithComputeEnvironment(computeEnvironmentResource C
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *executableResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ExecutableResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -20406,6 +20471,7 @@ type ProjectResource interface {
 	WithChildRelationship(child Resource) ProjectResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) ProjectResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) ProjectResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ProjectResource
 	WithConfig(config *TestConfigDto) ProjectResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) ProjectResource
 	WithContainerRegistry(registry Resource) ProjectResource
@@ -20946,6 +21012,18 @@ func (s *projectResource) WithComputeEnvironment(computeEnvironmentResource Comp
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *projectResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) ProjectResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -23778,6 +23856,7 @@ type TestDatabaseResource interface {
 	WithChildRelationship(child Resource) TestDatabaseResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) TestDatabaseResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) TestDatabaseResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) TestDatabaseResource
 	WithConfig(config *TestConfigDto) TestDatabaseResource
 	WithContainerBuildOptions(callback func(arg ContainerBuildOptionsCallbackContext)) TestDatabaseResource
 	WithContainerCertificatePaths(options ...*WithContainerCertificatePathsOptions) TestDatabaseResource
@@ -24358,6 +24437,18 @@ func (s *testDatabaseResource) WithComputeEnvironment(computeEnvironmentResource
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *testDatabaseResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) TestDatabaseResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 
@@ -25997,6 +26088,7 @@ type TestRedisResource interface {
 	WithChildRelationship(child Resource) TestRedisResource
 	WithCommand(name string, displayName string, executeCommand func(arg ExecuteCommandContext) *ExecuteCommandResult, options ...*WithCommandOptions) TestRedisResource
 	WithComputeEnvironment(computeEnvironmentResource ComputeEnvironmentResource) TestRedisResource
+	WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) TestRedisResource
 	WithConfig(config *TestConfigDto) TestRedisResource
 	WithConnectionProperty(name string, value any) TestRedisResource
 	WithConnectionString(connectionString *ReferenceExpression) TestRedisResource
@@ -26740,6 +26832,18 @@ func (s *testRedisResource) WithComputeEnvironment(computeEnvironmentResource Co
 	}
 	reqArgs["computeEnvironmentResource"] = serializeValue(computeEnvironmentResource)
 	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironment", reqArgs); err != nil { s.setErr(err) }
+	return s
+}
+
+// WithComputeEnvironments configures the compute environments that deploy the compute resource.
+func (s *testRedisResource) WithComputeEnvironments(computeEnvironmentResources []ComputeEnvironmentResource) TestRedisResource {
+	if s.err != nil { return s }
+	ctx := context.Background()
+	reqArgs := map[string]any{
+		"builder": s.handle.ToJSON(),
+	}
+	if computeEnvironmentResources != nil { reqArgs["computeEnvironmentResources"] = serializeValue(computeEnvironmentResources) }
+	if _, err := s.client.invokeCapability(ctx, "Aspire.Hosting/withComputeEnvironments", reqArgs); err != nil { s.setErr(err) }
 	return s
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -2813,6 +2813,15 @@ public class CSharpAppResource extends ProjectResource {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
     }
 
+    /** Configures the compute environments that deploy the compute resource. */
+    public CSharpAppResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
+    }
+
     /** Adds an HTTP health probe to the resource */
     public CSharpAppResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
         var path = optionsBag == null ? null : optionsBag.getPath();
@@ -6924,6 +6933,15 @@ public class ContainerResource extends ResourceBuilderBase {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
     }
 
+    /** Configures the compute environments that deploy the compute resource. */
+    public ContainerResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
+    }
+
     /** Adds an HTTP health probe to the resource */
     public ContainerResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
         var path = optionsBag == null ? null : optionsBag.getPath();
@@ -9589,6 +9607,15 @@ public class DotnetToolResource extends ExecutableResource {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
     }
 
+    /** Configures the compute environments that deploy the compute resource. */
+    public DotnetToolResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
+    }
+
     /** Adds an HTTP health probe to the resource */
     public DotnetToolResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
         var path = optionsBag == null ? null : optionsBag.getPath();
@@ -11909,6 +11936,15 @@ public class ExecutableResource extends ResourceBuilderBase {
 
     public ExecutableResource withComputeEnvironment(ResourceBuilderBase computeEnvironmentResource) {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
+    }
+
+    /** Configures the compute environments that deploy the compute resource. */
+    public ExecutableResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
     }
 
     /** Adds an HTTP health probe to the resource */
@@ -19905,6 +19941,15 @@ public class ProjectResource extends ResourceBuilderBase {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
     }
 
+    /** Configures the compute environments that deploy the compute resource. */
+    public ProjectResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
+    }
+
     /** Adds an HTTP health probe to the resource */
     public ProjectResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
         var path = optionsBag == null ? null : optionsBag.getPath();
@@ -23286,6 +23331,15 @@ public class TestDatabaseResource extends ContainerResource {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
     }
 
+    /** Configures the compute environments that deploy the compute resource. */
+    public TestDatabaseResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
+    }
+
     /** Adds an HTTP health probe to the resource */
     public TestDatabaseResource withHttpProbe(ProbeType probeType, WithHttpProbeOptions optionsBag) {
         var path = optionsBag == null ? null : optionsBag.getPath();
@@ -25482,6 +25536,15 @@ public class TestRedisResource extends ContainerResource {
 
     public TestRedisResource withComputeEnvironment(ResourceBuilderBase computeEnvironmentResource) {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
+    }
+
+    /** Configures the compute environments that deploy the compute resource. */
+    public TestRedisResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
     }
 
     /** Adds an HTTP health probe to the resource */
@@ -27693,6 +27756,15 @@ public class TestVaultResource extends ContainerResource {
 
     public TestVaultResource withComputeEnvironment(ResourceBuilderBase computeEnvironmentResource) {
         return withComputeEnvironment(new IComputeEnvironmentResource(computeEnvironmentResource.getHandle(), computeEnvironmentResource.getClient()));
+    }
+
+    /** Configures the compute environments that deploy the compute resource. */
+    public TestVaultResource withComputeEnvironments(IComputeEnvironmentResource[] computeEnvironmentResources) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("computeEnvironmentResources", AspireClient.serializeValue(computeEnvironmentResources));
+        getClient().invokeCapability("Aspire.Hosting/withComputeEnvironments", reqArgs);
+        return this;
     }
 
     /** Adds an HTTP health probe to the resource */

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -7548,6 +7548,10 @@ class AbstractComputeResource(AbstractResource):
         """Configures the compute environment for the compute resource."""
 
     @abc.abstractmethod
+    def with_compute_envs(self, compute_env_resources: typing.Iterable[AbstractComputeEnvironmentResource]) -> typing.Self:
+        """Configures the compute environments that deploy the compute resource."""
+
+    @abc.abstractmethod
     def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
         """Adds an asynchronous callback to configure container image push options for the resource."""
 
@@ -8986,6 +8990,7 @@ class ContainerResourceKwargs(_BaseResourceKwargs, total=False):
     without_https_certificate: typing.Literal[True]
     https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
+    compute_envs: typing.Iterable[AbstractComputeEnvironmentResource]
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
@@ -9643,6 +9648,17 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_compute_envs(self, compute_env_resources: typing.Iterable[AbstractComputeEnvironmentResource]) -> typing.Self:
+        """Configures the compute environments that deploy the compute resource."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['computeEnvironmentResources'] = compute_env_resources
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_http_probe(self, probe_type: ProbeType, *, path: str | None = None, initial_delay_seconds: int | None = None, period_seconds: int | None = None, timeout_seconds: int | None = None, failure_threshold: int | None = None, success_threshold: int | None = None, endpoint_name: str | None = None) -> typing.Self:
         """Adds an HTTP health probe to the resource"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -10229,6 +10245,13 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironment', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'compute_env'. Expected: AbstractComputeEnvironmentResource")
+        if _compute_envs := kwargs.pop("compute_envs", None):
+            if _validate_type(_compute_envs, typing.Iterable[AbstractComputeEnvironmentResource]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["computeEnvironmentResources"] = typing.cast(typing.Iterable[AbstractComputeEnvironmentResource], _compute_envs)
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironments', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'compute_envs'. Expected: Iterable[AbstractComputeEnvironmentResource]")
         if _http_probe := kwargs.pop("http_probe", None):
             if _validate_type(_http_probe, ProbeType):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -10340,6 +10363,7 @@ class ProjectResourceKwargs(_BaseResourceKwargs, total=False):
     without_https_certificate: typing.Literal[True]
     https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
+    compute_envs: typing.Iterable[AbstractComputeEnvironmentResource]
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
@@ -10785,6 +10809,17 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_compute_envs(self, compute_env_resources: typing.Iterable[AbstractComputeEnvironmentResource]) -> typing.Self:
+        """Configures the compute environments that deploy the compute resource."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['computeEnvironmentResources'] = compute_env_resources
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_http_probe(self, probe_type: ProbeType, *, path: str | None = None, initial_delay_seconds: int | None = None, period_seconds: int | None = None, timeout_seconds: int | None = None, failure_threshold: int | None = None, success_threshold: int | None = None, endpoint_name: str | None = None) -> typing.Self:
         """Adds an HTTP health probe to the resource"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -11200,6 +11235,13 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironment', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'compute_env'. Expected: AbstractComputeEnvironmentResource")
+        if _compute_envs := kwargs.pop("compute_envs", None):
+            if _validate_type(_compute_envs, typing.Iterable[AbstractComputeEnvironmentResource]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["computeEnvironmentResources"] = typing.cast(typing.Iterable[AbstractComputeEnvironmentResource], _compute_envs)
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironments', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'compute_envs'. Expected: Iterable[AbstractComputeEnvironmentResource]")
         if _http_probe := kwargs.pop("http_probe", None):
             if _validate_type(_http_probe, ProbeType):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -11318,6 +11360,7 @@ class ExecutableResourceKwargs(_BaseResourceKwargs, total=False):
     without_https_certificate: typing.Literal[True]
     https_certificate_config: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]
     compute_env: AbstractComputeEnvironmentResource
+    compute_envs: typing.Iterable[AbstractComputeEnvironmentResource]
     http_probe: ProbeType | HttpProbeParameters
     image_push_options: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]
     remote_image_name: str
@@ -11750,6 +11793,17 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_compute_envs(self, compute_env_resources: typing.Iterable[AbstractComputeEnvironmentResource]) -> typing.Self:
+        """Configures the compute environments that deploy the compute resource."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['computeEnvironmentResources'] = compute_env_resources
+        result = self._client.invoke_capability(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def with_http_probe(self, probe_type: ProbeType, *, path: str | None = None, initial_delay_seconds: int | None = None, period_seconds: int | None = None, timeout_seconds: int | None = None, failure_threshold: int | None = None, success_threshold: int | None = None, endpoint_name: str | None = None) -> typing.Self:
         """Adds an HTTP health probe to the resource"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
@@ -12144,6 +12198,13 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironment', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'compute_env'. Expected: AbstractComputeEnvironmentResource")
+        if _compute_envs := kwargs.pop("compute_envs", None):
+            if _validate_type(_compute_envs, typing.Iterable[AbstractComputeEnvironmentResource]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["computeEnvironmentResources"] = typing.cast(typing.Iterable[AbstractComputeEnvironmentResource], _compute_envs)
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withComputeEnvironments', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'compute_envs'. Expected: Iterable[AbstractComputeEnvironmentResource]")
         if _http_probe := kwargs.pop("http_probe", None):
             if _validate_type(_http_probe, ProbeType):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -2991,6 +2991,17 @@ impl CSharpAppResource {
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP health probe to the resource
     pub fn with_http_probe(&self, probe_type: ProbeType, path: Option<&str>, initial_delay_seconds: Option<f64>, period_seconds: Option<f64>, timeout_seconds: Option<f64>, failure_threshold: Option<f64>, success_threshold: Option<f64>, endpoint_name: Option<&str>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -5833,6 +5844,17 @@ impl ContainerResource {
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP health probe to the resource
     pub fn with_http_probe(&self, probe_type: ProbeType, path: Option<&str>, initial_delay_seconds: Option<f64>, period_seconds: Option<f64>, timeout_seconds: Option<f64>, failure_threshold: Option<f64>, success_threshold: Option<f64>, endpoint_name: Option<&str>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7712,6 +7734,17 @@ impl DotnetToolResource {
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP health probe to the resource
     pub fn with_http_probe(&self, probe_type: ProbeType, path: Option<&str>, initial_delay_seconds: Option<f64>, period_seconds: Option<f64>, timeout_seconds: Option<f64>, failure_threshold: Option<f64>, success_threshold: Option<f64>, endpoint_name: Option<&str>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -9544,6 +9577,17 @@ impl ExecutableResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("computeEnvironmentResource".to_string(), compute_environment_resource.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
@@ -15418,6 +15462,17 @@ impl ProjectResource {
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP health probe to the resource
     pub fn with_http_probe(&self, probe_type: ProbeType, path: Option<&str>, initial_delay_seconds: Option<f64>, period_seconds: Option<f64>, timeout_seconds: Option<f64>, failure_threshold: Option<f64>, success_threshold: Option<f64>, endpoint_name: Option<&str>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -17682,6 +17737,17 @@ impl TestDatabaseResource {
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
 
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
     /// Adds an HTTP health probe to the resource
     pub fn with_http_probe(&self, probe_type: ProbeType, path: Option<&str>, initial_delay_seconds: Option<f64>, period_seconds: Option<f64>, timeout_seconds: Option<f64>, failure_threshold: Option<f64>, success_threshold: Option<f64>, endpoint_name: Option<&str>) -> Result<IResourceWithEndpoints, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -19275,6 +19341,17 @@ impl TestRedisResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("computeEnvironmentResource".to_string(), compute_environment_resource.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IComputeResource::new(handle, self.client.clone()))
     }
@@ -20938,6 +21015,17 @@ impl TestVaultResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("computeEnvironmentResource".to_string(), compute_environment_resource.handle().to_json());
         let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironment", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IComputeResource::new(handle, self.client.clone()))
+    }
+
+    /// Configures the compute environments that deploy the compute resource.
+    pub fn with_compute_environments(&self, compute_environment_resources: Vec<IComputeEnvironmentResource>) -> Result<IComputeResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        let handles: Vec<Value> = compute_environment_resources.iter().map(|item| item.handle().to_json()).collect();
+        args.insert("computeEnvironmentResources".to_string(), Value::Array(handles));
+        let result = self.client.invoke_capability("Aspire.Hosting/withComputeEnvironments", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IComputeResource::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -378,6 +378,20 @@
     ]
   },
   {
+    CapabilityId: Aspire.Hosting/withComputeEnvironments,
+    MethodName: withComputeEnvironments,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IComputeResource,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
     CapabilityId: Aspire.Hosting/withContainerBuildOptions,
     MethodName: withContainerBuildOptions,
     TargetType: {

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -17188,6 +17188,15 @@ export interface ContainerResource {
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ContainerResourcePromise;
     /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ContainerResourcePromise;
+    /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
      */
@@ -17996,6 +18005,15 @@ export interface ContainerResourcePromise extends PromiseLike<ContainerResource>
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ContainerResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ContainerResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -20070,6 +20088,28 @@ class ContainerResourceImpl extends ResourceBuilderBase<ContainerResourceHandle>
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new ContainerResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -21234,6 +21274,10 @@ class ContainerResourcePromiseImpl implements ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ContainerResourcePromise {
+        return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ContainerResourcePromise {
         return new ContainerResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -21847,6 +21891,15 @@ export interface CSharpAppResource {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): CSharpAppResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): CSharpAppResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -22471,6 +22524,15 @@ export interface CSharpAppResourcePromise extends PromiseLike<CSharpAppResource>
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): CSharpAppResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): CSharpAppResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -24108,6 +24170,28 @@ class CSharpAppResourceImpl extends ResourceBuilderBase<CSharpAppResourceHandle>
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<CSharpAppResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new CSharpAppResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -25192,6 +25276,10 @@ class CSharpAppResourcePromiseImpl implements CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): CSharpAppResourcePromise {
+        return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): CSharpAppResourcePromise {
         return new CSharpAppResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -25833,6 +25921,15 @@ export interface DotnetToolResource {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): DotnetToolResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): DotnetToolResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -26479,6 +26576,15 @@ export interface DotnetToolResourcePromise extends PromiseLike<DotnetToolResourc
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): DotnetToolResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): DotnetToolResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -28200,6 +28306,28 @@ class DotnetToolResourceImpl extends ResourceBuilderBase<DotnetToolResourceHandl
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<DotnetToolResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new DotnetToolResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -29285,6 +29413,10 @@ class DotnetToolResourcePromiseImpl implements DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): DotnetToolResourcePromise {
+        return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): DotnetToolResourcePromise {
         return new DotnetToolResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -29896,6 +30028,15 @@ export interface ExecutableResource {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ExecutableResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ExecutableResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -30509,6 +30650,15 @@ export interface ExecutableResourcePromise extends PromiseLike<ExecutableResourc
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ExecutableResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ExecutableResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -32126,6 +32276,28 @@ class ExecutableResourceImpl extends ResourceBuilderBase<ExecutableResourceHandl
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<ExecutableResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new ExecutableResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -33185,6 +33357,10 @@ class ExecutableResourcePromiseImpl implements ExecutableResourcePromise {
 
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ExecutableResourcePromise {
         return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
+    }
+
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ExecutableResourcePromise {
+        return new ExecutableResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
     }
 
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ExecutableResourcePromise {
@@ -38229,6 +38405,15 @@ export interface ProjectResource {
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ProjectResourcePromise;
     /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ProjectResourcePromise;
+    /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
      */
@@ -38852,6 +39037,15 @@ export interface ProjectResourcePromise extends PromiseLike<ProjectResource> {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ProjectResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ProjectResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -40490,6 +40684,28 @@ class ProjectResourceImpl extends ResourceBuilderBase<ProjectResourceHandle> imp
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<ProjectResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new ProjectResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -41574,6 +41790,10 @@ class ProjectResourcePromiseImpl implements ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ProjectResourcePromise {
+        return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): ProjectResourcePromise {
         return new ProjectResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -42364,6 +42584,15 @@ export interface TestDatabaseResource {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestDatabaseResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestDatabaseResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -43173,6 +43402,15 @@ export interface TestDatabaseResourcePromise extends PromiseLike<TestDatabaseRes
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestDatabaseResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestDatabaseResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -45246,6 +45484,28 @@ class TestDatabaseResourceImpl extends ResourceBuilderBase<TestDatabaseResourceH
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<TestDatabaseResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new TestDatabaseResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -46410,6 +46670,10 @@ class TestDatabaseResourcePromiseImpl implements TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestDatabaseResourcePromise {
+        return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -47216,6 +47480,15 @@ export interface TestRedisResource {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestRedisResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestRedisResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -48089,6 +48362,15 @@ export interface TestRedisResourcePromise extends PromiseLike<TestRedisResource>
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestRedisResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestRedisResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -50246,6 +50528,28 @@ class TestRedisResourceImpl extends ResourceBuilderBase<TestRedisResourceHandle>
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<TestRedisResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<TestRedisResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new TestRedisResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -51629,6 +51933,10 @@ class TestRedisResourcePromiseImpl implements TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestRedisResourcePromise {
+        return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestRedisResourcePromise {
         return new TestRedisResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -52472,6 +52780,15 @@ export interface TestVaultResource {
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestVaultResourcePromise;
     /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestVaultResourcePromise;
+    /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
      */
@@ -53282,6 +53599,15 @@ export interface TestVaultResourcePromise extends PromiseLike<TestVaultResource>
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): TestVaultResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestVaultResourcePromise;
     /**
      * Adds an HTTP health probe to the resource
      * @param options Additional options.
@@ -55357,6 +55683,28 @@ class TestVaultResourceImpl extends ResourceBuilderBase<TestVaultResourceHandle>
     }
 
     /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<TestVaultResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<TestVaultResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new TestVaultResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
+    }
+
+    /** @internal */
     private async _withHttpProbeInternal(probeType: ProbeType, path?: string, initialDelaySeconds?: number, periodSeconds?: number, timeoutSeconds?: number, failureThreshold?: number, successThreshold?: number, endpointName?: string): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, probeType };
         if (path !== undefined) rpcArgs.path = path;
@@ -56536,6 +56884,10 @@ class TestVaultResourcePromiseImpl implements TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
     }
 
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): TestVaultResourcePromise {
+        return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
+    }
+
     withHttpProbe(probeType: ProbeType, options?: WithHttpProbeOptions): TestVaultResourcePromise {
         return new TestVaultResourcePromiseImpl(this._promise.then(obj => obj.withHttpProbe(probeType, options)), this._client);
     }
@@ -56748,6 +57100,15 @@ export interface ComputeResource {
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ComputeResourcePromise;
     /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ComputeResourcePromise;
+    /**
      * Adds an asynchronous callback to configure container image push options for the resource.
      *
      * This method allows customization of how container images are named and tagged when pushed to a registry using an asynchronous callback.
@@ -56786,6 +57147,15 @@ export interface ComputeResourcePromise extends PromiseLike<ComputeResource> {
      * @returns The resource builder.
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ComputeResourcePromise;
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ComputeResourcePromise;
     /**
      * Adds an asynchronous callback to configure container image push options for the resource.
      *
@@ -56845,6 +57215,28 @@ class ComputeResourceImpl extends ResourceBuilderBase<IComputeResourceHandle> im
      */
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ComputeResourcePromise {
         return new ComputeResourcePromiseImpl(this._withComputeEnvironmentInternal(computeEnvironmentResource), this._client);
+    }
+
+    /** @internal */
+    private async _withComputeEnvironmentsInternal(computeEnvironmentResources: ComputeEnvironmentResource[]): Promise<ComputeResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, computeEnvironmentResources };
+        const result = await this._client.invokeCapability<IComputeResourceHandle>(
+            'Aspire.Hosting/withComputeEnvironments',
+            rpcArgs
+        );
+        return new ComputeResourceImpl(result, this._client);
+    }
+
+    /**
+     * Configures the compute environments that deploy the compute resource.
+     *
+     * The resource runs once during local development. The selected environments create separate
+     * deployment targets during publish and deploy.
+     * @param computeEnvironmentResources The compute environments that deploy the resource.
+     * @returns The resource builder.
+     */
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ComputeResourcePromise {
+        return new ComputeResourcePromiseImpl(this._withComputeEnvironmentsInternal(computeEnvironmentResources), this._client);
     }
 
     /** @internal */
@@ -56940,6 +57332,10 @@ class ComputeResourcePromiseImpl implements ComputeResourcePromise {
 
     withComputeEnvironment(computeEnvironmentResource: Awaitable<ComputeEnvironmentResource>): ComputeResourcePromise {
         return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironment(computeEnvironmentResource)), this._client);
+    }
+
+    withComputeEnvironments(computeEnvironmentResources: ComputeEnvironmentResource[]): ComputeResourcePromise {
+        return new ComputeResourcePromiseImpl(this._promise.then(obj => obj.withComputeEnvironments(computeEnvironmentResources)), this._client);
     }
 
     withImagePushOptions(callback: (arg: ContainerImagePushOptionsCallbackContext) => Promise<void>): ComputeResourcePromise {

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentEndpointResolverTests.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests;
 
+#pragma warning disable ASPIRECOMPUTE004
+
 public class ComputeEnvironmentEndpointResolverTests
 {
     [Fact]
@@ -126,35 +128,79 @@ public class ComputeEnvironmentEndpointResolverTests
     }
 
     [Fact]
-    public void OwningResourceUnboundWithMultipleDeploymentTargets_Throws()
+    public void OwningResourceUnboundWithCurrentDeploymentTarget_ReturnsFalse()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
         var otherEnv = builder.AddResource(new TestComputeEnvironmentResource("other"));
-        // No binding: an unbound resource with more than one deployment target is ambiguous.
-        // TryGetEffectiveComputeEnvironment falls back to the parameterless GetDeploymentTargetAnnotation()
-        // which throws. This documents that the resolver does not swallow that ambiguity; the pipeline
-        // rejects this configuration earlier in practice.
         var agent = builder.AddResource(new TestComputeResource("agent"));
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(currentEnv.Resource) { ComputeEnvironment = currentEnv.Resource });
         agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(otherEnv.Resource) { ComputeEnvironment = otherEnv.Resource });
         var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
 
-        Assert.Throws<InvalidOperationException>(() =>
-            ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
-                endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out _));
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
     }
 
-    private static EndpointReference AddHttpEndpoint(TestComputeResource resource, int? port, int? targetPort)
+    [Fact]
+    public void OwningResourceHasMultipleRemoteDeploymentTargets_Throws()
     {
-        var endpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: port, targetPort: targetPort);
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestComputeEnvironmentResource("current"));
+        var eastEnv = builder.AddResource(new TestComputeEnvironmentResource("east"));
+        var westEnv = builder.AddResource(new TestComputeEnvironmentResource("west"));
+        var agent = builder.AddResource(new TestComputeResource("agent"));
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(eastEnv.Resource) { ComputeEnvironment = eastEnv.Resource });
+        agent.Resource.Annotations.Add(new DeploymentTargetAnnotation(westEnv.Resource) { ComputeEnvironment = westEnv.Resource });
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+                endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out _));
+
+        Assert.Contains("'east', 'west'", exception.Message);
+    }
+
+    [Fact]
+    public void OwningResourceExplicitlyTargetsCurrentAndOtherEnvironment_ReturnsFalse()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var currentEnv = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("current"));
+        var otherEnv = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("other"));
+        var agent = builder.AddResource(new TestComputeResource("agent"))
+            .WithComputeEnvironments([currentEnv, otherEnv]);
+        var endpoint = AddHttpEndpoint(agent.Resource, port: 8080, targetPort: 5000);
+
+        var resolved = ComputeEnvironmentEndpointResolver.TryGetCrossEnvironmentEndpointExpression(
+            endpoint.Property(EndpointProperty.Url), [currentEnv.Resource], out var expression);
+
+        Assert.False(resolved);
+        Assert.Null(expression);
+    }
+
+    private static EndpointReference AddHttpEndpoint(TestComputeResource resource, int? port, int? targetPort, bool isExternal = true)
+    {
+        var endpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: port, targetPort: targetPort, isExternal: isExternal);
         resource.Annotations.Add(endpoint);
 
         return new EndpointReference(resource, endpoint);
     }
 
     private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+#pragma warning disable ASPIRECOMPUTE002
+        public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
+            ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
+#pragma warning restore ASPIRECOMPUTE002
+    }
+
+    private sealed class TestMultiTargetComputeEnvironmentResource(string name) : Resource(name), IMultiTargetComputeEnvironmentResource
     {
 #pragma warning disable ASPIRECOMPUTE002
         public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -5,6 +5,8 @@ using System.Net.Sockets;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 
+#pragma warning disable ASPIRECOMPUTE004
+
 namespace Aspire.Hosting.Tests;
 
 [Trait("Partition", "6")]
@@ -43,6 +45,56 @@ public class ComputeEnvironmentValidationTests
         using var app = builder.Build();
 
         await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task MultipleComputeEnvironments_WithResourceBoundToAll_DoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments([env1, env2]);
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        Assert.Equal([env1.Resource, env2.Resource], api.Resource.GetComputeEnvironments());
+        Assert.Null(api.Resource.GetComputeEnvironment());
+    }
+
+    [Fact]
+    public void WithComputeEnvironment_ReplacesPluralSelection()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("env1"));
+        var env2 = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("env2"));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironments([env1, env2])
+            .WithComputeEnvironment(env1);
+
+        Assert.Equal([env1.Resource], api.Resource.GetComputeEnvironments());
+        Assert.Same(env1.Resource, api.Resource.GetComputeEnvironment());
+    }
+
+    [Fact]
+    public void WithComputeEnvironments_RejectsInvalidSelections()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        using var otherBuilder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestMultiTargetComputeEnvironmentResource("env"));
+        var unsupported = builder.AddResource(new TestComputeEnvironmentResource("unsupported"));
+        var other = otherBuilder.AddResource(new TestMultiTargetComputeEnvironmentResource("other"));
+        var api = builder.AddResource(new TestComputeResource("api"));
+
+        Assert.Throws<ArgumentException>(() => api.WithComputeEnvironments([]));
+        Assert.Throws<ArgumentException>(() => api.WithComputeEnvironments([env, env]));
+        Assert.Throws<ArgumentException>(() => api.WithComputeEnvironments([env, other]));
+        Assert.Throws<NotSupportedException>(() => api.WithComputeEnvironments([env, unsupported]));
     }
 
     [Fact]
@@ -104,6 +156,14 @@ public class ComputeEnvironmentValidationTests
     }
 
     private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    {
+#pragma warning disable ASPIRECOMPUTE002
+        public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
+            ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
+#pragma warning restore ASPIRECOMPUTE002
+    }
+
+    private sealed class TestMultiTargetComputeEnvironmentResource(string name) : Resource(name), IMultiTargetComputeEnvironmentResource
     {
 #pragma warning disable ASPIRECOMPUTE002
         public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -521,6 +521,134 @@ public class SchemaTests
     }
 
     [Fact]
+    public void ManifestWithPluralContainerDeploymentsIsAccepted()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "api": {
+                  "type": "container.v2",
+                  "image": "myimage:latest",
+                  "deployments": {
+                    "east": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-east.module.bicep"
+                    },
+                    "west": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-west.module.bicep"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertValid(manifestText);
+    }
+
+    [Fact]
+    public void ManifestWithPluralProjectDeploymentsIsAccepted()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "api": {
+                  "type": "project.v2",
+                  "path": "api/api.csproj",
+                  "deployments": {
+                    "east": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-east.module.bicep"
+                    },
+                    "west": {
+                      "type": "azure.bicep.v1",
+                      "path": "api-west.module.bicep",
+                      "scope": {
+                        "resourceGroup": "api-west-rg"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertValid(manifestText);
+    }
+
+    [Fact]
+    public void ManifestWithOnlyOnePluralDeploymentIsRejected()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "api": {
+                  "type": "project.v2",
+                  "path": "api/api.csproj",
+                  "deployments": {
+                    "east": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-east.module.bicep"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertInvalid(manifestText);
+    }
+
+    [Fact]
+    public void ManifestV2WithSingularDeploymentIsRejected()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "api": {
+                  "type": "project.v2",
+                  "path": "api/api.csproj",
+                  "deployment": {
+                    "type": "azure.bicep.v0",
+                    "path": "api.module.bicep"
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertInvalid(manifestText);
+    }
+
+    [Fact]
+    public void ManifestV1WithPluralDeploymentsIsRejected()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "api": {
+                  "type": "container.v1",
+                  "image": "myimage:latest",
+                  "deployments": {
+                    "east": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-east.module.bicep"
+                    },
+                    "west": {
+                      "type": "azure.bicep.v0",
+                      "path": "api-west.module.bicep"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertInvalid(manifestText);
+    }
+
+    [Fact]
     public void BicepManifestIsAccepted()
     {
         // The reason this large test is here is that when submitting the positive test cases to SchemaStore.org


### PR DESCRIPTION
## Description

Aspire's Azure Front Door integration could front individual deployed resources, but it could not expose one logical app deployed as regional stamps through one global endpoint. This change adds provider-neutral multi-environment compute targeting and uses it to deploy one Azure Container Apps workload into distinct regional resource groups behind an active-active Azure Front Door origin group.

The regional environments share one explicitly configured Azure Container Registry. Aspire builds and pushes the workload image once, provisions a regional pull identity and cross-scope `AcrPull` assignment for each environment, and removes every Aspire-owned regional resource group during `aspire destroy`.

### User-facing usage

**C# AppHost**

```csharp
#pragma warning disable ASPIRECOMPUTE003
#pragma warning disable ASPIRECOMPUTE004
#pragma warning disable ASPIREAZURERG001

var registry = builder.AddAzureContainerRegistry("registry");

var eastGroup = builder.AddAzureResourceGroup("app-east-rg", "eastus2");
var westGroup = builder.AddAzureResourceGroup("app-west-rg", "westus3");

var east = builder.AddAzureContainerAppEnvironment("east")
    .WithLocation("eastus2")
    .WithResourceGroup(eastGroup)
    .WithAzureContainerRegistry(registry);

var west = builder.AddAzureContainerAppEnvironment("west")
    .WithLocation("westus3")
    .WithResourceGroup(westGroup)
    .WithAzureContainerRegistry(registry);

var api = builder.AddProject<Projects.Api>("api")
    .WithExternalHttpEndpoints()
    .WithContainerRegistry(registry)
    .WithComputeEnvironments([east, west]);

builder.AddAzureFrontDoor("frontdoor")
    .WithOrigin(api);
```

**TypeScript AppHost**

```typescript
const registry = await builder.addAzureContainerRegistry("registry");

const eastGroup = await builder.addAzureResourceGroup("app-east-rg", "eastus2");
const westGroup = await builder.addAzureResourceGroup("app-west-rg", "westus3");

const east = await builder.addAzureContainerAppEnvironment("east")
  .withLocation("eastus2")
  .withResourceGroup(eastGroup)
  .withAzureContainerRegistry(registry);

const west = await builder.addAzureContainerAppEnvironment("west")
  .withLocation("westus3")
  .withResourceGroup(westGroup)
  .withAzureContainerRegistry(registry);

const api = await builder.addNodeApp("api", "../api", "server.js")
  .withExternalHttpEndpoints()
  .withContainerRegistry(registry)
  .withComputeEnvironments([east, west]);

await builder.addAzureFrontDoor("frontdoor")
  .withOrigin(api);
```

### Implementation

- Adds experimental `WithComputeEnvironments(...)` support while preserving one local run-mode instance.
- Adds Aspire-owned, subscription-scoped Azure resource groups with deterministic naming, location inheritance, deployment ordering, and aggregate cleanup.
- Emits one environment-qualified ACA deployment target per region while retaining the same physical app name in distinct groups.
- Adds `project.v2` and `container.v2` manifest shapes with a deployment map keyed by compute environment.
- Generates one Front Door endpoint, origin group, and route with equal-priority/equal-weight regional origins.
- Rejects ambiguous internal cross-environment ACA references and multi-target configurations that do not use distinct groups and one shared registry.

### Validation

- `./restore.sh`
- `./build.sh --build /p:SkipNativeBuild=true`
- `Aspire.Hosting.Tests`: 3,356 total; 3,351 passed; 5 platform skips
- `Aspire.Hosting.Azure.Tests`: 1,712 total; 1,707 passed; 5 existing emulator skips
- `Infrastructure.Tests`: 515 passed
- `Aspire.Cli.Tests`: 5,293 passed; 35 platform skips
- `Aspire.Dashboard.Tests`: 1,561 passed
- Go, Java, Python, Rust, and TypeScript code-generation suites: 212 passed
- TypeScript API compatibility: 8 passed
- Generated multi-region `main.bicep` compiled successfully with Azure Bicep CLI 0.46.1
- `Aspire.Deployment.EndToEnd.Tests` builds successfully

The complete local `./build.sh --test` sweep was also attempted twice. Remaining failures were local-environment prerequisites unrelated to this diff: Docker-only CLI E2E setup on a Podman host, transient npm registry resets, missing template-test SDK packs, macOS `/var` versus `/private/var` path assertions, Unix-socket startup tests, and container readiness/resource pressure. The affected product suites above were rerun cleanly in isolation.

### Security considerations

Regional ACA endpoints remain publicly reachable in this first version and can bypass Front Door. The change does not configure WAF, custom domains, private origins, Front Door-only ingress restrictions, or `X-Azure-FDID` validation. Each regional environment receives a distinct managed identity with least-privilege `AcrPull` access to the shared registry. Security review is requested for the public-origin model and cross-resource-group RBAC topology.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
