### PR TITLE
Fix dashboard browser launch blocking AppHost startup

### DIFF
--- a/extension/src/debugger/session/dashboardLauncher.ts
+++ b/extension/src/debugger/session/dashboardLauncher.ts
@@ -148,7 +148,7 @@ export class DashboardLauncher implements vscode.Disposable {
     });
 
     let didStart: boolean;
-    const start = Promise.resolve(vscode.debug.startDebugging(
+    const start = startStop(() => vscode.debug.startDebugging(
       undefined,
       debugConfig,
       this._host.parentSession));

--- a/extension/src/debugger/session/dashboardLauncher.ts
+++ b/extension/src/debugger/session/dashboardLauncher.ts
@@ -75,15 +75,15 @@ export class DashboardLauncher implements vscode.Disposable {
 
     switch (browserType) {
       case 'debugChrome':
-        await this.launchDebugBrowser(url, 'pwa-chrome');
+        this.launchDebugBrowserInBackground(url, 'pwa-chrome');
         break;
 
       case 'debugEdge':
-        await this.launchDebugBrowser(url, 'pwa-msedge');
+        this.launchDebugBrowserInBackground(url, 'pwa-msedge');
         break;
 
       case 'debugFirefox':
-        await this.launchDebugBrowser(url, 'firefox');
+        this.launchDebugBrowserInBackground(url, 'firefox');
         break;
 
       case 'integratedBrowser':
@@ -96,6 +96,15 @@ export class DashboardLauncher implements vscode.Disposable {
         await vscode.env.openExternal(vscode.Uri.parse(url));
         break;
     }
+  }
+
+  private launchDebugBrowserInBackground(
+    url: string,
+    debugType: 'pwa-chrome' | 'pwa-msedge' | 'firefox'): void {
+    void this.launchDebugBrowser(url, debugType).catch(error => {
+      extensionLogOutputChannel.warn(
+        `Failed to launch dashboard debug session (${debugType}): ${describeStopFailure(error)}`);
+    });
   }
 
   /**

--- a/extension/src/debugger/session/dashboardLauncher.ts
+++ b/extension/src/debugger/session/dashboardLauncher.ts
@@ -29,6 +29,7 @@ export class DashboardLauncher implements vscode.Disposable {
    * shutdown budget so a wedged browser adapter cannot starve AppHost and parent teardown.
    */
   private static readonly _dashboardStopTimeoutMs = 2000;
+  private static readonly _dashboardLateStartListenerTimeoutMs = 30000;
 
   private readonly _host: DashboardLauncherHost;
 
@@ -38,6 +39,8 @@ export class DashboardLauncher implements vscode.Disposable {
   private _dashboardTerminationPromise: Promise<void> | undefined;
   private _resolveDashboardTermination: (() => void) | undefined;
   private readonly _pendingDashboardDebugSessionStarts = new Set<Promise<void>>();
+  private readonly _pendingDashboardDebugSessionStartListeners = new Set<vscode.Disposable>();
+  private _pendingDashboardDebugSessionStartListenerCleanup: ReturnType<typeof setTimeout> | undefined;
   private _dashboardUrl: string | undefined;
 
   constructor(host: DashboardLauncherHost) {
@@ -139,13 +142,14 @@ export class DashboardLauncher implements vscode.Disposable {
     const disposable = vscode.debug.onDidStartDebugSession((session) => {
       if (session.parentSession?.id === this._host.parentSession.id && session.configuration.name === aspireDashboard && session.type === debugType) {
         this._dashboardDebugSession = session;
-        disposable.dispose();
+        this.disposeDashboardStartListener(disposable);
         this.trackDashboardTermination(session);
         if (this._host.isShuttingDown) {
           this.closeDashboardInBackground();
         }
       }
     });
+    this._pendingDashboardDebugSessionStartListeners.add(disposable);
 
     let didStart: boolean;
     const start = startStop(() => vscode.debug.startDebugging(
@@ -159,7 +163,7 @@ export class DashboardLauncher implements vscode.Disposable {
       didStart = await start;
     }
     catch (error) {
-      disposable.dispose();
+      this.disposeDashboardStartListener(disposable);
       throw error;
     }
     finally {
@@ -167,7 +171,7 @@ export class DashboardLauncher implements vscode.Disposable {
     }
 
     if (!didStart) {
-      disposable.dispose();
+      this.disposeDashboardStartListener(disposable);
       extensionLogOutputChannel.warn(`Failed to start debug browser (${debugType}), falling back to default browser`);
 
       // Falling back after disposal would pop an untracked browser window open during
@@ -251,6 +255,7 @@ export class DashboardLauncher implements vscode.Disposable {
           // A browser launch is optional UI work. Do not let a wedged launch block AppHost and
           // parent teardown; the start-event handler will close the browser if it appears later.
           this._pendingDashboardDebugSessionStarts.delete(pendingStarts[index]);
+          this.scheduleDashboardStartListenerCleanup();
           extensionLogOutputChannel.warn(`Dashboard debug session launch did not settle before shutdown: ${describeStopFailure((results[index] as PromiseRejectedResult).reason)}`);
         }
       }
@@ -261,6 +266,31 @@ export class DashboardLauncher implements vscode.Disposable {
       this._dashboardDebugSession?.name ?? aspireDashboard,
       deadline,
       () => { this._dashboardStopPromise = undefined; });
+  }
+
+  private disposeDashboardStartListener(disposable: vscode.Disposable): void {
+    disposable.dispose();
+    this._pendingDashboardDebugSessionStartListeners.delete(disposable);
+
+    if (this._pendingDashboardDebugSessionStartListeners.size === 0 && this._pendingDashboardDebugSessionStartListenerCleanup) {
+      clearTimeout(this._pendingDashboardDebugSessionStartListenerCleanup);
+      this._pendingDashboardDebugSessionStartListenerCleanup = undefined;
+    }
+  }
+
+  private scheduleDashboardStartListenerCleanup(): void {
+    if (this._pendingDashboardDebugSessionStartListeners.size === 0 || this._pendingDashboardDebugSessionStartListenerCleanup) {
+      return;
+    }
+
+    // Keep observing briefly after shutdown so a delayed browser can still be stopped, but do not
+    // retain the disposed Aspire session for the lifetime of the extension host if launch never settles.
+    this._pendingDashboardDebugSessionStartListenerCleanup = setTimeout(() => {
+      this._pendingDashboardDebugSessionStartListenerCleanup = undefined;
+      const listeners = [...this._pendingDashboardDebugSessionStartListeners];
+      this._pendingDashboardDebugSessionStartListeners.clear();
+      listeners.forEach(listener => listener.dispose());
+    }, DashboardLauncher._dashboardLateStartListenerTimeoutMs);
   }
 
   private trackDashboardTermination(session: vscode.DebugSession): void {
@@ -307,6 +337,7 @@ export class DashboardLauncher implements vscode.Disposable {
     // Normal teardown awaits this stop as part of stopAllSessions. Keep an idempotent background
     // fallback for direct finalization during extension shutdown.
     this.closeDashboardInBackground();
+    this.scheduleDashboardStartListenerCleanup();
     this._dashboardTerminationDisposable?.dispose();
     this._dashboardTerminationDisposable = undefined;
   }

--- a/extension/src/debugger/session/dashboardLauncher.ts
+++ b/extension/src/debugger/session/dashboardLauncher.ts
@@ -158,6 +158,10 @@ export class DashboardLauncher implements vscode.Disposable {
       // Start as a child debug session so it is stopped alongside this session in `dispose`.
       didStart = await start;
     }
+    catch (error) {
+      disposable.dispose();
+      throw error;
+    }
     finally {
       this._pendingDashboardDebugSessionStarts.delete(completion);
     }

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -92,10 +92,9 @@ suite('Aspire debug dashboard E2E', function () {
 
     test('closes the dashboard debug browser when the AppHost debug session stops', async function () {
         // js-debug cannot launch Chrome under the Linux xvfb runner: it activates on
-        // `onDebugResolve:pwa-chrome` and then never resolves `startDebugging`. Because
-        // `openDashboard` awaits that launch, the AppHost startup handshake stalls and every
-        // later test in this file fails too. Windows runs the real browser, so the shutdown
-        // behavior still gets end-to-end coverage there.
+        // `onDebugResolve:pwa-chrome` but never produces the real browser debug session this
+        // shutdown test requires. The product no longer blocks AppHost startup while the browser
+        // launches, but only Windows can exercise the child-session shutdown behavior end to end.
         if (process.platform !== 'win32') {
             this.skip();
         }

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -90,15 +90,7 @@ suite('Aspire debug dashboard E2E', function () {
         await waitForNoDebugSessions();
     });
 
-    test('closes the dashboard debug browser when the AppHost debug session stops', async function () {
-        // js-debug cannot launch Chrome under the Linux xvfb runner: it activates on
-        // `onDebugResolve:pwa-chrome` but never produces the real browser debug session this
-        // shutdown test requires. The product no longer blocks AppHost startup while the browser
-        // launches, but only Windows can exercise the child-session shutdown behavior end to end.
-        if (process.platform !== 'win32') {
-            this.skip();
-        }
-
+    test('starts the AppHost without waiting for the dashboard debug browser and closes the browser on Windows', async () => {
         writeWorkspaceSetting('aspire.dashboardBrowser', 'debugChrome');
 
         await openAspireView();
@@ -117,20 +109,24 @@ suite('Aspire debug dashboard E2E', function () {
         // look like a missing browser session.
         await waitForDebugDashboardUrl();
 
-        const browserSession = await waitForBrowserDebugSession();
-        assert.deepStrictEqual(
-            getBrowserDebugSessions().filter(session => session.parentSessionType === 'aspire').map(session => ({ id: session.id, type: session.type })),
-            [{ id: browserSession.id, type: 'pwa-chrome' }]);
+        if (process.platform === 'win32') {
+            const browserSession = await waitForBrowserDebugSession();
+            assert.deepStrictEqual(
+                getBrowserDebugSessions().filter(session => session.parentSessionType === 'aspire').map(session => ({ id: session.id, type: session.type })),
+                [{ id: browserSession.id, type: 'pwa-chrome' }]);
+        }
 
         await executeE2eControlCommand({ name: 'stopDebugging' });
         await waitForNoDebugSessions();
 
-        // The Aspire session ending is not enough on its own. VS Code leaves the child browser
-        // session running unless the extension stops it explicitly, which is what left orphaned
-        // dashboard browsers behind in https://github.com/microsoft/aspire/issues/19289. Asserting
-        // on the extension's own debugSessions cannot catch that regression: it was already empty
-        // while the browser kept running.
-        await waitForNoBrowserDebugSessions();
+        if (process.platform === 'win32') {
+            // The Aspire session ending is not enough on its own. VS Code leaves the child browser
+            // session running unless the extension stops it explicitly, which is what left orphaned
+            // dashboard browsers behind in https://github.com/microsoft/aspire/issues/19289. Asserting
+            // on the extension's own debugSessions cannot catch that regression: it was already empty
+            // while the browser kept running.
+            await waitForNoBrowserDebugSessions();
+        }
     });
 
     test('workspace debug stop removes running apphost', async () => {

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -1264,6 +1264,33 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         sinon.assert.calledOnce(startDebugging);
     });
 
+    test('a pending dashboard debug launch disposes its start listener after shutdown', async () => {
+        const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const disposeStartListener = sinon.stub();
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').returns({ dispose: disposeStartListener });
+        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(() => { }));
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        const stopPromise = aspireDebugSession.stopDebugging();
+        await clock.tickAsync(2000);
+        await stopPromise;
+        sinon.assert.notCalled(disposeStartListener);
+
+        await clock.tickAsync(29999);
+        sinon.assert.notCalled(disposeStartListener);
+
+        await clock.tickAsync(1);
+        sinon.assert.calledOnce(disposeStartListener);
+    });
+
     test('a rejected dashboard debug launch disposes its start listener and logs the failure', async () => {
         const parentDebugSession = {
             id: 'aspire-session',

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -1286,6 +1286,28 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             'Failed to launch dashboard debug session (pwa-msedge): Browser launch failed');
     });
 
+    test('a synchronous dashboard debug launch failure disposes its start listener and logs the failure', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const disposeStartListener = sinon.stub();
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').returns({ dispose: disposeStartListener });
+        sinon.stub(vscode.debug, 'startDebugging').throws(new Error('Browser launch failed'));
+        const warn = sinon.stub(extensionLogOutputChannel, 'warn');
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        await new Promise(resolve => setImmediate(resolve));
+
+        sinon.assert.calledOnce(disposeStartListener);
+        sinon.assert.calledOnceWithExactly(
+            warn,
+            'Failed to launch dashboard debug session (pwa-msedge): Browser launch failed');
+    });
+
     test('stopDebugging ignores a dashboard debug session that already terminated', async () => {
         const parentDebugSession = {
             id: 'aspire-session',

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -1248,6 +1248,22 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(stopDebugging.thirdCall.args[0], dashboardDebugSession);
     });
 
+    test('openDashboard does not wait for a dashboard debug session to start', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').returns({ dispose: sinon.stub() });
+        const startDebugging = sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(() => { }));
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+
+        sinon.assert.calledOnce(startDebugging);
+    });
+
     test('stopDebugging ignores a dashboard debug session that already terminated', async () => {
         const parentDebugSession = {
             id: 'aspire-session',
@@ -1310,9 +1326,10 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         });
         sinon.stub(vscode.debug, 'onDidTerminateDebugSession').returns({ dispose: sinon.stub() });
         let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
-        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+        const startDebuggingPromise = new Promise<boolean>(resolve => {
             resolveStartDebugging = resolve;
-        }));
+        });
+        sinon.stub(vscode.debug, 'startDebugging').returns(startDebuggingPromise);
         let dashboardStopAttempts = 0;
         const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').callsFake(async session => {
             if (session === dashboardDebugSession && dashboardStopAttempts++ === 0) {
@@ -1321,12 +1338,11 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         });
         const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
 
-        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
-        await Promise.resolve();
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
         const firstStop = aspireDebugSession.stopDebugging();
         startSessionCallback?.(dashboardDebugSession);
         resolveStartDebugging?.(true);
-        await openPromise;
+        await startDebuggingPromise;
 
         await firstStop;
 
@@ -1358,14 +1374,14 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         });
         sinon.stub(vscode.debug, 'onDidTerminateDebugSession').returns({ dispose: sinon.stub() });
         let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
-        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+        const startDebuggingPromise = new Promise<boolean>(resolve => {
             resolveStartDebugging = resolve;
-        }));
+        });
+        sinon.stub(vscode.debug, 'startDebugging').returns(startDebuggingPromise);
         const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
 
-        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
-        await Promise.resolve();
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
         const stopPromise = aspireDebugSession.stopDebugging();
         startSessionCallback?.(dashboardDebugSession);
         await clock.tickAsync(2000);
@@ -1375,7 +1391,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(stopDebugging.secondCall.args[0], parentDebugSession);
 
         resolveStartDebugging?.(true);
-        await openPromise;
+        await startDebuggingPromise;
     });
 
     test('a dashboard that starts after shutdown retries a failed background stop', async () => {
@@ -1400,9 +1416,10 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         });
         sinon.stub(vscode.debug, 'onDidTerminateDebugSession').returns({ dispose: sinon.stub() });
         let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
-        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+        const startDebuggingPromise = new Promise<boolean>(resolve => {
             resolveStartDebugging = resolve;
-        }));
+        });
+        sinon.stub(vscode.debug, 'startDebugging').returns(startDebuggingPromise);
         let dashboardStopAttempts = 0;
         const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').callsFake(async session => {
             if (session === dashboardDebugSession && dashboardStopAttempts++ === 0) {
@@ -1411,8 +1428,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         });
         const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
 
-        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
-        await Promise.resolve();
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
         const stopPromise = aspireDebugSession.stopDebugging();
         await clock.tickAsync(2000);
         await stopPromise;
@@ -1426,7 +1442,7 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(stopDebugging.thirdCall.args[0], dashboardDebugSession);
 
         resolveStartDebugging?.(true);
-        await openPromise;
+        await startDebuggingPromise;
     });
 
     test('stopDebugging treats dashboard termination during a pending stop as success', async () => {
@@ -1569,18 +1585,18 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
             return { dispose: sinon.stub() };
         });
         let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
-        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+        const startDebuggingPromise = new Promise<boolean>(resolve => {
             resolveStartDebugging = resolve;
-        }));
+        });
+        sinon.stub(vscode.debug, 'startDebugging').returns(startDebuggingPromise);
         const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
 
-        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
-        await Promise.resolve();
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
         aspireDebugSession.dispose();
         startSessionCallback?.(dashboardDebugSession);
         resolveStartDebugging?.(true);
-        await openPromise;
+        await startDebuggingPromise;
         await aspireDebugSession.stopDebugging();
 
         assert.strictEqual(stopDebugging.calledWith(dashboardDebugSession), true);
@@ -1596,18 +1612,18 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         } as unknown as vscode.DebugSession;
         sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake(() => ({ dispose: sinon.stub() }));
         let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
-        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+        const startDebuggingPromise = new Promise<boolean>(resolve => {
             resolveStartDebugging = resolve;
-        }));
+        });
+        sinon.stub(vscode.debug, 'startDebugging').returns(startDebuggingPromise);
         sinon.stub(vscode.debug, 'stopDebugging').resolves();
         const openExternal = sinon.stub(vscode.env, 'openExternal').resolves(true);
         const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
 
-        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
-        await Promise.resolve();
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
         aspireDebugSession.dispose();
         resolveStartDebugging?.(false);
-        await openPromise;
+        await startDebuggingPromise;
 
         assert.strictEqual(openExternal.called, false);
     });

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -1264,6 +1264,28 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         sinon.assert.calledOnce(startDebugging);
     });
 
+    test('a rejected dashboard debug launch disposes its start listener and logs the failure', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const disposeStartListener = sinon.stub();
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').returns({ dispose: disposeStartListener });
+        sinon.stub(vscode.debug, 'startDebugging').rejects(new Error('Browser launch failed'));
+        const warn = sinon.stub(extensionLogOutputChannel, 'warn');
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        await aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        await new Promise(resolve => setImmediate(resolve));
+
+        sinon.assert.calledOnce(disposeStartListener);
+        sinon.assert.calledOnceWithExactly(
+            warn,
+            'Failed to launch dashboard debug session (pwa-msedge): Browser launch failed');
+    });
+
     test('stopDebugging ignores a dashboard debug session that already terminated', async () => {
         const parentDebugSession = {
             id: 'aspire-session',


### PR DESCRIPTION
## Description

The Windows `debug-dashboard` E2E shard could time out after the dashboard was already running. A debugger-backed browser launch was awaited while the CLI startup handshake was still in progress, so a pending `vscode.debug.startDebugging()` kept `startupCompleted` false for the full 180-second test timeout.

Debugger-backed dashboard launches now run as observed background work. The Aspire debug session still owns pending and late browser sessions, closes them during shutdown, and logs launch failures. Pending start listeners remain active for a bounded post-shutdown grace period so late browser children can still be stopped without retaining the session for the lifetime of the extension host. Integrated and external browser launches keep their existing awaited behavior.

The Windows E2E still verifies real browser-child cleanup. The startup regression now runs cross-platform, including environments where js-debug never produces a browser session.

### User-facing usage

Users who debug an AppHost with a debugger-backed dashboard browser no longer wait for the browser debugger before Aspire startup completes:

```json
{
  "aspire.dashboardBrowser": "debugChrome"
}
```

Validation:

- `corepack yarn test` — 2,407 passing, 4 pending
- Focused `debugDashboard.e2e.test.js` Extension Host run — 7 passing
- Four-lane architecture, lifecycle, Aspire correctness, and real-path review — no blocking issues

Addresses #19282

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
