### PR TITLE
[release/13.5] Fix DevTunnel endpoint URL publication

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -837,7 +837,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
 
     private static bool NeedsPublicPort(IResource resource, EndpointAnnotation endpoint)
     {
-        return !endpoint.IsProxied && !TryGetEffectiveFixedPublicPort(resource, endpoint, randomizePorts: false, out _);
+        // DCP can allocate a port only for resources it launches as workloads. This includes compute
+        // resources and annotation-backed containers; integration-owned endpoints publish their own addresses.
+        return (resource is IComputeResource || resource.IsContainer()) &&
+            !endpoint.IsProxied &&
+            !TryGetEffectiveFixedPublicPort(resource, endpoint, randomizePorts: false, out _);
     }
 
     private int? TryGetPersistedProxylessEndpointPort(IResource resource, EndpointAnnotation endpoint)

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
@@ -409,7 +409,7 @@ public class DevTunnelResourceBuilderExtensionsTests
     {
         const int targetPort = 3000;
         const string tunnelUrl = "https://n4skq32k-3000.use.devtunnels.ms";
-        const string inspectUrl = "https://n4skq32k-3000-inspect.use.devtunnels.ms";
+        const string inspectUrl = "https://n4skq32k-3000-inspect.use.devtunnels.ms/";
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         var client = new TestDevTunnelClient
         {

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
@@ -404,6 +404,70 @@ public class DevTunnelResourceBuilderExtensionsTests
         Assert.NotSame(httpTunnelEndpoint.EndpointAnnotation, httpsTunnelEndpoint.EndpointAnnotation);
     }
 
+    [Fact]
+    public async Task DcpStartupPublishesDevTunnelUrls()
+    {
+        const int targetPort = 3000;
+        const string tunnelUrl = "https://n4skq32k-3000.use.devtunnels.ms";
+        const string inspectUrl = "https://n4skq32k-3000-inspect.use.devtunnels.ms";
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        var client = new TestDevTunnelClient
+        {
+            TunnelStatus = new("mytunnel", HostConnections: 1, ClientConnections: 0, Description: "", Labels: [])
+            {
+                Ports =
+                [
+                    new(targetPort, "http")
+                    {
+                        PortUri = new Uri($"{tunnelUrl}/")
+                    }
+                ]
+            }
+        };
+        var (command, arguments) = GetLongRunningCommand();
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["ASPIRE_DEVTUNNEL_CLI_PATH"] = command;
+        builder.Services.AddSingleton<IDevTunnelClient>(client);
+        builder.Services.AddSingleton<IRequiredCommandValidator, TestRequiredCommandValidator>();
+
+        var target = builder.AddExecutable("target", command, Environment.CurrentDirectory, arguments)
+            .WithHttpEndpoint(targetPort: targetPort, name: "http");
+        var tunnel = builder.AddDevTunnel("tunnel", "mytunnel")
+            .WithReference(target);
+        var tunnelPort = Assert.Single(tunnel.Resource.Ports);
+        foreach (var annotation in tunnel.Resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().ToArray())
+        {
+            tunnel.Resource.Annotations.Remove(annotation);
+        }
+        tunnel.WithArgs(arguments);
+
+        using var app = builder.Build();
+
+        var startTask = app.StartAsync(cts.Token);
+        var resourceEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            tunnelPort.Name,
+            e => e.Snapshot.State?.Text == KnownResourceStates.Running &&
+                e.Snapshot.Urls.Any(u => u.Url == tunnelUrl && !u.IsInactive) &&
+                e.Snapshot.Urls.Any(u => u.Url == inspectUrl && !u.IsInactive),
+            cts.Token);
+        await startTask;
+
+        Assert.Equal("n4skq32k-3000.use.devtunnels.ms", tunnelPort.TunnelEndpointAnnotation.AllocatedEndpoint?.Address);
+        Assert.Contains(resourceEvent.Snapshot.Urls, u => u.Url == tunnelUrl && !u.IsInactive);
+        Assert.Contains(resourceEvent.Snapshot.Urls, u => u.Url == inspectUrl && !u.IsInactive);
+
+        await app.StopAsync(cts.Token);
+    }
+
+    private static (string Command, string[] Arguments) GetLongRunningCommand()
+    {
+        // Windows has no sleep executable, and `timeout` exits immediately when stdin is redirected.
+        // Loopback ping is dependency-free and remains bounded if test cleanup is interrupted.
+        return OperatingSystem.IsWindows()
+            ? ("cmd.exe", ["/c", "ping", "-n", "180", "127.0.0.1"])
+            : ("sleep", ["180"]);
+    }
+
     private sealed class ProjectA : IProjectMetadata
     {
         public string ProjectPath => "projectA";

--- a/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
@@ -83,7 +83,7 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void AddDotnetProject_ResourceSupportsServiceDiscovery()
+    public void AddDotnetProject_ResourceSupportsServiceDiscoveryAndIsComputeResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
@@ -91,6 +91,7 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
 
         Assert.IsAssignableFrom<IResourceWithServiceDiscovery>(app.Resource);
         Assert.IsAssignableFrom<ExecutableResource>(app.Resource);
+        Assert.IsAssignableFrom<IComputeResource>(app.Resource);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -19,6 +19,7 @@ using System.Threading.Channels;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
+using Aspire.Hosting.DevTunnels;
 using Aspire.Hosting.Diagnostics;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Utils;
@@ -1049,6 +1050,88 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "NO_PORT_NO_TARGET_PORT").Value;
         Assert.False(string.IsNullOrWhiteSpace(envVarVal));
         Assert.Equal(allocatedPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task ProxylessPortAllocatorOnlyAllocatesPortsForDcpWorkloads()
+    {
+        var (rangeStart, rangeEnd) = GetAvailableConsecutivePortPair();
+        var builder = DistributedApplication.CreateBuilder();
+
+        var compute = builder.AddExecutable("compute", "compute", Environment.CurrentDirectory)
+            .WithEndpoint(name: "tcp", isProxied: false);
+        var target = builder.AddExecutable("target", "target", Environment.CurrentDirectory)
+            .WithHttpEndpoint(targetPort: 8000, name: "http");
+        builder.AddDevTunnel("tunnel")
+            .WithReference(target);
+
+        var dcpOptions = new DcpOptions
+        {
+            DashboardPath = "./dashboard",
+            ProxylessEndpointPortRangeStart = rangeStart,
+            ProxylessEndpointPortRangeEnd = rangeEnd
+        };
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var tunnelPort = Assert.Single(distributedAppModel.Resources.OfType<DevTunnelPortResource>());
+        var computeEndpoint = compute.GetEndpoint("tcp").EndpointAnnotation;
+        var tunnelEndpoint = Assert.Single(tunnelPort.Annotations.OfType<EndpointAnnotation>());
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions);
+
+        await appExecutor.RunApplicationAsync();
+
+        Assert.NotNull(computeEndpoint.AllocatedEndpoint);
+        var computePort = Assert.IsType<int>(computeEndpoint.Port);
+        Assert.InRange(computePort, rangeStart, rangeEnd);
+        Assert.Equal(computePort, computeEndpoint.TargetPort);
+        Assert.Null(tunnelEndpoint.Port);
+        Assert.Null(tunnelEndpoint.TargetPort);
+        Assert.Null(tunnelEndpoint.AllocatedEndpoint);
+    }
+
+    [Fact]
+    public async Task ProxylessPortAllocatorAllocatesPortForNonComputeContainerResource()
+    {
+        const int targetPort = 10000;
+        var (allocatedPort, _) = GetAvailableConsecutivePortPair();
+        var builder = DistributedApplication.CreateBuilder();
+
+        var emulator = builder.AddResource(new TestContainerResource("emulator"))
+            .WithAnnotation(new ContainerImageAnnotation { Image = "image" })
+            .WithAnnotation(new ContainerLifetimeAnnotation { Lifetime = ContainerLifetime.Persistent })
+            .WithHttpEndpoint(targetPort: targetPort, name: "http");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            })
+            .Build();
+        var dcpOptions = new DcpOptions
+        {
+            DashboardPath = "./dashboard",
+            ProxylessEndpointPortRangeStart = allocatedPort,
+            ProxylessEndpointPortRangeEnd = allocatedPort
+        };
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var endpoint = emulator.GetEndpoint("http").EndpointAnnotation;
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            configuration: configuration,
+            kubernetesService: kubernetesService,
+            dcpOptions: dcpOptions);
+
+        await appExecutor.RunApplicationAsync();
+
+        Assert.IsNotAssignableFrom<IComputeResource>(emulator.Resource);
+        Assert.True(emulator.Resource.IsContainer());
+        Assert.Equal(allocatedPort, endpoint.Port);
+        Assert.Equal(targetPort, endpoint.TargetPort);
+        Assert.Equal(allocatedPort, endpoint.AllocatedEndpoint?.Port);
+        Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == emulator.Resource.Name);
     }
 
     [Fact]
@@ -9580,6 +9663,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
     private sealed class TestExecutableResource(string directory) : ExecutableResource("TestExecutable", "test", directory);
     private sealed class TestOtherExecutableResource(string directory) : ExecutableResource("TestOtherExecutable", "test-other", directory);
+    private sealed class TestContainerResource(string name) : Resource(name), IResourceWithEndpoints;
 
     private sealed class NullValueProvider : IValueProvider
     {


### PR DESCRIPTION
## Description

Backport of #19590 to `release/13.5`.

After upgrading to Aspire 13.5, DevTunnel port resources can reach `Running` and `Healthy` while the Dashboard and MCP resource snapshots report no public URLs. This change prevents DCP from assigning temporary proxyless ports to integration-owned endpoints so DevTunnels can publish their actual public endpoints.

The cherry-pick conflict was resolved by retaining the release branch's existing DevTunnel tests and adding only the source PR's DCP regression scenario. The assertion preserves the trailing slash used by the 13.5 inspect URL format.

Fixes #19496

/cc @karolz-ms

## Customer Impact

Aspire 13.5 customers using Dev Tunnels see healthy, running tunnel port resources with no public URLs in the Dashboard or MCP resource snapshots, forcing them to discover and open the working URLs manually.

## Testing

Focused `release/13.5` tests passed for proxyless allocation on compute and annotation-backed container resources, `DotnetProjectResource` compute classification, and DCP-backed DevTunnel URL publication.

## Risk

Low. The change is localized to proxyless DCP port allocation and preserves allocation for compute/container workloads while excluding integration-owned endpoints; focused regression coverage exercises both sides.

## Regression?

Yes - regressed in 13.5 when proxyless endpoint allocation from #17924 assigned a temporary localhost port to DevTunnel port resources.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
