### PR TITLE
Add BuildKit cache support to Docker Compose generation and container image builds

### DIFF
--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Build.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Build.cs
@@ -76,6 +76,7 @@ public sealed class Build
     /// builder.AddProject&lt;Projects.MyApi&gt;("api")
     ///     .PublishAsDockerComposeService((resource, service) =>
     ///     {
+    ///         service.Build ??= new Build();
     ///         service.Build.CacheTo.Add("type=registry,ref=cr.example.com/api:cache");
     ///     });
     /// </code>

--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Build.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Build.cs
@@ -56,6 +56,34 @@ public sealed class Build
     public List<string> CacheFrom { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets a list of cache export destinations for the build process.
+    /// This property corresponds to the "cache_to" field in a Docker Compose
+    /// build configuration and allows exporting built layers as cache entries
+    /// so that subsequent builds can consume them via <see cref="CacheFrom"/>.
+    /// </summary>
+    /// <value>
+    /// A list of cache export definitions in the Compose long syntax, for example
+    /// "type=registry,ref=myregistry/myimage:cache,mode=max".
+    /// </value>
+    /// <remarks>
+    /// Exporting cache to a registry requires a BuildKit-enabled builder
+    /// (such as Docker Buildx); the legacy builder ignores this field.
+    /// See the <see href="https://compose-spec.readthedocs.io/en/latest/build.html#cache_to">Compose Build specification</see>.
+    /// </remarks>
+    /// <example>
+    /// Configure registry cache round-trips for a published service:
+    /// <code>
+    /// builder.AddProject&lt;Projects.MyApi&gt;("api")
+    ///     .PublishAsDockerComposeService((resource, service) =>
+    ///     {
+    ///         service.Build.CacheTo.Add("type=registry,ref=cr.example.com/api:cache");
+    ///     });
+    /// </code>
+    /// </example>
+    [YamlMember(Alias = "cache_to", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public List<string> CacheTo { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the collection of additional labels to be applied to the build.
     /// Labels are key-value pairs that provide metadata about the build.
     /// </summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerBuildOptionsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerBuildOptionsCallbackAnnotation.cs
@@ -121,4 +121,32 @@ public sealed class ContainerBuildOptionsCallbackContext
     /// Gets or sets the local image tag for the built container.
     /// </summary>
     public string? LocalImageTag { get; set; }
+
+    /// <summary>
+    /// Gets the list of additional arguments appended verbatim to the container
+    /// build command. Use this for builder flags that are not represented by the
+    /// typed properties above, such as BuildKit cache configuration
+    /// (<c>--cache-from</c>/<c>--cache-to</c>) or <c>--secret</c> mounts.
+    /// </summary>
+    /// <remarks>
+    /// Each entry must be a complete argument token, including its flag. For example,
+    /// to export build cache to a registry, add <c>"--cache-to"</c> followed by
+    /// <c>"type=registry,ref=myregistry/myimage:cache"</c>.
+    /// Entries are only applied to builder-based builds (docker buildx / podman build).
+    /// They do not apply to project resources built via <c>dotnet publish /t:PublishContainer</c>,
+    /// which does not invoke a container builder directly.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// builder.AddDockerfile("api", "./src")
+    ///     .WithContainerBuildOptions(ctx =>
+    ///     {
+    ///         ctx.AdditionalArguments.Add("--cache-from");
+    ///         ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/api:cache");
+    ///         ctx.AdditionalArguments.Add("--cache-to");
+    ///         ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/api:cache,mode=max");
+    ///     });
+    /// </code>
+    /// </example>
+    public List<string> AdditionalArguments { get; } = [];
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -176,7 +176,8 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
             var buildOptions = new ContainerImageBuildOptions
             {
                 ImageName = originalImageName,
-                TargetPlatform = context.TargetPlatform ?? ContainerTargetPlatform.LinuxAmd64
+                TargetPlatform = context.TargetPlatform ?? ContainerTargetPlatform.LinuxAmd64,
+                AdditionalArguments = [.. context.AdditionalArguments]
             };
 
             await containerRuntime.BuildImageAsync(

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -276,6 +276,24 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     }
 
     /// <summary>
+    /// Builds a string of additional arguments for container build commands.
+    /// Entries are appended verbatim because each entry must be a complete argument
+    /// token (flag plus value), such as "--cache-from" or "type=registry,ref=img:cache".
+    /// Quoting them would corrupt flags like --cache-to whose values contain commas.
+    /// </summary>
+    /// <param name="additionalArguments">The additional arguments to append.</param>
+    /// <returns>A string containing the space-joined arguments, or empty string if none are provided.</returns>
+    protected static string BuildAdditionalArgumentsString(IReadOnlyList<string>? additionalArguments)
+    {
+        if (additionalArguments is not { Count: > 0 })
+        {
+            return string.Empty;
+        }
+
+        return " " + string.Join(" ", additionalArguments);
+    }
+
+    /// <summary>
     /// Executes a container runtime command and returns the process result without throwing for non-zero exit codes.
     /// </summary>
     protected async Task<ProcessResult> ExecuteContainerCommandWithResultAsync(

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -86,6 +86,9 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             // Add stage if specified
             arguments += BuildStageString(stage);
 
+            // Add additional arguments if specified (e.g., BuildKit cache configuration)
+            arguments += BuildAdditionalArgumentsString(options?.AdditionalArguments);
+
             arguments += $" \"{contextPath}\"";
 
             // Prepare environment variables for build secrets

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -194,6 +194,9 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
         // Add stage if specified
         arguments += BuildStageString(stage);
 
+        // Add additional arguments if specified (e.g., cache backend configuration)
+        arguments += BuildAdditionalArgumentsString(options?.AdditionalArguments);
+
         arguments += $" \"{contextPath}\"";
 
         // Prepare environment variables for build secrets (only for environment-type secrets)

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -127,6 +127,13 @@ public class ContainerImageBuildOptions
     /// Gets the target platform for the container.
     /// </summary>
     public ContainerTargetPlatform? TargetPlatform { get; init; }
+
+    /// <summary>
+    /// Gets the additional arguments appended verbatim to the container build command.
+    /// Each entry must be a complete argument token, including its flag
+    /// (for example "--cache-from" or "type=registry,ref=myregistry/myimage:cache").
+    /// </summary>
+    public IReadOnlyList<string>? AdditionalArguments { get; init; }
 }
 
 /// <summary>
@@ -178,6 +185,7 @@ internal sealed class ResourceContainerImageManager(
         public ContainerImageDestination? Destination { get; set; }
         public string LocalImageName { get; set; } = string.Empty;
         public string LocalImageTag { get; set; } = "latest";
+        public IReadOnlyList<string> AdditionalArguments { get; set; } = [];
     }
 
     private async Task<ResolvedContainerBuildOptions> ResolveContainerBuildOptionsAsync(
@@ -202,6 +210,7 @@ internal sealed class ResourceContainerImageManager(
         options.Destination = context.Destination;
         options.LocalImageName = context.LocalImageName ?? options.LocalImageName;
         options.LocalImageTag = context.LocalImageTag ?? options.LocalImageTag;
+        options.AdditionalArguments = [.. context.AdditionalArguments];
 
         return options;
     }
@@ -493,7 +502,8 @@ internal sealed class ResourceContainerImageManager(
             Tag = imageTag,
             OutputPath = options.OutputPath,
             ImageFormat = options.ImageFormat,
-            TargetPlatform = options.TargetPlatform
+            TargetPlatform = options.TargetPlatform,
+            AdditionalArguments = options.AdditionalArguments
         };
 
         try

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -265,6 +265,34 @@ public class DockerComposeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DockerComposeBuildCacheFromAndCacheToSerializedCorrectly()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        builder.AddDockerComposeEnvironment("cache-env");
+
+        builder.AddContainer("my-service", "my-image:latest")
+            .PublishAsDockerComposeService((resource, service) =>
+            {
+                service.Build ??= new Aspire.Hosting.Docker.Resources.ServiceNodes.Build();
+                service.Build.CacheFrom.Add("type=registry,ref=cr.example.com/my-service:cache");
+                service.Build.CacheTo.Add("type=registry,ref=cr.example.com/my-service:cache,mode=max");
+            });
+
+        using var app = builder.Build();
+        app.Run();
+
+        var composeFile = Path.Combine(workspace.Path, "docker-compose.yaml");
+        Assert.True(File.Exists(composeFile), "Docker Compose file was not created.");
+        var composeContent = File.ReadAllText(composeFile);
+
+        await Verify(composeContent, "yaml");
+    }
+
+    [Fact]
     public async Task GetHostAddressExpression()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeBuildCacheFromAndCacheToSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeBuildCacheFromAndCacheToSerializedCorrectly.verified.yaml
@@ -1,0 +1,23 @@
+﻿services:
+  cache-env-dashboard:
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    ports:
+      - "18888"
+    expose:
+      - "18889"
+      - "18890"
+    networks:
+      - "aspire"
+    restart: "always"
+  my-service:
+    image: "my-image:latest"
+    build:
+      cache_from:
+        - "type=registry,ref=cr.example.com/my-service:cache"
+      cache_to:
+        - "type=registry,ref=cr.example.com/my-service:cache,mode=max"
+    networks:
+      - "aspire"
+networks:
+  aspire:
+    driver: "bridge"

--- a/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
@@ -26,6 +26,29 @@ public class ContainerRuntimeBaseTests
         Assert.Contains("stderr-final-line", exception.Message);
     }
 
+    [Fact]
+    public void BuildAdditionalArgumentsString_EmptyOrNull_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, TestContainerRuntime.BuildAdditionalArguments(null));
+        Assert.Equal(string.Empty, TestContainerRuntime.BuildAdditionalArguments([]));
+    }
+
+    [Fact]
+    public void BuildAdditionalArgumentsString_AppendsEntriesVerbatim()
+    {
+        // Entries must not be quoted or escaped: cache flags like
+        // --cache-to take comma-separated key=value lists that quoting would corrupt.
+        var result = TestContainerRuntime.BuildAdditionalArguments(
+        [
+            "--cache-from",
+            "type=registry,ref=cr.example.com/app:cache",
+            "--cache-to",
+            "type=registry,ref=cr.example.com/app:cache,mode=max"
+        ]);
+
+        Assert.Equal(" --cache-from type=registry,ref=cr.example.com/app:cache --cache-to type=registry,ref=cr.example.com/app:cache,mode=max", result);
+    }
+
     private sealed class TestContainerRuntime(string? runtimeExecutable = null)
         : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance, new DefaultProcessRunner())
     {
@@ -54,5 +77,11 @@ public class ContainerRuntimeBaseTests
                 "Test command failed with exit code {0}.",
                 cancellationToken);
         }
+
+        public static string BuildAdditionalArguments(IReadOnlyList<string>? additionalArguments)
+        {
+            return BuildAdditionalArgumentsString(additionalArguments);
+        }
     }
 }
+

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -473,6 +473,44 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task BuildImageAsync_FlowsAdditionalArgumentsToContainerRuntime()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(output);
+
+        var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
+
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
+        var container = builder.AddDockerfile("container", tempDockerfileContext.ContextPath, tempDockerfileContext.DockerfilePath)
+            .WithContainerBuildOptions(ctx =>
+            {
+                ctx.AdditionalArguments.Add("--cache-from");
+                ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/container:cache");
+                ctx.AdditionalArguments.Add("--cache-to");
+                ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/container:cache,mode=max");
+            });
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
+        await imageBuilder.BuildImageAsync(container.Resource, cts.Token);
+
+        // Assert
+        Assert.True(fakeContainerRuntime.WasBuildImageCalled);
+        var buildCall = Assert.Single(fakeContainerRuntime.BuildImageCalls);
+        Assert.NotNull(buildCall.options?.AdditionalArguments);
+        Assert.Equal(
+            [
+                "--cache-from",
+                "type=registry,ref=cr.example.com/container:cache",
+                "--cache-to",
+                "type=registry,ref=cr.example.com/container:cache,mode=max"
+            ],
+            buildCall.options.AdditionalArguments);
+    }
+
+    [Fact]
     public async Task PushImageAsync_ThrowsWhenContainerRuntimeFails()
     {
         using var builder = TestDistributedApplicationBuilder.Create(output);


### PR DESCRIPTION
## Description

Adds BuildKit cache support to both places where Aspire builds container images, enabling registry-based layer cache round-trips (`--cache-from` / `--cache-to`, e.g. `type=registry,ref=cr.example.com/app:cache`) in CI and deployment pipelines. This resolves the scenario described in #13491: today there is no way to persist build cache (including `RUN --mount=type=cache` mounts) across pipeline runs, which costs build time and — for some users — billable package-download bandwidth.

Two complementary changes:

**1. Compose generation: `cache_to` on the build model**

`Aspire.Hosting.Docker`'s compose service model exposed `build.cache_from` but had no way to export cache, so compose builds could *consume* registry cache but never *produce* it. Added a `CacheTo` property mirroring `CacheFrom`:

```csharp
builder.AddProject<Projects.MyApi>("api")
    .PublishAsDockerComposeService((resource, service) =>
    {
        service.Build.CacheTo.Add("type=registry,ref=cr.example.com/api:cache,mode=max");
    });
```

Generated compose output:

```yaml
services:
  my-service:
    build:
      cache_from:
        - "type=registry,ref=cr.example.com/my-service:cache"
      cache_to:
        - "type=registry,ref=cr.example.com/my-service:cache,mode=max"
```

**2. Pipeline image builds: `AdditionalArguments`**

Aspire-owned builds run `docker buildx build` / `podman build` via the push pipeline (`aspire deploy` → push step), but the build options callback exposed no surface for builder flags that aren't modeled as typed properties. Following the direction suggested on #13491, added an `AdditionalArguments` list to `ContainerBuildOptionsCallbackContext` that flows through to both runtimes:

```csharp
builder.AddDockerfile("api", "./src")
    .WithContainerBuildOptions(ctx =>
    {
        ctx.AdditionalArguments.Add("--cache-from");
        ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/api:cache");
        ctx.AdditionalArguments.Add("--cache-to");
        ctx.AdditionalArguments.Add("type=registry,ref=cr.example.com/api:cache,mode=max");
    });
```

Entries are appended verbatim before the build context path; each entry must be a complete argument token including its flag. Entries apply to builder-based builds only — project resources built via `dotnet publish /t:PublishContainer` don't invoke a container builder directly, so this is documented as not applicable to that path.

An earlier attempt at this API (#13566) was closed unmerged; this PR reworks it against the current annotation/callback-based options flow.

Fixes #13491

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
