### PR TITLE
Remove obsolete certificate service exception

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -232,7 +232,3 @@ internal sealed class CertificateService(
         }
     }
 }
-
-internal sealed class CertificateServiceException(string message) : Exception(message)
-{
-}

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -152,14 +152,7 @@ internal sealed class InitCommand : BaseCommand
         // ignore failures since `aspire doctor` / `aspire certs trust` provide a fallback.
         if (isCSharp)
         {
-            try
-            {
-                _ = await _certificateService.EnsureCertificatesTrustedAsync(cancellationToken);
-            }
-            catch (CertificateServiceException)
-            {
-                // Non-fatal: surface via aspire doctor / aspire certs trust.
-            }
+            _ = await _certificateService.EnsureCertificatesTrustedAsync(cancellationToken);
         }
 
         // Step 4: Chain to aspire agent init for MCP server + skill configuration.

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -626,13 +626,6 @@ internal sealed class RunCommand : BaseCommand
             Telemetry.RecordError(ex.Message, ex);
             return CommandResult.FromExitCode(InteractionService.DisplayIncompatibleVersionError(ex, ex.AspireHostingVersion ?? ex.RequiredCapability));
         }
-        catch (CertificateServiceException ex)
-        {
-            runActivity?.SetTag(TelemetryConstants.Tags.ErrorType, "certificate_trust_failed");
-            var errorMessage = string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message);
-            Telemetry.RecordError(errorMessage, ex);
-            return CommandResult.Failure(CliExitCodes.FailedToTrustCertificates, errorMessage);
-        }
         catch (FailedToConnectBackchannelConnection ex)
         {
             // The AppHost process exited before the backchannel could connect. This is an

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -169,15 +169,6 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to An error occurred while trusting the certificates: {0}.
-        /// </summary>
-        public static string CertificateTrustError {
-            get {
-                return ResourceManager.GetString("CertificateTrustError", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Create NuGet.config for selected channels?.
         /// </summary>
         public static string CreateNugetConfigConfirmation {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -219,10 +219,6 @@
     <value>Project created successfully in {0}.</value>
     <comment>{0} is a path</comment>
   </data>
-  <data name="CertificateTrustError" xml:space="preserve">
-    <value>An error occurred while trusting the certificates: {0}</value>
-    <comment>{0} is an exception message</comment>
-  </data>
   <data name="SearchingForAvailableTemplateVersions" xml:space="preserve">
     <value>Searching for available project template versions...</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Musí se zadat aspoň jeden objekt pro vytváření šablon.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Při vytváření vztahu důvěryhodnosti k certifikátům došlo k chybě: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Chcete vytvořit soubor NuGet.config pro vybrané kanály?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Es muss mindestens eine Vorlagenfactory angegeben werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Fehler beim Einstufen der Zertifikate als vertrauenswürdig: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">NuGet.config für die ausgewählten Kanäle erstellen?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Se debe proporcionar al menos un generador de plantillas.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Se produjo un error al confiar en los certificados: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">¿Crear NuGet.config para los canales seleccionados?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Au moins une fabrique de modèles doit être fournie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Une erreur s’est produite lors de l’approbation des certificats : {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Voulez-vous créer un fichier NuGet.config pour les canaux sélectionnés ?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -62,11 +62,6 @@
         <target state="translated">È necessario specificare almeno una factory di modelli.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Errore durante la verifica di attendibilità dei certificati: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Creare il file NuGet.config per i canali selezionati?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -62,11 +62,6 @@
         <target state="translated">少なくとも 1 つのテンプレート ファクトリを指定する必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">証明書の信頼処理でエラーが発生しました: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">選択したチャネルの NuGet.config を作成しますか?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -62,11 +62,6 @@
         <target state="translated">하나 이상의 템플릿 센터를 제공해야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">인증서의 신뢰성을 확인하는 중에 오류가 발생했습니다. {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">선택한 채널에 대한 NuGet.config를 만드시겠습니까?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Należy podać co najmniej jedną fabrykę szablonów.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Wystąpił błąd podczas ustanawiania relacji zaufania z certyfikatem: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Utworzyć plik NuGet.config dla wybranych kanałów?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Pelo menos uma fábrica de modelo deve ser fornecida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Ocorreu um erro ao confiar nos certificados: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Criar NuGet.config para os canais selecionados?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -62,11 +62,6 @@
         <target state="translated">Необходимо предоставить хотя бы одну фабрику шаблонов.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">При доверии сертификатам возникла ошибка: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Создать NuGet.config для выбранных каналов?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -62,11 +62,6 @@
         <target state="translated">En az bir şablon atölyesi sağlanmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">Sertifikaları güvenilirken bir hata oluştu: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">Seçilen kanallar için NuGet.config oluşturulsun mu?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -62,11 +62,6 @@
         <target state="translated">必须提供至少一个模板工厂。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">信任证书时出错: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">是否为所选通道创建 NuGet.config?</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -62,11 +62,6 @@
         <target state="translated">至少必須提供一個範本工廠。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CertificateTrustError">
-        <source>An error occurred while trusting the certificates: {0}</source>
-        <target state="translated">信任憑證時發生錯誤: {0}</target>
-        <note>{0} is an exception message</note>
-      </trans-unit>
       <trans-unit id="CreateNugetConfigConfirmation">
         <source>Create NuGet.config for selected channels?</source>
         <target state="translated">為所選通道建立 NuGet.config?</target>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -568,11 +568,6 @@ internal class DotNetTemplateFactory(
         {
             return new TemplateResult(CliExitCodes.Cancelled);
         }
-        catch (CertificateServiceException ex)
-        {
-            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.CertificateTrustError, ex.Message));
-            return new TemplateResult(CliExitCodes.FailedToTrustCertificates);
-        }
         catch (Exceptions.ChannelNotFoundException ex)
         {
             interactionService.DisplayError(ex.Message);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Xml.Linq;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Utils;
-using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using RootCommand = Aspire.Cli.Commands.RootCommand;
 using Aspire.Cli.Configuration;
@@ -657,45 +656,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NewCommand_WhenCertificateServiceThrows_ReturnsNonZeroExitCode()
-    {
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var services = CreateServiceCollection(workspace, options =>
-        {
-            options.NewCommandPrompterFactory = (sp) => {
-                var interactionService = sp.GetRequiredService<IInteractionService>();
-                var prompter = new TestNewCommandPrompter(interactionService);
-                return prompter;
-            };
-            options.CertificateServiceFactory = _ => new ThrowingCertificateService();
-
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = CreateTestRunnerWithStandardPackages();
-
-                runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, options, cancellationToken) =>
-                {
-                    return (0, version); // Success, return the template version
-                };
-
-                runner.NewProjectAsyncCallback = (templateName, name, outputPath, options, cancellationToken) =>
-                {
-                    return 0; // Success
-                };
-
-                return runner;
-            };
-        });
-        using var provider = services.BuildServiceProvider();
-
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
-
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(CliExitCodes.FailedToTrustCertificates, exitCode);
-    }
-
-    [Fact]
     public async Task NewCommandWithExitCode73ShowsUserFriendlyError()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -790,16 +750,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             .Where(pattern => pattern is not null)
             .Select(pattern => pattern!)
             .ToArray();
-    }
-
-    private sealed class ThrowingCertificateService : ICertificateService
-    {
-        public Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
-        {
-            throw new CertificateServiceException("Failed to trust certificates");
-        }
-
-        public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1282,38 +1282,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task RunCommand_WhenCertificateServiceThrows_ReturnsNonZeroExitCode()
-    {
-        var runnerFactory = (IServiceProvider sp) =>
-        {
-            var runner = new TestDotNetCliRunner();
-
-            // Fake apphost information to return a compatable app host.
-            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
-
-            return runner;
-        };
-
-        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
-
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
-        {
-            options.CertificateServiceFactory = _ => new ThrowingCertificateService();
-            options.DotNetCliRunnerFactory = runnerFactory;
-            options.ProjectLocatorFactory = projectLocatorFactory;
-        });
-
-        using var provider = services.BuildServiceProvider();
-
-        var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("run");
-
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(CliExitCodes.FailedToTrustCertificates, exitCode);
-    }
-
-    [Fact]
     public async Task RunCommand_WhenBackchannelDisconnectsDuringStartup_WaitsForAppHostExitAndSurfacesWrappedError()
     {
         // Covers the catastrophic-disconnect path: the backchannel itself died (e.g. AppHost
@@ -1966,16 +1934,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
             yield break;
         }
-    }
-
-    private sealed class ThrowingCertificateService : Aspire.Cli.Certificates.ICertificateService
-    {
-        public Task<Aspire.Cli.Certificates.EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
-        {
-            throw new Aspire.Cli.Certificates.CertificateServiceException("Failed to trust certificates");
-        }
-
-        public string? ExportDevCertificatePem(CancellationToken cancellationToken) => null;
     }
 
     private sealed class NoProjectFileProjectLocator : IProjectLocator
@@ -4246,21 +4204,25 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         using var fixture = new TelemetryFixture();
 
-        var runnerFactory = (IServiceProvider sp) =>
-        {
-            var runner = new TestDotNetCliRunner();
-            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
-            return runner;
-        };
-
-        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
-
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = CreateAppHostFile(workspace);
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            RunAsyncCallback = (context, _) =>
+            {
+                context.BuildCompletionSource?.TrySetResult(false);
+                return Task.FromResult(CliExitCodes.FailedToBuildArtifacts);
+            }
+        };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.CertificateServiceFactory = _ => new ThrowingCertificateService();
-            options.DotNetCliRunnerFactory = runnerFactory;
-            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.AppHostProjectFactory = _ => projectFactory;
             options.TelemetryFactory = _ => fixture.Telemetry;
 
             if (detached)
@@ -4286,7 +4248,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(KnownLanguageId.CSharp, tags[TelemetryConstants.Tags.AppHostLanguage]);
         Assert.Equal(detached, tags[TelemetryConstants.Tags.AppHostDetached]);
         Assert.Equal(isolated, tags[TelemetryConstants.Tags.AppHostIsolated]);
-        Assert.Equal("certificate_trust_failed", tags[TelemetryConstants.Tags.ErrorType]);
+        Assert.Equal("build_failed", tags[TelemetryConstants.Tags.ErrorType]);
     }
 
     private async Task AssertProfileTransferAsync(


### PR DESCRIPTION
## Description

Certificate trust failures have been reported through `EnsureCertificatesTrustedResult` and user-visible warnings since #9384, leaving `CertificateServiceException` without any production throw sites. This removes that obsolete internal exception contract, its unreachable command catches, and tests that only simulated the dead behavior.

The broader run telemetry test now uses the normal build-failure path instead of throwing the obsolete exception. Ordinary certificate warning and result behavior is unchanged, including the nonzero result from `aspire certs trust` when trust is unsuccessful.

Validation:

- Built `tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` with no warnings or errors.
- Ran 181 focused Aspire CLI tests covering certificate service, certificate commands, template creation, init, new, and run telemetry.
- Confirmed the current repository tree contains no `CertificateServiceException` references.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
