### PR TITLE
fix(cli): show resource command help for invalid arguments

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -53,6 +53,7 @@ internal abstract class BaseCommand : Command
     private readonly CliExecutionContext _executionContext;
     private bool _isJsonFormatRequested;
     private bool? _prefetchesTemplatePackageMetadataForInvocation;
+    private bool _extensionInteractionFlushTimedOut;
 
     protected CliExecutionContext ExecutionContext => _executionContext;
 
@@ -273,9 +274,9 @@ internal abstract class BaseCommand : Command
         return false;
     }
 
-    protected static async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)
+    protected async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)
     {
-        if (interactionService is not IExtensionInteractionService extensionInteractionService)
+        if (_extensionInteractionFlushTimedOut || interactionService is not IExtensionInteractionService extensionInteractionService)
         {
             return;
         }
@@ -290,8 +291,9 @@ internal abstract class BaseCommand : Command
         }
         catch (OperationCanceledException) when (flushCancellationTokenSource.IsCancellationRequested)
         {
-            // Prefer returning the command's chosen exit code over hanging indefinitely when
-            // VS Code has already gone away or stopped responding to backchannel requests.
+            // Do not spend another full timeout in the final drain after this same extension queue
+            // has already failed to drain. Prefer returning the command's chosen exit code.
+            _extensionInteractionFlushTimedOut = true;
         }
     }
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -273,7 +273,7 @@ internal abstract class BaseCommand : Command
         return false;
     }
 
-    private static async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)
+    protected static async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)
     {
         if (interactionService is not IExtensionInteractionService extensionInteractionService)
         {

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -50,6 +50,8 @@ internal abstract class BaseCommand : Command
     /// </summary>
     protected virtual TimeSpan GracefulShutdownBudget => TimeSpan.Zero;
 
+    protected virtual TimeSpan ExtensionInteractionFlushTimeout => s_extensionInteractionFlushTimeout;
+
     private readonly CliExecutionContext _executionContext;
     private bool _isJsonFormatRequested;
     private bool? _prefetchesTemplatePackageMetadataForInvocation;
@@ -284,7 +286,7 @@ internal abstract class BaseCommand : Command
         // Command cancellation has already been translated into CommandResult; using a canceled
         // token here would skip the final debug-console drain or throw after the command selected
         // its exit code. Bound the drain separately so a broken extension cannot hang CLI exit.
-        using var flushCancellationTokenSource = new CancellationTokenSource(s_extensionInteractionFlushTimeout);
+        using var flushCancellationTokenSource = new CancellationTokenSource(ExtensionInteractionFlushTimeout);
         try
         {
             await extensionInteractionService.FlushAsync(flushCancellationTokenSource.Token).ConfigureAwait(false);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -163,10 +163,12 @@ internal sealed class ResourceCommand : BaseCommand
             return await LoadCommandArgumentsAsync(parseResult, connection, resourceName, commandName, commandArguments, cancellationToken).ConfigureAwait(false);
         }
 
+        (int ExitCode, ExecuteResourceCommandResponse Response) commandResult;
+
         // Use display metadata for well-known command names.
         if (s_wellKnownCommands.TryGetValue(commandName, out var knownCommand))
         {
-            return CommandResult.FromExitCode(await ResourceCommandHelper.ExecuteResourceCommandAsync(
+            commandResult = await ResourceCommandHelper.ExecuteResourceCommandWithResponseAsync(
                 connection,
                 InteractionService,
                 _logger,
@@ -176,25 +178,27 @@ internal sealed class ResourceCommand : BaseCommand
                 knownCommand.BaseVerb,
                 knownCommand.PastTenseVerb,
                 commandArguments,
-                cancellationToken));
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            commandResult = await ResourceCommandHelper.ExecuteGenericCommandWithResponseAsync(
+                connection,
+                InteractionService,
+                _logger,
+                resourceName,
+                commandName,
+                commandArguments,
+                cancellationToken).ConfigureAwait(false);
         }
 
-        var genericCommandResult = await ResourceCommandHelper.ExecuteGenericCommandWithResponseAsync(
-            connection,
-            InteractionService,
-            _logger,
-            resourceName,
-            commandName,
-            commandArguments,
-            cancellationToken).ConfigureAwait(false);
-
-        if (command is not null && IsHostingUnknownArgumentFailure(genericCommandResult.Response, commandName))
+        if (command is not null && IsHostingUnknownArgumentFailure(commandResult.Response, commandName))
         {
             await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
             ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
         }
 
-        return CommandResult.FromExitCode(genericCommandResult.ExitCode);
+        return CommandResult.FromExitCode(commandResult.ExitCode);
     }
 
     private static bool IsHostingUnknownArgumentFailure(ExecuteResourceCommandResponse response, string commandName)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -144,6 +144,15 @@ internal sealed class ResourceCommand : BaseCommand
         var commandArgumentsResult = CreateCommandArguments(command, capturedArguments, loadArguments ? CommandArgumentParseMode.LoadArguments : CommandArgumentParseMode.Execute);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
+            if (!loadArguments && command is not null)
+            {
+                InteractionService.DisplayError(errorMessage);
+                await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+
+                ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
+                return CommandResult.FromExitCode(CliExitCodes.InvalidCommand);
+            }
+
             return CommandResult.Failure(CliExitCodes.InvalidCommand, errorMessage);
         }
 
@@ -735,7 +744,6 @@ internal sealed class ResourceCommand : BaseCommand
             var appHostOptionValue = GetOptionTokenValue(parseResult, s_appHostOption.InnerOption) ?? GetOptionTokenValue(parseResult, s_appHostOption.LegacyOption);
 
             var hasResourceName = !string.IsNullOrEmpty(resourceName) && !IsOptionLikeToken(resourceName);
-
             // The command slot is considered empty when it has no token, when it captured an option like --help,
             // or when it captured the value for --apphost/--project instead of an actual resource command name.
             var hasNoCommandName = string.IsNullOrEmpty(commandName) ||
@@ -751,7 +759,7 @@ internal sealed class ResourceCommand : BaseCommand
             return result?.Tokens.Count > 0 ? result.Tokens[0].Value : null;
         }
 
-        private static void WriteResourceCommandHelp(TextWriter writer, System.CommandLine.Parsing.CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)
+        internal static void WriteResourceCommandHelp(TextWriter writer, System.CommandLine.Parsing.CommandResult commandResult, string resourceName, ResourceSnapshotCommand command)
         {
             var cliOptionNames = GetCliOptionNames(commandResult);
 
@@ -897,5 +905,4 @@ internal sealed class ResourceCommand : BaseCommand
             return string.Join(" ", parts);
         }
     }
-
 }

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -141,11 +141,7 @@ internal sealed class ResourceCommand : BaseCommand
 
         var connection = result.Connection!;
         var command = await GetCommandMetadataAsync(connection, resourceName, commandName, includeHidden, cancellationToken).ConfigureAwait(false);
-        var commandArgumentsResult = CreateCommandArguments(
-            command,
-            capturedArguments,
-            loadArguments ? CommandArgumentParseMode.LoadArguments : CommandArgumentParseMode.Execute,
-            argumentMetadataAuthoritative: connection.SupportsV3);
+        var commandArgumentsResult = CreateCommandArguments(command, capturedArguments, loadArguments ? CommandArgumentParseMode.LoadArguments : CommandArgumentParseMode.Execute);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
             if (!loadArguments && command is not null)
@@ -165,6 +161,28 @@ internal sealed class ResourceCommand : BaseCommand
         if (loadArguments)
         {
             return await LoadCommandArgumentsAsync(parseResult, connection, resourceName, commandName, commandArguments, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (command is not null && commandArgumentsResult.RequiresHostingValidation)
+        {
+            var validationResponse = await ValidateHostingCommandArgumentsAsync(
+                connection,
+                resourceName,
+                commandName,
+                commandArguments,
+                cancellationToken).ConfigureAwait(false);
+
+            if (IsHostingUnknownArgumentValidationFailure(validationResponse, commandName))
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var validationErrorMessage = validationResponse.Message ?? validationResponse.ErrorMessage!;
+#pragma warning restore CS0618 // Type or member is obsolete
+                InteractionService.DisplayError(validationErrorMessage);
+                await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+
+                ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
+                return CommandResult.FromExitCode(CliExitCodes.InvalidCommand);
+            }
         }
 
         (int ExitCode, ExecuteResourceCommandResponse Response) commandResult;
@@ -196,21 +214,35 @@ internal sealed class ResourceCommand : BaseCommand
                 cancellationToken).ConfigureAwait(false);
         }
 
-        if (command is not null && IsLegacyHostingUnknownArgumentFailure(connection, commandResult.Response, commandName))
-        {
-            await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
-            ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
-        }
-
         return CommandResult.FromExitCode(commandResult.ExitCode);
     }
 
-    private static bool IsLegacyHostingUnknownArgumentFailure(IAppHostAuxiliaryBackchannel connection, ExecuteResourceCommandResponse response, string commandName)
+    private static async Task<ExecuteResourceCommandResponse> ValidateHostingCommandArgumentsAsync(
+        IAppHostAuxiliaryBackchannel connection,
+        string resourceName,
+        string commandName,
+        JsonNode? commandArguments,
+        CancellationToken cancellationToken)
     {
-        // V3 resource snapshots carry command argument metadata, so current AppHosts never need to
-        // infer argument-parse failures from human-readable callback messages. The text fallback is
-        // retained only for older AppHosts that may not expose command argument metadata.
-        if (connection.SupportsV3 || response.Success || response.Canceled)
+        return await connection.ExecuteResourceCommandAsync(
+            resourceName,
+            commandName,
+            new ExecuteResourceCommandOptions
+            {
+                Arguments = commandArguments,
+                ValidateOnly = true,
+                NonInteractive = true,
+                ReturnArgumentInputs = true
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsHostingUnknownArgumentValidationFailure(ExecuteResourceCommandResponse response, string commandName)
+    {
+        // This response comes from a ValidateOnly request, so resource command callbacks have not
+        // executed and cannot spoof the parser diagnostic. Keep the legacy text recognition scoped
+        // to this validation-only path instead of classifying arbitrary execution failures by text.
+        if (response.Success || response.Canceled)
         {
             return false;
         }
@@ -300,11 +332,7 @@ internal sealed class ResourceCommand : BaseCommand
             .ToArray();
     }
 
-    private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(
-        ResourceSnapshotCommand? command,
-        string[] capturedArguments,
-        CommandArgumentParseMode parseMode,
-        bool argumentMetadataAuthoritative)
+    private static (JsonNode? Arguments, string? ErrorMessage, bool RequiresHostingValidation) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments, CommandArgumentParseMode parseMode)
     {
         capturedArguments = RemoveDelimiter(capturedArguments);
 
@@ -312,30 +340,23 @@ internal sealed class ResourceCommand : BaseCommand
         {
             if (command?.ArgumentInputs is { Length: > 0 } inputs)
             {
-                return CreateCommandArguments(inputs, capturedArguments, parseMode);
+                var parsedArguments = CreateCommandArguments(inputs, capturedArguments, parseMode);
+                return (parsedArguments.Arguments, parsedArguments.ErrorMessage, false);
             }
 
-            return (null, null);
+            return (null, null, false);
         }
 
         if (command?.ArgumentInputs is not { Length: > 0 } argumentInputs)
         {
-            if (command is not null && argumentMetadataAuthoritative)
-            {
-                // Current AppHosts expose command argument metadata in V3 resource snapshots. When
-                // such a command declares no inputs, every remaining token is invalid and can be
-                // rejected locally without invoking a callback whose failure text could mimic a
-                // hosting parser diagnostic.
-                return CreateCommandArguments([], capturedArguments, parseMode);
-            }
-
-            // Older AppHosts may not expose command metadata. Forward tokens as unknown names and
-            // let hosting-side validation reject them; the legacy response-message fallback below
-            // remains scoped to those pre-V3 peers.
-            return (CreateUnknownArguments(capturedArguments), null);
+            // Without command metadata there are no options to give System.CommandLine. Preserve the
+            // raw tokens and ask the AppHost to validate them explicitly before command execution;
+            // this distinguishes hosting argument rejection from arbitrary callback failure text.
+            return (CreateUnknownArguments(capturedArguments), null, command is not null);
         }
 
-        return CreateCommandArguments(argumentInputs, capturedArguments, parseMode);
+        var result = CreateCommandArguments(argumentInputs, capturedArguments, parseMode);
+        return (result.Arguments, result.ErrorMessage, false);
     }
 
     private static (JsonObject Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommandArgument[] argumentInputs, string[] capturedArguments, CommandArgumentParseMode parseMode)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -141,7 +141,11 @@ internal sealed class ResourceCommand : BaseCommand
 
         var connection = result.Connection!;
         var command = await GetCommandMetadataAsync(connection, resourceName, commandName, includeHidden, cancellationToken).ConfigureAwait(false);
-        var commandArgumentsResult = CreateCommandArguments(command, capturedArguments, loadArguments ? CommandArgumentParseMode.LoadArguments : CommandArgumentParseMode.Execute);
+        var commandArgumentsResult = CreateCommandArguments(
+            command,
+            capturedArguments,
+            loadArguments ? CommandArgumentParseMode.LoadArguments : CommandArgumentParseMode.Execute,
+            argumentMetadataAuthoritative: connection.SupportsV3);
         if (commandArgumentsResult.ErrorMessage is { } errorMessage)
         {
             if (!loadArguments && command is not null)
@@ -192,7 +196,7 @@ internal sealed class ResourceCommand : BaseCommand
                 cancellationToken).ConfigureAwait(false);
         }
 
-        if (command is not null && IsHostingUnknownArgumentFailure(commandResult.Response, commandName))
+        if (command is not null && IsLegacyHostingUnknownArgumentFailure(connection, commandResult.Response, commandName))
         {
             await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
             ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
@@ -201,13 +205,21 @@ internal sealed class ResourceCommand : BaseCommand
         return CommandResult.FromExitCode(commandResult.ExitCode);
     }
 
-    private static bool IsHostingUnknownArgumentFailure(ExecuteResourceCommandResponse response, string commandName)
+    private static bool IsLegacyHostingUnknownArgumentFailure(IAppHostAuxiliaryBackchannel connection, ExecuteResourceCommandResponse response, string commandName)
     {
+        // V3 resource snapshots carry command argument metadata, so current AppHosts never need to
+        // infer argument-parse failures from human-readable callback messages. The text fallback is
+        // retained only for older AppHosts that may not expose command argument metadata.
+        if (connection.SupportsV3 || response.Success || response.Canceled)
+        {
+            return false;
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         var message = response.Message ?? response.ErrorMessage;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        if (response.Success || response.Canceled || string.IsNullOrEmpty(message))
+        if (string.IsNullOrEmpty(message))
         {
             return false;
         }
@@ -288,7 +300,11 @@ internal sealed class ResourceCommand : BaseCommand
             .ToArray();
     }
 
-    private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(ResourceSnapshotCommand? command, string[] capturedArguments, CommandArgumentParseMode parseMode)
+    private static (JsonNode? Arguments, string? ErrorMessage) CreateCommandArguments(
+        ResourceSnapshotCommand? command,
+        string[] capturedArguments,
+        CommandArgumentParseMode parseMode,
+        bool argumentMetadataAuthoritative)
     {
         capturedArguments = RemoveDelimiter(capturedArguments);
 
@@ -304,8 +320,18 @@ internal sealed class ResourceCommand : BaseCommand
 
         if (command?.ArgumentInputs is not { Length: > 0 } argumentInputs)
         {
-            // Without command metadata there are no options to give System.CommandLine, so do not infer any values.
-            // Forward tokens as unknown names and let hosting-side validation reject them.
+            if (command is not null && argumentMetadataAuthoritative)
+            {
+                // Current AppHosts expose command argument metadata in V3 resource snapshots. When
+                // such a command declares no inputs, every remaining token is invalid and can be
+                // rejected locally without invoking a callback whose failure text could mimic a
+                // hosting parser diagnostic.
+                return CreateCommandArguments([], capturedArguments, parseMode);
+            }
+
+            // Older AppHosts may not expose command metadata. Forward tokens as unknown names and
+            // let hosting-side validation reject them; the legacy response-message fallback below
+            // remains scoped to those pre-V3 peers.
             return (CreateUnknownArguments(capturedArguments), null);
         }
 

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -163,28 +163,6 @@ internal sealed class ResourceCommand : BaseCommand
             return await LoadCommandArgumentsAsync(parseResult, connection, resourceName, commandName, commandArguments, cancellationToken).ConfigureAwait(false);
         }
 
-        if (connection.SupportsV3 && command is not null && commandArgumentsResult.RequiresHostingValidation)
-        {
-            var validationResponse = await ValidateHostingCommandArgumentsAsync(
-                connection,
-                resourceName,
-                commandName,
-                commandArguments,
-                cancellationToken).ConfigureAwait(false);
-
-            if (IsHostingUnknownArgumentValidationFailure(validationResponse, commandName))
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var validationErrorMessage = validationResponse.Message ?? validationResponse.ErrorMessage!;
-#pragma warning restore CS0618 // Type or member is obsolete
-                InteractionService.DisplayError(validationErrorMessage);
-                await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
-
-                ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
-                return CommandResult.FromExitCode(CliExitCodes.InvalidCommand);
-            }
-        }
-
         (int ExitCode, ExecuteResourceCommandResponse Response) commandResult;
 
         // Use display metadata for well-known command names.
@@ -214,8 +192,7 @@ internal sealed class ResourceCommand : BaseCommand
                 cancellationToken).ConfigureAwait(false);
         }
 
-        if (!connection.SupportsV3 &&
-            command is not null &&
+        if (command is not null &&
             commandArgumentsResult.RequiresHostingValidation &&
             IsHostingUnknownArgumentValidationFailure(commandResult.Response, commandName))
         {
@@ -225,26 +202,6 @@ internal sealed class ResourceCommand : BaseCommand
         }
 
         return CommandResult.FromExitCode(commandResult.ExitCode);
-    }
-
-    private static async Task<ExecuteResourceCommandResponse> ValidateHostingCommandArgumentsAsync(
-        IAppHostAuxiliaryBackchannel connection,
-        string resourceName,
-        string commandName,
-        JsonNode? commandArguments,
-        CancellationToken cancellationToken)
-    {
-        return await connection.ExecuteResourceCommandAsync(
-            resourceName,
-            commandName,
-            new ExecuteResourceCommandOptions
-            {
-                Arguments = commandArguments,
-                ValidateOnly = true,
-                NonInteractive = true,
-                ReturnArgumentInputs = true
-            },
-            cancellationToken).ConfigureAwait(false);
     }
 
     private static bool IsHostingUnknownArgumentValidationFailure(ExecuteResourceCommandResponse response, string commandName)
@@ -364,8 +321,8 @@ internal sealed class ResourceCommand : BaseCommand
         if (command?.ArgumentInputs is not { Length: > 0 } argumentInputs)
         {
             // Without command metadata there are no options to give System.CommandLine. Preserve the
-            // raw tokens and ask a capable AppHost to validate them before command execution. Older
-            // AppHosts stay on the single-execution compatibility path so they cannot execute twice.
+            // raw tokens and let the AppHost validate them in the single execution request. This
+            // keeps older AppHosts compatible without risking a validation request executing twice.
             return (CreateUnknownArguments(capturedArguments), null, command is not null);
         }
 

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -179,14 +179,38 @@ internal sealed class ResourceCommand : BaseCommand
                 cancellationToken));
         }
 
-        return CommandResult.FromExitCode(await ResourceCommandHelper.ExecuteGenericCommandAsync(
+        var genericCommandResult = await ResourceCommandHelper.ExecuteGenericCommandWithResponseAsync(
             connection,
             InteractionService,
             _logger,
             resourceName,
             commandName,
             commandArguments,
-            cancellationToken));
+            cancellationToken).ConfigureAwait(false);
+
+        if (command is not null && IsHostingUnknownArgumentFailure(genericCommandResult.Response, commandName))
+        {
+            await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+            ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
+        }
+
+        return CommandResult.FromExitCode(genericCommandResult.ExitCode);
+    }
+
+    private static bool IsHostingUnknownArgumentFailure(ExecuteResourceCommandResponse response, string commandName)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        var message = response.Message ?? response.ErrorMessage;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        if (response.Success || response.Canceled || string.IsNullOrEmpty(message))
+        {
+            return false;
+        }
+
+        return (message.StartsWith("Unknown argument '", StringComparison.Ordinal) &&
+                message.EndsWith($" for command '{commandName}'.", StringComparison.Ordinal)) ||
+            message.StartsWith($"Unknown arguments for command '{commandName}':", StringComparison.Ordinal);
     }
 
     private static async Task<CommandResult> LoadCommandArgumentsAsync(

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -221,6 +221,7 @@ internal sealed class ResourceCommand : BaseCommand
         {
             await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
             ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
+            return CommandResult.FromExitCode(CliExitCodes.InvalidCommand);
         }
 
         return CommandResult.FromExitCode(commandResult.ExitCode);

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -163,7 +163,7 @@ internal sealed class ResourceCommand : BaseCommand
             return await LoadCommandArgumentsAsync(parseResult, connection, resourceName, commandName, commandArguments, cancellationToken).ConfigureAwait(false);
         }
 
-        if (command is not null && commandArgumentsResult.RequiresHostingValidation)
+        if (connection.SupportsV3 && command is not null && commandArgumentsResult.RequiresHostingValidation)
         {
             var validationResponse = await ValidateHostingCommandArgumentsAsync(
                 connection,
@@ -214,6 +214,15 @@ internal sealed class ResourceCommand : BaseCommand
                 cancellationToken).ConfigureAwait(false);
         }
 
+        if (!connection.SupportsV3 &&
+            command is not null &&
+            commandArgumentsResult.RequiresHostingValidation &&
+            IsHostingUnknownArgumentValidationFailure(commandResult.Response, commandName))
+        {
+            await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+            ResourceCommandHelpAction.WriteResourceCommandHelp(parseResult.InvocationConfiguration.Output, parseResult.CommandResult, resourceName, command);
+        }
+
         return CommandResult.FromExitCode(commandResult.ExitCode);
     }
 
@@ -239,9 +248,6 @@ internal sealed class ResourceCommand : BaseCommand
 
     private static bool IsHostingUnknownArgumentValidationFailure(ExecuteResourceCommandResponse response, string commandName)
     {
-        // This response comes from a ValidateOnly request, so resource command callbacks have not
-        // executed and cannot spoof the parser diagnostic. Keep the legacy text recognition scoped
-        // to this validation-only path instead of classifying arbitrary execution failures by text.
         if (response.Success || response.Canceled)
         {
             return false;
@@ -256,6 +262,13 @@ internal sealed class ResourceCommand : BaseCommand
             return false;
         }
 
+        var resolvedCommandName = s_legacyCommandNameMap.GetValueOrDefault(commandName, commandName);
+        return MatchesUnknownArgumentMessage(message, commandName) ||
+            (!string.Equals(resolvedCommandName, commandName, StringComparison.Ordinal) && MatchesUnknownArgumentMessage(message, resolvedCommandName));
+    }
+
+    private static bool MatchesUnknownArgumentMessage(string message, string commandName)
+    {
         return (message.StartsWith("Unknown argument '", StringComparison.Ordinal) &&
                 message.EndsWith($" for command '{commandName}'.", StringComparison.Ordinal)) ||
             message.StartsWith($"Unknown arguments for command '{commandName}':", StringComparison.Ordinal);
@@ -350,8 +363,8 @@ internal sealed class ResourceCommand : BaseCommand
         if (command?.ArgumentInputs is not { Length: > 0 } argumentInputs)
         {
             // Without command metadata there are no options to give System.CommandLine. Preserve the
-            // raw tokens and ask the AppHost to validate them explicitly before command execution;
-            // this distinguishes hosting argument rejection from arbitrary callback failure text.
+            // raw tokens and ask a capable AppHost to validate them before command execution. Older
+            // AppHosts stay on the single-execution compatibility path so they cannot execute twice.
             return (CreateUnknownArguments(capturedArguments), null, command is not null);
         }
 

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -69,6 +69,27 @@ internal static class ResourceCommandHelper
         JsonNode? arguments,
         CancellationToken cancellationToken)
     {
+        var result = await ExecuteGenericCommandWithResponseAsync(
+            connection,
+            interactionService,
+            logger,
+            resourceName,
+            commandName,
+            arguments,
+            cancellationToken).ConfigureAwait(false);
+
+        return result.ExitCode;
+    }
+
+    internal static async Task<(int ExitCode, ExecuteResourceCommandResponse Response)> ExecuteGenericCommandWithResponseAsync(
+        IAppHostAuxiliaryBackchannel connection,
+        IInteractionService interactionService,
+        ILogger logger,
+        string resourceName,
+        string commandName,
+        JsonNode? arguments,
+        CancellationToken cancellationToken)
+    {
         logger.LogDebug("Executing command '{CommandName}' on resource '{ResourceName}'", commandName, resourceName);
 
         var response = await interactionService.ShowStatusAsync(
@@ -90,7 +111,7 @@ internal static class ResourceCommandHelper
         else if (response.Canceled)
         {
             interactionService.DisplayMessage(KnownEmojis.Warning, $"Command '{commandName}' on '{resourceName}' was canceled.");
-            return CliExitCodes.FailedToExecuteResourceCommand;
+            return (CliExitCodes.FailedToExecuteResourceCommand, response);
         }
         else
         {
@@ -114,7 +135,7 @@ internal static class ResourceCommandHelper
             DisplayCommandResult(interactionService, response.Value);
         }
 
-        return response.Success ? CliExitCodes.Success : CliExitCodes.FailedToExecuteResourceCommand;
+        return (response.Success ? CliExitCodes.Success : CliExitCodes.FailedToExecuteResourceCommand, response);
     }
 
     private static int HandleResponse(

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -40,6 +40,33 @@ internal static class ResourceCommandHelper
         JsonNode? arguments,
         CancellationToken cancellationToken)
     {
+        var result = await ExecuteResourceCommandWithResponseAsync(
+            connection,
+            interactionService,
+            logger,
+            resourceName,
+            commandName,
+            progressVerb,
+            baseVerb,
+            pastTenseVerb,
+            arguments,
+            cancellationToken).ConfigureAwait(false);
+
+        return result.ExitCode;
+    }
+
+    internal static async Task<(int ExitCode, ExecuteResourceCommandResponse Response)> ExecuteResourceCommandWithResponseAsync(
+        IAppHostAuxiliaryBackchannel connection,
+        IInteractionService interactionService,
+        ILogger logger,
+        string resourceName,
+        string commandName,
+        string progressVerb,
+        string baseVerb,
+        string pastTenseVerb,
+        JsonNode? arguments,
+        CancellationToken cancellationToken)
+    {
         logger.LogDebug("{Verb} resource '{ResourceName}'", progressVerb, resourceName);
 
         var response = await interactionService.ShowStatusAsync(
@@ -54,7 +81,7 @@ internal static class ResourceCommandHelper
                 },
                 cancellationToken));
 
-        return HandleResponse(response, interactionService, resourceName, commandName, progressVerb, baseVerb, pastTenseVerb);
+        return (HandleResponse(response, interactionService, resourceName, commandName, progressVerb, baseVerb, pastTenseVerb), response);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ResourceCommandTests.cs
@@ -108,6 +108,93 @@ public sealed class ResourceCommandTests(ITestOutputHelper output)
 
     [Fact]
     [CaptureWorkspaceOnFailure]
+    public async Task ResourceCommand_InvalidArgumentShowsErrorBeforeCommandHelp()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var projectSuffix = Guid.NewGuid().ToString("N")[..6];
+        var projectName = $"ResourceCmdInvalidArgApp_{projectSuffix}";
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
+
+        await auto.TypeAsync($"cd {projectName}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, projectName, "apphost.cs");
+        var content = File.ReadAllText(appHostFilePath);
+        var sdkLine = content.Split('\n', 2)[0].TrimEnd('\r');
+
+        var newContent = $$"""
+            {{sdkLine}}
+
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            var resource = builder.AddParameter("test-resource");
+
+            resource.WithCommand(
+                name: "configure",
+                displayName: "Configure",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()),
+                commandOptions: new CommandOptions
+                {
+                    Description = "Configures the resource.",
+                    Arguments =
+                    [
+                        new InteractionInput
+                        {
+                            Name = "message",
+                            Label = "Message",
+                            Description = "Message to send.",
+                            InputType = InputType.Text,
+                            Required = true
+                        }
+                    ]
+                });
+
+            builder.Build().Run();
+            """;
+
+        File.WriteAllText(appHostFilePath, newContent);
+
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync(RunCommandStrings.AppHostStartedSuccessfully, timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync($"aspire resource test-resource configure --unknown value > /tmp/resource-invalid-output.txt 2>&1; if [ $? -eq {CliExitCodes.InvalidCommand} ]; then echo RESOURCE_CMD_EXIT_CODE_CORRECT; else echo RESOURCE_CMD_UNEXPECTED_EXIT_CODE; fi");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("RESOURCE_CMD_EXIT_CODE_CORRECT", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.RunCommandAsync(
+            "grep -qF \"Unrecognized command option '--unknown value'.\" /tmp/resource-invalid-output.txt && grep -qF 'Configures the resource.' /tmp/resource-invalid-output.txt && grep -qF 'Usage:' /tmp/resource-invalid-output.txt && grep -qF -- '--message <value>' /tmp/resource-invalid-output.txt",
+            counter,
+            TimeSpan.FromSeconds(10));
+
+        await auto.RunCommandAsync(
+            "ERROR_LINE=$(grep -nF \"Unrecognized command option '--unknown value'.\" /tmp/resource-invalid-output.txt | head -n1 | cut -d: -f1); HELP_LINE=$(grep -nF 'Usage:' /tmp/resource-invalid-output.txt | head -n1 | cut -d: -f1); test -n \"$ERROR_LINE\" && test -n \"$HELP_LINE\" && test \"$ERROR_LINE\" -lt \"$HELP_LINE\"",
+            counter,
+            TimeSpan.FromSeconds(10));
+
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitUntilAppHostStoppedSuccessfullyAsync(timeout: TimeSpan.FromMinutes(1));
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/17485")]
     public async Task ResourceCommand_FailsWhenInteractionServiceIsRequired()
     {

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
@@ -15,15 +15,18 @@ namespace Aspire.Cli.Tests.Commands;
 public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task CurrentHostZeroArgumentCommandRejectsUnknownOptionBeforeCallback()
+    public async Task MetadataMissingCommandValidatesUnknownOptionBeforeExecution()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var output = new StringWriter();
         var interactionService = new TestInteractionService();
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
-            SupportsV3 = true,
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--unknown value' for command 'configure'."
+            },
             ResourceSnapshots =
             [
                 CreateResourceSnapshot(
@@ -39,21 +42,23 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
 
         Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
-        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
-        Assert.Equal("Unrecognized command option '--unknown value'.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.NotNull(backchannel.ExecuteResourceCommandOptions);
+        Assert.True(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
+        Assert.True(backchannel.ExecuteResourceCommandOptions.ReturnArgumentInputs);
+        Assert.Equal("Unknown argument '--unknown value' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
         Assert.Contains("Configures the browser.", output.ToString());
         Assert.Contains("Usage:", output.ToString());
     }
 
     [Fact]
-    public async Task CurrentHostCallbackFailureWithParserLikeTextDoesNotShowHelp()
+    public async Task CallbackFailureWithParserLikeTextDoesNotShowHelp()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var output = new StringWriter();
         var interactionService = new TestInteractionService();
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
-            SupportsV3 = true,
             ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
             {
                 Success = false,
@@ -78,42 +83,10 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
 
         Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.NotNull(backchannel.ExecuteResourceCommandOptions);
+        Assert.False(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
         Assert.Contains("Unknown argument '--pretend' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
         Assert.Empty(output.ToString());
-    }
-
-    [Fact]
-    public async Task PreV3HostKeepsLegacyUnknownArgumentFallback()
-    {
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var output = new StringWriter();
-        var interactionService = new TestInteractionService();
-        var backchannel = new TestAppHostAuxiliaryBackchannel
-        {
-            SupportsV3 = false,
-            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
-            {
-                Success = false,
-                Message = "Unknown argument '--unknown value' for command 'configure'."
-            },
-            ResourceSnapshots =
-            [
-                CreateResourceSnapshot(
-                    "web-browser-automation",
-                    CreateCommand("configure", "Configures the browser."))
-            ]
-        };
-        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
-
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
-
-        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
-
-        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
-        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
-        Assert.Contains("Configures the browser.", output.ToString());
-        Assert.Contains("Usage:", output.ToString());
     }
 
     private ServiceProvider CreateServiceProvider(

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.Tests.Commands;
 public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task MetadataMissingCommandValidatesUnknownOptionBeforeExecution()
+    public async Task MetadataMissingCommandUsesSingleExecutionForUnknownOption()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var output = new StringWriter();
@@ -45,8 +45,8 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
         Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.NotNull(backchannel.ExecuteResourceCommandOptions);
-        Assert.True(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
-        Assert.True(backchannel.ExecuteResourceCommandOptions.ReturnArgumentInputs);
+        Assert.False(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
+        Assert.False(backchannel.ExecuteResourceCommandOptions.ReturnArgumentInputs);
         Assert.Equal("Unknown argument '--unknown value' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
         Assert.Contains("Configures the browser.", output.ToString());
         Assert.Contains("Usage:", output.ToString());
@@ -60,6 +60,7 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
         var interactionService = new TestInteractionService();
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
+            SupportsV3 = true,
             ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
             {
                 Success = false,
@@ -88,6 +89,42 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
         Assert.False(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
         Assert.Contains("Unknown argument '--pretend' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
         Assert.Empty(output.ToString());
+    }
+
+    [Fact]
+    public async Task LegacyMetadataMissingCommandUsesSameSingleExecutionFallback()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--unknown value' for command 'configure'."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.NotNull(backchannel.ExecuteResourceCommandOptions);
+        Assert.False(backchannel.ExecuteResourceCommandOptions.ValidateOnly);
+        Assert.Equal("Unknown argument '--unknown value' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Contains("Configures the browser.", output.ToString());
+        Assert.Contains("Usage:", output.ToString());
     }
 
     private ServiceProvider CreateServiceProvider(

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using InvocationConfiguration = System.CommandLine.InvocationConfiguration;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CurrentHostZeroArgumentCommandRejectsUnknownOptionBeforeCallback()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            SupportsV3 = true,
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Equal("Unrecognized command option '--unknown value'.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Contains("Configures the browser.", output.ToString());
+        Assert.Contains("Usage:", output.ToString());
+    }
+
+    [Fact]
+    public async Task CurrentHostCallbackFailureWithParserLikeTextDoesNotShowHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            SupportsV3 = true,
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--pretend' for command 'configure'."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("message")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --message hello""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Unknown argument '--pretend' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Empty(output.ToString());
+    }
+
+    [Fact]
+    public async Task PreV3HostKeepsLegacyUnknownArgumentFallback()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            SupportsV3 = false,
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--unknown value' for command 'configure'."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Configures the browser.", output.ToString());
+        Assert.Contains("Usage:", output.ToString());
+    }
+
+    private ServiceProvider CreateServiceProvider(
+        TemporaryWorkspace workspace,
+        TestAppHostAuxiliaryBackchannel backchannel,
+        TestInteractionService interactionService)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.InteractionServiceFactory = _ => interactionService;
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ResourceSnapshot CreateResourceSnapshot(string name, params ResourceSnapshotCommand[] commands)
+    {
+        return new ResourceSnapshot
+        {
+            Name = name,
+            DisplayName = name,
+            State = "Running",
+            Commands = commands
+        };
+    }
+
+    private static ResourceSnapshotCommand CreateCommand(string name, string description, params ResourceSnapshotCommandArgument[] argumentInputs)
+    {
+        return new ResourceSnapshotCommand
+        {
+            Name = name,
+            Description = description,
+            State = "Enabled",
+            Visibility = KnownCommandVisibility.Default,
+            ArgumentInputs = argumentInputs
+        };
+    }
+
+    private static ResourceSnapshotCommandArgument CreateArgument(string name)
+    {
+        return new ResourceSnapshotCommandArgument
+        {
+            Name = name,
+            InputType = "Text"
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHostingValidationClassificationTests.cs
@@ -22,6 +22,7 @@ public class ResourceCommandHostingValidationClassificationTests(ITestOutputHelp
         var interactionService = new TestInteractionService();
         var backchannel = new TestAppHostAuxiliaryBackchannel
         {
+            SupportsV3 = true,
             ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
             {
                 Success = false,

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
@@ -74,26 +74,60 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
         var monitor = new TestAuxiliaryBackchannelMonitor();
         monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
 
+        var events = new List<string>();
         TestExtensionInteractionService? interactionService = null;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
-            options.InteractionServiceFactory = sp => interactionService = new TestExtensionInteractionService(sp);
+            options.InteractionServiceFactory = sp => interactionService = new TestExtensionInteractionService(sp)
+            {
+                DisplayErrorCallback = _ => events.Add("error"),
+                FlushAsyncCallback = _ =>
+                {
+                    events.Add("flush");
+                    return Task.CompletedTask;
+                }
+            };
         });
         await using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("""resource web-browser-automation configure --unknown value""");
-        var output = new FlushAssertingTextWriter(() => interactionService?.FlushAsyncCalled is true);
+        var output = new FirstWriteCallbackTextWriter(() => events.Add("help"));
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
 
         Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.NotNull(interactionService);
-        Assert.True(interactionService.FlushAsyncCalled);
-        Assert.True(output.AssertedFlushBeforeWrite);
+        Assert.Equal(["error", "flush", "help", "flush"], events);
+        Assert.Equal(2, interactionService.FlushAsyncCallCount);
         Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
+    public async Task BaseCommand_TimedOutPreFlushIsNotRetriedByFinalFlush()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        TestExtensionInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = sp => interactionService = new TestExtensionInteractionService(sp)
+            {
+                FlushAsyncCallback = cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+            };
+        });
+        await using var provider = services.BuildServiceProvider();
+
+        var command = new FlushTimeoutTestCommand(provider.GetRequiredService<CommonCommandServices>());
+        var result = command.Parse(string.Empty);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(interactionService);
+        Assert.Equal(1, interactionService.FlushAsyncCallCount);
     }
 
     [Fact]
@@ -291,15 +325,30 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
         };
     }
 
-    private sealed class FlushAssertingTextWriter(Func<bool> isFlushed) : StringWriter
+    private sealed class FirstWriteCallbackTextWriter(Action onFirstWrite) : StringWriter
     {
-        public bool AssertedFlushBeforeWrite { get; private set; }
+        private bool _hasWritten;
 
         public override void WriteLine(string? value)
         {
-            Assert.True(isFlushed(), "Extension interactions must be flushed before command help is written.");
-            AssertedFlushBeforeWrite = true;
+            if (!_hasWritten)
+            {
+                _hasWritten = true;
+                onFirstWrite();
+            }
+
             base.WriteLine(value);
+        }
+    }
+
+    private sealed class FlushTimeoutTestCommand(CommonCommandServices services) : BaseCommand("flush-timeout-test", "Tests extension flush timeout behavior.", services)
+    {
+        protected override TimeSpan ExtensionInteractionFlushTimeout => TimeSpan.FromMilliseconds(20);
+
+        protected override async Task<CommandResult> ExecuteAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)
+        {
+            await FlushExtensionInteractionServiceAsync(InteractionService).ConfigureAwait(false);
+            return CommandResult.Success();
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
@@ -191,7 +191,7 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
 
-        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.Contains("Unknown argument '--unknown value' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
 
@@ -230,7 +230,7 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
 
         var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
 
-        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
         Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
         Assert.Contains("Unknown argument '--unknown value' for command 'start'.", Assert.Single(interactionService.DisplayedErrors));
 

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
@@ -87,6 +87,79 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
         Assert.Empty(output.ToString());
     }
 
+    [Fact]
+    public async Task ResourceCommand_HostingUnknownArgumentShowsCommandSpecificHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--unknown value' for command 'configure'."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Unknown argument '--unknown value' for command 'configure'.", Assert.Single(interactionService.DisplayedErrors));
+
+        var helpOutput = output.ToString();
+        Assert.Contains("Configures the browser.", helpOutput);
+        Assert.Contains("Usage:", helpOutput);
+        Assert.Contains("aspire resource web-browser-automation configure [options] [[--] <command-options>...]", helpOutput);
+        Assert.Contains("Options:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_OrdinaryExecutionFailureDoesNotShowCommandHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Command execution failed."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("configure", "Configures the browser."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Command execution failed.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Empty(output.ToString());
+    }
+
     private ServiceProvider CreateServiceProvider(
         TemporaryWorkspace workspace,
         TestAppHostAuxiliaryBackchannel backchannel,

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using InvocationConfiguration = System.CommandLine.InvocationConfiguration;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ResourceCommand_InvalidCommandArgumentShowsCommandSpecificHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("message", description: "Message to send.", required: true)))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Equal("Unrecognized command option '--unknown value'.", Assert.Single(interactionService.DisplayedErrors));
+
+        var helpOutput = output.ToString();
+        Assert.Contains("Configures the browser.", helpOutput);
+        Assert.Contains("Usage:", helpOutput);
+        Assert.Contains("aspire resource web-browser-automation configure [options] [[--] <command-options>...]", helpOutput);
+        Assert.Contains("--message <value>", helpOutput);
+        Assert.Contains("Message to send. Required.", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_LoadArgumentsInvalidInputDoesNotWriteHumanHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("message", description: "Message to send.")))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --load-arguments --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Equal("Unrecognized command option '--unknown value'.", Assert.Single(interactionService.DisplayedErrors));
+        Assert.Empty(output.ToString());
+    }
+
+    private ServiceProvider CreateServiceProvider(
+        TemporaryWorkspace workspace,
+        TestAppHostAuxiliaryBackchannel backchannel,
+        TestInteractionService interactionService)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.InteractionServiceFactory = _ => interactionService;
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ResourceSnapshot CreateResourceSnapshot(string name, params ResourceSnapshotCommand[] commands)
+    {
+        return new ResourceSnapshot
+        {
+            Name = name,
+            DisplayName = name,
+            State = "Running",
+            Commands = commands
+        };
+    }
+
+    private static ResourceSnapshotCommand CreateCommand(string name, string description, params ResourceSnapshotCommandArgument[] argumentInputs)
+    {
+        return new ResourceSnapshotCommand
+        {
+            Name = name,
+            Description = description,
+            State = "Enabled",
+            Visibility = KnownCommandVisibility.Default,
+            ArgumentInputs = argumentInputs
+        };
+    }
+
+    private static ResourceSnapshotCommandArgument CreateArgument(string name, string? description = null, bool required = false)
+    {
+        return new ResourceSnapshotCommandArgument
+        {
+            Name = name,
+            Description = description,
+            InputType = "Text",
+            Required = required
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandInvalidArgumentHelpTests.cs
@@ -55,6 +55,48 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
     }
 
     [Fact]
+    public async Task ResourceCommand_ExtensionErrorIsFlushedBeforeHelpIsWritten()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand(
+                        "configure",
+                        "Configures the browser.",
+                        CreateArgument("message", description: "Message to send.", required: true)))
+            ]
+        };
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        monitor.AddConnection("hash", "/tmp/test.sock", backchannel);
+
+        TestExtensionInteractionService? interactionService = null;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = sp => interactionService = new TestExtensionInteractionService(sp);
+        });
+        await using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation configure --unknown value""");
+        var output = new FlushAssertingTextWriter(() => interactionService?.FlushAsyncCalled is true);
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.NotNull(interactionService);
+        Assert.True(interactionService.FlushAsyncCalled);
+        Assert.True(output.AssertedFlushBeforeWrite);
+        Assert.Equal(0, backchannel.ExecuteResourceCommandCallCount);
+    }
+
+    [Fact]
     public async Task ResourceCommand_LoadArgumentsInvalidInputDoesNotWriteHumanHelp()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -124,6 +166,44 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
         Assert.Contains("Usage:", helpOutput);
         Assert.Contains("aspire resource web-browser-automation configure [options] [[--] <command-options>...]", helpOutput);
         Assert.Contains("Options:", helpOutput);
+    }
+
+    [Fact]
+    public async Task ResourceCommand_HostingUnknownArgumentForWellKnownCommandShowsCommandSpecificHelp()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var output = new StringWriter();
+        var interactionService = new TestInteractionService();
+
+        var backchannel = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                Message = "Unknown argument '--unknown value' for command 'start'."
+            },
+            ResourceSnapshots =
+            [
+                CreateResourceSnapshot(
+                    "web-browser-automation",
+                    CreateCommand("start", "Starts the resource."))
+            ]
+        };
+        await using var provider = CreateServiceProvider(workspace, backchannel, interactionService);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("""resource web-browser-automation start --unknown value""");
+
+        var exitCode = await result.InvokeAsync(new InvocationConfiguration { Output = output }).DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToExecuteResourceCommand, exitCode);
+        Assert.Equal(1, backchannel.ExecuteResourceCommandCallCount);
+        Assert.Contains("Unknown argument '--unknown value' for command 'start'.", Assert.Single(interactionService.DisplayedErrors));
+
+        var helpOutput = output.ToString();
+        Assert.Contains("Starts the resource.", helpOutput);
+        Assert.Contains("Usage:", helpOutput);
+        Assert.Contains("aspire resource web-browser-automation start [options] [[--] <command-options>...]", helpOutput);
     }
 
     [Fact]
@@ -209,5 +289,17 @@ public class ResourceCommandInvalidArgumentHelpTests(ITestOutputHelper outputHel
             InputType = "Text",
             Required = required
         };
+    }
+
+    private sealed class FlushAssertingTextWriter(Func<bool> isFlushed) : StringWriter
+    {
+        public bool AssertedFlushBeforeWrite { get; private set; }
+
+        public override void WriteLine(string? value)
+        {
+            Assert.True(isFlushed(), "Extension interactions must be flushed before command help is written.");
+            AssertedFlushBeforeWrite = true;
+            base.WriteLine(value);
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -27,15 +27,17 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     public Func<string, Func<string, ValidationResult>?, bool, bool, PromptBinding<string?>?, CancellationToken, Task<string>>? PromptForStringCallback { get; set; }
     public Func<string, IReadOnlyList<string>, string>? SelectionCallback { get; set; }
     public Func<IRenderable, Func<Action<IRenderable>, Task>, Task>? DisplayLiveAsyncCallback { get; set; }
+    public Func<CancellationToken, Task>? FlushAsyncCallback { get; set; }
     public List<(OutputLineStream Stream, string Line)> DisplayedLines { get; } = [];
-    public bool FlushAsyncCalled { get; private set; }
+    public int FlushAsyncCallCount { get; private set; }
+    public bool FlushAsyncCalled => FlushAsyncCallCount > 0;
 
     public IExtensionBackchannel Backchannel { get; } = serviceProvider.GetRequiredService<IExtensionBackchannel>();
 
     public Task FlushAsync(CancellationToken cancellationToken = default)
     {
-        FlushAsyncCalled = true;
-        return Task.CompletedTask;
+        FlushAsyncCallCount++;
+        return FlushAsyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
     }
 
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)


### PR DESCRIPTION
## Description

When a resource command receives an invalid command-specific argument, the CLI currently reports the parsing error but does not show the dynamically resolved help for that resource command.

This change reuses the existing command-specific help writer after command-argument parsing fails. The parse error is displayed first, followed by the resolved command description, usage, command options, and visible CLI options. The hidden `--load-arguments` path is intentionally left unchanged so its machine-readable output is not mixed with human help text.

Focused regression coverage verifies that invalid command arguments do not execute the resource command, do display the command-specific help, and do not add human help to the `--load-arguments` path.

### Validation

- Added focused unit coverage for the invalid-argument help path and the `--load-arguments` guard.
- Local .NET test execution is unavailable in the current execution environment, so upstream CI is the executable verification gate.

Fixes #19610

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No