### PR TITLE
Remove unnecessary friend assembly declarations

### DIFF
--- a/src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj
@@ -13,10 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.ContainerRegistry" />

--- a/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
@@ -15,11 +15,6 @@
   <ItemGroup>
     <Compile Remove="tools\**\*.cs" />
     <Compile Include="$(SharedDir)BicepFormattingHelpers.cs" LinkBase="Shared\BicepFormattingHelpers.cs" />
-    <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="Utils\PathLookupHelper.cs" />
-    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Process\ProcessResult.cs" />
-    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Process\ProcessSpec.cs" />
-    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Process\ProcessOutputCapture.cs" />
-    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Process\ProcessUtil.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.CodeGeneration.Go/Aspire.Hosting.CodeGeneration.Go.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Go/Aspire.Hosting.CodeGeneration.Go.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="aspire" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.Go.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Java/Aspire.Hosting.CodeGeneration.Java.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Java/Aspire.Hosting.CodeGeneration.Java.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="aspire" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.Java.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Python/Aspire.Hosting.CodeGeneration.Python.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Python/Aspire.Hosting.CodeGeneration.Python.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="aspire" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.Python.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.Rust/Aspire.Hosting.CodeGeneration.Rust.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/Aspire.Hosting.CodeGeneration.Rust.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="aspire" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.Rust.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="aspire" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.TypeScript.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Docker/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.Docker/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Aspire.Hosting.Docker.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/Aspire.Hosting.Dotnet/Aspire.Hosting.Dotnet.csproj
+++ b/src/Aspire.Hosting.Dotnet/Aspire.Hosting.Dotnet.csproj
@@ -32,8 +32,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Aspire.Hosting.Dotnet.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -14,8 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" LinkBase="Process" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" LinkBase="Process" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" LinkBase="Process" />
+    <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" LinkBase="Process" />
+    <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)PathLookupHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Redis/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.Redis/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Aspire.Hosting.Redis.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj
+++ b/src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj
@@ -47,8 +47,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Aspire.Cli.Tests"/>
-  </ItemGroup>
-
 </Project>

--- a/src/Aspire.Hosting/ApplicationModel/ProjectLaunchDefaultsAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectLaunchDefaultsAnnotation.cs
@@ -27,7 +27,7 @@ public sealed class ProjectLaunchDefaultsAnnotation : IResourceAnnotation
     /// The https endpoint that was added as a default. It is excluded from the port and Kestrel
     /// override environment because the target (e.g. a container) likely won't listen on https.
     /// </summary>
-    internal EndpointAnnotation? DefaultHttpsEndpoint { get; set; }
+    public EndpointAnnotation? DefaultHttpsEndpoint { get; set; }
 
     /// <summary>
     /// Whether any endpoints originated from Kestrel configuration.

--- a/src/Aspire.Hosting/ApplicationModel/ProjectLaunchDefaultsAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectLaunchDefaultsAnnotation.cs
@@ -27,7 +27,7 @@ public sealed class ProjectLaunchDefaultsAnnotation : IResourceAnnotation
     /// The https endpoint that was added as a default. It is excluded from the port and Kestrel
     /// override environment because the target (e.g. a container) likely won't listen on https.
     /// </summary>
-    public EndpointAnnotation? DefaultHttpsEndpoint { get; set; }
+    public EndpointAnnotation? DefaultHttpsEndpoint { get; internal set; }
 
     /// <summary>
     /// Whether any endpoints originated from Kestrel configuration.

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -142,12 +142,7 @@
     <InternalsVisibleTo Include="Aspire.Hosting.Rust.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Testing.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />
-    <InternalsVisibleTo Include="Aspire.Hosting.DotnetTool.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.EntityFrameworkCore" />
-    <InternalsVisibleTo Include="Aspire.TestUtilities" />
-    <InternalsVisibleTo Include="Aspire.Cli.Tests" />
-    <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes" />
-    <InternalsVisibleTo Include="Aspire.Hosting.Radius" />
     <InternalsVisibleTo Include="Aspire.Hosting.Radius.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Foundry.Tests" />


### PR DESCRIPTION
## Description

Reduces the repository's friend-assembly surface after auditing every `InternalsVisibleTo` declaration and verifying actual internal-member usage from each named assembly.

This removes 15 unnecessary declarations, including redundant source-level attributes in the Docker and Redis integrations. Required declarations remain in place where removing them produced internal-access or analyzer failures. To remove the production friendships from `Aspire.Hosting` to the Kubernetes and Radius integrations, the Kubernetes process helpers are now compiled directly into `Aspire.Hosting.Kubernetes`, and `ProjectLaunchDefaultsAnnotation.DefaultHttpsEndpoint` is public.

Validation:

```powershell
$env:MSBUILDDISABLENODEREUSE='1'
.\build.cmd /p:SkipNativeBuild=true /p:BuildInParallel=false /m:1 /nr:false
```

Build succeeded with 0 warnings and 0 errors.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
