### PR TITLE
Fix consistent extension E2E failures

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -744,6 +744,7 @@ jobs:
             Get-ChildItem -Path $ridNugets -Recurse -File -Filter '*.nupkg' | Copy-Item -Destination $hiveDir -Force
           }
 
+          "ASPIRE_CLI_PACKAGES=$hiveDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "ASPIRE_EXTENSION_E2E_CLI_PATH=$($cli.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "ASPIRE_EXTENSION_E2E_APPHOST_SDK_VERSION=$(($samplePackage.Name -replace '^Aspire\.Hosting\.AppHost\.', '') -replace '\.nupkg$', '')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           & $cli.FullName --version

--- a/extension/src/test-e2e/edgeCases.e2e.test.ts
+++ b/extension/src/test-e2e/edgeCases.e2e.test.ts
@@ -1,11 +1,11 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { AspireExtensionE2EControlCommand } from '../types/extensionApi';
+import type { AspireExtensionE2ECodeLensProbeResult, AspireExtensionE2EControlCommand } from '../types/extensionApi';
 import { getCommandInvocationCount, getDebugLaunchCount, isSamePath, waitForCommandOutcome, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForSelectedWorkspaceAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
 import { createEmptyAppHostProject, createExternalSingleFileAppHost, executeE2eControlCommand, getGeneratedAppHostPath, getGeneratedProjectRoot, isProcessAlive, removeExternalSingleFileAppHost, removeGeneratedProject, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setDebugLaunchSuppressedForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, waitForKnownProcessExit, writeFileWithRetry, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath, getWorkspaceRoot } from './helpers/paths';
-import { chooseActiveQuickPick, executeCommandFromPalette, openAspireView, waitForCodeLensText, waitForEditorTitle, waitForNotificationMessage } from './helpers/vscode';
+import { chooseActiveQuickPick, executeCommandFromPalette, openAspireView, waitForEditorTitle, waitForNotificationMessage } from './helpers/vscode';
 
 interface DebugSessionProcessInfo {
     appHostPath?: string;
@@ -213,9 +213,19 @@ builder.Build().Run();`));
             60000);
         await notification.dismiss();
 
-        await executeE2eControlCommand({ name: 'openFile', filePath: appHostPath });
-        await waitForEditorTitle('apphost.cs');
-        await waitForCodeLensText('apphost.cs', 'Set up Python debugger', 60000);
+        const timeoutMs = 60000;
+        const started = Date.now();
+        let lastResult: AspireExtensionE2ECodeLensProbeResult | undefined;
+        while (Date.now() - started < timeoutMs) {
+            lastResult = (await executeE2eControlCommand({ name: 'getCodeLenses', filePath: appHostPath })).result as AspireExtensionE2ECodeLensProbeResult;
+            if (lastResult.commandTitles.some(title => title.includes('Set up Python debugger'))) {
+                return;
+            }
+
+            await delay(500);
+        }
+
+        throw new Error(`Timed out after ${timeoutMs}ms waiting for the Python debugger CodeLens. Last provider result: ${JSON.stringify(lastResult)}`);
     });
 
     test('process-owner cleanup stops the owned CLI and AppHost process tree', async () => {
@@ -248,3 +258,7 @@ builder.Build().Run();`));
         await waitForNoRunningAppHost(120000, appHostPath);
     });
 });
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/extension/src/test/e2eDiagnosticsProbe.test.ts
+++ b/extension/src/test/e2eDiagnosticsProbe.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { getDiagnosticsForFile } from '../testing/e2eStateFileBridge';
+import { getCodeLensesForFile, getDiagnosticsForFile } from '../testing/e2eStateFileBridge';
 
 import { removeDirectorySafely } from './testHelpers';
 /**
@@ -84,6 +84,39 @@ suite('E2E diagnostics probe', () => {
         assert.ok(
             openPaths.includes(expectedPath),
             `Probing must not close an editor the caller already had open. Open tabs: ${JSON.stringify(openPaths)}`);
+    });
+
+    test('probing CodeLenses does not show the document', async () => {
+        temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-diagnostics-probe-'));
+
+        const filePath = path.join(temporaryDirectory, 'CodeLensProbe.ts');
+        fs.writeFileSync(filePath, 'const probe = true;\n');
+        const expectedPath = vscode.Uri.file(filePath).fsPath;
+        const provider = vscode.languages.registerCodeLensProvider(
+            { language: 'typescript', scheme: 'file' },
+            {
+                provideCodeLenses(document) {
+                    if (document.uri.fsPath !== expectedPath) {
+                        return [];
+                    }
+
+                    return [new vscode.CodeLens(
+                        new vscode.Range(0, 0, 0, 0),
+                        { title: 'Probe CodeLens', command: 'aspire-vscode.test.probeCodeLens' })];
+                },
+            });
+
+        try {
+            const result = await getCodeLensesForFile(filePath);
+
+            assert.strictEqual(result.filePath, expectedPath);
+            assert.strictEqual(result.languageId, 'typescript');
+            assert.ok(result.commandTitles.includes('Probe CodeLens'));
+            assert.ok(!vscode.window.visibleTextEditors.some(editor => editor.document.uri.fsPath === expectedPath));
+        }
+        finally {
+            provider.dispose();
+        }
     });
 });
 

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -1078,7 +1078,10 @@ suite('E2E launch profile', () => {
         assert.ok(!workspaceTargetProofSource.includes('const wrapperPath = path.join(folderPath, `aspire-${folderName}`);'));
 
         const edgeCases = getTestBlock(edgeCasesSource, 'shows debugger install guidance while the Aspire panel and AppHost source are closed');
-        assert.ok(edgeCases.includes("waitForCodeLensText('apphost.cs', 'Set up Python debugger', 60000)"));
+        assert.ok(edgeCases.includes("executeE2eControlCommand({ name: 'getCodeLenses', filePath: appHostPath })"));
+        assert.ok(edgeCases.includes("title.includes('Set up Python debugger')"));
+        assert.ok(!edgeCases.includes("waitForCodeLensText("));
+        assert.ok(!edgeCases.includes("name: 'openFile'"));
         assert.ok(!edgeCases.includes("waitForWorkbenchText('Set up Python debugger'"));
 
         const workspaceCollision = getTestBlock(workspaceTargetProofSource, 'reopens the project folder picker after a colliding selection');

--- a/extension/src/testing/e2eStateFileBridge.ts
+++ b/extension/src/testing/e2eStateFileBridge.ts
@@ -13,7 +13,7 @@ import type { AspireResourceExtendedDebugConfiguration, EnvVar, ExecutableLaunch
 import { createStateSnapshot, getSensitiveDashboardUrl, isSamePath } from '../extensionState';
 import type { PreparableAppHostLifecycleTool } from '../lm/appHostLifecycleTools';
 import { AppHostLaunchRequestedEvent, AppHostLaunchService } from '../services/AppHostLaunchService';
-import type { AspireDebugConsoleOutputEvent, AspireExtensionE2EBrowserDebugSession, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2EStoppingPathEvent, AspireExtensionE2ETaskProcessEvent, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
+import type { AspireDebugConsoleOutputEvent, AspireExtensionE2EBrowserDebugSession, AspireExtensionE2ECodeLensProbeResult, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2EStoppingPathEvent, AspireExtensionE2ETaskProcessEvent, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
 import { AspireTerminalCommandEvent, AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { delay } from '../utils/async';
 import { dashboardDefaultChangedNotificationKey } from '../utils/dashboardNotificationState';
@@ -787,6 +787,11 @@ export async function executeE2eControlCommand(
     case 'getDiagnostics': {
       markStarted();
       return await getDiagnosticsForFile(command.filePath);
+    }
+    case 'getCodeLenses': {
+      const filePath = getE2eRunPath(command.filePath, command.name);
+      markStarted();
+      return await getCodeLensesForFile(filePath);
     }
     case 'snapshotClipboard': {
       markStarted();
@@ -1845,13 +1850,13 @@ function getWorkspaceFolderInfo(): Array<{ name: string; uri: string; fileName: 
   })) ?? [];
 }
 
-function getE2eRunPath(filePath: unknown): string {
+function getE2eRunPath(filePath: unknown, commandName = 'openFile'): string {
   if (typeof filePath !== 'string' || filePath.length === 0 || !path.isAbsolute(filePath)) {
-    throw new Error('Aspire extension E2E openFile requires an absolute file path.');
+    throw new Error(`Aspire extension E2E ${commandName} requires an absolute file path.`);
   }
 
   if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-    throw new Error(`Aspire extension E2E openFile requires an existing file: ${filePath}`);
+    throw new Error(`Aspire extension E2E ${commandName} requires an existing file: ${filePath}`);
   }
 
   // The workspace root is normally inside the run root, but a run whose workspace has to live
@@ -1863,7 +1868,7 @@ function getE2eRunPath(filePath: unknown): string {
   ].filter((root): root is string => typeof root === 'string' && root.length > 0);
 
   if (!allowedRoots.some(root => isPathWithinDirectory(filePath, root))) {
-    throw new Error('Aspire extension E2E openFile can only open files inside the configured E2E run root or workspace root.');
+    throw new Error(`Aspire extension E2E ${commandName} can only open files inside the configured E2E run root or workspace root.`);
   }
 
   return filePath;
@@ -1991,6 +1996,20 @@ export async function getDiagnosticsForFile(filePath: string): Promise<{ message
   }
 
   return diagnostics;
+}
+
+export async function getCodeLensesForFile(filePath: string): Promise<AspireExtensionE2ECodeLensProbeResult> {
+  const uri = vscode.Uri.file(filePath);
+  const document = await vscode.workspace.openTextDocument(uri);
+  const codeLenses = await vscode.commands.executeCommand<vscode.CodeLens[] | undefined>('vscode.executeCodeLensProvider', uri);
+
+  return {
+    filePath: document.uri.fsPath,
+    languageId: document.languageId,
+    commandTitles: (codeLenses ?? [])
+      .map(codeLens => codeLens.command?.title)
+      .filter((title): title is string => typeof title === 'string' && title.length > 0),
+  };
 }
 
 function isFileOpenInAnyTab(uri: vscode.Uri): boolean {

--- a/extension/src/types/extensionApi.ts
+++ b/extension/src/types/extensionApi.ts
@@ -157,6 +157,12 @@ export interface AspireExtensionE2ETaskProcessEvent extends AspireExtensionE2ESe
     exitCode?: number;
 }
 
+export interface AspireExtensionE2ECodeLensProbeResult {
+    filePath: string;
+    languageId: string;
+    commandTitles: readonly string[];
+}
+
 export interface AspireDebugConsoleOutputEvent {
     debugSessionId: string;
     appHostPath: string | undefined;
@@ -235,6 +241,7 @@ export type AspireExtensionE2EControlCommand =
     | { name: 'getExtensionPackageJson' }
     | { name: 'getExtensionFileStatus'; relativePaths: readonly string[] }
     | { name: 'getDiagnostics'; filePath: string }
+    | { name: 'getCodeLenses'; filePath: string }
     | { name: 'snapshotClipboard' }
     | { name: 'restoreClipboardSnapshot' }
     | { name: 'captureWorkspaceAppHostPathClipboardExpectation' }

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -45,6 +45,10 @@ public sealed class ExtensionE2eWorkflowTests
             "\"ASPIRE_DCP_PATH=$($dcp.Directory.FullName)\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append",
             prepareCliScript,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "\"ASPIRE_CLI_PACKAGES=$hiveDir\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append",
+            prepareCliScript,
+            StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The extension E2E suite has two failures that reproduce consistently after merges to `main`:

- Linux `workspace-target-proof` cannot resolve the locally built `Aspire.ProjectTemplates` package because the local-channel CLI is pointed at a `daily` hive.
- Windows `edge-cases` finds the missing Python debugger metadata but times out waiting for VS Code to render the matching CodeLens widget.

This exports the workflow's flat package hive through `ASPIRE_CLI_PACKAGES`, so the local CLI resolves the packages built by the same run. It also checks the Python debugger CodeLens through VS Code's provider API instead of relying on editor widget materialization. Production CodeLens behavior is unchanged.

### Testing

- `corepack yarn test` — 2,621 passing, 5 pending
- `corepack yarn compile-e2e`
- `ExtensionE2eWorkflowTests` — 2 passing

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
