### PR TITLE
Use separate timeout for DCP initialization

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -92,6 +92,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
     private bool _disposed;
 
     public TimeSpan MaxRetryDuration { get; set; } = TimeSpan.FromSeconds(20);
+    public TimeSpan KubernetesConfigInitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
     public Task<T> GetAsync<T>(string name, string? namespaceParameter = null, CancellationToken cancellationToken = default)
         where T : CustomResource, IKubernetesStaticMetadata
@@ -474,20 +475,34 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         using var activity = ProfilingTelemetry.StartDcpKubernetesApi(configuration, operationType, resourceType);
         var retryCount = 0;
 
-        var resiliencePipeline = CreateKubernetesCallResiliencePipeline(isRetryable, activity, () => retryCount++);
-
         try
         {
-            return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
+            async ValueTask EnsureKubernetesClientAsync(CancellationToken cancellationToken)
             {
-                // Establish (or re-establish) the connection to DCP inside the retry loop,
-                // to guard against a failure from missing or partially-written kubeconfig.
                 var clientReady = await EnsureKubernetesAsync(cancellationToken).ConfigureAwait(false);
                 if (clientReady.Initialized)
                 {
                     activity.AddKubernetesClientReady(clientReady.WaitMilliseconds, clientReady.Initialized);
                 }
+            }
 
+            if (_kubernetes is null)
+            {
+                // The first DCP request must also wait for DCP to create its kubeconfig. Give that initialization
+                // its own budget so slower hosts do not consume the shorter already-running API retry budget.
+                var initializationPipeline = CreateKubernetesCallResiliencePipeline(
+                    KubernetesConfigInitializationTimeout,
+                    RetryOnConnectivityErrors,
+                    activity,
+                    () => retryCount++);
+                await initializationPipeline.ExecuteAsync(EnsureKubernetesClientAsync, cancellationToken).ConfigureAwait(false);
+            }
+
+            var resiliencePipeline = CreateKubernetesCallResiliencePipeline(MaxRetryDuration, isRetryable, activity, () => retryCount++);
+            return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
+            {
+                // Keep connection establishment inside the retry loop so kubeconfig read failures remain retryable.
+                await EnsureKubernetesClientAsync(cancellationToken).ConfigureAwait(false);
                 return await operation(_kubernetes!).ConfigureAwait(false);
             }, cancellationToken).ConfigureAwait(false);
         }
@@ -503,7 +518,8 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         ex is KubeConfigException ||
         (ex is HttpOperationException hoe && hoe.Response.StatusCode == System.Net.HttpStatusCode.Conflict);
 
-    private ResiliencePipeline CreateKubernetesCallResiliencePipeline(
+    private static ResiliencePipeline CreateKubernetesCallResiliencePipeline(
+        TimeSpan retryDuration,
         Func<Exception, bool> isRetryable,
         ProfilingTelemetry.ActivityScope activity,
         Action recordRetry)
@@ -511,7 +527,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         var resiliencePipeline = new ResiliencePipelineBuilder()
             .AddTimeout(new TimeoutStrategyOptions
             {
-                Timeout = MaxRetryDuration,
+                Timeout = retryDuration,
                 OnTimeout = (_) =>
                 {
                     activity.AddKubernetesApiTimeout();

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Polly.Timeout;
 
 namespace Aspire.Hosting.Tests.Dcp;
 
@@ -41,6 +42,51 @@ public class KubernetesServiceTests
 
         var result = await listTask;
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetry_UsesInitializationTimeout_WhenKubeconfigAppearsAfterApiRetryBudget()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService(
+            maxRetryDuration: TimeSpan.FromSeconds(1));
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
+
+        // The kubeconfig appears after the normal API retry budget. Initial DCP connection establishment
+        // needs its own startup budget because DCP has not exposed an API endpoint yet.
+        await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        var result = await listTask;
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetry_UsesApiRetryDuration_AfterKubernetesClientInitialization()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService(
+            maxRetryDuration: TimeSpan.FromMilliseconds(500),
+            kubernetesConfigInitializationTimeout: TimeSpan.FromSeconds(5));
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        // The fourth API request succeeds after exponential retry delays of 100, 200, and 400 milliseconds.
+        // It is reachable under the initialization budget but not the 500-millisecond API budget.
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token, successfulRequestNumber: 4);
+        var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
+
+        await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        await Assert.ThrowsAsync<TimeoutRejectedException>(() => listTask);
     }
 
     // Verifies that establishing the connection survives a partially-written kubeconfig: when the file exists
@@ -72,7 +118,9 @@ public class KubernetesServiceTests
         Assert.Empty(result);
     }
 
-    private static (KubernetesService Service, string KubeconfigPath, IDisposable FileSystem) CreateService()
+    private static (KubernetesService Service, string KubeconfigPath, IDisposable FileSystem) CreateService(
+        TimeSpan? maxRetryDuration = null,
+        TimeSpan? kubernetesConfigInitializationTimeout = null)
     {
         var configuration = new ConfigurationBuilder().Build();
 
@@ -92,7 +140,8 @@ public class KubernetesServiceTests
             var service = new KubernetesService(NullLogger<KubernetesService>.Instance, dcpOptions, locations, configuration)
             {
                 // Generous enough that the test can flip the kubeconfig before the retry budget is exhausted.
-                MaxRetryDuration = TimeSpan.FromSeconds(30),
+                MaxRetryDuration = maxRetryDuration ?? TimeSpan.FromSeconds(30),
+                KubernetesConfigInitializationTimeout = kubernetesConfigInitializationTimeout ?? TimeSpan.FromSeconds(60),
             };
 
             return (service, locations.DcpKubeconfigPath, fileSystem);
@@ -232,8 +281,8 @@ public class KubernetesServiceTests
         }
     }
 
-    // A minimal stand-in for the DCP API server. It answers every request with an empty Kubernetes list, which
-    // is enough for ListAsync<Container>() to deserialize successfully.
+    // A minimal stand-in for the DCP API server. It can return conflicts for a configured number of requests,
+    // then answers with an empty Kubernetes list that ListAsync<Container>() can deserialize successfully.
     //
     // It runs a real Kestrel server bound to port 0 so the OS assigns a free port that Kestrel actually binds and
     // holds for the lifetime of the server. The bound port is read back after startup. This avoids the classic
@@ -250,7 +299,9 @@ public class KubernetesServiceTests
 
         public int Port { get; }
 
-        public static async Task<TestDcpApiServer> StartAsync(CancellationToken cancellationToken = default)
+        public static async Task<TestDcpApiServer> StartAsync(
+            CancellationToken cancellationToken = default,
+            int successfulRequestNumber = 1)
         {
             var builder = WebApplication.CreateSlimBuilder();
             // Keep the test output clean; the fake server's logs are noise.
@@ -261,9 +312,15 @@ public class KubernetesServiceTests
 
             var app = builder.Build();
 
-            // Answer every request with an empty container list.
+            var requestCount = 0;
             app.Run(async context =>
             {
+                if (Interlocked.Increment(ref requestCount) < successfulRequestNumber)
+                {
+                    context.Response.StatusCode = StatusCodes.Status409Conflict;
+                    return;
+                }
+
                 context.Response.StatusCode = StatusCodes.Status200OK;
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync("""{"apiVersion":"usvc-dev.developer.microsoft.com/v1","kind":"ContainerList","items":[]}""");


### PR DESCRIPTION
## Description

DCP can take longer than 20 seconds to write its initial kubeconfig on contended CI hosts. When that happens, AppHost startup currently aborts even though the existing kubeconfig read policy allows up to 30 seconds.

This gives initial kubeconfig discovery and client creation a separate 60-second timeout. Once the client is initialized, DCP API calls continue to use the existing 20-second retry budget.

This reproduced consistently in the macOS x64 CLI starter validation after #19631: the original run timed out while starting the TypeScript starter, and the rerun timed out while starting the C# starter. Both failed from `EnsureKubernetesAsync` at exactly 20 seconds.

Added regression coverage for both timeout boundaries:

- Initial kubeconfig creation can exceed the normal API retry duration.
- API retries after initialization do not inherit the longer startup timeout.

Fixes #18041

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
