### PR TITLE
Add environment variable as msbuild properties too

### DIFF
--- a/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Maui.Annotations;
+
+/// <summary>
+/// Carries a lazily-evaluated, cached generator for the MSBuild files that surface a resource's
+/// <c>WithEnvironment</c> values to a MAUI build.
+/// </summary>
+/// <remarks>
+/// The files can only be generated at launch time because environment values are resolved then, yet both the
+/// serialized pre-build in <c>MauiBuildQueueEventSubscriber</c> and the later DCP <c>/t:Run</c> launch command
+/// need the exact same file paths. Generation is therefore deferred and cached here so whichever consumer runs
+/// first produces the files and every other consumer reuses them — independent of event subscriber ordering.
+/// </remarks>
+internal sealed class MauiEnvironmentFilesAnnotation(
+    Func<ILogger, CancellationToken, Task<(string? PropsFilePath, string? TargetsFilePath)>> generateAsync) : IResourceAnnotation
+{
+    private readonly Func<ILogger, CancellationToken, Task<(string? PropsFilePath, string? TargetsFilePath)>> _generateAsync = generateAsync;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private (string? PropsFilePath, string? TargetsFilePath)? _generated;
+
+    /// <summary>
+    /// Generates the environment files on the first call and returns the cached paths on subsequent calls.
+    /// </summary>
+    public async Task<(string? PropsFilePath, string? TargetsFilePath)> GetOrCreateAsync(ILogger logger, CancellationToken cancellationToken)
+    {
+        if (_generated is { } generated)
+        {
+            return generated;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _generated ??= await _generateAsync(logger, cancellationToken).ConfigureAwait(false);
+            return _generated.Value;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
@@ -11,10 +11,13 @@ namespace Aspire.Hosting.Maui.Annotations;
 /// <c>WithEnvironment</c> values to a MAUI build.
 /// </summary>
 /// <remarks>
-/// The files can only be generated at launch time because environment values are resolved then, yet both the
-/// serialized pre-build in <c>MauiBuildQueueEventSubscriber</c> and the later DCP <c>/t:Run</c> launch command
-/// need the exact same file paths. Generation is therefore deferred and cached here so whichever consumer runs
-/// first produces the files and every other consumer reuses them — independent of event subscriber ordering.
+/// The files can only be generated at launch time because environment values are resolved then. For Android
+/// and iOS the exact same file paths are needed by two consumers: the serialized pre-build in
+/// <c>MauiBuildQueueEventSubscriber</c> and the later DCP <c>/t:Run</c> launch command (via each platform's
+/// command-line callback). For Windows and Mac Catalyst there is no launch-command callback — only the
+/// pre-build consumes the props file. Generation is therefore deferred and cached here so that, when there
+/// are multiple consumers, whichever runs first produces the files and the rest reuse them — independent of
+/// event subscriber ordering.
 /// </remarks>
 internal sealed class MauiEnvironmentFilesAnnotation(
     Func<ILogger, CancellationToken, Task<(string? PropsFilePath, string? TargetsFilePath)>> generateAsync) : IResourceAnnotation

--- a/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Annotations/MauiEnvironmentFilesAnnotation.cs
@@ -7,29 +7,38 @@ using Microsoft.Extensions.Logging;
 namespace Aspire.Hosting.Maui.Annotations;
 
 /// <summary>
-/// Carries a lazily-evaluated, cached generator for the MSBuild files that surface a resource's
+/// Carries a lazily-evaluated, cached generator for the MSBuild inputs that surface a resource's
 /// <c>WithEnvironment</c> values to a MAUI build.
 /// </summary>
 /// <remarks>
-/// The files can only be generated at launch time because environment values are resolved then. For Android
-/// and iOS the exact same file paths are needed by two consumers: the serialized pre-build in
+/// The inputs can only be produced at launch time because environment values are resolved then. Each resource
+/// exposes its environment variables as global MSBuild properties (a set of <c>-p:NAME=VALUE</c> arguments);
+/// Android and iOS additionally emit a targets file carrying the platform launch items. For Android and iOS
+/// the exact same inputs are needed by two consumers: the serialized pre-build in
 /// <c>MauiBuildQueueEventSubscriber</c> and the later DCP <c>/t:Run</c> launch command (via each platform's
 /// command-line callback). For Windows and Mac Catalyst there is no launch-command callback — only the
-/// pre-build consumes the props file. Generation is therefore deferred and cached here so that, when there
-/// are multiple consumers, whichever runs first produces the files and the rest reuse them — independent of
-/// event subscriber ordering.
+/// pre-build consumes them. Generation is therefore deferred and cached here so that, when there are multiple
+/// consumers, whichever runs first produces the inputs and the rest reuse them — independent of event
+/// subscriber ordering.
+/// <para>
+/// The cache is scoped to a single launch, not to the whole app-model lifetime. Environment values can
+/// change between a stop and a restart, so <see cref="Invalidate"/> is called at the start of each
+/// <c>BeforeResourceStartedEvent</c> to drop inputs generated for a previous start; the current launch then
+/// regenerates them once and its consumers reuse the fresh inputs.
+/// </para>
 /// </remarks>
 internal sealed class MauiEnvironmentFilesAnnotation(
-    Func<ILogger, CancellationToken, Task<(string? PropsFilePath, string? TargetsFilePath)>> generateAsync) : IResourceAnnotation
+    Func<ILogger, CancellationToken, Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)>> generateAsync) : IResourceAnnotation
 {
-    private readonly Func<ILogger, CancellationToken, Task<(string? PropsFilePath, string? TargetsFilePath)>> _generateAsync = generateAsync;
+    private readonly Func<ILogger, CancellationToken, Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)>> _generateAsync = generateAsync;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private (string? PropsFilePath, string? TargetsFilePath)? _generated;
+    private (IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)? _generated;
 
     /// <summary>
-    /// Generates the environment files on the first call and returns the cached paths on subsequent calls.
+    /// Generates the environment inputs on the first call and returns the cached values on subsequent calls
+    /// until <see cref="Invalidate"/> is called.
     /// </summary>
-    public async Task<(string? PropsFilePath, string? TargetsFilePath)> GetOrCreateAsync(ILogger logger, CancellationToken cancellationToken)
+    public async Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)> GetOrCreateAsync(ILogger logger, CancellationToken cancellationToken)
     {
         if (_generated is { } generated)
         {
@@ -41,6 +50,23 @@ internal sealed class MauiEnvironmentFilesAnnotation(
         {
             _generated ??= await _generateAsync(logger, cancellationToken).ConfigureAwait(false);
             return _generated.Value;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Drops the cached inputs so the next <see cref="GetOrCreateAsync"/> regenerates them. Called at the
+    /// start of each launch so a restart does not reuse inputs built from stale environment values.
+    /// </summary>
+    public void Invalidate()
+    {
+        _gate.Wait();
+        try
+        {
+            _generated = null;
         }
         finally
         {

--- a/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
+++ b/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
@@ -130,20 +130,13 @@ internal class MauiBuildQueueEventSubscriber(
     }
 
     /// <summary>
-    /// Runs <c>dotnet build</c> as a subprocess and pipes its output to the resource logger.
+    /// Builds the <c>dotnet build</c> argument list, appending the environment MSBuild files when present so
+    /// that <c>WithEnvironment</c> values influence the actual compilation (build-time conditions/properties
+    /// and, for Android, the <c>AndroidEnvironment</c> items baked into the app). The same cached files are
+    /// reused by the no-build Run launch command via the environment subscriber's command-line callback.
     /// </summary>
-    internal virtual async Task RunBuildAsync(IResource resource, ILogger logger, CancellationToken cancellationToken)
+    internal static async Task<List<string>> BuildDotnetBuildArgumentsAsync(IResource resource, MauiBuildInfoAnnotation buildInfo, ILogger logger, CancellationToken cancellationToken)
     {
-        if (!resource.TryGetLastAnnotation<MauiBuildInfoAnnotation>(out var buildInfo))
-        {
-            logger.LogWarning("No build info annotation found for resource '{ResourceName}'. Startup cannot proceed.", resource.Name);
-            throw new InvalidOperationException(
-                $"Resource '{resource.Name}' is missing MauiBuildInfoAnnotation. " +
-                "Cannot proceed with build — the semaphore would be held indefinitely.");
-        }
-
-        // Match DCP's launch configuration so the no-build Run target starts the exact outputs
-        // produced by this serialized build.
         var args = new List<string> { "build", buildInfo.ProjectPath };
 
         if (!string.IsNullOrEmpty(buildInfo.TargetFramework))
@@ -159,6 +152,44 @@ internal class MauiBuildQueueEventSubscriber(
         }
 
         args.AddRange(buildInfo.AdditionalBuildArguments);
+
+        if (resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
+        {
+            var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(logger, cancellationToken).ConfigureAwait(false);
+
+            // Imported early (before the project body) so environment values are visible to project-level
+            // property definitions and conditions.
+            if (propsFilePath is not null)
+            {
+                args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
+            }
+
+            // Imported late so platform launch item hooks run after the common targets have defined them.
+            if (targetsFilePath is not null)
+            {
+                args.Add($"-p:CustomAfterMicrosoftCommonTargets={targetsFilePath}");
+            }
+        }
+
+        return args;
+    }
+
+    /// <summary>
+    /// Runs <c>dotnet build</c> as a subprocess and pipes its output to the resource logger.
+    /// </summary>
+    internal virtual async Task RunBuildAsync(IResource resource, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (!resource.TryGetLastAnnotation<MauiBuildInfoAnnotation>(out var buildInfo))
+        {
+            logger.LogWarning("No build info annotation found for resource '{ResourceName}'. Startup cannot proceed.", resource.Name);
+            throw new InvalidOperationException(
+                $"Resource '{resource.Name}' is missing MauiBuildInfoAnnotation. " +
+                "Cannot proceed with build — the semaphore would be held indefinitely.");
+        }
+
+        // Match DCP's launch configuration so the no-build Run target starts the exact outputs
+        // produced by this serialized build.
+        var args = await BuildDotnetBuildArgumentsAsync(resource, buildInfo, logger, cancellationToken).ConfigureAwait(false);
 
         var psi = new ProcessStartInfo("dotnet")
         {

--- a/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
+++ b/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
@@ -55,6 +55,14 @@ internal class MauiBuildQueueEventSubscriber(
         var parent = mauiResource.Parent;
         var logger = loggerService.GetLogger(resource);
 
+        // Environment values are re-resolved on every launch (they can change between a stop and a restart),
+        // so drop any files cached from a previous start. This launch's pre-build regenerates them and the
+        // later DCP Run launch command reuses the same freshly generated files.
+        if (resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFilesAnnotation))
+        {
+            envFilesAnnotation.Invalidate();
+        }
+
         if (!parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var queueAnnotation))
         {
             return;
@@ -130,9 +138,9 @@ internal class MauiBuildQueueEventSubscriber(
     }
 
     /// <summary>
-    /// Builds the <c>dotnet build</c> argument list, appending the environment MSBuild files when present so
+    /// Builds the <c>dotnet build</c> argument list, appending the environment MSBuild inputs when present so
     /// that <c>WithEnvironment</c> values influence the actual compilation (build-time conditions/properties
-    /// and, for Android, the <c>AndroidEnvironment</c> items baked into the app). The same cached files are
+    /// and, for Android, the <c>AndroidEnvironment</c> items baked into the app). The same cached inputs are
     /// reused by the no-build Run launch command via the environment subscriber's command-line callback.
     /// </summary>
     internal static async Task<List<string>> BuildDotnetBuildArgumentsAsync(IResource resource, MauiBuildInfoAnnotation buildInfo, ILogger logger, CancellationToken cancellationToken)
@@ -155,14 +163,13 @@ internal class MauiBuildQueueEventSubscriber(
 
         if (resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
         {
-            var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(logger, cancellationToken).ConfigureAwait(false);
+            var (propertyArgs, targetsFilePath) = await envFiles.GetOrCreateAsync(logger, cancellationToken).ConfigureAwait(false);
 
-            // Imported early (before the project body) so environment values are visible to project-level
-            // property definitions and conditions.
-            if (propsFilePath is not null)
-            {
-                args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
-            }
+            // Passed as global MSBuild properties (rather than importing a props file via the single
+            // CustomBeforeMicrosoftCommonProps slot) so the user's own props extension is preserved. Global
+            // properties are evaluated before any import, so they are visible to project-level property
+            // definitions and conditions.
+            args.AddRange(propertyArgs);
 
             // Imported late so platform launch item hooks run after the common targets have defined them.
             if (targetsFilePath is not null)

--- a/src/Aspire.Hosting.Maui/MauiAndroidExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiAndroidExtensions.cs
@@ -160,6 +160,8 @@ public static class MauiAndroidExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(androidDeviceResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             .WithAnnotation(new MauiAndroidEnvironmentAnnotation()) // Enable environment variable support via targets file
+            // Attached at creation so both the serialized pre-build and the launch command import the same files.
+            .WithAnnotation(MauiEnvironmentHelper.CreateAndroidEnvironmentFilesAnnotation(builder.ApplicationBuilder, androidDeviceResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",
@@ -365,6 +367,8 @@ public static class MauiAndroidExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(androidEmulatorResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             .WithAnnotation(new MauiAndroidEnvironmentAnnotation()) // Enable environment variable support via targets file
+            // Attached at creation so both the serialized pre-build and the launch command import the same files.
+            .WithAnnotation(MauiEnvironmentHelper.CreateAndroidEnvironmentFilesAnnotation(builder.ApplicationBuilder, androidEmulatorResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
@@ -91,7 +91,7 @@ public static class MauiMacCatalystExtensions
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(macCatalystResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
-            // Attached at creation so both the serialized pre-build and the launch command import the same file.
+            // Attached at creation; consumed only by the serialized pre-build (Mac Catalyst has no launch-command callback).
             .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, macCatalystResource, "maccatalyst"))
             .WithAnnotation(new ExecutableAnnotation
             {

--- a/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Maui;
+using Aspire.Hosting.Maui.Utilities;
 
 namespace Aspire.Hosting;
 
@@ -90,6 +91,8 @@ public static class MauiMacCatalystExtensions
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(macCatalystResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
+            // Attached at creation so both the serialized pre-build and the launch command import the same file.
+            .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, macCatalystResource, "maccatalyst"))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
@@ -92,7 +92,7 @@ public static class MauiMacCatalystExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(macCatalystResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             // Attached at creation; consumed only by the serialized pre-build (Mac Catalyst has no launch-command callback).
-            .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, macCatalystResource, "maccatalyst"))
+            .WithAnnotation(MauiEnvironmentHelper.CreateEnvironmentPropertyArgsAnnotation(builder.ApplicationBuilder, macCatalystResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
@@ -91,7 +91,7 @@ public static class MauiWindowsExtensions
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(windowsResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
-            // Attached at creation so both the serialized pre-build and the launch command import the same file.
+            // Attached at creation; consumed only by the serialized pre-build (Windows has no launch-command callback).
             .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, windowsResource, "windows"))
             .WithAnnotation(new ExecutableAnnotation
             {

--- a/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
@@ -92,7 +92,7 @@ public static class MauiWindowsExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(windowsResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             // Attached at creation; consumed only by the serialized pre-build (Windows has no launch-command callback).
-            .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, windowsResource, "windows"))
+            .WithAnnotation(MauiEnvironmentHelper.CreateEnvironmentPropertyArgsAnnotation(builder.ApplicationBuilder, windowsResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Maui;
+using Aspire.Hosting.Maui.Utilities;
 
 namespace Aspire.Hosting;
 
@@ -90,6 +91,8 @@ public static class MauiWindowsExtensions
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(windowsResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
+            // Attached at creation so both the serialized pre-build and the launch command import the same file.
+            .WithAnnotation(MauiEnvironmentHelper.CreatePropsEnvironmentFilesAnnotation(builder.ApplicationBuilder, windowsResource, "windows"))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/MauiiOSExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiiOSExtensions.cs
@@ -167,6 +167,8 @@ public static class MauiiOSExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(iOSDeviceResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             .WithAnnotation(new MauiiOSEnvironmentAnnotation()) // Enable environment variable support via targets file
+            // Attached at creation so both the serialized pre-build and the launch command import the same files.
+            .WithAnnotation(MauiEnvironmentHelper.CreateiOSEnvironmentFilesAnnotation(builder.ApplicationBuilder, iOSDeviceResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",
@@ -378,6 +380,8 @@ public static class MauiiOSExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(iOSSimulatorResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             .WithAnnotation(new MauiiOSEnvironmentAnnotation()) // Enable environment variable support via targets file
+            // Attached at creation so both the serialized pre-build and the launch command import the same files.
+            .WithAnnotation(MauiEnvironmentHelper.CreateiOSEnvironmentFilesAnnotation(builder.ApplicationBuilder, iOSSimulatorResource))
             .WithAnnotation(new ExecutableAnnotation
             {
                 Command = "dotnet",

--- a/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
@@ -72,10 +72,10 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that appends the generated MSBuild files to the DCP launch
-            // command. The files themselves are produced by the MauiEnvironmentFilesAnnotation attached at
+            // Add a CommandLineArgsCallback that appends the environment MSBuild inputs to the DCP launch
+            // command. The inputs themselves are produced by the MauiEnvironmentFilesAnnotation attached at
             // resource creation, which caches them so the serialized pre-build and this launch share the
-            // exact same paths regardless of subscriber ordering.
+            // exact same values regardless of subscriber ordering.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
                 if (!resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
@@ -83,13 +83,14 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
                     return;
                 }
 
-                var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
+                var (propertyArgs, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
 
-                // The props file is imported early (before the project body) so the environment values are
-                // visible to project-level property definitions and conditions.
-                if (propsFilePath is not null)
+                // Passed as global MSBuild properties (rather than importing a props file via the single
+                // CustomBeforeMicrosoftCommonProps slot) so the user's own props extension is preserved.
+                // Global properties are visible to project-level property definitions and conditions.
+                foreach (var propertyArg in propertyArgs)
                 {
-                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
+                    context.Args.Add(propertyArg);
                 }
 
                 // The targets file is imported late so the AndroidEnvironment launch item hooks run after

--- a/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
@@ -76,17 +76,17 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the targets file
+            // Add a CommandLineArgsCallback that will generate the MSBuild files
             // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the file once
-            string? generatedFilePath = null;
+            // The callback itself ensures idempotency by only generating the files once
+            (string? PropsFilePath, string? TargetsFilePath)? generatedFiles = null;
 
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the file once, even if this callback is invoked multiple times
-                if (generatedFilePath is null)
+                // Only generate the files once, even if this callback is invoked multiple times
+                if (generatedFiles is null)
                 {
-                    generatedFilePath = await MauiEnvironmentHelper.CreateAndroidEnvironmentTargetsFileAsync(
+                    generatedFiles = await MauiEnvironmentHelper.CreateAndroidEnvironmentFilesAsync(
                         fileSystemService,
                         resource,
                         executionContext,
@@ -94,17 +94,27 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
                         cancellationToken
                     ).ConfigureAwait(false);
 
-                    if (generatedFilePath is not null)
+                    if (generatedFiles.Value.PropsFilePath is not null || generatedFiles.Value.TargetsFilePath is not null)
                     {
-                        logger.LogInformation("Generated environment targets file for Android: {Path}", generatedFilePath);
+                        logger.LogInformation(
+                            "Generated environment files for Android (props: {Props}, targets: {Targets})",
+                            generatedFiles.Value.PropsFilePath,
+                            generatedFiles.Value.TargetsFilePath);
                     }
                 }
 
-                if (generatedFilePath is not null)
+                // The props file is imported early (before the project body) so the environment values are
+                // visible to project-level property definitions and conditions.
+                if (generatedFiles.Value.PropsFilePath is not null)
                 {
-                    // Add the targets file as an MSBuild property via command-line argument
-                    var commandLineArg = $"-p:CustomAfterMicrosoftCommonTargets={generatedFilePath}";
-                    context.Args.Add(commandLineArg);
+                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={generatedFiles.Value.PropsFilePath}");
+                }
+
+                // The targets file is imported late so the AndroidEnvironment launch item hooks run after
+                // the common targets have defined them.
+                if (generatedFiles.Value.TargetsFilePath is not null)
+                {
+                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={generatedFiles.Value.TargetsFilePath}");
                 }
             }));
 

--- a/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiAndroidEnvironmentAnnotation.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
-
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
-using Microsoft.Extensions.DependencyInjection;
+using Aspire.Hosting.Maui.Annotations;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Maui.Utilities;
@@ -39,10 +37,8 @@ internal sealed class MauiAndroidEnvironmentProcessedAnnotation : IResourceAnnot
 /// Event subscriber that processes <see cref="MauiAndroidEnvironmentAnnotation"/> annotations.
 /// </summary>
 internal sealed class MauiAndroidEnvironmentSubscriber(
-    DistributedApplicationExecutionContext executionContext,
     ResourceLoggerService loggerService,
-    ResourceNotificationService notificationService,
-    IFileSystemService fileSystemService) : IDistributedApplicationEventingSubscriber
+    ResourceNotificationService notificationService) : IDistributedApplicationEventingSubscriber
 {
     public Task SubscribeAsync(IDistributedApplicationEventing eventing, DistributedApplicationExecutionContext execContext, CancellationToken cancellationToken)
     {
@@ -76,45 +72,31 @@ internal sealed class MauiAndroidEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the MSBuild files
-            // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the files once
-            (string? PropsFilePath, string? TargetsFilePath)? generatedFiles = null;
-
+            // Add a CommandLineArgsCallback that appends the generated MSBuild files to the DCP launch
+            // command. The files themselves are produced by the MauiEnvironmentFilesAnnotation attached at
+            // resource creation, which caches them so the serialized pre-build and this launch share the
+            // exact same paths regardless of subscriber ordering.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the files once, even if this callback is invoked multiple times
-                if (generatedFiles is null)
+                if (!resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
                 {
-                    generatedFiles = await MauiEnvironmentHelper.CreateAndroidEnvironmentFilesAsync(
-                        fileSystemService,
-                        resource,
-                        executionContext,
-                        logger,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-
-                    if (generatedFiles.Value.PropsFilePath is not null || generatedFiles.Value.TargetsFilePath is not null)
-                    {
-                        logger.LogInformation(
-                            "Generated environment files for Android (props: {Props}, targets: {Targets})",
-                            generatedFiles.Value.PropsFilePath,
-                            generatedFiles.Value.TargetsFilePath);
-                    }
+                    return;
                 }
+
+                var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
 
                 // The props file is imported early (before the project body) so the environment values are
                 // visible to project-level property definitions and conditions.
-                if (generatedFiles.Value.PropsFilePath is not null)
+                if (propsFilePath is not null)
                 {
-                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={generatedFiles.Value.PropsFilePath}");
+                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
                 }
 
                 // The targets file is imported late so the AndroidEnvironment launch item hooks run after
                 // the common targets have defined them.
-                if (generatedFiles.Value.TargetsFilePath is not null)
+                if (targetsFilePath is not null)
                 {
-                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={generatedFiles.Value.TargetsFilePath}");
+                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={targetsFilePath}");
                 }
             }));
 

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -92,6 +92,10 @@ internal static class MauiEnvironmentHelper
             new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets')")
         ));
 
+        // Also surface the environment variables as MSBuild properties so they can be consumed by the
+        // project build itself (e.g. in $(NAME) references or property conditions), not just the launch tooling.
+        AddEnvironmentPropertyGroup(projectElement, environmentVariables);
+
         // Create an ItemGroup for AndroidEnvironment files to be generated
         var itemGroup = new XElement("ItemGroup");
         foreach (var (key, value) in environmentVariables.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
@@ -193,6 +197,38 @@ internal static class MauiEnvironmentHelper
         return new string(chars);
     }
 
+    /// <summary>
+    /// Adds a <c>PropertyGroup</c> that exposes each environment variable as an MSBuild property so the
+    /// values injected by Aspire are visible to the project build itself (for example in <c>$(NAME)</c>
+    /// references or property conditions), not just to the platform launch tooling.
+    /// </summary>
+    /// <remarks>
+    /// Environment variable names are encoded to valid MSBuild property identifiers via
+    /// <see cref="EnvironmentVariableNameEncoder.Encode(string)"/>: names that are already valid are used
+    /// unchanged, otherwise invalid characters are replaced with '_'. Values are written verbatim; XML
+    /// special characters are escaped automatically by <see cref="XElement"/>.
+    /// </remarks>
+    internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables)
+    {
+        var propertyGroup = new XElement("PropertyGroup");
+
+        foreach (var (key, value) in environmentVariables.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var propertyName = EnvironmentVariableNameEncoder.Encode(key);
+
+            // An empty encoded name only occurs for an empty key, which cannot form a valid MSBuild
+            // property (or XML element) name, so skip it.
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                continue;
+            }
+
+            propertyGroup.Add(new XElement(propertyName, value));
+        }
+
+        projectElement.Add(propertyGroup);
+    }
+
     internal static string EncodeMSBuildItemValue(string value, out bool wasEncoded)
     {
         wasEncoded = value.Contains('%', StringComparison.Ordinal) || value.Contains(';', StringComparison.Ordinal);
@@ -267,6 +303,10 @@ internal static class MauiEnvironmentHelper
             new XAttribute("Project", "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets"),
             new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets')")
         ));
+
+        // Also surface the environment variables as MSBuild properties so they can be consumed by the
+        // project build itself (e.g. in $(NAME) references or property conditions), not just mlaunch.
+        AddEnvironmentPropertyGroup(projectElement, environmentVariables);
 
         // Create an ItemGroup to add environment variables using MlaunchEnvironmentVariables
         // iOS apps need environment variables passed to mlaunch as KEY=VALUE pairs

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -56,44 +56,38 @@ internal static class MauiEnvironmentHelper
     }
 
     /// <summary>
-    /// Creates a lazy generator annotation for a resource's environment props file, capturing the services
-    /// needed to generate it at launch time. Unlike the Android and iOS variants, this produces only the
-    /// early-imported props file (no platform-specific targets file), so it fits platforms such as Windows
-    /// and Mac Catalyst that surface <c>WithEnvironment</c> values as MSBuild properties but do not need
-    /// extra platform launch item hooks.
+    /// Creates a lazy generator annotation for a resource's environment properties, capturing the services
+    /// needed to resolve them at launch time. Unlike the Android and iOS variants, this produces only the
+    /// global MSBuild property arguments (no platform-specific targets file), so it fits platforms such as
+    /// Windows and Mac Catalyst that surface <c>WithEnvironment</c> values as MSBuild properties but do not
+    /// need extra platform launch item hooks.
     /// </summary>
     /// <remarks>
     /// Attached at resource creation. Unlike Android and iOS, these platforms have no launch-command callback,
-    /// so only the serialized pre-build consumes the generated props file. See <see cref="MauiEnvironmentFilesAnnotation"/>.
+    /// so only the serialized pre-build consumes the generated properties. See <see cref="MauiEnvironmentFilesAnnotation"/>.
     /// </remarks>
-    public static MauiEnvironmentFilesAnnotation CreatePropsEnvironmentFilesAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource, string platformMoniker)
+    public static MauiEnvironmentFilesAnnotation CreateEnvironmentPropertyArgsAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource)
     {
-        var fileSystemService = appBuilder.FileSystemService;
         var executionContext = appBuilder.ExecutionContext;
         return new MauiEnvironmentFilesAnnotation((logger, ct) =>
-            CreatePropsEnvironmentFilesAsync(fileSystemService, resource, executionContext, platformMoniker, logger, ct));
+            CreateEnvironmentPropertyArgsAsync(resource, executionContext, logger, ct));
     }
 
     /// <summary>
-    /// Creates the MSBuild props file that exposes a resource's environment variables to the project build
-    /// as MSBuild properties, without generating any platform-specific targets file.
+    /// Resolves a resource's environment variables into global MSBuild property arguments, without generating
+    /// any platform-specific targets file.
     /// </summary>
-    /// <param name="fileSystemService">The file system service for managing temp files.</param>
     /// <param name="resource">The resource to collect environment variables from.</param>
     /// <param name="executionContext">The execution context.</param>
-    /// <param name="platformMoniker">A short platform identifier (for example <c>windows</c> or <c>maccatalyst</c>) used to name the temp directory and generated file.</param>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// The path of the generated props file and a null targets path, or nulls if no environment variables are
-    /// present. The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so
-    /// its properties are visible to the project body.
+    /// The <c>-p:NAME=VALUE</c> arguments exposing the environment variables as MSBuild properties and a null
+    /// targets path, or an empty list if no environment variables are present.
     /// </returns>
-    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreatePropsEnvironmentFilesAsync(
-        IFileSystemService fileSystemService,
+    public static async Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)> CreateEnvironmentPropertyArgsAsync(
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
-        string platformMoniker,
         ILogger logger,
         CancellationToken cancellationToken)
     {
@@ -102,29 +96,15 @@ internal static class MauiEnvironmentHelper
             .BuildAsync(executionContext, logger, cancellationToken)
             .ConfigureAwait(false);
 
-        // If no environment variables, return nulls
         if (!executionConfiguration.EnvironmentVariables.Any())
         {
-            return (null, null);
+            return (Array.Empty<string>(), null);
         }
 
         var environmentVariables = executionConfiguration.EnvironmentVariables.ToDictionary();
 
-        // Create a temporary directory to hold the generated props file
-        var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory($"aspire-maui-{platformMoniker}-env").Path;
-
-        // Prune old generated files
-        PruneOldGeneratedFiles(tempDirectory, logger);
-
-        var sanitizedName = SanitizeFileName(resource.Name + "-" + platformMoniker);
-        var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-
-        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
-        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-
-        // No platform-specific targets file: Windows and Mac Catalyst consume the environment values through
-        // the early props import; only the Android/iOS launch tooling needs the extra targets item hooks.
-        return (propsFilePath, null);
+        // Windows and Mac Catalyst have no platform launch item hooks, so only the global properties are needed.
+        return (BuildEnvironmentPropertyArgs(environmentVariables, logger), null);
     }
 
     /// <summary>
@@ -137,12 +117,12 @@ internal static class MauiEnvironmentHelper
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// The paths of the generated props and targets files, or nulls if no environment variables are present.
-    /// The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so its
-    /// properties are visible to the project body; the targets file is imported late (via
-    /// <c>CustomAfterMicrosoftCommonTargets</c>) so the Android launch item hooks run after the common targets.
+    /// The <c>-p:NAME=VALUE</c> arguments exposing the environment variables as MSBuild properties and the path
+    /// of the generated targets file, or an empty list and null if no environment variables are present. The
+    /// targets file is imported late (via <c>CustomAfterMicrosoftCommonTargets</c>) so the Android launch item
+    /// hooks run after the common targets.
     /// </returns>
-    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreateAndroidEnvironmentFilesAsync(
+    public static async Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)> CreateAndroidEnvironmentFilesAsync(
         IFileSystemService fileSystemService,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
@@ -165,28 +145,23 @@ internal static class MauiEnvironmentHelper
             environmentVariables[normalizedKey] = envVar.Value;
         }
 
-        // If no environment variables, return nulls
+        // If no environment variables, return an empty result
         if (environmentVariables.Count == 0)
         {
-            return (null, null);
+            return (Array.Empty<string>(), null);
         }
 
-        // Create a temporary directory to hold the generated props and targets files
+        // Create a temporary directory to hold the generated targets file. The directory is tracked by the
+        // file system service and removed on app shutdown (honoring ASPIRE_PRESERVE_TEMP_FILES).
         var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-android-env").Path;
-
-        // Prune old generated files
-        PruneOldGeneratedFiles(tempDirectory, logger);
 
         var sanitizedName = SanitizeFileName(resource.Name + "-android");
         var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
 
-        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
-        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-
         var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
         await File.WriteAllTextAsync(targetsFilePath, GenerateAndroidTargetsFileContent(environmentVariables), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
 
-        return (propsFilePath, targetsFilePath);
+        return (BuildEnvironmentPropertyArgs(environmentVariables, logger), targetsFilePath);
     }
 
     /// <summary>
@@ -252,51 +227,6 @@ internal static class MauiEnvironmentHelper
         return SerializeProject(projectElement);
     }
 
-    private static void PruneOldGeneratedFiles(string directory, ILogger logger)
-    {
-        // Each run creates a brand-new unique subdirectory via CreateTempSubdirectory, so `directory` itself
-        // is empty and never holds stale artifacts. Leftovers from prior (including crashed) runs live in
-        // *sibling* directories under the shared temp root, so prune those instead by scanning the parent.
-        var parent = Directory.GetParent(directory)?.FullName;
-        if (parent is null)
-        {
-            return;
-        }
-
-        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
-        var deletedDirectories = new List<string>();
-
-        // All of this helper's temp subdirectories are created with an "aspire-maui-" prefix
-        // (e.g. aspire-maui-android-env, aspire-maui-mlaunch-env, aspire-maui-windows-env), so match that.
-        foreach (var siblingDirectory in Directory.EnumerateDirectories(parent, "aspire-maui-*", SearchOption.TopDirectoryOnly))
-        {
-            // Never delete the directory that was just created for the current run.
-            if (string.Equals(Path.GetFullPath(siblingDirectory), Path.GetFullPath(directory), StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            try
-            {
-                var info = new DirectoryInfo(siblingDirectory);
-                if (info.Exists && info.LastWriteTimeUtc < expiration)
-                {
-                    info.Delete(recursive: true);
-                    deletedDirectories.Add(info.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Failed to prune stale MAUI environment directory '{Directory}'.", siblingDirectory);
-            }
-        }
-
-        if (deletedDirectories.Count > 0)
-        {
-            logger.LogDebug("Pruned {Count} stale MAUI environment directory(ies): {Directories}", deletedDirectories.Count, string.Join(", ", deletedDirectories));
-        }
-    }
-
     internal static string SanitizeFileName(string name)
     {
         var invalidCharacters = Path.GetInvalidFileNameChars();
@@ -318,43 +248,23 @@ internal static class MauiEnvironmentHelper
     }
 
     /// <summary>
-    /// Generates the content of an MSBuild <c>.props</c> file that exposes the environment variables as
-    /// MSBuild properties. This file is imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so the
-    /// values are visible to project-level property definitions and conditions, unlike the late
-    /// <c>.targets</c> import which only carries the platform launch items.
+    /// Builds the <c>-p:NAME=VALUE</c> MSBuild command-line arguments that expose the environment variables as
+    /// MSBuild properties. Global (command-line) properties are used instead of a generated props file imported
+    /// through <c>CustomBeforeMicrosoftCommonProps</c>: that slot is a single-file extension point, so claiming
+    /// it would replace (and there is no reliable way to recover) a user-supplied value — for example one set in
+    /// a <c>Directory.Build.rsp</c> response file, which becomes an opaque global property. Global properties are
+    /// also evaluated before any import, so the values are visible to project-level property definitions and
+    /// conditions just like an early props import would be.
     /// </summary>
-    internal static string GenerateEnvironmentPropsFileContent(Dictionary<string, string> environmentVariables, ILogger logger)
+    internal static List<string> BuildEnvironmentPropertyArgs(Dictionary<string, string> environmentVariables, ILogger logger)
     {
-        var projectElement = new XElement("Project");
+        var args = new List<string>();
+        foreach (var (name, value) in EnumerateEmittableProperties(environmentVariables, logger))
+        {
+            args.Add($"-p:{name}={value}");
+        }
 
-        // We claim the single CustomBeforeMicrosoftCommonProps extension slot by passing -p: on the command
-        // line, which is a global property and therefore overrides (and hides) any value the user supplied
-        // via the environment or a response file. To avoid silently dropping a user-provided extension file,
-        // recover and chain the original value here.
-        //
-        // The value is read with GetEnvironmentVariable rather than $(CustomBeforeMicrosoftCommonProps)
-        // because the latter already resolves to *this* generated file (that is how we got imported); the raw
-        // environment variable is not shadowed by the global -p: property, so it still exposes the user's
-        // original path. If the user set nothing, fall back to MSBuild's conventional default extension file,
-        // which is exactly what MSBuild would have imported into this slot on its own.
-        const string originalPropName = "_AspireOriginalCustomBeforeMicrosoftCommonProps";
-        const string conventionalDefault = "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props";
-
-        projectElement.Add(new XElement(
-            "PropertyGroup",
-            new XElement(originalPropName, "$([System.Environment]::GetEnvironmentVariable('CustomBeforeMicrosoftCommonProps'))"),
-            new XElement(originalPropName, new XAttribute("Condition", $"'$({originalPropName})' == ''"), conventionalDefault)
-        ));
-
-        projectElement.Add(new XElement(
-            "Import",
-            new XAttribute("Project", $"$({originalPropName})"),
-            new XAttribute("Condition", $"'$({originalPropName})' != '' and Exists('$({originalPropName})')")
-        ));
-
-        AddEnvironmentPropertyGroup(projectElement, environmentVariables, logger);
-
-        return SerializeProject(projectElement);
+        return args;
     }
 
     // MSBuild's reserved (read-only) property names. Defining any of these in a project file throws MSB4004
@@ -398,30 +308,50 @@ internal static class MauiEnvironmentHelper
     /// references or property conditions), not just to the platform launch tooling.
     /// </summary>
     /// <remarks>
-    /// Environment variable names are encoded to valid MSBuild property identifiers via
-    /// <see cref="EnvironmentVariableNameEncoder.Encode(string)"/>: names that are already valid are used
-    /// unchanged, otherwise invalid characters are replaced with '_'. Because that encoding (and MSBuild's
-    /// case-insensitive property names) can map two distinct variables to the same property name, collisions
-    /// are detected and only the first variable is emitted; the rest are logged rather than silently
-    /// overwriting each other. Names that map to a reserved MSBuild property are skipped (and logged) so they
-    /// do not fail the build with MSB4004. Values are escaped via <see cref="EscapeMSBuildPropertyValue"/> so
-    /// MSBuild syntax in a value (such as <c>$(Configuration)</c>) is preserved literally instead of
-    /// expanding; XML special characters are escaped automatically by <see cref="XElement"/>.
+    /// The emitted names/values follow the rules described on <see cref="EnumerateEmittableProperties"/>.
+    /// XML special characters in the value are escaped automatically by <see cref="XElement"/>.
     /// </remarks>
     internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables, ILogger logger)
     {
         var propertyGroup = new XElement("PropertyGroup");
 
-        // MSBuild property names are case-insensitive, and Encode maps invalid characters to '_', so two
-        // distinct variables can collide (e.g. "services:api:0" and "services_api_0", or "Foo" and "FOO").
-        // Track emitted names case-insensitively and skip later collisions so MSBuild does not silently take
-        // the last definition. The colliding variables still reach the app via the launch items, which use
-        // the original (unencoded) names.
+        foreach (var (name, value) in EnumerateEmittableProperties(environmentVariables, logger))
+        {
+            propertyGroup.Add(new XElement(name, value));
+        }
+
+        projectElement.Add(propertyGroup);
+    }
+
+    /// <summary>
+    /// Yields the encoded property name and escaped value for each environment variable that can be surfaced
+    /// as an MSBuild property, in a stable ordinal-ignore-case order.
+    /// </summary>
+    /// <remarks>
+    /// Environment variable names are encoded to valid MSBuild property identifiers via
+    /// <see cref="EncodeMSBuildPropertyName(string)"/>: names that are already valid are used unchanged,
+    /// otherwise invalid characters are replaced with '_'. Unlike a plain environment-variable encoder this
+    /// keeps hyphens, because MSBuild allows '-' after the first character of a property name (for example
+    /// <c>$(MY-VAR)</c>), so a hyphenated variable maps to the matching property instead of collapsing to an
+    /// underscore. Because that encoding (and MSBuild's case-insensitive property names) can still map two
+    /// distinct variables to the same property name, collisions are detected and only the first variable is
+    /// emitted; the rest are logged rather than silently overwriting each other. Names that map to a reserved
+    /// MSBuild property are skipped (and logged) so they do not fail the build with MSB4004. Values are escaped
+    /// via <see cref="EscapeMSBuildPropertyValue"/> so MSBuild syntax in a value (such as
+    /// <c>$(Configuration)</c>) is preserved literally instead of expanding.
+    /// </remarks>
+    internal static IEnumerable<(string Name, string Value)> EnumerateEmittableProperties(Dictionary<string, string> environmentVariables, ILogger logger)
+    {
+        // MSBuild property names are case-insensitive, and EncodeMSBuildPropertyName maps invalid characters
+        // to '_', so two distinct variables can collide (e.g. "services:api:0" and "services_api_0", or "Foo"
+        // and "FOO"). Track emitted names case-insensitively and skip later collisions so MSBuild does not
+        // silently take the last definition. The colliding variables still reach the app via the launch items,
+        // which use the original (unencoded) names.
         var emittedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, value) in environmentVariables.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
         {
-            var propertyName = EnvironmentVariableNameEncoder.Encode(key);
+            var propertyName = EncodeMSBuildPropertyName(key);
 
             // An empty encoded name only occurs for an empty key, which cannot form a valid MSBuild
             // property (or XML element) name, so skip it.
@@ -453,10 +383,41 @@ internal static class MauiEnvironmentHelper
                 continue;
             }
 
-            propertyGroup.Add(new XElement(propertyName, EscapeMSBuildPropertyValue(value)));
+            yield return (propertyName, EscapeMSBuildPropertyValue(value));
+        }
+    }
+
+    /// <summary>
+    /// Encodes an environment variable name into a valid MSBuild property name.
+    /// </summary>
+    /// <remarks>
+    /// MSBuild property names must start with a letter or underscore and may then contain letters, digits,
+    /// underscores and hyphens (for example <c>$(MY-VAR)</c> is valid). Unlike a plain environment-variable
+    /// encoder, hyphens are preserved so a hyphenated variable maps to the matching MSBuild property rather
+    /// than collapsing to '_' (which could collide with a differently spelled variable). Any other character
+    /// is replaced with '_', and a leading character that is not a letter or underscore is prefixed with '_'.
+    /// </remarks>
+    internal static string EncodeMSBuildPropertyName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
         }
 
-        projectElement.Add(propertyGroup);
+        var builder = new StringBuilder(name.Length + 1);
+
+        // A valid MSBuild property name cannot start with a digit or hyphen, so prefix '_' when it would.
+        if (!char.IsAsciiLetter(name[0]) && name[0] != '_')
+        {
+            builder.Append('_');
+        }
+
+        foreach (var c in name)
+        {
+            builder.Append(char.IsAsciiLetterOrDigit(c) || c is '_' or '-' ? c : '_');
+        }
+
+        return builder.ToString();
     }
 
     internal static string EncodeMSBuildItemValue(string value, out bool wasEncoded)
@@ -544,12 +505,12 @@ internal static class MauiEnvironmentHelper
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// The paths of the generated props and targets files, or nulls if no environment variables are present.
-    /// The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so its
-    /// properties are visible to the project body; the targets file is imported late (via
-    /// <c>CustomAfterMicrosoftCommonTargets</c>) so the mlaunch item hooks run after the common targets.
+    /// The <c>-p:NAME=VALUE</c> arguments exposing the environment variables as MSBuild properties and the path
+    /// of the generated targets file, or an empty list and null if no environment variables are present. The
+    /// targets file is imported late (via <c>CustomAfterMicrosoftCommonTargets</c>) so the mlaunch item hooks
+    /// run after the common targets.
     /// </returns>
-    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreateiOSEnvironmentFilesAsync(
+    public static async Task<(IReadOnlyList<string> PropertyArgs, string? TargetsFilePath)> CreateiOSEnvironmentFilesAsync(
         IFileSystemService fileSystemService,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
@@ -561,30 +522,25 @@ internal static class MauiEnvironmentHelper
             .BuildAsync(executionContext, logger, cancellationToken)
             .ConfigureAwait(false);
 
-        // If no environment variables, return nulls
+        // If no environment variables, return an empty result
         if (!executionConfiguration.EnvironmentVariables.Any())
         {
-            return (null, null);
+            return (Array.Empty<string>(), null);
         }
 
         var environmentVariables = executionConfiguration.EnvironmentVariables.ToDictionary();
 
-        // Create a temporary directory to hold the generated props and targets files
+        // Create a temporary directory to hold the generated targets file. The directory is tracked by the
+        // file system service and removed on app shutdown (honoring ASPIRE_PRESERVE_TEMP_FILES).
         var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-mlaunch-env").Path;
-
-        // Prune old generated files
-        PruneOldGeneratedFiles(tempDirectory, logger);
 
         var sanitizedName = SanitizeFileName(resource.Name + "-ios");
         var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
 
-        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
-        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-
         var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
         await File.WriteAllTextAsync(targetsFilePath, GenerateiOSTargetsFileContent(environmentVariables), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
 
-        return (propsFilePath, targetsFilePath);
+        return (BuildEnvironmentPropertyArgs(environmentVariables, logger), targetsFilePath);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -63,8 +63,8 @@ internal static class MauiEnvironmentHelper
     /// extra platform launch item hooks.
     /// </summary>
     /// <remarks>
-    /// Attached at resource creation so both the serialized pre-build and the DCP launch command can share
-    /// the same generated file regardless of eventing order. See <see cref="MauiEnvironmentFilesAnnotation"/>.
+    /// Attached at resource creation. Unlike Android and iOS, these platforms have no launch-command callback,
+    /// so only the serialized pre-build consumes the generated props file. See <see cref="MauiEnvironmentFilesAnnotation"/>.
     /// </remarks>
     public static MauiEnvironmentFilesAnnotation CreatePropsEnvironmentFilesAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource, string platformMoniker)
     {
@@ -254,36 +254,46 @@ internal static class MauiEnvironmentHelper
 
     private static void PruneOldGeneratedFiles(string directory, ILogger logger)
     {
-        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
-        var deletedFiles = new List<string>();
-
-        // Both the early ".props" and the late ".targets" files are generated per run, so prune both.
-        foreach (var file in Directory.EnumerateFiles(directory, "*.*", SearchOption.TopDirectoryOnly))
+        // Each run creates a brand-new unique subdirectory via CreateTempSubdirectory, so `directory` itself
+        // is empty and never holds stale artifacts. Leftovers from prior (including crashed) runs live in
+        // *sibling* directories under the shared temp root, so prune those instead by scanning the parent.
+        var parent = Directory.GetParent(directory)?.FullName;
+        if (parent is null)
         {
-            if (!file.EndsWith(".props", StringComparison.OrdinalIgnoreCase) &&
-                !file.EndsWith(".targets", StringComparison.OrdinalIgnoreCase))
+            return;
+        }
+
+        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
+        var deletedDirectories = new List<string>();
+
+        // All of this helper's temp subdirectories are created with an "aspire-maui-" prefix
+        // (e.g. aspire-maui-android-env, aspire-maui-mlaunch-env, aspire-maui-windows-env), so match that.
+        foreach (var siblingDirectory in Directory.EnumerateDirectories(parent, "aspire-maui-*", SearchOption.TopDirectoryOnly))
+        {
+            // Never delete the directory that was just created for the current run.
+            if (string.Equals(Path.GetFullPath(siblingDirectory), Path.GetFullPath(directory), StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
 
             try
             {
-                var info = new FileInfo(file);
+                var info = new DirectoryInfo(siblingDirectory);
                 if (info.Exists && info.LastWriteTimeUtc < expiration)
                 {
-                    info.Delete();
-                    deletedFiles.Add(info.Name);
+                    info.Delete(recursive: true);
+                    deletedDirectories.Add(info.Name);
                 }
             }
             catch (Exception ex)
             {
-                logger.LogDebug(ex, "Failed to prune stale MAUI environment file '{File}'.", file);
+                logger.LogDebug(ex, "Failed to prune stale MAUI environment directory '{Directory}'.", siblingDirectory);
             }
         }
 
-        if (deletedFiles.Count > 0)
+        if (deletedDirectories.Count > 0)
         {
-            logger.LogDebug("Pruned {Count} stale MAUI environment file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
+            logger.LogDebug("Pruned {Count} stale MAUI environment directory(ies): {Directories}", deletedDirectories.Count, string.Join(", ", deletedDirectories));
         }
     }
 
@@ -317,12 +327,29 @@ internal static class MauiEnvironmentHelper
     {
         var projectElement = new XElement("Project");
 
-        // Re-import the default Custom.Before.Microsoft.Common.props so overriding
-        // CustomBeforeMicrosoftCommonProps via -p: does not suppress a user-provided extension file.
+        // We claim the single CustomBeforeMicrosoftCommonProps extension slot by passing -p: on the command
+        // line, which is a global property and therefore overrides (and hides) any value the user supplied
+        // via the environment or a response file. To avoid silently dropping a user-provided extension file,
+        // recover and chain the original value here.
+        //
+        // The value is read with GetEnvironmentVariable rather than $(CustomBeforeMicrosoftCommonProps)
+        // because the latter already resolves to *this* generated file (that is how we got imported); the raw
+        // environment variable is not shadowed by the global -p: property, so it still exposes the user's
+        // original path. If the user set nothing, fall back to MSBuild's conventional default extension file,
+        // which is exactly what MSBuild would have imported into this slot on its own.
+        const string originalPropName = "_AspireOriginalCustomBeforeMicrosoftCommonProps";
+        const string conventionalDefault = "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props";
+
+        projectElement.Add(new XElement(
+            "PropertyGroup",
+            new XElement(originalPropName, "$([System.Environment]::GetEnvironmentVariable('CustomBeforeMicrosoftCommonProps'))"),
+            new XElement(originalPropName, new XAttribute("Condition", $"'$({originalPropName})' == ''"), conventionalDefault)
+        ));
+
         projectElement.Add(new XElement(
             "Import",
-            new XAttribute("Project", "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props"),
-            new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props')")
+            new XAttribute("Project", $"$({originalPropName})"),
+            new XAttribute("Condition", $"'$({originalPropName})' != '' and Exists('$({originalPropName})')")
         ));
 
         AddEnvironmentPropertyGroup(projectElement, environmentVariables, logger);

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -56,6 +56,78 @@ internal static class MauiEnvironmentHelper
     }
 
     /// <summary>
+    /// Creates a lazy generator annotation for a resource's environment props file, capturing the services
+    /// needed to generate it at launch time. Unlike the Android and iOS variants, this produces only the
+    /// early-imported props file (no platform-specific targets file), so it fits platforms such as Windows
+    /// and Mac Catalyst that surface <c>WithEnvironment</c> values as MSBuild properties but do not need
+    /// extra platform launch item hooks.
+    /// </summary>
+    /// <remarks>
+    /// Attached at resource creation so both the serialized pre-build and the DCP launch command can share
+    /// the same generated file regardless of eventing order. See <see cref="MauiEnvironmentFilesAnnotation"/>.
+    /// </remarks>
+    public static MauiEnvironmentFilesAnnotation CreatePropsEnvironmentFilesAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource, string platformMoniker)
+    {
+        var fileSystemService = appBuilder.FileSystemService;
+        var executionContext = appBuilder.ExecutionContext;
+        return new MauiEnvironmentFilesAnnotation((logger, ct) =>
+            CreatePropsEnvironmentFilesAsync(fileSystemService, resource, executionContext, platformMoniker, logger, ct));
+    }
+
+    /// <summary>
+    /// Creates the MSBuild props file that exposes a resource's environment variables to the project build
+    /// as MSBuild properties, without generating any platform-specific targets file.
+    /// </summary>
+    /// <param name="fileSystemService">The file system service for managing temp files.</param>
+    /// <param name="resource">The resource to collect environment variables from.</param>
+    /// <param name="executionContext">The execution context.</param>
+    /// <param name="platformMoniker">A short platform identifier (for example <c>windows</c> or <c>maccatalyst</c>) used to name the temp directory and generated file.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The path of the generated props file and a null targets path, or nulls if no environment variables are
+    /// present. The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so
+    /// its properties are visible to the project body.
+    /// </returns>
+    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreatePropsEnvironmentFilesAsync(
+        IFileSystemService fileSystemService,
+        IResource resource,
+        DistributedApplicationExecutionContext executionContext,
+        string platformMoniker,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var executionConfiguration = await ExecutionConfigurationBuilder.Create(resource)
+            .WithEnvironmentVariablesConfig()
+            .BuildAsync(executionContext, logger, cancellationToken)
+            .ConfigureAwait(false);
+
+        // If no environment variables, return nulls
+        if (!executionConfiguration.EnvironmentVariables.Any())
+        {
+            return (null, null);
+        }
+
+        var environmentVariables = executionConfiguration.EnvironmentVariables.ToDictionary();
+
+        // Create a temporary directory to hold the generated props file
+        var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory($"aspire-maui-{platformMoniker}-env").Path;
+
+        // Prune old generated files
+        PruneOldGeneratedFiles(tempDirectory, logger);
+
+        var sanitizedName = SanitizeFileName(resource.Name + "-" + platformMoniker);
+        var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
+        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+
+        // No platform-specific targets file: Windows and Mac Catalyst consume the environment values through
+        // the early props import; only the Android/iOS launch tooling needs the extra targets item hooks.
+        return (propsFilePath, null);
+    }
+
+    /// <summary>
     /// Creates the MSBuild files that expose an Android resource's environment variables both to the
     /// project build (as properties) and to the Android launch tooling (as <c>AndroidEnvironment</c> items).
     /// </summary>

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Globalization;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
@@ -143,11 +144,7 @@ internal static class MauiEnvironmentHelper
 
         projectElement.Add(targetElement);
 
-        var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), projectElement);
-
-        using var stringWriter = new StringWriter();
-        document.Save(stringWriter);
-        return stringWriter.ToString();
+        return SerializeProject(projectElement);
     }
 
     private static void PruneOldGeneratedFiles(string directory, ILogger logger)
@@ -225,11 +222,7 @@ internal static class MauiEnvironmentHelper
 
         AddEnvironmentPropertyGroup(projectElement, environmentVariables, logger);
 
-        var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), projectElement);
-
-        using var stringWriter = new StringWriter();
-        document.Save(stringWriter);
-        return stringWriter.ToString();
+        return SerializeProject(projectElement);
     }
 
     /// <summary>
@@ -243,8 +236,9 @@ internal static class MauiEnvironmentHelper
     /// unchanged, otherwise invalid characters are replaced with '_'. Because that encoding (and MSBuild's
     /// case-insensitive property names) can map two distinct variables to the same property name, collisions
     /// are detected and only the first variable is emitted; the rest are logged rather than silently
-    /// overwriting each other. Values are written verbatim; XML special characters are escaped automatically
-    /// by <see cref="XElement"/>.
+    /// overwriting each other. Values are escaped via <see cref="EscapeMSBuildPropertyValue"/> so MSBuild
+    /// syntax in a value (such as <c>$(Configuration)</c>) is preserved literally instead of expanding; XML
+    /// special characters are escaped automatically by <see cref="XElement"/>.
     /// </remarks>
     internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables, ILogger logger)
     {
@@ -278,7 +272,7 @@ internal static class MauiEnvironmentHelper
                 continue;
             }
 
-            propertyGroup.Add(new XElement(propertyName, value));
+            propertyGroup.Add(new XElement(propertyName, EscapeMSBuildPropertyValue(value)));
         }
 
         projectElement.Add(propertyGroup);
@@ -297,6 +291,66 @@ internal static class MauiEnvironmentHelper
         return value
             .Replace("%", "%25", StringComparison.Ordinal)
             .Replace(";", "%3B", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Escapes MSBuild metacharacters in an environment value so it is surfaced as a literal MSBuild property
+    /// value rather than being interpreted as MSBuild syntax (for example a value of <c>$(Configuration)</c>
+    /// or <c>@(Compile)</c> must not expand).
+    /// </summary>
+    /// <remarks>
+    /// MSBuild un-escapes <c>%XX</c> hex sequences when a property is consumed, so encoding the special
+    /// characters here yields the original literal value at use time. <c>%</c> is encoded first so the escapes
+    /// introduced for the other characters are not themselves re-decoded.
+    /// </remarks>
+    internal static string EscapeMSBuildPropertyValue(string value)
+    {
+        // Matches MSBuild's escaping set (Microsoft.Build.Shared.EscapingUtilities): the characters that carry
+        // syntactic meaning in an MSBuild property value.
+        if (value.AsSpan().IndexOfAny("%$@();'*?") < 0)
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '%':
+                    builder.Append("%25");
+                    break;
+                case '$':
+                    builder.Append("%24");
+                    break;
+                case '@':
+                    builder.Append("%40");
+                    break;
+                case '(':
+                    builder.Append("%28");
+                    break;
+                case ')':
+                    builder.Append("%29");
+                    break;
+                case ';':
+                    builder.Append("%3B");
+                    break;
+                case '\'':
+                    builder.Append("%27");
+                    break;
+                case '*':
+                    builder.Append("%2A");
+                    break;
+                case '?':
+                    builder.Append("%3F");
+                    break;
+                default:
+                    builder.Append(c);
+                    break;
+            }
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -394,10 +448,26 @@ internal static class MauiEnvironmentHelper
             )
         ));
 
-        var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), projectElement);
+        return SerializeProject(projectElement);
+    }
+
+    // MSBuild reads these files as UTF-8 (both callers write them with Encoding.UTF8). XDocument.Save emits an
+    // XML declaration matching the writer's UTF-16 encoding, which would mislabel the persisted UTF-8 bytes and
+    // can make MSBuild reject the import, so omit the declaration entirely (it is optional for MSBuild files).
+    private static string SerializeProject(XElement projectElement)
+    {
+        var settings = new XmlWriterSettings
+        {
+            OmitXmlDeclaration = true,
+            Indent = true,
+        };
 
         using var stringWriter = new StringWriter();
-        document.Save(stringWriter);
+        using (var xmlWriter = XmlWriter.Create(stringWriter, settings))
+        {
+            projectElement.Save(xmlWriter);
+        }
+
         return stringWriter.ToString();
     }
 }

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -330,6 +330,41 @@ internal static class MauiEnvironmentHelper
         return SerializeProject(projectElement);
     }
 
+    // MSBuild's reserved (read-only) property names. Defining any of these in a project file throws MSB4004
+    // ("The name '...' is reserved, and cannot be modified."), which would break the build for an otherwise
+    // valid WithEnvironment call. Membership is exact (case-insensitive), not prefix based: MSBuild only
+    // reserves this specific set, so custom "MSBuild"-prefixed names remain settable.
+    // Mirrors Microsoft.Build.Internal.ReservedPropertyNames.ReservedProperties:
+    // https://github.com/dotnet/msbuild/blob/main/src/Build/Resources/Constants.cs
+    private static readonly HashSet<string> s_reservedMSBuildPropertyNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "MSBuildProjectDirectory",
+        "MSBuildProjectDirectoryNoRoot",
+        "MSBuildProjectFile",
+        "MSBuildProjectExtension",
+        "MSBuildProjectFullPath",
+        "MSBuildProjectName",
+        "MSBuildThisFileDirectory",
+        "MSBuildThisFileDirectoryNoRoot",
+        "MSBuildThisFile",
+        "MSBuildThisFileExtension",
+        "MSBuildThisFileFullPath",
+        "MSBuildThisFileName",
+        "MSBuildBinPath",
+        "MSBuildProjectDefaultTargets",
+        "MSBuildToolsPath",
+        "MSBuildToolsVersion",
+        "MSBuildRuntimeType",
+        "MSBuildStartupDirectory",
+        "MSBuildNodeCount",
+        "MSBuildLastTaskResult",
+        "MSBuildProgramFiles32",
+        "MSBuildAssemblyVersion",
+        "MSBuildVersion",
+        "MSBuildInteractive",
+        "MSBuildDisableFeaturesFromVersion",
+    };
+
     /// <summary>
     /// Adds a <c>PropertyGroup</c> that exposes each environment variable as an MSBuild property so the
     /// values injected by Aspire are visible to the project build itself (for example in <c>$(NAME)</c>
@@ -341,9 +376,10 @@ internal static class MauiEnvironmentHelper
     /// unchanged, otherwise invalid characters are replaced with '_'. Because that encoding (and MSBuild's
     /// case-insensitive property names) can map two distinct variables to the same property name, collisions
     /// are detected and only the first variable is emitted; the rest are logged rather than silently
-    /// overwriting each other. Values are escaped via <see cref="EscapeMSBuildPropertyValue"/> so MSBuild
-    /// syntax in a value (such as <c>$(Configuration)</c>) is preserved literally instead of expanding; XML
-    /// special characters are escaped automatically by <see cref="XElement"/>.
+    /// overwriting each other. Names that map to a reserved MSBuild property are skipped (and logged) so they
+    /// do not fail the build with MSB4004. Values are escaped via <see cref="EscapeMSBuildPropertyValue"/> so
+    /// MSBuild syntax in a value (such as <c>$(Configuration)</c>) is preserved literally instead of
+    /// expanding; XML special characters are escaped automatically by <see cref="XElement"/>.
     /// </remarks>
     internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables, ILogger logger)
     {
@@ -364,6 +400,19 @@ internal static class MauiEnvironmentHelper
             // property (or XML element) name, so skip it.
             if (string.IsNullOrEmpty(propertyName))
             {
+                continue;
+            }
+
+            // Reserved names (e.g. MSBuildProjectDirectory, MSBuildVersion) cannot be redefined in a project
+            // file; emitting them would fail the whole build with MSB4004. Skip them so an otherwise valid
+            // WithEnvironment call still works — the value is still passed to the app via the launch items.
+            if (s_reservedMSBuildPropertyNames.Contains(propertyName))
+            {
+                logger.LogWarning(
+                    "Environment variable '{Key}' maps to reserved MSBuild property '{PropertyName}', which cannot be redefined in a project file. " +
+                    "Its value is not surfaced as an MSBuild property (it is still passed to the app).",
+                    key,
+                    propertyName);
                 continue;
             }
 

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -22,15 +22,21 @@ namespace Aspire.Hosting.Maui.Utilities;
 internal static class MauiEnvironmentHelper
 {
     /// <summary>
-    /// Creates an MSBuild targets file for Android that sets environment variables.
+    /// Creates the MSBuild files that expose an Android resource's environment variables both to the
+    /// project build (as properties) and to the Android launch tooling (as <c>AndroidEnvironment</c> items).
     /// </summary>
     /// <param name="fileSystemService">The file system service for managing temp files.</param>
     /// <param name="resource">The resource to collect environment variables from.</param>
     /// <param name="executionContext">The execution context.</param>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The path to the generated targets file, or null if no environment variables are present.</returns>
-    public static async Task<string?> CreateAndroidEnvironmentTargetsFileAsync(
+    /// <returns>
+    /// The paths of the generated props and targets files, or nulls if no environment variables are present.
+    /// The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so its
+    /// properties are visible to the project body; the targets file is imported late (via
+    /// <c>CustomAfterMicrosoftCommonTargets</c>) so the Android launch item hooks run after the common targets.
+    /// </returns>
+    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreateAndroidEnvironmentFilesAsync(
         IFileSystemService fileSystemService,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
@@ -53,29 +59,28 @@ internal static class MauiEnvironmentHelper
             environmentVariables[normalizedKey] = envVar.Value;
         }
 
-        // If no environment variables, return null
+        // If no environment variables, return nulls
         if (environmentVariables.Count == 0)
         {
-            return null;
+            return (null, null);
         }
 
-        // Create a temporary targets file
+        // Create a temporary directory to hold the generated props and targets files
         var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-android-env").Path;
 
-        // Prune old targets files
-        PruneOldTargets(tempDirectory, logger);
+        // Prune old generated files
+        PruneOldGeneratedFiles(tempDirectory, logger);
 
         var sanitizedName = SanitizeFileName(resource.Name + "-android");
         var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
+        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+
         var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
+        await File.WriteAllTextAsync(targetsFilePath, GenerateAndroidTargetsFileContent(environmentVariables), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
 
-        // Generate the targets file content
-        var targetsContent = GenerateAndroidTargetsFileContent(environmentVariables);
-
-        // Write the file
-        await File.WriteAllTextAsync(targetsFilePath, targetsContent, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-
-        return targetsFilePath;
+        return (propsFilePath, targetsFilePath);
     }
 
     /// <summary>
@@ -91,10 +96,6 @@ internal static class MauiEnvironmentHelper
             new XAttribute("Project", "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets"),
             new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets')")
         ));
-
-        // Also surface the environment variables as MSBuild properties so they can be consumed by the
-        // project build itself (e.g. in $(NAME) references or property conditions), not just the launch tooling.
-        AddEnvironmentPropertyGroup(projectElement, environmentVariables);
 
         // Create an ItemGroup for AndroidEnvironment files to be generated
         var itemGroup = new XElement("ItemGroup");
@@ -149,13 +150,20 @@ internal static class MauiEnvironmentHelper
         return stringWriter.ToString();
     }
 
-    private static void PruneOldTargets(string directory, ILogger logger)
+    private static void PruneOldGeneratedFiles(string directory, ILogger logger)
     {
         var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
         var deletedFiles = new List<string>();
 
-        foreach (var file in Directory.EnumerateFiles(directory, "*.targets", SearchOption.TopDirectoryOnly))
+        // Both the early ".props" and the late ".targets" files are generated per run, so prune both.
+        foreach (var file in Directory.EnumerateFiles(directory, "*.*", SearchOption.TopDirectoryOnly))
         {
+            if (!file.EndsWith(".props", StringComparison.OrdinalIgnoreCase) &&
+                !file.EndsWith(".targets", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             try
             {
                 var info = new FileInfo(file);
@@ -167,13 +175,13 @@ internal static class MauiEnvironmentHelper
             }
             catch (Exception ex)
             {
-                logger.LogDebug(ex, "Failed to prune stale Android environment targets file '{TargetsFile}'.", file);
+                logger.LogDebug(ex, "Failed to prune stale MAUI environment file '{File}'.", file);
             }
         }
 
         if (deletedFiles.Count > 0)
         {
-            logger.LogDebug("Pruned {Count} stale Android environment targets file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
+            logger.LogDebug("Pruned {Count} stale MAUI environment file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
         }
     }
 
@@ -198,6 +206,33 @@ internal static class MauiEnvironmentHelper
     }
 
     /// <summary>
+    /// Generates the content of an MSBuild <c>.props</c> file that exposes the environment variables as
+    /// MSBuild properties. This file is imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so the
+    /// values are visible to project-level property definitions and conditions, unlike the late
+    /// <c>.targets</c> import which only carries the platform launch items.
+    /// </summary>
+    internal static string GenerateEnvironmentPropsFileContent(Dictionary<string, string> environmentVariables, ILogger logger)
+    {
+        var projectElement = new XElement("Project");
+
+        // Re-import the default Custom.Before.Microsoft.Common.props so overriding
+        // CustomBeforeMicrosoftCommonProps via -p: does not suppress a user-provided extension file.
+        projectElement.Add(new XElement(
+            "Import",
+            new XAttribute("Project", "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props"),
+            new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.Before.Microsoft.Common.props')")
+        ));
+
+        AddEnvironmentPropertyGroup(projectElement, environmentVariables, logger);
+
+        var document = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), projectElement);
+
+        using var stringWriter = new StringWriter();
+        document.Save(stringWriter);
+        return stringWriter.ToString();
+    }
+
+    /// <summary>
     /// Adds a <c>PropertyGroup</c> that exposes each environment variable as an MSBuild property so the
     /// values injected by Aspire are visible to the project build itself (for example in <c>$(NAME)</c>
     /// references or property conditions), not just to the platform launch tooling.
@@ -205,12 +240,22 @@ internal static class MauiEnvironmentHelper
     /// <remarks>
     /// Environment variable names are encoded to valid MSBuild property identifiers via
     /// <see cref="EnvironmentVariableNameEncoder.Encode(string)"/>: names that are already valid are used
-    /// unchanged, otherwise invalid characters are replaced with '_'. Values are written verbatim; XML
-    /// special characters are escaped automatically by <see cref="XElement"/>.
+    /// unchanged, otherwise invalid characters are replaced with '_'. Because that encoding (and MSBuild's
+    /// case-insensitive property names) can map two distinct variables to the same property name, collisions
+    /// are detected and only the first variable is emitted; the rest are logged rather than silently
+    /// overwriting each other. Values are written verbatim; XML special characters are escaped automatically
+    /// by <see cref="XElement"/>.
     /// </remarks>
-    internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables)
+    internal static void AddEnvironmentPropertyGroup(XElement projectElement, Dictionary<string, string> environmentVariables, ILogger logger)
     {
         var propertyGroup = new XElement("PropertyGroup");
+
+        // MSBuild property names are case-insensitive, and Encode maps invalid characters to '_', so two
+        // distinct variables can collide (e.g. "services:api:0" and "services_api_0", or "Foo" and "FOO").
+        // Track emitted names case-insensitively and skip later collisions so MSBuild does not silently take
+        // the last definition. The colliding variables still reach the app via the launch items, which use
+        // the original (unencoded) names.
+        var emittedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, value) in environmentVariables.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
         {
@@ -220,6 +265,16 @@ internal static class MauiEnvironmentHelper
             // property (or XML element) name, so skip it.
             if (string.IsNullOrEmpty(propertyName))
             {
+                continue;
+            }
+
+            if (!emittedNames.Add(propertyName))
+            {
+                logger.LogWarning(
+                    "Environment variable '{Key}' maps to MSBuild property '{PropertyName}', which is already defined by another variable. " +
+                    "Its value is not surfaced as an MSBuild property (it is still passed to the app). Rename the variable to avoid the collision.",
+                    key,
+                    propertyName);
                 continue;
             }
 
@@ -245,15 +300,21 @@ internal static class MauiEnvironmentHelper
     }
 
     /// <summary>
-    /// Creates an MSBuild targets file for iOS that sets environment variables.
+    /// Creates the MSBuild files that expose an iOS resource's environment variables both to the project
+    /// build (as properties) and to the iOS launch tooling (as <c>MlaunchEnvironmentVariables</c> items).
     /// </summary>
     /// <param name="fileSystemService">The file system service for managing temp files.</param>
     /// <param name="resource">The resource to collect environment variables from.</param>
     /// <param name="executionContext">The execution context.</param>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The path to the generated targets file, or null if no environment variables are present.</returns>
-    public static async Task<string?> CreateiOSEnvironmentTargetsFileAsync(
+    /// <returns>
+    /// The paths of the generated props and targets files, or nulls if no environment variables are present.
+    /// The props file is meant to be imported early (via <c>CustomBeforeMicrosoftCommonProps</c>) so its
+    /// properties are visible to the project body; the targets file is imported late (via
+    /// <c>CustomAfterMicrosoftCommonTargets</c>) so the mlaunch item hooks run after the common targets.
+    /// </returns>
+    public static async Task<(string? PropsFilePath, string? TargetsFilePath)> CreateiOSEnvironmentFilesAsync(
         IFileSystemService fileSystemService,
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
@@ -265,29 +326,30 @@ internal static class MauiEnvironmentHelper
             .BuildAsync(executionContext, logger, cancellationToken)
             .ConfigureAwait(false);
 
-        // If no environment variables, return null
+        // If no environment variables, return nulls
         if (!executionConfiguration.EnvironmentVariables.Any())
         {
-            return null;
+            return (null, null);
         }
 
-        // Create a temporary targets file
+        var environmentVariables = executionConfiguration.EnvironmentVariables.ToDictionary();
+
+        // Create a temporary directory to hold the generated props and targets files
         var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("aspire-maui-mlaunch-env").Path;
 
-        // Prune old targets files
-        PruneOldTargetsiOS(tempDirectory, logger);
+        // Prune old generated files
+        PruneOldGeneratedFiles(tempDirectory, logger);
 
         var sanitizedName = SanitizeFileName(resource.Name + "-ios");
         var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        var propsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.props");
+        await File.WriteAllTextAsync(propsFilePath, GenerateEnvironmentPropsFileContent(environmentVariables, logger), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+
         var targetsFilePath = Path.Combine(tempDirectory, $"{sanitizedName}-{uniqueId}.targets");
+        await File.WriteAllTextAsync(targetsFilePath, GenerateiOSTargetsFileContent(environmentVariables), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
 
-        // Generate the targets file content
-        var targetsContent = GenerateiOSTargetsFileContent(executionConfiguration.EnvironmentVariables.ToDictionary());
-
-        // Write the file
-        await File.WriteAllTextAsync(targetsFilePath, targetsContent, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-
-        return targetsFilePath;
+        return (propsFilePath, targetsFilePath);
     }
 
     /// <summary>
@@ -303,10 +365,6 @@ internal static class MauiEnvironmentHelper
             new XAttribute("Project", "$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets"),
             new XAttribute("Condition", "Exists('$(MSBuildExtensionsPath)/v$(MSBuildToolsVersion)/Custom.After.Microsoft.Common.targets')")
         ));
-
-        // Also surface the environment variables as MSBuild properties so they can be consumed by the
-        // project build itself (e.g. in $(NAME) references or property conditions), not just mlaunch.
-        AddEnvironmentPropertyGroup(projectElement, environmentVariables);
 
         // Create an ItemGroup to add environment variables using MlaunchEnvironmentVariables
         // iOS apps need environment variables passed to mlaunch as KEY=VALUE pairs
@@ -341,33 +399,5 @@ internal static class MauiEnvironmentHelper
         using var stringWriter = new StringWriter();
         document.Save(stringWriter);
         return stringWriter.ToString();
-    }
-
-    private static void PruneOldTargetsiOS(string directory, ILogger logger)
-    {
-        var expiration = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
-        var deletedFiles = new List<string>();
-
-        foreach (var file in Directory.EnumerateFiles(directory, "*.targets", SearchOption.TopDirectoryOnly))
-        {
-            try
-            {
-                var info = new FileInfo(file);
-                if (info.Exists && info.LastWriteTimeUtc < expiration)
-                {
-                    info.Delete();
-                    deletedFiles.Add(info.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Failed to prune stale iOS environment targets file '{TargetsFile}'.", file);
-            }
-        }
-
-        if (deletedFiles.Count > 0)
-        {
-            logger.LogDebug("Pruned {Count} stale iOS environment targets file(s): {Files}", deletedFiles.Count, string.Join(", ", deletedFiles));
-        }
     }
 }

--- a/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiEnvironmentHelper.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Maui.Annotations;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Maui.Utilities;
@@ -22,6 +23,38 @@ namespace Aspire.Hosting.Maui.Utilities;
 /// </remarks>
 internal static class MauiEnvironmentHelper
 {
+    /// <summary>
+    /// Creates a lazy generator annotation for an Android resource's environment files, capturing the
+    /// services needed to generate them at launch time.
+    /// </summary>
+    /// <remarks>
+    /// Attached at resource creation so both the serialized pre-build and the DCP launch command can share
+    /// the same generated files regardless of eventing order. See <see cref="MauiEnvironmentFilesAnnotation"/>.
+    /// </remarks>
+    public static MauiEnvironmentFilesAnnotation CreateAndroidEnvironmentFilesAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource)
+    {
+        var fileSystemService = appBuilder.FileSystemService;
+        var executionContext = appBuilder.ExecutionContext;
+        return new MauiEnvironmentFilesAnnotation((logger, ct) =>
+            CreateAndroidEnvironmentFilesAsync(fileSystemService, resource, executionContext, logger, ct));
+    }
+
+    /// <summary>
+    /// Creates a lazy generator annotation for an iOS resource's environment files, capturing the
+    /// services needed to generate them at launch time.
+    /// </summary>
+    /// <remarks>
+    /// Attached at resource creation so both the serialized pre-build and the DCP launch command can share
+    /// the same generated files regardless of eventing order. See <see cref="MauiEnvironmentFilesAnnotation"/>.
+    /// </remarks>
+    public static MauiEnvironmentFilesAnnotation CreateiOSEnvironmentFilesAnnotation(IDistributedApplicationBuilder appBuilder, IResource resource)
+    {
+        var fileSystemService = appBuilder.FileSystemService;
+        var executionContext = appBuilder.ExecutionContext;
+        return new MauiEnvironmentFilesAnnotation((logger, ct) =>
+            CreateiOSEnvironmentFilesAsync(fileSystemService, resource, executionContext, logger, ct));
+    }
+
     /// <summary>
     /// Creates the MSBuild files that expose an Android resource's environment variables both to the
     /// project build (as properties) and to the Android launch tooling (as <c>AndroidEnvironment</c> items).

--- a/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
-
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
-using Microsoft.Extensions.DependencyInjection;
+using Aspire.Hosting.Maui.Annotations;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Maui.Utilities;
@@ -39,10 +37,8 @@ internal sealed class MauiiOSEnvironmentProcessedAnnotation : IResourceAnnotatio
 /// Event subscriber that processes <see cref="MauiiOSEnvironmentAnnotation"/> annotations.
 /// </summary>
 internal sealed class MauiiOSEnvironmentSubscriber(
-    DistributedApplicationExecutionContext executionContext,
     ResourceLoggerService loggerService,
-    ResourceNotificationService notificationService,
-    IFileSystemService fileSystemService) : IDistributedApplicationEventingSubscriber
+    ResourceNotificationService notificationService) : IDistributedApplicationEventingSubscriber
 {
     public Task SubscribeAsync(IDistributedApplicationEventing eventing, DistributedApplicationExecutionContext execContext, CancellationToken cancellationToken)
     {
@@ -76,45 +72,31 @@ internal sealed class MauiiOSEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the MSBuild files
-            // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the files once
-            (string? PropsFilePath, string? TargetsFilePath)? generatedFiles = null;
-
+            // Add a CommandLineArgsCallback that appends the generated MSBuild files to the DCP launch
+            // command. The files themselves are produced by the MauiEnvironmentFilesAnnotation attached at
+            // resource creation, which caches them so the serialized pre-build and this launch share the
+            // exact same paths regardless of subscriber ordering.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the files once, even if this callback is invoked multiple times
-                if (generatedFiles is null)
+                if (!resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
                 {
-                    generatedFiles = await MauiEnvironmentHelper.CreateiOSEnvironmentFilesAsync(
-                        fileSystemService,
-                        resource,
-                        executionContext,
-                        logger,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-
-                    if (generatedFiles.Value.PropsFilePath is not null || generatedFiles.Value.TargetsFilePath is not null)
-                    {
-                        logger.LogInformation(
-                            "Generated environment files for iOS (props: {Props}, targets: {Targets})",
-                            generatedFiles.Value.PropsFilePath,
-                            generatedFiles.Value.TargetsFilePath);
-                    }
+                    return;
                 }
+
+                var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
 
                 // The props file is imported early (before the project body) so the environment values are
                 // visible to project-level property definitions and conditions.
-                if (generatedFiles.Value.PropsFilePath is not null)
+                if (propsFilePath is not null)
                 {
-                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={generatedFiles.Value.PropsFilePath}");
+                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
                 }
 
                 // The targets file is imported late so the mlaunch launch item hooks run after the common
                 // targets have defined them.
-                if (generatedFiles.Value.TargetsFilePath is not null)
+                if (targetsFilePath is not null)
                 {
-                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={generatedFiles.Value.TargetsFilePath}");
+                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={targetsFilePath}");
                 }
             }));
 

--- a/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
@@ -72,10 +72,10 @@ internal sealed class MauiiOSEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that appends the generated MSBuild files to the DCP launch
-            // command. The files themselves are produced by the MauiEnvironmentFilesAnnotation attached at
+            // Add a CommandLineArgsCallback that appends the environment MSBuild inputs to the DCP launch
+            // command. The inputs themselves are produced by the MauiEnvironmentFilesAnnotation attached at
             // resource creation, which caches them so the serialized pre-build and this launch share the
-            // exact same paths regardless of subscriber ordering.
+            // exact same values regardless of subscriber ordering.
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
                 if (!resource.TryGetLastAnnotation<MauiEnvironmentFilesAnnotation>(out var envFiles))
@@ -83,13 +83,14 @@ internal sealed class MauiiOSEnvironmentSubscriber(
                     return;
                 }
 
-                var (propsFilePath, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
+                var (propertyArgs, targetsFilePath) = await envFiles.GetOrCreateAsync(context.Logger, context.CancellationToken).ConfigureAwait(false);
 
-                // The props file is imported early (before the project body) so the environment values are
-                // visible to project-level property definitions and conditions.
-                if (propsFilePath is not null)
+                // Passed as global MSBuild properties (rather than importing a props file via the single
+                // CustomBeforeMicrosoftCommonProps slot) so the user's own props extension is preserved.
+                // Global properties are visible to project-level property definitions and conditions.
+                foreach (var propertyArg in propertyArgs)
                 {
-                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={propsFilePath}");
+                    context.Args.Add(propertyArg);
                 }
 
                 // The targets file is imported late so the mlaunch launch item hooks run after the common

--- a/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting.Maui/Utilities/MauiiOSEnvironmentAnnotation.cs
@@ -76,17 +76,17 @@ internal sealed class MauiiOSEnvironmentSubscriber(
 
         try
         {
-            // Add a CommandLineArgsCallback that will generate the targets file
+            // Add a CommandLineArgsCallback that will generate the MSBuild files
             // This runs AFTER all environment callbacks have been processed
-            // The callback itself ensures idempotency by only generating the file once
-            string? generatedFilePath = null;
+            // The callback itself ensures idempotency by only generating the files once
+            (string? PropsFilePath, string? TargetsFilePath)? generatedFiles = null;
 
             resource.Annotations.Add(new CommandLineArgsCallbackAnnotation(async context =>
             {
-                // Only generate the file once, even if this callback is invoked multiple times
-                if (generatedFilePath is null)
+                // Only generate the files once, even if this callback is invoked multiple times
+                if (generatedFiles is null)
                 {
-                    generatedFilePath = await MauiEnvironmentHelper.CreateiOSEnvironmentTargetsFileAsync(
+                    generatedFiles = await MauiEnvironmentHelper.CreateiOSEnvironmentFilesAsync(
                         fileSystemService,
                         resource,
                         executionContext,
@@ -94,17 +94,27 @@ internal sealed class MauiiOSEnvironmentSubscriber(
                         cancellationToken
                     ).ConfigureAwait(false);
 
-                    if (generatedFilePath is not null)
+                    if (generatedFiles.Value.PropsFilePath is not null || generatedFiles.Value.TargetsFilePath is not null)
                     {
-                        logger.LogInformation("Generated environment targets file for iOS: {Path}", generatedFilePath);
+                        logger.LogInformation(
+                            "Generated environment files for iOS (props: {Props}, targets: {Targets})",
+                            generatedFiles.Value.PropsFilePath,
+                            generatedFiles.Value.TargetsFilePath);
                     }
                 }
 
-                if (generatedFilePath is not null)
+                // The props file is imported early (before the project body) so the environment values are
+                // visible to project-level property definitions and conditions.
+                if (generatedFiles.Value.PropsFilePath is not null)
                 {
-                    // Add the targets file as an MSBuild property via command-line argument
-                    var commandLineArg = $"-p:CustomAfterMicrosoftCommonTargets={generatedFilePath}";
-                    context.Args.Add(commandLineArg);
+                    context.Args.Add($"-p:CustomBeforeMicrosoftCommonProps={generatedFiles.Value.PropsFilePath}");
+                }
+
+                // The targets file is imported late so the mlaunch launch item hooks run after the common
+                // targets have defined them.
+                if (generatedFiles.Value.TargetsFilePath is not null)
+                {
+                    context.Args.Add($"-p:CustomAfterMicrosoftCommonTargets={generatedFiles.Value.TargetsFilePath}");
                 }
             }));
 

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -3,6 +3,7 @@
 
 using System.Xml.Linq;
 using Aspire.Hosting.Maui.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 
@@ -184,37 +185,52 @@ public class MauiEnvironmentHelperTests
     }
 
     [Fact]
-    public void GenerateAndroidTargetsFileContent_ExposesEnvironmentVariablesAsProperties()
+    public void GenerateEnvironmentPropsFileContent_ExposesEnvironmentVariablesAsProperties()
     {
         var envVars = new Dictionary<string, string>
         {
             ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317",
+            ["MY_VAR"] = "hello"
+        };
+
+        var content = MauiEnvironmentHelper.GenerateEnvironmentPropsFileContent(envVars, NullLogger.Instance);
+        var doc = XDocument.Parse(content);
+
+        Assert.Equal("Project", doc.Root!.Name.LocalName);
+
+        var propertyGroup = doc.Root.Elements("PropertyGroup").Single();
+        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
+        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+    }
+
+    [Fact]
+    public void GenerateAndroidTargetsFileContent_DoesNotContainPropertyGroup()
+    {
+        var envVars = new Dictionary<string, string>
+        {
             ["MY_VAR"] = "hello"
         };
 
         var content = MauiEnvironmentHelper.GenerateAndroidTargetsFileContent(envVars);
         var doc = XDocument.Parse(content);
 
-        var propertyGroup = doc.Root!.Elements("PropertyGroup").Single();
-        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
-        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+        // Properties are surfaced through the early .props file, not the late .targets file.
+        Assert.Empty(doc.Descendants("PropertyGroup"));
     }
 
     [Fact]
-    public void GenerateiOSTargetsFileContent_ExposesEnvironmentVariablesAsProperties()
+    public void GenerateiOSTargetsFileContent_DoesNotContainPropertyGroup()
     {
         var envVars = new Dictionary<string, string>
         {
-            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317",
             ["MY_VAR"] = "hello"
         };
 
         var content = MauiEnvironmentHelper.GenerateiOSTargetsFileContent(envVars);
         var doc = XDocument.Parse(content);
 
-        var propertyGroup = doc.Root!.Elements("PropertyGroup").Single();
-        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
-        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+        // Properties are surfaced through the early .props file, not the late .targets file.
+        Assert.Empty(doc.Descendants("PropertyGroup"));
     }
 
     [Fact]
@@ -227,13 +243,37 @@ public class MauiEnvironmentHelperTests
         };
 
         var projectElement = new XElement("Project");
-        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars);
+        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars, NullLogger.Instance);
 
         var propertyGroup = projectElement.Elements("PropertyGroup").Single();
 
         // ':' is invalid in an MSBuild property name and a leading digit requires a '_' prefix.
         Assert.Equal("http://localhost:5000", propertyGroup.Element("services_api_0")?.Value);
         Assert.Equal("value", propertyGroup.Element("_1LEADING_DIGIT")?.Value);
+    }
+
+    [Fact]
+    public void AddEnvironmentPropertyGroup_CollidingNames_EmitsFirstAndDoesNotDuplicate()
+    {
+        // "services:api:0" and "services_api_0" both encode to "services_api_0", and MSBuild property
+        // names are case-insensitive, so these three variables collapse to a single property. The first
+        // in ordinal-ignore-case order wins ('':'' sorts before ''_''); the rest are dropped (and logged)
+        // rather than overwriting.
+        var envVars = new Dictionary<string, string>
+        {
+            ["services:api:0"] = "colon",
+            ["services_api_0"] = "underscore",
+            ["SERVICES_API_0"] = "upper"
+        };
+
+        var projectElement = new XElement("Project");
+        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars, NullLogger.Instance);
+
+        var properties = projectElement.Elements("PropertyGroup").Single().Elements().ToList();
+
+        var property = Assert.Single(properties);
+        Assert.Equal("services_api_0", property.Name.LocalName);
+        Assert.Equal("colon", property.Value);
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -198,7 +198,9 @@ public class MauiEnvironmentHelperTests
 
         Assert.Equal("Project", doc.Root!.Name.LocalName);
 
-        var propertyGroup = doc.Root.Elements("PropertyGroup").Single();
+        // The file also contains a PropertyGroup that recovers the user's original
+        // CustomBeforeMicrosoftCommonProps; select the one that carries the environment variables.
+        var propertyGroup = doc.Root.Elements("PropertyGroup").Single(pg => pg.Element("MY_VAR") is not null);
         Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
         Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
     }

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -257,7 +257,7 @@ public class MauiEnvironmentHelperTests
     {
         // "services:api:0" and "services_api_0" both encode to "services_api_0", and MSBuild property
         // names are case-insensitive, so these three variables collapse to a single property. The first
-        // in ordinal-ignore-case order wins ('':'' sorts before ''_''); the rest are dropped (and logged)
+        // in ordinal-ignore-case order wins (':' sorts before '_'); the rest are dropped (and logged)
         // rather than overwriting.
         var envVars = new Dictionary<string, string>
         {

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -277,6 +277,30 @@ public class MauiEnvironmentHelperTests
     }
 
     [Fact]
+    public void AddEnvironmentPropertyGroup_SkipsReservedMSBuildPropertyNames()
+    {
+        // Reserved MSBuild property names cannot be redefined in a project file (MSB4004), so they must not
+        // be emitted as properties. Non-reserved variables in the same call are still surfaced.
+        var envVars = new Dictionary<string, string>
+        {
+            ["MSBuildProjectDirectory"] = "/should/not/be/emitted",
+            ["MSBuildVersion"] = "99.99",
+            // Reserved-name matching is case-insensitive, matching MSBuild's own comparison.
+            ["msbuildtoolsversion"] = "1.0",
+            ["MY_VAR"] = "hello"
+        };
+
+        var projectElement = new XElement("Project");
+        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars, NullLogger.Instance);
+
+        var properties = projectElement.Elements("PropertyGroup").Single().Elements().ToList();
+
+        var property = Assert.Single(properties);
+        Assert.Equal("MY_VAR", property.Name.LocalName);
+        Assert.Equal("hello", property.Value);
+    }
+
+    [Fact]
     public void AddEnvironmentPropertyGroup_EscapesMSBuildSyntaxInValues()
     {
         // Values containing MSBuild syntax must be surfaced literally, not expanded. MSBuild un-escapes the

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -185,7 +185,7 @@ public class MauiEnvironmentHelperTests
     }
 
     [Fact]
-    public void GenerateEnvironmentPropsFileContent_ExposesEnvironmentVariablesAsProperties()
+    public void BuildEnvironmentPropertyArgs_ExposesEnvironmentVariablesAsProperties()
     {
         var envVars = new Dictionary<string, string>
         {
@@ -193,16 +193,12 @@ public class MauiEnvironmentHelperTests
             ["MY_VAR"] = "hello"
         };
 
-        var content = MauiEnvironmentHelper.GenerateEnvironmentPropsFileContent(envVars, NullLogger.Instance);
-        var doc = XDocument.Parse(content);
+        var args = MauiEnvironmentHelper.BuildEnvironmentPropertyArgs(envVars, NullLogger.Instance);
 
-        Assert.Equal("Project", doc.Root!.Name.LocalName);
-
-        // The file also contains a PropertyGroup that recovers the user's original
-        // CustomBeforeMicrosoftCommonProps; select the one that carries the environment variables.
-        var propertyGroup = doc.Root.Elements("PropertyGroup").Single(pg => pg.Element("MY_VAR") is not null);
-        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
-        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+        // Emitted as global -p: properties in ordinal-ignore-case key order.
+        Assert.Equal(
+            new[] { "-p:MY_VAR=hello", "-p:OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317" },
+            args);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -183,6 +183,59 @@ public class MauiEnvironmentHelperTests
             items);
     }
 
+    [Fact]
+    public void GenerateAndroidTargetsFileContent_ExposesEnvironmentVariablesAsProperties()
+    {
+        var envVars = new Dictionary<string, string>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317",
+            ["MY_VAR"] = "hello"
+        };
+
+        var content = MauiEnvironmentHelper.GenerateAndroidTargetsFileContent(envVars);
+        var doc = XDocument.Parse(content);
+
+        var propertyGroup = doc.Root!.Elements("PropertyGroup").Single();
+        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
+        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+    }
+
+    [Fact]
+    public void GenerateiOSTargetsFileContent_ExposesEnvironmentVariablesAsProperties()
+    {
+        var envVars = new Dictionary<string, string>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4317",
+            ["MY_VAR"] = "hello"
+        };
+
+        var content = MauiEnvironmentHelper.GenerateiOSTargetsFileContent(envVars);
+        var doc = XDocument.Parse(content);
+
+        var propertyGroup = doc.Root!.Elements("PropertyGroup").Single();
+        Assert.Equal("hello", propertyGroup.Element("MY_VAR")?.Value);
+        Assert.Equal("http://localhost:4317", propertyGroup.Element("OTEL_EXPORTER_OTLP_ENDPOINT")?.Value);
+    }
+
+    [Fact]
+    public void AddEnvironmentPropertyGroup_EncodesInvalidPropertyNames()
+    {
+        var envVars = new Dictionary<string, string>
+        {
+            ["services:api:0"] = "http://localhost:5000",
+            ["1LEADING_DIGIT"] = "value"
+        };
+
+        var projectElement = new XElement("Project");
+        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars);
+
+        var propertyGroup = projectElement.Elements("PropertyGroup").Single();
+
+        // ':' is invalid in an MSBuild property name and a leading digit requires a '_' prefix.
+        Assert.Equal("http://localhost:5000", propertyGroup.Element("services_api_0")?.Value);
+        Assert.Equal("value", propertyGroup.Element("_1LEADING_DIGIT")?.Value);
+    }
+
     [Theory]
     [InlineData("simple-value", "simple-value", false)]
     [InlineData("has;semicolons", "has%3Bsemicolons", true)]

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentHelperTests.cs
@@ -276,6 +276,44 @@ public class MauiEnvironmentHelperTests
         Assert.Equal("colon", property.Value);
     }
 
+    [Fact]
+    public void AddEnvironmentPropertyGroup_EscapesMSBuildSyntaxInValues()
+    {
+        // Values containing MSBuild syntax must be surfaced literally, not expanded. MSBuild un-escapes the
+        // %XX sequences when the property is consumed, so these encoded values yield the original text.
+        var envVars = new Dictionary<string, string>
+        {
+            ["PROPERTY_REF"] = "$(Configuration)",
+            ["ITEM_REF"] = "@(Compile)",
+            ["LITERAL_PERCENT"] = "50%$(Foo)"
+        };
+
+        var projectElement = new XElement("Project");
+        MauiEnvironmentHelper.AddEnvironmentPropertyGroup(projectElement, envVars, NullLogger.Instance);
+
+        var propertyGroup = projectElement.Elements("PropertyGroup").Single();
+
+        Assert.Equal("%24%28Configuration%29", propertyGroup.Element("PROPERTY_REF")?.Value);
+        Assert.Equal("%40%28Compile%29", propertyGroup.Element("ITEM_REF")?.Value);
+        // '%' is encoded first so the escapes introduced for '$'/'(' are not re-decoded by MSBuild.
+        Assert.Equal("50%25%24%28Foo%29", propertyGroup.Element("LITERAL_PERCENT")?.Value);
+    }
+
+    [Theory]
+    [InlineData("plain-value", "plain-value")]
+    [InlineData("$(Configuration)", "%24%28Configuration%29")]
+    [InlineData("@(Compile)", "%40%28Compile%29")]
+    [InlineData("50%off", "50%25off")]
+    [InlineData("a;b", "a%3Bb")]
+    [InlineData("it's", "it%27s")]
+    [InlineData("a*b?c", "a%2Ab%3Fc")]
+    [InlineData("", "")]
+    public void EscapeMSBuildPropertyValue_EncodesMetacharacters(string input, string expected)
+    {
+        var result = MauiEnvironmentHelper.EscapeMSBuildPropertyValue(input);
+        Assert.Equal(expected, result);
+    }
+
     [Theory]
     [InlineData("simple-value", "simple-value", false)]
     [InlineData("has;semicolons", "has%3Bsemicolons", true)]

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
@@ -117,6 +117,50 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
         Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task WindowsBuild_ImportsGeneratedProps()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-windows10.0.19041.0"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var windows = maui.AddWindowsDevice()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var args = await GetBuildArgumentsAsync(windows.Resource);
+
+        // Windows surfaces WithEnvironment values as MSBuild properties via the early props import. It has no
+        // platform launch item hooks, so no targets file is generated.
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.DoesNotContain(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MacCatalystBuild_ImportsGeneratedProps()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-maccatalyst"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var macCatalyst = maui.AddMacCatalystDevice()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var args = await GetBuildArgumentsAsync(macCatalyst.Resource);
+
+        // Mac Catalyst surfaces WithEnvironment values as MSBuild properties via the early props import. It has
+        // no platform launch item hooks, so no targets file is generated.
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.DoesNotContain(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
     private static async Task<List<string>> GetBuildArgumentsAsync(IResource resource)
     {
         var buildInfo = resource.Annotations.OfType<MauiBuildInfoAnnotation>().Last();

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
@@ -15,9 +15,9 @@ namespace Aspire.Hosting.Tests;
 
 /// <summary>
 /// Regression tests for the MAUI environment subscribers. Unlike <see cref="MauiEnvironmentHelperTests"/>,
-/// which only inspects the helper-generated XML, these tests drive the subscriber's command-line callback so
-/// that a regression which stops importing the generated files (for example dropping the
-/// <c>CustomBeforeMicrosoftCommonProps</c> argument) is caught.
+/// which only inspects the helper output, these tests drive the subscriber's command-line callback so that a
+/// regression which stops passing the injected environment values (as global <c>-p:</c> properties) or which
+/// starts stealing the user's <c>CustomBeforeMicrosoftCommonProps</c> slot is caught.
 /// </summary>
 public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 {
@@ -43,10 +43,10 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(android.Resource);
 
-        // The props file must be imported early (before the project body) and the targets file late; both
-        // are required for the injected environment values to reach the build and the launch tooling.
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        // Environment values are passed as global MSBuild properties (never via the CustomBeforeMicrosoftCommonProps
+        // slot); the targets file is still imported late so the Android launch items reach the build.
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Equal(new[] { "-p:CustomAfterMicrosoftCommonTargets" }, GetCustomImportArgKeys(args));
     }
 
     [Fact]
@@ -71,8 +71,10 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(ios.Resource);
 
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        // Environment values are passed as global MSBuild properties (never via the CustomBeforeMicrosoftCommonProps
+        // slot); the targets file is still imported late so the mlaunch launch items reach the build.
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Equal(new[] { "-p:CustomAfterMicrosoftCommonTargets" }, GetCustomImportArgKeys(args));
     }
 
     [Fact]
@@ -91,10 +93,11 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await GetBuildArgumentsAsync(android.Resource);
 
-        // The actual `dotnet build` (not just the launch command) must import the generated files, otherwise
-        // build-time conditions and Android environment items never see WithEnvironment values.
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        // The actual `dotnet build` (not just the launch command) must carry the environment values as global
+        // properties and import the targets file, otherwise build-time conditions and Android environment items
+        // never see WithEnvironment values.
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Equal(new[] { "-p:CustomAfterMicrosoftCommonTargets" }, GetCustomImportArgKeys(args));
     }
 
     [Fact]
@@ -113,8 +116,8 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await GetBuildArgumentsAsync(ios.Resource);
 
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Equal(new[] { "-p:CustomAfterMicrosoftCommonTargets" }, GetCustomImportArgKeys(args));
     }
 
     [Fact]
@@ -133,10 +136,10 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await GetBuildArgumentsAsync(windows.Resource);
 
-        // Windows surfaces WithEnvironment values as MSBuild properties via the early props import. It has no
-        // platform launch item hooks, so no targets file is generated.
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.DoesNotContain(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        // Windows surfaces WithEnvironment values as global MSBuild properties. It has no platform launch item
+        // hooks, so no targets file is generated and the user's props extension slot is never touched.
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Empty(GetCustomImportArgKeys(args));
     }
 
     [Fact]
@@ -155,10 +158,10 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         var args = await GetBuildArgumentsAsync(macCatalyst.Resource);
 
-        // Mac Catalyst surfaces WithEnvironment values as MSBuild properties via the early props import. It has
-        // no platform launch item hooks, so no targets file is generated.
-        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
-        Assert.DoesNotContain(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+        // Mac Catalyst surfaces WithEnvironment values as global MSBuild properties. It has no platform launch
+        // item hooks, so no targets file is generated and the user's props extension slot is never touched.
+        Assert.Contains("-p:MY_VAR=hello", args);
+        Assert.Empty(GetCustomImportArgKeys(args));
     }
 
     private static async Task<List<string>> GetBuildArgumentsAsync(IResource resource)
@@ -166,6 +169,15 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
         var buildInfo = resource.Annotations.OfType<MauiBuildInfoAnnotation>().Last();
         return await MauiBuildQueueEventSubscriber.BuildDotnetBuildArgumentsAsync(resource, buildInfo, NullLogger.Instance, CancellationToken.None);
     }
+
+    // Returns the ordered set of "-p:Custom..." MSBuild extension-import argument keys (without their
+    // generated file paths) so tests can assert the complete set of imports rather than an absence.
+    private static string[] GetCustomImportArgKeys(IEnumerable<string> args) =>
+        args
+            .Where(a => a.StartsWith("-p:Custom", StringComparison.Ordinal))
+            .Select(a => a.Split('=', 2)[0])
+            .OrderBy(a => a, StringComparer.Ordinal)
+            .ToArray();
 
     private static async Task PublishBeforeResourceStartedAsync(
         DistributedApplication app,

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
@@ -1,14 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
-
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Maui.Annotations;
+using Aspire.Hosting.Maui.Lifecycle;
 using Aspire.Hosting.Maui.Utilities;
 using Aspire.Hosting.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 
@@ -35,10 +36,8 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
         await using var app = appBuilder.Build();
 
         var subscriber = new MauiAndroidEnvironmentSubscriber(
-            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
             app.Services.GetRequiredService<ResourceLoggerService>(),
-            app.Services.GetRequiredService<ResourceNotificationService>(),
-            app.Services.GetRequiredService<IFileSystemService>());
+            app.Services.GetRequiredService<ResourceNotificationService>());
 
         await PublishBeforeResourceStartedAsync(app, subscriber, android.Resource);
 
@@ -65,10 +64,8 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
         await using var app = appBuilder.Build();
 
         var subscriber = new MauiiOSEnvironmentSubscriber(
-            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
             app.Services.GetRequiredService<ResourceLoggerService>(),
-            app.Services.GetRequiredService<ResourceNotificationService>(),
-            app.Services.GetRequiredService<IFileSystemService>());
+            app.Services.GetRequiredService<ResourceNotificationService>());
 
         await PublishBeforeResourceStartedAsync(app, subscriber, ios.Resource);
 
@@ -76,6 +73,54 @@ public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
 
         Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
         Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AndroidBuild_ImportsGeneratedPropsAndTargets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var android = maui.AddAndroidEmulator()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var args = await GetBuildArgumentsAsync(android.Resource);
+
+        // The actual `dotnet build` (not just the launch command) must import the generated files, otherwise
+        // build-time conditions and Android environment items never see WithEnvironment values.
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task iOSBuild_ImportsGeneratedPropsAndTargets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var ios = maui.AddiOSSimulator()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var args = await GetBuildArgumentsAsync(ios.Resource);
+
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    private static async Task<List<string>> GetBuildArgumentsAsync(IResource resource)
+    {
+        var buildInfo = resource.Annotations.OfType<MauiBuildInfoAnnotation>().Last();
+        return await MauiBuildQueueEventSubscriber.BuildDotnetBuildArgumentsAsync(resource, buildInfo, NullLogger.Instance, CancellationToken.None);
     }
 
     private static async Task PublishBeforeResourceStartedAsync(

--- a/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiEnvironmentSubscriberTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Maui.Utilities;
+using Aspire.Hosting.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests;
+
+/// <summary>
+/// Regression tests for the MAUI environment subscribers. Unlike <see cref="MauiEnvironmentHelperTests"/>,
+/// which only inspects the helper-generated XML, these tests drive the subscriber's command-line callback so
+/// that a regression which stops importing the generated files (for example dropping the
+/// <c>CustomBeforeMicrosoftCommonProps</c> argument) is caught.
+/// </summary>
+public class MauiEnvironmentSubscriberTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task AndroidSubscriber_ImportsGeneratedPropsAndTargets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-android"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var android = maui.AddAndroidEmulator()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var subscriber = new MauiAndroidEnvironmentSubscriber(
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services.GetRequiredService<ResourceLoggerService>(),
+            app.Services.GetRequiredService<ResourceNotificationService>(),
+            app.Services.GetRequiredService<IFileSystemService>());
+
+        await PublishBeforeResourceStartedAsync(app, subscriber, android.Resource);
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(android.Resource);
+
+        // The props file must be imported early (before the project body) and the targets file late; both
+        // are required for the injected environment values to reach the build and the launch tooling.
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task iOSSubscriber_ImportsGeneratedPropsAndTargets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempFile = Path.Combine(workspace.Path, "TempMauiProject.csproj");
+        File.WriteAllText(tempFile, MauiTestHelper.CreateProjectContent("net10.0-ios"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+        var ios = maui.AddiOSSimulator()
+            .WithEnvironment("MY_VAR", "hello");
+
+        await using var app = appBuilder.Build();
+
+        var subscriber = new MauiiOSEnvironmentSubscriber(
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services.GetRequiredService<ResourceLoggerService>(),
+            app.Services.GetRequiredService<ResourceNotificationService>(),
+            app.Services.GetRequiredService<IFileSystemService>());
+
+        await PublishBeforeResourceStartedAsync(app, subscriber, ios.Resource);
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(ios.Resource);
+
+        Assert.Contains(args, a => a.StartsWith("-p:CustomBeforeMicrosoftCommonProps=", StringComparison.Ordinal));
+        Assert.Contains(args, a => a.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
+    }
+
+    private static async Task PublishBeforeResourceStartedAsync(
+        DistributedApplication app,
+        IDistributedApplicationEventingSubscriber subscriber,
+        IResource resource)
+    {
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+        var execContext = app.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+
+        await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None);
+        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource, app.Services), CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Description

Environment variables should also be pushed as msbuild properties for build time stuff.

Fixes #19571

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
