### PR TITLE
Fix dashboard graph rendering for multi-path icons

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -86,8 +86,21 @@ public static class ResourceGraphMapper
 
     public static string GetIconPathData(Icon icon)
     {
-        var p = icon.Content;
-        var e = XElement.Parse(p);
-        return e.Attribute("d")!.Value;
+        // Fluent UI icon content is an SVG fragment. Most icons contain one path:
+        //   <path d="M..." />
+        // Some icons, such as DocumentMultiple, contain sibling paths:
+        //   <path d="M..." /><path d="M..." />
+        // Wrap the fragment so XML parsing accepts both shapes, then combine the path data into one compound SVG path.
+        var iconContent = XElement.Parse($"<svg>{icon.Content}</svg>");
+        var pathData = iconContent.Elements()
+            .Select(e => e.Attribute("d")?.Value ?? throw new InvalidOperationException($"Icon '{icon.Name}' contains an element without path data."))
+            .ToArray();
+
+        if (pathData.Length == 0)
+        {
+            throw new InvalidOperationException($"Icon '{icon.Name}' doesn't contain path data.");
+        }
+
+        return string.Join(' ', pathData);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceGraphMapperTests.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Xml.Linq;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ResourceGraph;
 using Aspire.Dashboard.Resources;
 using Aspire.Tests.Shared.DashboardModel;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Tests.Model;
 
@@ -155,5 +157,29 @@ public class ResourceGraphMapperTests
         var dto = ResourceGraphMapper.MapResource(resource, [resource], resources, new TestStringLocalizer<Columns>(), showHiddenResources: false, _iconResolver);
 
         Assert.Empty(dto.ReferencedNames);
+    }
+
+    [Fact]
+    public void GetIconPathData_SinglePath_ReturnsPathData()
+    {
+        var icon = new Icons.Filled.Size24.Box();
+        var expectedPathData = XElement.Parse(icon.Content).Attribute("d")!.Value;
+
+        var pathData = ResourceGraphMapper.GetIconPathData(icon);
+
+        Assert.Equal(expectedPathData, pathData);
+    }
+
+    [Fact]
+    public void GetIconPathData_MultiplePaths_ReturnsCombinedPathData()
+    {
+        var icon = new Icons.Filled.Size24.DocumentMultiple();
+        var iconContent = XElement.Parse($"<svg>{icon.Content}</svg>");
+        var expectedPaths = iconContent.Elements().Select(e => e.Attribute("d")!.Value).ToArray();
+        Assert.Equal(3, expectedPaths.Length);
+
+        var pathData = ResourceGraphMapper.GetIconPathData(icon);
+
+        Assert.Equal(string.Join(' ', expectedPaths), pathData);
     }
 }


### PR DESCRIPTION
## Description

The Dashboard Graph view crashes when an AppHost uses `AddBlobs` because its `DocumentMultiple` icon contains multiple sibling SVG paths, while the graph mapper expects one XML root.

This parses Fluent UI icon content as an SVG fragment and combines each path's data into one compound SVG path, preserving the existing graph DTO and JavaScript rendering contract.

### User-facing usage

AppHosts with Azure Blob resources can switch to Graph view without breaking the dashboard circuit:

```csharp
var storage = builder.AddAzureStorage("storage")
    .RunAsEmulator();

storage.AddBlobs("blobs");
```

Targeted `ResourceGraphMapperTests` cover both single-path icons and the multi-path `DocumentMultiple` icon.

Fixes: #19489

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No