### PR TITLE
Exclude unused hex1bpty.exe from published CLI archives

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,6 +14,29 @@
     <MakeDir Directories="$(MSBuildProjectDirectory)/api" Condition="!Exists('$(MSBuildProjectDirectory)/api')" />
   </Target>
 
+  <!--
+    Hex1b's win-x64/win-arm64 native assets carry hex1bpty.exe, a ~5 MB PTY host that Hex1b launches
+    only when *it* owns the pseudo-terminal for a child process. Nothing we ship takes that path: DCP
+    creates and owns every PTY we surface, and Aspire.TerminalHost just proxies the byte stream DCP is
+    already producing (see src/Aspire.TerminalHost/TerminalReplica.cs). So the helper is dead weight in
+    every Windows CLI archive, and it is also a second executable that downstream stores have to
+    account for — winget runs executable and malware checks against every binary in the archive, which
+    turned it into submission friction on https://github.com/microsoft/winget-pkgs/pull/421219.
+
+    Unix is unaffected: there the package's native asset is libhex1binterop.{so,dylib}, the
+    termios/ioctl shim the TUI does need, and it keeps flowing through.
+
+    Deliberately scoped to src/. Test projects drive real terminals through Hex1b.Automation, which
+    genuinely needs the PTY host, and this file does not apply to them.
+  -->
+  <Target Name="RemoveUnusedHex1bPtyHostFromPublish"
+          AfterTargets="ComputeResolvedFilesToPublishList"
+          Condition="'$(PublishHex1bPtyHost)' != 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish->WithMetadataValue('Filename', 'hex1bpty'))" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting'))


### PR DESCRIPTION
## Description

The `Hex1b` package ships a `hex1bpty.exe` PTY host in its `win-x64` / `win-arm64` native runtime assets. NuGet resolves it as a native asset for those RIDs, publish copies it, and `Microsoft.DotNet.Build.Tasks.Archives` zips the whole publish directory — so it lands in `aspire-cli-win-{x64,arm64}-<version>.zip`, which is exactly the artifact the WinGet manifest points at.

Aspire never uses it. Hex1b only spawns that helper when *it* owns the pseudo-terminal for a child process, and nothing we ship does: DCP creates and owns every PTY we surface, and `Aspire.TerminalHost` just proxies the byte stream DCP is already producing (see `src/Aspire.TerminalHost/TerminalReplica.cs`). The CLI and dashboard consume only Hex1b's rendering, input, and widget APIs.

Carrying it anyway costs us twice:

- **Size** — ~5 MB in each Windows CLI archive, plus another ~5 MB inside every Windows `aspire.exe` because `Aspire.Managed` (dashboard + terminal host) picks it up too and gets embedded as the bundle payload.
- **Store submission friction** — WinGet runs executable and malware checks against *every* binary in the archive, so an unused helper becomes something a reviewer has to ask about. That is what stalled the 13.5.0 submission in [microsoft/winget-pkgs#421219](https://github.com/microsoft/winget-pkgs/pull/421219).

The alternative would be to add `hex1bpty.exe` to the set of binaries we sign, but signing a file we never execute just to get it through validation is the wrong trade — better not to ship it at all.

This adds a single target to `src/Directory.Build.targets` that drops it from `ResolvedFileToPublish`. Kept intentionally small so it backports cleanly to `release/13.5`.

### Scoping

- **`src/` only.** Test projects import the root `Directory.Build.targets`, not this one. That matters: the CLI and deployment E2E tests drive real terminals through `Hex1b.Automation`, which genuinely needs the PTY host.
- **Windows only in effect.** On Unix the package's native asset is `libhex1binterop.{so,dylib}` — the termios/ioctl shim the TUI P/Invokes — and it keeps flowing through untouched.
- **`PublishHex1bPtyHost=true`** re-enables it if a shipping project ever needs the helper.

### Validation

Verified locally on macOS by cross-publishing for `win-x64`:

- A/B publish of `Aspire.Cli` — `hex1bpty.exe` absent by default, present with `/p:PublishHex1bPtyHost=true`, confirming the filter is what removes it.
- Full `eng/clipack/Aspire.Cli.win-x64.csproj` archive build — the produced zip contains no `hex1bpty.exe`.
- Same A/B on `Aspire.Managed`, confirming the bundle payload embedded in `aspire.exe` is covered as well.
- Checked the released 13.5.0 archives for every RID to confirm nothing else depends on the file: Windows ships `aspire.exe` + `libsodium.dll`, Linux/macOS ship `aspire` + `libsodium.*` + `libhex1binterop.*`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
