### PR TITLE
Avoid duplicate dashboard connection metadata

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -103,9 +103,11 @@ internal sealed class ApplicationOrchestrator
 
             await _notificationService.PublishUpdateAsync(resourceWithConnectionString, state => state with
             {
-                Properties = [.. state.Properties,
+                Properties = state.Properties.SetResourcePropertyRange(
+                [
                     new(CustomResourceKnownProperties.ConnectionString, connectionString) { IsSensitive = true },
-                    new(CustomResourceKnownProperties.ConnectionProperties, connectionProperties) { IsSensitive = true }]
+                    new(CustomResourceKnownProperties.ConnectionProperties, connectionProperties) { IsSensitive = true }
+                ])
             })
             .ConfigureAwait(false);
         }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -447,7 +447,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task ConnectionStringAvailableEventPublishesConnectionStringAndResolvableProperties()
+    public async Task ConnectionStringAvailableEventUpdatesConnectionStringAndResolvablePropertiesWithoutDuplicates()
     {
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
@@ -465,48 +465,30 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: applicationEventing);
         await appOrchestrator.RunApplicationAsync();
 
-        string? connectionStringProperty = null;
-        IReadOnlyDictionary<string, string?>? connectionProperties = null;
-        bool? isConnectionStringSensitive = null;
-        bool? areConnectionPropertiesSensitive = null;
-        var hasDatabaseNameProperty = false;
-        var watchResourceTask = Task.Run(async () =>
-        {
-            await foreach (var item in resourceNotificationService.WatchAsync())
-            {
-                if (item.Resource == resource.Resource)
-                {
-                    var connectionStringProp = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ConnectionString);
-                    if (connectionStringProp is not null)
-                    {
-                        connectionStringProperty = connectionStringProp.Value?.ToString();
-                        isConnectionStringSensitive = connectionStringProp.IsSensitive;
-                        var connectionPropertiesProp = item.Snapshot.Properties.Single(p => p.Name == KnownProperties.Resource.ConnectionProperties);
-                        connectionProperties = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string?>>(connectionPropertiesProp.Value);
-                        areConnectionPropertiesSensitive = connectionPropertiesProp.IsSensitive;
-                        hasDatabaseNameProperty = item.Snapshot.Properties.Any(p => p.Name == "resource.DatabaseName");
-                        return;
-                    }
-                }
-            }
-        });
-
-        // Publish the ConnectionStringAvailableEvent to trigger the update
+        await applicationEventing.PublishAsync(new ConnectionStringAvailableEvent(resource.Resource, app.Services), CancellationToken.None);
         await applicationEventing.PublishAsync(new ConnectionStringAvailableEvent(resource.Resource, app.Services), CancellationToken.None);
 
-        await watchResourceTask.DefaultTimeout();
-
-        Assert.Equal("Server=localhost:5432;Database=testdb", connectionStringProperty);
-        Assert.True(isConnectionStringSensitive);
-        Assert.Equal(
-            new Dictionary<string, string?>
+        Assert.True(resourceNotificationService.TryGetCurrentState(resource.Resource.Name, out var currentState));
+        Assert.Collection(
+            currentState.Snapshot.Properties,
+            connectionStringProperty =>
             {
-                ["DatabaseName"] = "testdb",
-                ["Host"] = "localhost"
+                Assert.Equal(KnownProperties.Resource.ConnectionString, connectionStringProperty.Name);
+                Assert.Equal("Server=localhost:5432;Database=testdb", connectionStringProperty.Value);
+                Assert.True(connectionStringProperty.IsSensitive);
             },
-            connectionProperties);
-        Assert.True(areConnectionPropertiesSensitive);
-        Assert.False(hasDatabaseNameProperty);
+            connectionPropertiesProperty =>
+            {
+                Assert.Equal(KnownProperties.Resource.ConnectionProperties, connectionPropertiesProperty.Name);
+                Assert.Equal(
+                    new Dictionary<string, string?>
+                    {
+                        ["DatabaseName"] = "testdb",
+                        ["Host"] = "localhost"
+                    },
+                    Assert.IsAssignableFrom<IReadOnlyDictionary<string, string?>>(connectionPropertiesProperty.Value));
+                Assert.True(connectionPropertiesProperty.IsSensitive);
+            });
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Azure provisioning can raise `ConnectionStringAvailableEvent` multiple times for a resource, causing the orchestrator to append duplicate dashboard connection metadata and emit duplicate-property warnings.

This makes connection metadata publication idempotent by replacing existing `resource.connectionString` and `resource.connectionProperties` values by property name. Repeated lifecycle events remain available to consumers, while the dashboard receives one current value for each property.

Validated with:

- `ConnectionStringAvailableEventUpdatesConnectionStringAndResolvablePropertiesWithoutDuplicates`
- All 28 `ApplicationOrchestratorTests`

Fixes: #19612

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No