### PR TITLE
Show consistent pause warnings across dashboard pages

### DIFF
--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -333,12 +333,13 @@ Use this when verifying the installed/released dashboard instead of the repo-loc
 
 ```powershell
 $appHost = "<path-to-AppHost.csproj>"
-$dashboard = "$HOME\.aspire\bundle\managed\aspire-managed.exe"
+$managedExecutable = if ($env:OS -eq "Windows_NT") { "aspire-managed.exe" } else { "aspire-managed" }
+$dashboard = Join-Path $HOME ".aspire/bundle/managed/$managedExecutable"
 dotnet build $appHost /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
 aspire run --no-build --apphost $appHost
 ```
 
-- Verify the dashboard resource in Aspire metadata/logs before treating the run as a stock baseline. The source/executable must be `aspire-managed.exe`, not `Aspire.Dashboard.csproj`.
+- Verify the dashboard resource in Aspire metadata/logs before treating the run as a stock baseline. The source/executable must be `aspire-managed` (`aspire-managed.exe` on Windows), not `Aspire.Dashboard.csproj`.
 
 ## Test Conventions
 

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -333,8 +333,38 @@ Use this when verifying the installed/released dashboard instead of the repo-loc
 
 ```powershell
 $appHost = "<path-to-AppHost.csproj>"
+$doctor = aspire doctor --format Json --non-interactive 2>$null | ConvertFrom-Json
+$installation = $doctor.installations | Where-Object pathStatus -eq "active" | Select-Object -First 1
+if ($null -eq $installation)
+{
+    throw "Could not find the active Aspire CLI installation."
+}
+
+$aspireDirectory = Split-Path $installation.canonicalPath -Parent
+if ($installation.route -in @("script", "pr", "localhive"))
+{
+    $bundleRoot = Split-Path $aspireDirectory -Parent
+}
+elseif ($installation.route -in @("winget", "brew", "dotnet-tool"))
+{
+    $bundleRoot = $aspireDirectory
+}
+elseif ($env:ASPIRE_HOME)
+{
+    $bundleRoot = $env:ASPIRE_HOME
+}
+else
+{
+    $bundleRoot = Join-Path $HOME ".aspire"
+}
+
 $managedExecutable = if ($env:OS -eq "Windows_NT") { "aspire-managed.exe" } else { "aspire-managed" }
-$dashboard = Join-Path $HOME ".aspire/bundle/managed/$managedExecutable"
+$dashboard = Join-Path $bundleRoot "bundle/managed/$managedExecutable"
+if (-not (Test-Path $dashboard))
+{
+    throw "Could not find the installed dashboard at '$dashboard'."
+}
+
 dotnet build $appHost /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
 aspire run --no-build --apphost $appHost
 ```

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -331,13 +331,13 @@ Use this when verifying the installed/released dashboard instead of the repo-loc
 - In-repo playground AppHosts can add `Projects.Aspire_Dashboard` for local dashboard development. Running an installed `aspire` CLI is not enough when the AppHost model already contains that local project.
 - Use `SkipDashboardProjectReference=true` to opt out of the shared playground dashboard project reference, and point `AspireDashboardPath` at the installed bundle.
 
-Run `aspire doctor --format Json --non-interactive` and use the active installation's `canonicalPath` and `route` to locate its bundle root:
+Run `aspire doctor --format json --non-interactive` and use the first installation row, which represents the running CLI. Use `canonicalPath` together with `route` to locate its bundle root. If `canonicalPath` is absent, stop rather than guessing from `path`, which can be an unresolved package-manager symlink.
 
 | Installation route | Bundle root |
 | --- | --- |
 | `script`, `pr`, `localhive` | Parent of the directory containing `canonicalPath` |
 | `winget`, `brew`, `dotnet-tool` | Directory containing `canonicalPath` |
-| Other or no sidecar | `ASPIRE_HOME` when set; otherwise `~/.aspire` |
+| `nix`, other, or no sidecar | `ASPIRE_HOME` when set; otherwise `~/.aspire` |
 
 ```powershell
 $appHost = "<path-to-AppHost.csproj>"
@@ -350,10 +350,12 @@ if (-not (Test-Path $dashboard))
 }
 
 dotnet build $appHost /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
+$env:ASPIRE_DASHBOARD_PATH = $dashboard
 aspire run --no-build --apphost $appHost
+Remove-Item Env:ASPIRE_DASHBOARD_PATH
 ```
 
-- Verify the dashboard resource in Aspire metadata/logs before treating the run as a stock baseline. The source/executable must be `aspire-managed` (`aspire-managed.exe` on Windows), not `Aspire.Dashboard.csproj`.
+- Verify the dashboard resource in Aspire metadata/logs before treating the run as a stock baseline. Its resolved executable path must equal `$dashboard`, and its source must be `aspire-managed` (`aspire-managed.exe` on Windows), not `Aspire.Dashboard.csproj`.
 
 ## Test Conventions
 

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -338,7 +338,7 @@ dotnet build $appHost /p:SkipDashboardProjectReference=true "/p:AspireDashboardP
 aspire run --no-build --apphost $appHost
 ```
 
-- Verify the dashboard resource in Aspire metadata/logs before treating screenshots as baseline. The source/executable must be `aspire-managed.exe`, not `Aspire.Dashboard.csproj`.
+- Verify the dashboard resource in Aspire metadata/logs before treating the run as a stock baseline. The source/executable must be `aspire-managed.exe`, not `Aspire.Dashboard.csproj`.
 
 ## Test Conventions
 

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -331,33 +331,17 @@ Use this when verifying the installed/released dashboard instead of the repo-loc
 - In-repo playground AppHosts can add `Projects.Aspire_Dashboard` for local dashboard development. Running an installed `aspire` CLI is not enough when the AppHost model already contains that local project.
 - Use `SkipDashboardProjectReference=true` to opt out of the shared playground dashboard project reference, and point `AspireDashboardPath` at the installed bundle.
 
+Run `aspire doctor --format Json --non-interactive` and use the active installation's `canonicalPath` and `route` to locate its bundle root:
+
+| Installation route | Bundle root |
+| --- | --- |
+| `script`, `pr`, `localhive` | Parent of the directory containing `canonicalPath` |
+| `winget`, `brew`, `dotnet-tool` | Directory containing `canonicalPath` |
+| Other or no sidecar | `ASPIRE_HOME` when set; otherwise `~/.aspire` |
+
 ```powershell
 $appHost = "<path-to-AppHost.csproj>"
-$doctor = aspire doctor --format Json --non-interactive 2>$null | ConvertFrom-Json
-$installation = $doctor.installations | Where-Object pathStatus -eq "active" | Select-Object -First 1
-if ($null -eq $installation)
-{
-    throw "Could not find the active Aspire CLI installation."
-}
-
-$aspireDirectory = Split-Path $installation.canonicalPath -Parent
-if ($installation.route -in @("script", "pr", "localhive"))
-{
-    $bundleRoot = Split-Path $aspireDirectory -Parent
-}
-elseif ($installation.route -in @("winget", "brew", "dotnet-tool"))
-{
-    $bundleRoot = $aspireDirectory
-}
-elseif ($env:ASPIRE_HOME)
-{
-    $bundleRoot = $env:ASPIRE_HOME
-}
-else
-{
-    $bundleRoot = Join-Path $HOME ".aspire"
-}
-
+$bundleRoot = "<bundle-root-from-the-table>"
 $managedExecutable = if ($env:OS -eq "Windows_NT") { "aspire-managed.exe" } else { "aspire-managed" }
 $dashboard = Join-Path $bundleRoot "bundle/managed/$managedExecutable"
 if (-not (Test-Path $dashboard))

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -328,14 +328,14 @@ var resource = ModelTestHelpers.CreateResource(
 
 Use this when verifying the installed/released dashboard instead of the repo-local one.
 
-- TestShop adds `Projects.Aspire_Dashboard` by default for local dashboard development.
-- The MSBuild opt-out property is `SkipDashboardProjectReference=true`.
-- Running installed `aspire` from inside this repo is not enough by itself; without the opt-out, TestShop still references the local dashboard project.
+- In-repo playground AppHosts can add `Projects.Aspire_Dashboard` for local dashboard development. Running an installed `aspire` CLI is not enough when the AppHost model already contains that local project.
+- Use `SkipDashboardProjectReference=true` to opt out of the shared playground dashboard project reference, and point `AspireDashboardPath` at the installed bundle.
 
 ```powershell
+$appHost = "<path-to-AppHost.csproj>"
 $dashboard = "$HOME\.aspire\bundle\managed\aspire-managed.exe"
-dotnet build .\playground\TestShop\TestShop.AppHost\TestShop.AppHost.csproj /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
-aspire run --no-build --apphost .\playground\TestShop\TestShop.AppHost\TestShop.AppHost.csproj
+dotnet build $appHost /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
+aspire run --no-build --apphost $appHost
 ```
 
 - Verify the dashboard resource in Aspire metadata/logs before treating screenshots as baseline. The source/executable must be `aspire-managed.exe`, not `Aspire.Dashboard.csproj`.

--- a/.agents/skills/dashboard-testing/SKILL.md
+++ b/.agents/skills/dashboard-testing/SKILL.md
@@ -324,6 +324,22 @@ var resource = ModelTestHelpers.CreateResource(
     state: KnownResourceState.Running);
 ```
 
+## Stock/baseline dashboard verification
+
+Use this when verifying the installed/released dashboard instead of the repo-local one.
+
+- TestShop adds `Projects.Aspire_Dashboard` by default for local dashboard development.
+- The MSBuild opt-out property is `SkipDashboardProjectReference=true`.
+- Running installed `aspire` from inside this repo is not enough by itself; without the opt-out, TestShop still references the local dashboard project.
+
+```powershell
+$dashboard = "$HOME\.aspire\bundle\managed\aspire-managed.exe"
+dotnet build .\playground\TestShop\TestShop.AppHost\TestShop.AppHost.csproj /p:SkipDashboardProjectReference=true "/p:AspireDashboardPath=$dashboard"
+aspire run --no-build --apphost .\playground\TestShop\TestShop.AppHost\TestShop.AppHost.csproj
+```
+
+- Verify the dashboard resource in Aspire metadata/logs before treating screenshots as baseline. The source/executable must be `aspire-managed.exe`, not `Aspire.Dashboard.csproj`.
+
 ## Test Conventions
 
 ### DO: Use `[UseCulture("en-US")]` for Culture-Sensitive Component Tests

--- a/playground/TestShop/TestShop.AppHost/AppHost.cs
+++ b/playground/TestShop/TestShop.AppHost/AppHost.cs
@@ -132,8 +132,8 @@ yarp.WithConfiguration(builder =>
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// or build with `/p:SkipDashboardReference=true`, to test end developer
-// dashboard launch experience, Refer to Directory.Build.props for the path to
+// or build with `/p:SkipDashboardProjectReference=true` to test the end developer
+// dashboard launch experience. Refer to Directory.Build.props for the path to
 // the dashboard binary (defaults to the Aspire.Dashboard bin output in the
 // artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);

--- a/playground/TestShop/TestShop.AppHost/AppHost.cs
+++ b/playground/TestShop/TestShop.AppHost/AppHost.cs
@@ -133,9 +133,9 @@ yarp.WithConfiguration(builder =>
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // or build with `/p:SkipDashboardProjectReference=true` to test the end developer
-// dashboard launch experience. Refer to Directory.Build.props for the path to
-// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
-// artifacts dir).
+// dashboard launch experience. The opt-out and project reference are defined in
+// playground/Directory.Build.targets. The repo-root Directory.Build.props sets the
+// default dashboard binary path to the Aspire.Dashboard output in the artifacts dir.
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
 #endif
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -51,11 +51,5 @@ else
                 </div>
             </FluentTab>
         </FluentTabs>
-        <div class="metrics-chart-footer">
-            @if (PauseText is not null)
-            {
-                <PauseWarning PauseText="@PauseText" />
-            }
-        </div>
     </div>
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -43,9 +43,6 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     [Parameter, EditorRequired]
     public required List<OtlpResource> Resources { get; set; }
 
-    [Parameter, EditorRequired]
-    public required string? PauseText { get; set; }
-
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -174,5 +174,11 @@
                     ShowResourcePrefix="@_isSubscribedToAll"/>
             }
         </MainSection>
+        <FooterSection>
+            @if (_activeView == ConsoleLogsView.Console && PauseText is not null)
+            {
+                <PauseWarning PauseText="@PauseText" />
+            }
+        </FooterSection>
     </AspirePageContentLayout>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -175,7 +175,7 @@
             }
         </MainSection>
         <FooterSection>
-            @if (_activeView == ConsoleLogsView.Console && PauseText is not null)
+            @if (PauseText is not null)
             {
                 <PauseWarning PauseText="@PauseText" />
             }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -1219,6 +1219,13 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         await ConsoleLogsManager.UpdateFiltersAsync(newFilters);
     }
 
+    private string? PauseText => PauseManager.ConsoleLogPauseIntervals.LastOrDefault() is { End: null } pause
+        ? string.Format(
+            CultureInfo.CurrentCulture,
+            Loc[nameof(Dashboard.Resources.ConsoleLogs.PauseInProgressText)],
+            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, pause.Start, MillisecondsDisplay.Truncated))
+        : null;
+
     private void OnPausedChanged(bool isPaused)
     {
         Logger.LogDebug("Console logs paused new value: {IsPausedNewValue}", isPaused);

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -1223,7 +1223,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         ? string.Format(
             CultureInfo.CurrentCulture,
             Loc[nameof(Dashboard.Resources.ConsoleLogs.PauseInProgressText)],
-            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, pause.Start, MillisecondsDisplay.Truncated))
+            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, pause.Start))
         : null;
 
     private void OnPausedChanged(bool isPaused)

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -109,8 +109,7 @@
                                             Duration="PageViewModel.SelectedDuration.Id"
                                             ActiveView="@(PageViewModel.SelectedViewKind ?? Metrics.MetricViewKind.Graph)"
                                             OnViewChangedAsync="@OnViewChangedAsync"
-                                            Resources="@_resources"
-                                            PauseText="@PauseText" />
+                                            Resources="@_resources" />
                                     }
                                     else if (PageViewModel.SelectedMeter != null)
                                     {
@@ -174,5 +173,11 @@
                 }
             </div>
         </MainSection>
+        <FooterSection>
+            @if (PauseText is not null)
+            {
+                <PauseWarning PauseText="@PauseText" />
+            }
+        </FooterSection>
     </AspirePageContentLayout>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -249,7 +249,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
         ? string.Format(
             CultureInfo.CurrentCulture,
             Loc[nameof(Dashboard.Resources.Metrics.PauseInProgressText)],
-            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value, MillisecondsDisplay.Truncated))
+            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value))
         : null;
 
     public sealed class MetricsViewModel

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -28,8 +28,7 @@
     grid-template-rows: auto 1fr;
     grid-template-areas:
         "header"
-        "chart"
-        "footer";
+        "chart";
     width: 100%;
     gap: calc(var(--design-unit) * 4px);
 }
@@ -43,11 +42,6 @@
 ::deep .metrics-chart-header {
     grid-area: header;
     overflow-x: hidden;
-}
-
-::deep .metrics-chart-footer {
-    grid-area: footer;
-    margin-bottom: calc(var(--design-unit) * 4px);
 }
 
 ::deep .metrics-chart-header h3 {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -440,7 +440,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         ? string.Format(
             CultureInfo.CurrentCulture,
             Loc[nameof(Dashboard.Resources.StructuredLogs.PauseInProgressText)],
-            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value, MillisecondsDisplay.Truncated))
+            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value))
         : null;
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -289,7 +289,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         ? string.Format(
             CultureInfo.CurrentCulture,
             Loc[nameof(Dashboard.Resources.Traces.PauseInProgressText)],
-            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value, MillisecondsDisplay.Truncated))
+            FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, startTime.Value))
         : null;
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -158,6 +158,12 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ConsoleLogsPauseActive", resourceCulture);
             }
         }
+
+        public static string PauseInProgressText {
+            get {
+                return ResourceManager.GetString("PauseInProgressText", resourceCulture);
+            }
+        }
         
         public static string ConsoleLogsPauseDetails {
             get {

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -176,6 +176,10 @@
     <value>&lt;Log capture paused at {0}, {1} log(s) filtered out&gt;</value>
     <comment>{0} is a date, {1} is a number</comment>
   </data>
+  <data name="PauseInProgressText" xml:space="preserve">
+    <value>Console logs capture paused at {0}</value>
+    <comment>{0} is a time</comment>
+  </data>
   <data name="ConsoleLogsPauseDetails" xml:space="preserve">
     <value>&lt;Log capture paused between {0} and {1}, {2} log(s) filtered out&gt;</value>
     <comment>{0} is a date, {1} is a date, {2} is a number.</comment>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Stav protokolu služby</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Status des Dienstprotokolls</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Estado del registro de servicio</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">État du journal de service</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Stato del log del servizio</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -127,6 +127,11 @@
         <target state="translated">サービス ログの状態</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -127,6 +127,11 @@
         <target state="translated">서비스 로그 상태</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Stan dziennika usługi</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Status de log de serviço</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Состояние журнала службы</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Hizmet günlüğü durumu</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -127,6 +127,11 @@
         <target state="translated">服务日志状态</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -127,6 +127,11 @@
         <target state="translated">服務記錄狀態</target>
         <note />
       </trans-unit>
+      <trans-unit id="PauseInProgressText">
+        <source>Console logs capture paused at {0}</source>
+        <target state="new">Console logs capture paused at {0}</target>
+        <note>{0} is a time</note>
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -140,6 +140,57 @@ public partial class ConsoleLogsTests
     }
 
     [Fact]
+    public async Task TerminalResource_PausedConsoleLogs_DisplaysWarningOnTerminalView()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var terminalResource = CreateTerminalResource("terminal-resource", replicaIndex: 0, replicaCount: 1, state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [terminalResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+        SetupTerminalViewJsInterop();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "terminal-resource"));
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "terminal-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == terminalResource.Name);
+        cut.WaitForState(() => cut.FindComponents<TerminalView>().Count > 0);
+
+        await cut.InvokeAsync(() => instance.HandleViewChangedForTestAsync(nameof(ConsoleLogs.ConsoleLogsView.Console)));
+        cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(Services.GetRequiredService<PauseManager>().ConsoleLogsPaused);
+            Assert.True(cut.HasComponent<PauseWarning>());
+        });
+
+        await cut.InvokeAsync(() => instance.HandleViewChangedForTestAsync(nameof(ConsoleLogs.ConsoleLogsView.Terminal)));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(ConsoleLogs.ConsoleLogsView.Terminal, instance.ActiveViewForTest);
+            Assert.False(cut.HasComponent<PauseIncomingDataSwitch>());
+            Assert.True(cut.HasComponent<PauseWarning>());
+        });
+    }
+
+    [Fact]
     public async Task TerminalResource_NotLive_Selected_RendersBothViews_DefaultsToConsole()
     {
         var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Threading.Channels;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Resize;
@@ -827,7 +828,19 @@ public partial class ConsoleLogsTests : DashboardTestContext
         logger.LogInformation("Pause logs.");
         var pauseResumeButton = cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button");
         pauseResumeButton.Click();
-        cut.WaitForAssertion(() => Assert.True(pauseManager.ConsoleLogsPaused));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(pauseManager.ConsoleLogsPaused);
+            var activePause = pauseManager.ConsoleLogPauseIntervals[^1];
+            var pauseWarning = cut.FindComponent<PauseWarning>();
+            Assert.Equal(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    loc[nameof(Resources.ConsoleLogs.PauseInProgressText)],
+                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, activePause.Start, MillisecondsDisplay.Truncated)),
+                pauseWarning.Instance.PauseText);
+            Assert.Single(cut.Find("footer").QuerySelectorAll(".block-warning"));
+        });
 
         logger.LogInformation("Wait for pause log.");
         var pauseConsoleLogLine = cut.WaitForElement(".log-pause");
@@ -857,7 +870,11 @@ public partial class ConsoleLogsTests : DashboardTestContext
         // - the log viewer shows the new log
         // - the log viewer does not show the discarded log
         pauseResumeButton.Click();
-        cut.WaitForAssertion(() => Assert.False(pauseManager.ConsoleLogsPaused));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(pauseManager.ConsoleLogsPaused);
+            Assert.False(cut.HasComponent<PauseWarning>());
+        });
 
         logger.LogInformation("Assert that pause log has expected content.");
         cut.WaitForAssertion(() =>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -837,7 +837,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
                 string.Format(
                     CultureInfo.CurrentCulture,
                     loc[nameof(Resources.ConsoleLogs.PauseInProgressText)],
-                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, activePause.Start, MillisecondsDisplay.Truncated)),
+                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, activePause.Start)),
                 pauseWarning.Instance.PauseText);
             Assert.Single(cut.Find("footer").QuerySelectorAll(".block-warning"));
         });

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -238,7 +238,7 @@ public partial class MetricsTests : DashboardTestContext
                 string.Format(
                     CultureInfo.CurrentCulture,
                     loc[nameof(Resources.Metrics.PauseInProgressText)],
-                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, pausedAt.Value, MillisecondsDisplay.Truncated)),
+                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, pausedAt.Value)),
                 pauseWarning.Instance.PauseText);
             Assert.Single(cut.Find("footer").QuerySelectorAll(".block-warning"));
         });

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Web;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
@@ -15,6 +17,7 @@ using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Metrics.V1;
 using Xunit;
@@ -182,6 +185,71 @@ public partial class MetricsTests : DashboardTestContext
         Assert.Equal("test-instrument", query["instrument"]);
         Assert.Equal("720", query["duration"]);
         Assert.Equal(MetricViewKind.Table.ToString(), query["view"]);
+    }
+
+    [Fact]
+    public void PauseIncomingData_DisplaysPauseWarningInPageFooter()
+    {
+        MetricsSetupHelpers.SetupMetricsPage(this);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test-instrument", startTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: "TestApp", meter: "test-meter", instrument: "test-instrument"));
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var cut = RenderComponent<Metrics>(builder =>
+        {
+            builder.Add(m => m.ResourceName, "TestApp");
+            builder.AddCascadingValue(viewport);
+        });
+
+        cut.WaitForState(() => cut.Instance.PageViewModel.SelectedInstrument is not null);
+
+        var pauseManager = Services.GetRequiredService<PauseManager>();
+        var timeProvider = Services.GetRequiredService<BrowserTimeProvider>();
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.Metrics>>();
+
+        cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(pauseManager.AreMetricsPaused(out var pausedAt));
+            var pauseWarning = cut.FindComponent<PauseWarning>();
+            Assert.Equal(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    loc[nameof(Resources.Metrics.PauseInProgressText)],
+                    FormatHelpers.FormatTimeWithOptionalDate(timeProvider, pausedAt.Value, MillisecondsDisplay.Truncated)),
+                pauseWarning.Instance.PauseText);
+            Assert.Single(cut.Find("footer").QuerySelectorAll(".block-warning"));
+        });
+
+        cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(pauseManager.AreMetricsPaused(out _));
+            Assert.False(cut.HasComponent<PauseWarning>());
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Pausing console logs previously only inserted an inline log entry, while the metrics pause warning was rendered inside scrollable chart content where it could sit below the fold. This made the active pause state easy to miss and inconsistent with structured logs and traces.

This change:

- Adds a localized capture-paused warning to the console logs page footer.
- Moves the metrics warning from `ChartContainer` into the page footer.
- Keeps both warnings visible at the bottom of the viewport and removes them immediately when capture resumes.

### User-facing usage

When users pause console logs or metrics, the dashboard now displays the yellow **Capture paused** banner in the sticky page footer, matching the structured logs and traces experience.

### Screenshots / Recordings

| Page | Before — Aspire 13.5.2 | After — This PR |
| --- | --- | --- |
| Console logs paused | <img width="2479" height="1432" alt="Console logs before" src="https://github.com/user-attachments/assets/70c05cda-d1e7-4347-a151-4a7466149a78" /> | <img width="2475" height="1443" alt="Console logs after" src="https://github.com/user-attachments/assets/17651684-2aaa-4bb7-a5ae-75c52756973a" /> |
| Metrics paused | <img width="2481" height="1432" alt="Metrics before" src="https://github.com/user-attachments/assets/d25eff34-e878-41fc-b4f8-e11032f4b865" /> | <img width="2469" height="1439" alt="Metrics after" src="https://github.com/user-attachments/assets/2ca19adf-75a1-44d8-bb81-db436f9dd351" /> |

### Validation

- `dotnet test --project tests\Aspire.Dashboard.Components.Tests\Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.ConsoleLogsTests" --filter-class "*.MetricsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (30 passed)
- Manually verified both pause banners in the TestShop dashboard:
  - Console logs warning appears in the page footer and clears on resume.
  - Metrics warning appears in the page footer, outside the scrollable chart, and clears on resume.

Fixes #19020

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
