### PR TITLE
Update Tuf and Sigstore to 1.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -148,8 +148,8 @@
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
     <PackageVersion Include="Semver" Version="3.0.0" />
-    <PackageVersion Include="Sigstore" Version="1.0.0" />
-    <PackageVersion Include="Tuf" Version="1.0.0" />
+    <PackageVersion Include="Sigstore" Version="1.0.1-beta.122.1.7bc133a" />
+    <PackageVersion Include="Tuf" Version="1.0.1-beta.122.1.7bc133a" />
     <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.51" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -148,8 +148,8 @@
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
     <PackageVersion Include="Semver" Version="3.0.0" />
-    <PackageVersion Include="Sigstore" Version="1.0.1-beta.122.1.7bc133a" />
-    <PackageVersion Include="Tuf" Version="1.0.1-beta.122.1.7bc133a" />
+    <PackageVersion Include="Sigstore" Version="1.0.1" />
+    <PackageVersion Include="Tuf" Version="1.0.1" />
     <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.51" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,7 +14,6 @@
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <!-- If the dotnet-public, dotnet9, or dotnet-libraries sources change, update tests/Shared/Docker/NuGet.DotnetTool.config for daily dotnet tool smoke tests. -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -24,10 +23,6 @@
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
-      <package pattern="Sigstore" />
-      <package pattern="Tuf" />
-    </packageSource>
     <packageSource key="dotnet9-transport">
       <package pattern="*WorkloadBuildTasks*" />
     </packageSource>
@@ -51,7 +46,6 @@
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>
-    <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
     <!--  End: Package sources from dotnet-dotnet -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <!-- If the dotnet-public, dotnet9, or dotnet-libraries sources change, update tests/Shared/Docker/NuGet.DotnetTool.config for daily dotnet tool smoke tests. -->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -23,6 +24,10 @@
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="Sigstore" />
+      <package pattern="Tuf" />
+    </packageSource>
     <packageSource key="dotnet9-transport">
       <package pattern="*WorkloadBuildTasks*" />
     </packageSource>
@@ -46,6 +51,7 @@
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>
+    <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
     <!--  End: Package sources from dotnet-dotnet -->


### PR DESCRIPTION
## Description

Updates the Aspire CLI's `Sigstore` and `Tuf` dependencies from `1.0.0` to stable `1.0.1`.

Version `1.0.1` updates the embedded Sigstore TUF trust root to v15 and hardens sequential trust-root rotation verification. Both packages are now mirrored in `dotnet-public`, so this PR uses the repository's normal dnceng package sources without a nuget.org override.

Validation:

- Restored the Aspire CLI from a fresh isolated NuGet package cache using only the repository's dnceng feeds; both packages resolved at `1.0.1`.
- Built a Linux ARM64 local-hive archive containing stable `Sigstore` and `Tuf` `1.0.1`.
- Ran `NewWithAgentInitTests` and `PlaywrightCliInstallTests` against that archive: 3 passed.

### Security considerations

This updates the trust root and verification implementation used for Sigstore provenance checks. The package update preserves sequential verification of every intermediate TUF root and includes production trust root v15.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No