### PR TITLE
Omit registry URLs from standalone npm lockfiles

### DIFF
--- a/playground/AspireWithJavaScript/AspireJavaScript.Vite/.npmrc
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vite/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/AspireWithJavaScript/AspireJavaScript.Vite/package-lock.json
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vite/package-lock.json
@@ -31,7 +31,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -46,7 +45,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -56,7 +54,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/core/-/core-7.29.6.tgz",
       "integrity": "sha1-LywsoXKK5zybaOzpHRrm3uGP+Do=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +84,6 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -97,7 +93,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha1-zKC4gn5rzzuhdniOfzsYCtbbL6M=",
       "dev": true,
       "license": "MIT",
@@ -114,7 +109,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -131,7 +125,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -141,7 +134,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -151,7 +143,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -165,7 +156,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -183,7 +173,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -193,7 +182,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -203,7 +191,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -213,7 +200,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -227,7 +213,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "dev": true,
       "license": "MIT",
@@ -243,7 +228,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -258,7 +242,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha1-xHsHpBuV2gkH0Ca13YlNmN59Ly0=",
       "dev": true,
       "license": "MIT",
@@ -277,7 +260,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "dev": true,
       "license": "MIT",
@@ -291,7 +273,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -303,7 +284,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -314,7 +294,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -325,7 +304,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -344,7 +322,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -354,7 +331,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -369,7 +345,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
       "integrity": "sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=",
       "dev": true,
       "license": "Apache-2.0",
@@ -382,7 +357,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -395,7 +369,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=",
       "dev": true,
       "license": "MIT",
@@ -416,7 +389,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -426,7 +398,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -440,7 +411,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -450,7 +420,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -464,7 +433,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -478,7 +446,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -492,7 +459,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
@@ -503,7 +469,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
@@ -514,7 +479,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
@@ -524,14 +488,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
@@ -542,7 +504,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -561,7 +522,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -571,7 +531,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -588,7 +547,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -605,7 +563,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -622,7 +579,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -639,7 +595,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -656,7 +611,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -673,7 +627,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -690,7 +643,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -707,7 +659,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -724,7 +675,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -741,7 +691,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -758,7 +707,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -775,7 +723,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -794,7 +741,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -811,7 +757,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -828,14 +773,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -846,28 +789,24 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
@@ -877,7 +816,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
@@ -887,7 +825,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
@@ -897,7 +834,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -926,7 +862,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -951,7 +886,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -973,7 +907,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -991,7 +924,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -1008,7 +940,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -1033,7 +964,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -1047,7 +977,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -1075,7 +1004,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -1099,7 +1027,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -1117,7 +1044,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1130,7 +1056,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -1156,7 +1081,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1169,7 +1093,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1179,7 +1102,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1196,7 +1118,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1206,7 +1127,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha1-GV3MdrqiaaSX8LB97Kzhaf7prFg=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1219,7 +1139,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
@@ -1232,7 +1151,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.28.4.tgz",
       "integrity": "sha1-3YuBZ6MoRf9fjNbOE/WruhbNBMk=",
       "dev": true,
       "funding": [
@@ -1266,7 +1184,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
       "integrity": "sha1-uJbHc+HDlACAlBUWK7UyA3EpGzY=",
       "dev": true,
       "funding": [
@@ -1287,14 +1204,12 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1309,14 +1224,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1334,14 +1247,12 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1351,14 +1262,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.387",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
       "integrity": "sha1-086CGwo3r1pG4tKjM3ns+hYwNjY=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1368,7 +1277,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1381,7 +1289,6 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.8.0.tgz",
       "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
@@ -1440,7 +1347,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha1-5nQsrXXZcMCj8w19P6gKR4T1WSc=",
       "dev": true,
       "license": "MIT",
@@ -1460,7 +1366,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.5.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
       "integrity": "sha1-AxEhhjEZP8HqHDdTGh5whagTu2A=",
       "dev": true,
       "license": "MIT",
@@ -1470,7 +1375,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1489,7 +1393,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1502,7 +1405,6 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1515,7 +1417,6 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -1525,7 +1426,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1543,7 +1443,6 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1556,7 +1455,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1569,7 +1467,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1582,7 +1479,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1592,7 +1488,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1602,28 +1497,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -1641,7 +1532,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -1654,7 +1544,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1671,7 +1560,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -1685,14 +1573,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1707,7 +1593,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
@@ -1717,7 +1602,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1730,7 +1614,6 @@
     },
     "node_modules/globals": {
       "version": "16.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-16.5.0.tgz",
       "integrity": "sha1-zPFZSkN7l2U7K+E+1Nj1yfhQysE=",
       "dev": true,
       "license": "MIT",
@@ -1743,14 +1626,12 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
       "license": "MIT",
@@ -1760,7 +1641,6 @@
     },
     "node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
@@ -1770,7 +1650,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -1780,7 +1659,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -1790,7 +1668,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -1803,21 +1680,18 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -1830,28 +1704,24 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -1864,7 +1734,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -1874,7 +1743,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -1888,7 +1756,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1918,7 +1785,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1939,7 +1805,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1960,7 +1825,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1981,7 +1845,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -2002,7 +1865,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -2023,7 +1885,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -2044,7 +1905,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2065,7 +1925,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2086,7 +1945,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2107,7 +1965,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -2128,7 +1985,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -2149,7 +2005,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2165,7 +2020,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2175,7 +2029,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2191,14 +2044,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -2217,14 +2068,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha1-WXGXqFIHHOQvwlUOWOIjJCvLqWk=",
       "dev": true,
       "license": "MIT",
@@ -2234,7 +2083,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2252,7 +2100,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2268,7 +2115,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2284,7 +2130,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -2294,7 +2139,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2304,14 +2148,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2324,7 +2166,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "dev": true,
       "funding": [
@@ -2353,7 +2194,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -2363,7 +2203,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2373,7 +2212,6 @@
     },
     "node_modules/react": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
@@ -2382,7 +2220,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
@@ -2394,7 +2231,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -2428,20 +2264,17 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -2454,7 +2287,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -2467,7 +2299,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -2477,7 +2308,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2487,7 +2317,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -2504,7 +2333,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -2517,7 +2345,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -2525,7 +2352,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -2538,7 +2364,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2552,7 +2377,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -2576,14 +2400,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -2614,7 +2436,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2624,7 +2445,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.3.tgz",
       "integrity": "sha1-zgW0RbUBAUoQ5agHOBF1nCI+isI=",
       "dev": true,
       "license": "MIT",
@@ -2702,7 +2522,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -2718,7 +2537,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -2728,14 +2546,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -2748,7 +2564,6 @@
     },
     "node_modules/zod": {
       "version": "4.1.13",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
@@ -2758,7 +2573,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",

--- a/playground/AspireWithJavaScript/AspireJavaScript.Vue/.npmrc
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vue/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/AspireWithJavaScript/AspireJavaScript.Vue/package-lock.json
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vue/package-lock.json
@@ -31,7 +31,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
@@ -40,7 +39,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
@@ -49,7 +47,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "license": "MIT",
       "dependencies": {
@@ -64,7 +61,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "license": "MIT",
       "dependencies": {
@@ -77,7 +73,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -89,7 +84,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -100,7 +94,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -111,7 +104,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
       "integrity": "sha1-iRG9crLDZApUNgngQAuMTS5+fLY=",
       "dev": true,
       "license": "MIT",
@@ -130,7 +122,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -140,7 +131,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -155,7 +145,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
       "integrity": "sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=",
       "dev": true,
       "license": "Apache-2.0",
@@ -168,7 +157,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -181,7 +169,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -191,7 +178,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -205,7 +191,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -215,7 +200,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -229,7 +213,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -243,7 +226,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -257,13 +239,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -282,7 +262,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
@@ -296,7 +275,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -306,7 +284,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
@@ -320,7 +297,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -330,7 +306,6 @@
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
       "license": "MIT",
@@ -343,7 +318,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -360,7 +334,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -377,7 +350,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -394,7 +366,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -411,7 +382,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -428,7 +398,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -445,7 +414,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -462,7 +430,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -479,7 +446,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -496,7 +462,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -513,7 +478,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -530,7 +494,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -547,7 +510,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -566,7 +528,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -583,7 +544,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -600,21 +560,18 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
       "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node20": {
       "version": "20.1.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tsconfig/node20/-/node20-20.1.8.tgz",
       "integrity": "sha512-Em+IdPfByIzWRRpqWL4Z7ArLHZGxmc36BxE3jCz9nBFSm+5aLaPMZyjwu4yetvyKXeogWcxik4L1jB5JTWfw7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -625,28 +582,24 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
@@ -656,7 +609,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -685,7 +637,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -695,7 +646,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -720,7 +670,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -742,7 +691,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -760,7 +708,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -777,7 +724,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -802,7 +748,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -816,7 +761,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -844,7 +788,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -868,7 +811,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -886,7 +828,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -899,7 +840,6 @@
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
       "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
       "dev": true,
       "license": "MIT",
@@ -916,7 +856,6 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@volar/language-core/-/language-core-2.4.23.tgz",
       "integrity": "sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==",
       "dev": true,
       "license": "MIT",
@@ -926,14 +865,12 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@volar/source-map/-/source-map-2.4.23.tgz",
       "integrity": "sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@volar/typescript/-/typescript-2.4.23.tgz",
       "integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
       "dev": true,
       "license": "MIT",
@@ -945,7 +882,6 @@
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
       "integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
       "license": "MIT",
       "dependencies": {
@@ -958,7 +894,6 @@
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
       "integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
       "license": "MIT",
       "dependencies": {
@@ -968,7 +903,6 @@
     },
     "node_modules/@vue/compiler-sfc": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
       "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
       "license": "MIT",
       "dependencies": {
@@ -985,7 +919,6 @@
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
       "integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
       "license": "MIT",
       "dependencies": {
@@ -995,7 +928,6 @@
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "10.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/eslint-config-prettier/-/eslint-config-prettier-10.2.0.tgz",
       "integrity": "sha512-GL3YBLwv/+b86yHcNNfPJxOTtVFJ4Mbc9UU3zR+KVoG7SwGTjPT+32fXamscNumElhcpXW3mT0DgzS9w32S7Bw==",
       "dev": true,
       "license": "MIT",
@@ -1010,7 +942,6 @@
     },
     "node_modules/@vue/eslint-config-typescript": {
       "version": "14.9.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vue/eslint-config-typescript/-/eslint-config-typescript-14.9.0.tgz",
       "integrity": "sha1-XQGB9eC80k6IEMz6ZrxV9djLScg=",
       "dev": true,
       "license": "MIT",
@@ -1039,7 +970,6 @@
     },
     "node_modules/@vue/language-core": {
       "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/language-core/-/language-core-3.1.5.tgz",
       "integrity": "sha512-FMcqyzWN+sYBeqRMWPGT2QY0mUasZMVIuHvmb5NT3eeqPrbHBYtCP8JWEUCDCgM+Zr62uuWY/qoeBrPrzfa78w==",
       "dev": true,
       "license": "MIT",
@@ -1063,7 +993,6 @@
     },
     "node_modules/@vue/language-core/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -1076,7 +1005,6 @@
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/reactivity/-/reactivity-3.5.25.tgz",
       "integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
       "license": "MIT",
       "dependencies": {
@@ -1085,7 +1013,6 @@
     },
     "node_modules/@vue/runtime-core": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
       "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
       "license": "MIT",
       "dependencies": {
@@ -1095,7 +1022,6 @@
     },
     "node_modules/@vue/runtime-dom": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
       "integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
       "license": "MIT",
       "dependencies": {
@@ -1107,7 +1033,6 @@
     },
     "node_modules/@vue/server-renderer": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
       "integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
       "license": "MIT",
       "dependencies": {
@@ -1120,13 +1045,11 @@
     },
     "node_modules/@vue/shared": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/shared/-/shared-3.5.25.tgz",
       "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
       "license": "MIT"
     },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
       "integrity": "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==",
       "dev": true,
       "license": "MIT",
@@ -1145,7 +1068,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1158,7 +1080,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1168,7 +1089,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1185,14 +1105,12 @@
     },
     "node_modules/alien-signals": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/alien-signals/-/alien-signals-3.1.1.tgz",
       "integrity": "sha512-ogkIWbVrLwKtHY6oOAXaYkAxP+cTH7V5FZ5+Tm4NZFd8VDZ6uNMDrfzqctTZ42eTMCSR3ne3otpcxmqSnFfPYA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1202,14 +1120,12 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
@@ -1222,7 +1138,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
@@ -1235,7 +1150,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1250,7 +1164,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true,
       "license": "MIT",
@@ -1263,13 +1176,11 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1287,14 +1198,12 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1304,7 +1213,6 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
@@ -1316,7 +1224,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1329,7 +1236,6 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.8.0.tgz",
       "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
@@ -1388,7 +1294,6 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
@@ -1404,7 +1309,6 @@
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
       "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
       "dev": true,
       "license": "MIT",
@@ -1435,7 +1339,6 @@
     },
     "node_modules/eslint-plugin-vue": {
       "version": "10.10.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
       "integrity": "sha1-6Ve1aFPepU5zgTbYSdhZKZVL3z0=",
       "dev": true,
       "license": "MIT",
@@ -1467,7 +1370,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1486,7 +1388,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1499,7 +1400,6 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1512,7 +1412,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1530,7 +1429,6 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1543,7 +1441,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1556,7 +1453,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1569,7 +1465,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1579,13 +1474,11 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1595,21 +1488,18 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
@@ -1626,7 +1516,6 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -1639,21 +1528,18 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
@@ -1663,7 +1549,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -1676,7 +1561,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
@@ -1689,7 +1573,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1706,7 +1589,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -1720,14 +1602,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1742,7 +1622,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1755,7 +1634,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
@@ -1765,7 +1643,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -1775,7 +1652,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -1785,7 +1661,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -1798,7 +1673,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -1808,21 +1682,18 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
       "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
       "dev": true,
       "license": "MIT",
@@ -1832,21 +1703,18 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -1856,7 +1724,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -1870,7 +1737,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1900,7 +1766,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1921,7 +1786,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1942,7 +1806,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1963,7 +1826,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -1984,7 +1846,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -2005,7 +1866,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -2026,7 +1886,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2047,7 +1906,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2068,7 +1926,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2089,7 +1946,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -2110,7 +1966,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -2131,7 +1986,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2147,7 +2001,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
@@ -2156,7 +2009,6 @@
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
       "dev": true,
       "engines": {
@@ -2165,7 +2017,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
@@ -2175,7 +2026,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
@@ -2189,7 +2039,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2205,21 +2054,18 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
       "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "funding": [
         {
@@ -2237,14 +2083,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
       "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
       "dev": true,
       "license": "ISC",
@@ -2254,7 +2098,6 @@
     },
     "node_modules/npm-run-all2": {
       "version": "8.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/npm-run-all2/-/npm-run-all2-8.0.4.tgz",
       "integrity": "sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==",
       "dev": true,
       "license": "MIT",
@@ -2281,7 +2124,6 @@
     },
     "node_modules/npm-run-all2/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -2294,7 +2136,6 @@
     },
     "node_modules/npm-run-all2/node_modules/isexe": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
       "license": "ISC",
@@ -2304,7 +2145,6 @@
     },
     "node_modules/npm-run-all2/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2317,7 +2157,6 @@
     },
     "node_modules/npm-run-all2/node_modules/shell-quote": {
       "version": "1.9.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shell-quote/-/shell-quote-1.9.0.tgz",
       "integrity": "sha1-4QixoTZYbVlk7bMwABbUvtug/lc=",
       "dev": true,
       "license": "MIT",
@@ -2330,7 +2169,6 @@
     },
     "node_modules/npm-run-all2/node_modules/which": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
@@ -2346,7 +2184,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2359,7 +2196,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2377,7 +2213,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2393,7 +2228,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2409,14 +2243,12 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -2426,7 +2258,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2436,13 +2267,11 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -2455,7 +2284,6 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/pidtree/-/pidtree-0.6.0.tgz",
       "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2296,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "funding": [
         {
@@ -2496,7 +2323,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
       "integrity": "sha1-adx6UmUXVy/2sVDjUrNqAWAXtIU=",
       "dev": true,
       "license": "MIT",
@@ -2510,7 +2336,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -2520,7 +2345,6 @@
     },
     "node_modules/prettier": {
       "version": "3.7.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
@@ -2536,7 +2360,6 @@
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
       "license": "MIT",
@@ -2549,7 +2372,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2559,7 +2381,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
@@ -2580,7 +2401,6 @@
     },
     "node_modules/read-package-json-fast": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/read-package-json-fast/-/read-package-json-fast-4.0.0.tgz",
       "integrity": "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==",
       "dev": true,
       "license": "ISC",
@@ -2594,7 +2414,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
@@ -2605,7 +2424,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -2639,14 +2457,12 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
@@ -2670,7 +2486,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -2683,7 +2498,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -2696,7 +2510,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -2706,7 +2519,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -2715,7 +2527,6 @@
     },
     "node_modules/synckit": {
       "version": "0.11.11",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/synckit/-/synckit-0.11.11.tgz",
       "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
       "dev": true,
       "license": "MIT",
@@ -2731,7 +2542,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -2748,7 +2558,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -2766,7 +2575,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2779,7 +2587,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -2792,7 +2599,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -2805,7 +2611,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -2813,7 +2618,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -2826,7 +2630,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -2840,7 +2643,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -2864,14 +2666,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2881,14 +2681,12 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.2.tgz",
       "integrity": "sha1-OsKbWGjM8oxZMhORvh6+kG8TXr0=",
       "dev": true,
       "license": "MIT",
@@ -2966,7 +2764,6 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2979,14 +2776,12 @@
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vue": {
       "version": "3.5.25",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
       "dependencies": {
@@ -3007,7 +2802,6 @@
     },
     "node_modules/vue-eslint-parser": {
       "version": "10.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vue-eslint-parser/-/vue-eslint-parser-10.4.1.tgz",
       "integrity": "sha1-PQqrtmBNrD/NlPiTKRy551TMOSw=",
       "dev": true,
       "license": "MIT",
@@ -3031,7 +2825,6 @@
     },
     "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3044,7 +2837,6 @@
     },
     "node_modules/vue-tsc": {
       "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vue-tsc/-/vue-tsc-3.1.5.tgz",
       "integrity": "sha512-L/G9IUjOWhBU0yun89rv8fKqmKC+T0HfhrFjlIml71WpfBv9eb4E9Bev8FMbyueBIU9vxQqbd+oOsVcDa5amGw==",
       "dev": true,
       "license": "MIT",
@@ -3061,7 +2853,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -3077,7 +2868,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -3087,7 +2877,6 @@
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha1-gr6blX96/az5YeWYDxvyJ8C/dnM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3097,7 +2886,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",

--- a/playground/FoundryAgentEnterprise/frontend/.npmrc
+++ b/playground/FoundryAgentEnterprise/frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/FoundryAgentEnterprise/frontend/package-lock.json
+++ b/playground/FoundryAgentEnterprise/frontend/package-lock.json
@@ -31,7 +31,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -46,7 +45,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -56,7 +54,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +84,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
       "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
       "dev": true,
       "license": "MIT",
@@ -104,7 +100,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -121,7 +116,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -131,7 +125,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -145,7 +138,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -163,7 +155,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -173,7 +164,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -183,7 +173,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -193,7 +182,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -207,7 +195,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
       "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
       "dev": true,
       "license": "MIT",
@@ -223,7 +210,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -238,7 +224,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
       "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
       "dev": true,
       "license": "MIT",
@@ -257,7 +242,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
       "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
       "dev": true,
       "license": "MIT",
@@ -271,7 +255,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -283,7 +266,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -294,7 +276,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -305,7 +286,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -324,7 +304,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -337,7 +316,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -347,7 +325,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -362,7 +339,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
       "integrity": "sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=",
       "dev": true,
       "license": "Apache-2.0",
@@ -375,7 +351,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -388,7 +363,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=",
       "dev": true,
       "license": "MIT",
@@ -409,7 +383,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -419,7 +392,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -433,7 +405,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -443,7 +414,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -457,7 +427,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -471,7 +440,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -485,7 +453,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -496,7 +463,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "dev": true,
       "license": "MIT",
@@ -507,7 +473,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -517,14 +482,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -535,7 +498,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -554,7 +516,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -564,7 +525,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -581,7 +541,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -598,7 +557,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -615,7 +573,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -632,7 +589,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -649,7 +605,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -666,7 +621,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -683,7 +637,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -700,7 +653,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -717,7 +669,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -734,7 +685,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -751,7 +701,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -768,7 +717,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -787,7 +735,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -804,7 +751,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -821,14 +767,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -839,28 +783,24 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-24.9.1.tgz",
       "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
       "dev": true,
       "license": "MIT",
@@ -870,7 +810,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
@@ -880,7 +819,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
@@ -890,7 +828,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -919,7 +856,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -929,7 +865,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -954,7 +889,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -976,7 +910,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -994,7 +927,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -1011,7 +943,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -1036,7 +967,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -1050,7 +980,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -1078,7 +1007,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -1091,7 +1019,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -1115,7 +1042,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -1133,7 +1059,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -1159,7 +1084,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1172,7 +1096,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1182,7 +1105,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1199,7 +1121,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1209,7 +1130,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
       "integrity": "sha1-fjHYtLqOMkr5mfjzWu3wtBC+pSY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1222,7 +1142,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
@@ -1235,7 +1154,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
       "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
@@ -1269,7 +1187,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -1290,14 +1207,12 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1312,14 +1227,12 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1337,14 +1250,12 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1354,14 +1265,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.399",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
       "integrity": "sha1-1FIumDONZcpP6kmjySIEdMfAKKc=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1371,7 +1280,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1384,7 +1292,6 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.8.0.tgz",
       "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
@@ -1443,7 +1350,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha1-5nQsrXXZcMCj8w19P6gKR4T1WSc=",
       "dev": true,
       "license": "MIT",
@@ -1463,7 +1369,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.5.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
       "integrity": "sha1-AxEhhjEZP8HqHDdTGh5whagTu2A=",
       "dev": true,
       "license": "MIT",
@@ -1473,7 +1378,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1492,7 +1396,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1505,7 +1408,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1523,7 +1425,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1536,7 +1437,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1549,7 +1449,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1559,7 +1458,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1569,28 +1467,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -1603,7 +1497,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1620,7 +1513,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -1634,14 +1526,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1656,7 +1546,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
@@ -1666,7 +1555,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1679,7 +1567,6 @@
     },
     "node_modules/globals": {
       "version": "16.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globals/-/globals-16.4.0.tgz",
       "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
       "dev": true,
       "license": "MIT",
@@ -1692,14 +1579,12 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha1-au7BfRmDtOq/aXIfOqPrcFsX9IA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha1-W+Dkh7IJCIbGK9ihFyTNdm1fVNE=",
       "dev": true,
       "license": "MIT",
@@ -1709,7 +1594,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -1719,7 +1603,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -1729,7 +1612,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -1739,7 +1621,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -1752,21 +1633,18 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -1779,28 +1657,24 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -1813,7 +1687,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -1823,7 +1696,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -1837,7 +1709,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1867,7 +1738,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1888,7 +1758,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1909,7 +1778,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1930,7 +1798,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -1951,7 +1818,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -1972,7 +1838,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -1993,7 +1858,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2014,7 +1878,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2035,7 +1898,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2056,7 +1918,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -2077,7 +1938,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -2098,7 +1958,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2114,7 +1973,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2124,7 +1982,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2140,14 +1997,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -2166,14 +2021,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -2183,7 +2036,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2201,7 +2053,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2217,7 +2068,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2233,7 +2083,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -2243,7 +2092,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2253,14 +2101,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "dev": true,
       "funding": [
@@ -2289,7 +2135,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -2299,7 +2144,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2309,7 +2153,6 @@
     },
     "node_modules/react": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
@@ -2318,7 +2161,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
@@ -2330,7 +2172,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -2364,20 +2205,17 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -2387,7 +2225,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -2400,7 +2237,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -2410,7 +2246,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2420,7 +2255,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -2437,7 +2271,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -2455,7 +2288,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2300,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -2481,7 +2312,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -2489,7 +2319,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -2502,7 +2331,6 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2516,7 +2344,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -2540,14 +2367,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -2578,7 +2403,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2588,7 +2412,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.2.tgz",
       "integrity": "sha1-OsKbWGjM8oxZMhORvh6+kG8TXr0=",
       "dev": true,
       "license": "MIT",
@@ -2666,7 +2489,6 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2679,7 +2501,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -2695,7 +2516,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -2705,14 +2525,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -2725,7 +2543,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "dev": true,
       "license": "MIT",
@@ -2735,7 +2552,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha1-vGBeuknOD81ZjBJ/7hwja+PyKRg=",
       "dev": true,
       "license": "MIT",

--- a/playground/JavaAppHost/api/.npmrc
+++ b/playground/JavaAppHost/api/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/JavaAppHost/api/package-lock.json
+++ b/playground/JavaAppHost/api/package-lock.json
@@ -22,7 +22,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
       "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
       "cpu": [
         "ppc64"
@@ -39,7 +38,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
       "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
       "cpu": [
         "arm"
@@ -56,7 +54,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
       "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
       "cpu": [
         "arm64"
@@ -73,7 +70,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
       "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
       "cpu": [
         "x64"
@@ -90,7 +86,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
       "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
       "cpu": [
         "arm64"
@@ -107,7 +102,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
       "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
       "cpu": [
         "x64"
@@ -124,7 +118,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
       "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
       "cpu": [
         "arm64"
@@ -141,7 +134,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
       "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
       "cpu": [
         "x64"
@@ -158,7 +150,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
       "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
       "cpu": [
         "arm"
@@ -175,7 +166,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
       "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
       "cpu": [
         "arm64"
@@ -192,7 +182,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
       "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
       "cpu": [
         "ia32"
@@ -209,7 +198,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
       "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
       "cpu": [
         "loong64"
@@ -226,7 +214,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
       "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
       "cpu": [
         "mips64el"
@@ -243,7 +230,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
       "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
       "cpu": [
         "ppc64"
@@ -260,7 +246,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
       "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
       "cpu": [
         "riscv64"
@@ -277,7 +262,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
       "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
       "cpu": [
         "s390x"
@@ -294,7 +278,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
       "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
       "cpu": [
         "x64"
@@ -311,7 +294,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
       "cpu": [
         "arm64"
@@ -328,7 +310,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
       "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
       "cpu": [
         "x64"
@@ -345,7 +326,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
       "cpu": [
         "arm64"
@@ -362,7 +342,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
       "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
       "cpu": [
         "x64"
@@ -379,7 +358,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
       "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
       "cpu": [
         "arm64"
@@ -396,7 +374,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
       "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
       "cpu": [
         "x64"
@@ -413,7 +390,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
       "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
       "cpu": [
         "arm64"
@@ -430,7 +406,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
       "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
       "cpu": [
         "ia32"
@@ -447,7 +422,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
       "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
       "cpu": [
         "x64"
@@ -464,7 +438,6 @@
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha1-5z/1fZeALwY5mVRfQ+uyseymXZ0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -477,7 +450,6 @@
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.8.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha1-WmspDMv7GuL2d1r7dOmJi9jF1Og=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -495,7 +467,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
       "license": "ISC",
       "dependencies": {
@@ -512,7 +483,6 @@
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha1-kpn4KHS6ueTH+cSNhlvsv+jWkHw=",
       "license": "MIT",
       "funding": {
@@ -522,7 +492,6 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha1-wbA0beM2ulWvLVp5cIggN7rt7AU=",
       "license": "Apache-2.0",
       "engines": {
@@ -531,7 +500,6 @@
     },
     "node_modules/@opentelemetry/api-logs": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
       "integrity": "sha1-e5gY6N/fHT3KuIv+TWck8vgx9+w=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -543,7 +511,6 @@
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
       "version": "0.76.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.76.0.tgz",
       "integrity": "sha1-649kbe4dfp1EVaavJHBFw4h1EBg=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -606,7 +573,6 @@
     },
     "node_modules/@opentelemetry/configuration": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/configuration/-/configuration-0.218.0.tgz",
       "integrity": "sha1-pf3VDsnPoK2zu0EgLLOfecX059k=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -622,7 +588,6 @@
     },
     "node_modules/@opentelemetry/configuration/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -637,7 +602,6 @@
     },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
       "integrity": "sha1-FVWm+yaVlkFtjGJv0CDD8sOOBx8=",
       "license": "Apache-2.0",
       "engines": {
@@ -649,7 +613,6 @@
     },
     "node_modules/@opentelemetry/core": {
       "version": "2.10.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.10.0.tgz",
       "integrity": "sha1-qnf3E450ulOZ1fO7DereDBaPALI=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -664,7 +627,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz",
       "integrity": "sha1-flp+YkB01kSVkMhR1Y7+YAljFLM=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -684,7 +646,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -699,7 +660,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
       "integrity": "sha1-CZbLReDrxsdGVEVDCgGO3KyYcbQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -718,7 +678,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -733,7 +692,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz",
       "integrity": "sha1-5TlyCy4UXoWnpJAaHquwsud5kPg=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -754,7 +712,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -769,7 +726,6 @@
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -785,7 +741,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz",
       "integrity": "sha1-bWbCY4cCSJ0GO4hXdB7unOodIdY=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -807,7 +762,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -822,7 +776,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -838,7 +791,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -854,7 +806,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
       "integrity": "sha1-wgVYFYXQTFEG0cp2biNjIAbkaiw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -873,7 +824,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -888,7 +838,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -904,7 +853,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -920,7 +868,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz",
       "integrity": "sha1-ZmQri7XmVMp6WUSk8LSQgU/Idf0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -940,7 +887,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -955,7 +901,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -971,7 +916,6 @@
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -987,7 +931,6 @@
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz",
       "integrity": "sha1-Qb3cl9NM2dmZM4K5wQ/tGajeY/Q=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1005,7 +948,6 @@
     },
     "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1020,7 +962,6 @@
     },
     "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1036,7 +977,6 @@
     },
     "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1052,7 +992,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz",
       "integrity": "sha1-XVUyq5TVUUvsiu3BnOMXC2OB7tE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1073,7 +1012,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1088,7 +1026,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1104,7 +1041,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha1-Ntar9tY5ueqGFgPGH0NHUcCxoOo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1123,7 +1059,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1138,7 +1073,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1154,7 +1088,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz",
       "integrity": "sha1-3gsrNUUUna/t0rlI+4kfm/lilAw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1173,7 +1106,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1188,7 +1120,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1204,7 +1135,6 @@
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz",
       "integrity": "sha1-O3nSI63IwJe6MyPk3k7Yq7g8eJ4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1222,7 +1152,6 @@
     },
     "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1237,7 +1166,6 @@
     },
     "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1253,7 +1181,6 @@
     },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
       "integrity": "sha1-/M60/7RfmcDSkmAHaRUPxZRNw+k=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1270,7 +1197,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
       "version": "0.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.65.0.tgz",
       "integrity": "sha1-moNxED+QANsjB01+PxQwxA0kek4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1287,7 +1213,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
       "version": "0.70.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.70.0.tgz",
       "integrity": "sha1-SuMVokwFTGR740fV0/34fKIlouk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1304,7 +1229,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
       "version": "0.73.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.73.0.tgz",
       "integrity": "sha1-LO3WcPNs5njW4AnNZZGxeuwdEws=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1321,7 +1245,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
       "version": "0.63.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.63.0.tgz",
       "integrity": "sha1-Ak74rH8bu+mc1E2Xnp0TLkuH33g=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1338,7 +1261,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
       "version": "0.63.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.63.0.tgz",
       "integrity": "sha1-EmDpzdubMaEJNB/oYVGOYmY6QUs=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1354,7 +1276,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
       "version": "0.61.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.61.0.tgz",
       "integrity": "sha1-t/Edo6m9gPwiR0fkTPV5oarZTZM=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1372,7 +1293,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-cucumber": {
       "version": "0.34.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.34.0.tgz",
       "integrity": "sha1-5WGlMHSefnX8UFMT1HwojvPvSq8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1388,7 +1308,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
       "version": "0.35.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.35.0.tgz",
       "integrity": "sha1-0PABG9+tRh5b1j7rie3+DFj7k8g=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1403,7 +1322,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
       "version": "0.61.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.61.0.tgz",
       "integrity": "sha1-V7rS8rgfaoRWP6zZ8zErrJS1AWY=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1418,7 +1336,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-express": {
       "version": "0.66.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-express/-/instrumentation-express-0.66.0.tgz",
       "integrity": "sha1-QfEvZXESogSaegB9suvbFTOLAdo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1435,7 +1352,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
       "version": "0.37.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.37.0.tgz",
       "integrity": "sha1-x5gqMwpMmN6osavDcsmAov0szKg=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1451,7 +1367,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
       "version": "0.61.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.61.0.tgz",
       "integrity": "sha1-s9s5/Qzp3pZ6FE280AG2F6k4nM4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1466,7 +1381,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.66.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.66.0.tgz",
       "integrity": "sha1-qsU+5nnttlTbvRLpLri8Lr8iExI=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1481,7 +1395,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.218.0.tgz",
       "integrity": "sha1-yI7bIJhq/DduLy8schzg0F/TonM=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1497,7 +1410,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.64.0.tgz",
       "integrity": "sha1-DKkXh8owRsMRSRRcxRbpddisHas=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1514,7 +1426,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-http/-/instrumentation-http-0.218.0.tgz",
       "integrity": "sha1-Cya3AqYoj6Eb3qSP9KNjU4Wn1Yc=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1532,7 +1443,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1547,7 +1457,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
       "version": "0.66.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.66.0.tgz",
       "integrity": "sha1-8DBqWg/4DutxMS4trBnRvszJGOw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1564,7 +1473,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.27.0.tgz",
       "integrity": "sha1-XmCMAg0XoZIqoGdEFO0nGOGExIM=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1580,7 +1488,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
       "version": "0.62.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.62.0.tgz",
       "integrity": "sha1-ds/+aGdYMSszc53QYN3DArt0olM=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1596,7 +1503,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.66.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.66.0.tgz",
       "integrity": "sha1-a6Xi+XQAvNqkCFu66F/pU3gNKwo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1613,7 +1519,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
       "version": "0.62.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.62.0.tgz",
       "integrity": "sha1-e6NK4SxJMwIPhx7W5DCeD3YxHGI=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1628,7 +1533,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
       "version": "0.61.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.61.0.tgz",
       "integrity": "sha1-+kk9BImUNyGXpiYuwSof5xmAKiI=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1645,7 +1549,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.71.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.71.0.tgz",
       "integrity": "sha1-0BE5PMsNBJ/BOhPKqC4//HnhZS4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1661,7 +1564,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.64.0.tgz",
       "integrity": "sha1-NLQ6fm8yrgcTQ2sWl1FN5Jt4Pdg=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1678,7 +1580,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.64.0.tgz",
       "integrity": "sha1-5rWJRbYYLFl7/EER8HYHiQl+700=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1695,7 +1596,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.64.0.tgz",
       "integrity": "sha1-XAe/T+7cbAcWAbVeXQd9Qj6yYok=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1712,7 +1612,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.64.0.tgz",
       "integrity": "sha1-pXOH26qi8SLK85pD/E5XtxWVpAA=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1728,7 +1627,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-net": {
       "version": "0.62.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-net/-/instrumentation-net-0.62.0.tgz",
       "integrity": "sha1-gzOfYWY0QcRbYyejxqJk8k8ttE8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1744,7 +1642,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-openai": {
       "version": "0.16.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-openai/-/instrumentation-openai-0.16.0.tgz",
       "integrity": "sha1-iD1OpMKS4e+HeVqvG1fVL/jCm4M=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1761,7 +1658,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-oracledb": {
       "version": "0.43.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-oracledb/-/instrumentation-oracledb-0.43.0.tgz",
       "integrity": "sha1-NRruc/7KjH2YVsrvLXoW0klfWpc=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1778,7 +1674,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
       "version": "0.70.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.70.0.tgz",
       "integrity": "sha1-9eFqeORDLFKgeXHOGs8arCoZ6rQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1798,7 +1693,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
       "version": "0.64.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.64.0.tgz",
       "integrity": "sha1-MQfetKwpR0yk4MSgRLuhvhdAv4Y=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1815,7 +1709,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
       "version": "0.66.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.66.0.tgz",
       "integrity": "sha1-YEhs9FE80KFB42IDzl/CKN0rGIo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1832,7 +1725,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
       "version": "0.63.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.63.0.tgz",
       "integrity": "sha1-TXzCtFHONmZFws2DQnsmuelbuGU=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1849,7 +1741,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-router": {
       "version": "0.62.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-router/-/instrumentation-router-0.62.0.tgz",
       "integrity": "sha1-VzohByktDLvzQqJb8wKzG2yFxQ4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1865,7 +1756,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-runtime-node": {
       "version": "0.31.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.31.0.tgz",
       "integrity": "sha1-Ck5g831RoH3ErMHyfdn0Fr9y9i4=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1882,7 +1772,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-socket.io": {
       "version": "0.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.65.0.tgz",
       "integrity": "sha1-NAcOYF7khUmkcdFGtC8krmsl1bA=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1897,7 +1786,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.37.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.37.0.tgz",
       "integrity": "sha1-Xj7rM2XcWIEKK0uJnEBiLgVCkbo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1914,7 +1802,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
       "version": "0.28.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.28.0.tgz",
       "integrity": "sha1-zI+bZ9PbmJnPkn/btX+zOVppkF8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1931,7 +1818,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
       "version": "0.62.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.62.0.tgz",
       "integrity": "sha1-QcErVZbpcJoJ9GlLYzjrQCTB3v8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1947,7 +1833,6 @@
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
       "integrity": "sha1-8z4yF85Wh1a6oTL6vjDwyTRdsIY=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1963,7 +1848,6 @@
     },
     "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1978,7 +1862,6 @@
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz",
       "integrity": "sha1-3Fof7HFiRdhNxBZ96bHGB+B/tqc=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1996,7 +1879,6 @@
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2011,7 +1893,6 @@
     },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
       "integrity": "sha1-Z4TQ3dE4A8Y6GyQHJgbAL8IbkHE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2031,7 +1912,6 @@
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2046,7 +1926,6 @@
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2062,7 +1941,6 @@
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2078,7 +1956,6 @@
     },
     "node_modules/@opentelemetry/propagator-b3": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz",
       "integrity": "sha1-EH/j4W0HKMSJ7brSIcQC7hl1FKQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2093,7 +1970,6 @@
     },
     "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2108,7 +1984,6 @@
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
       "integrity": "sha1-6Ovz9sDpqlJc8EGJNCWInPPmkSU=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2123,7 +1998,6 @@
     },
     "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2138,7 +2012,6 @@
     },
     "node_modules/@opentelemetry/redis-common": {
       "version": "0.38.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
       "integrity": "sha1-MaBGSkipkcKUCGFONyXZTbfBGu4=",
       "license": "Apache-2.0",
       "engines": {
@@ -2147,7 +2020,6 @@
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
       "version": "0.33.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.33.8.tgz",
       "integrity": "sha1-tjmh2A5YB/wK1x7vKZaXkbF423g=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2163,7 +2035,6 @@
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
       "version": "2.21.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.21.0.tgz",
       "integrity": "sha1-hS7/4J5I+v+N72AYnReP+0XVc2s=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2180,7 +2051,6 @@
     },
     "node_modules/@opentelemetry/resource-detector-azure": {
       "version": "0.26.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.26.0.tgz",
       "integrity": "sha1-b97TpvTHSLiZ8wo3BTZvjfQZ3wk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2197,7 +2067,6 @@
     },
     "node_modules/@opentelemetry/resource-detector-container": {
       "version": "0.8.12",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resource-detector-container/-/resource-detector-container-0.8.12.tgz",
       "integrity": "sha1-C4w/nmdGMQLVUYlviZ2eGZUoEPQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2213,7 +2082,6 @@
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
       "version": "0.53.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.53.0.tgz",
       "integrity": "sha1-ZGn5dyKMIitACmCSpc1Rby0pct0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2230,7 +2098,6 @@
     },
     "node_modules/@opentelemetry/resources": {
       "version": "2.10.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.10.0.tgz",
       "integrity": "sha1-znbBwbqvzkx3vCmJCWW6H1ZnGsw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2246,7 +2113,6 @@
     },
     "node_modules/@opentelemetry/sdk-logs": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
       "integrity": "sha1-eIhv4wC4KALO6ZYyCLKvMmuSivU=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2264,7 +2130,6 @@
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2279,7 +2144,6 @@
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2295,7 +2159,6 @@
     },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.10.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
       "integrity": "sha1-Go841FFkuj77s1Bb62jK9KPs8tk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2311,7 +2174,6 @@
     },
     "node_modules/@opentelemetry/sdk-node": {
       "version": "0.218.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz",
       "integrity": "sha1-z4vcDJkzhxicfEdGEuD4AVBf65c=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2350,7 +2212,6 @@
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2365,7 +2226,6 @@
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2381,7 +2241,6 @@
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha1-txP2ndZ5M+zJxhNX8dRSzcn04oE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2397,7 +2256,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha1-kWDDr57yIZwmVjq9E24i+30Zs08=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2414,7 +2272,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2429,7 +2286,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2445,7 +2301,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
       "integrity": "sha1-VN7bjnf6UabQL8IZIJdzkmbIIWg=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2462,7 +2317,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
       "version": "2.7.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2477,7 +2331,6 @@
     },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha1-8/Rn42wnMy8Oc17IbNzXjdbyeGU=",
       "license": "Apache-2.0",
       "engines": {
@@ -2486,7 +2339,6 @@
     },
     "node_modules/@opentelemetry/sql-common": {
       "version": "0.41.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
       "integrity": "sha1-f0oUFmz9bJ/+iQltscx16vZEOxk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2501,7 +2353,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
       "license": "MIT",
       "optional": true,
@@ -2511,31 +2362,26 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha1-2TFa188/MKrHC9o8BoRD3G8UNlk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha1-1RLLJsCuAmCR7iwRZ/G+b69chCo=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha1-TW/ADI+2QBalyBtGnVSQRjUPEGU=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2544,37 +2390,31 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha1-eNR2Mz2F1bHHkuJXvKdLoIDaSaQ=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.162",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
       "integrity": "sha1-WJz+zdo6mW6b3yCnOiaggRyvtUk=",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha1-GFm+u4/X2smRikXVTBlxq4ta9HQ=",
       "dev": true,
       "license": "MIT",
@@ -2585,7 +2425,6 @@
     },
     "node_modules/@types/bunyan": {
       "version": "1.8.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/bunyan/-/bunyan-1.8.11.tgz",
       "integrity": "sha1-C551eKWqI5D68SpGCCcVSQIpljg=",
       "license": "MIT",
       "dependencies": {
@@ -2594,7 +2433,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg=",
       "license": "MIT",
       "dependencies": {
@@ -2603,7 +2441,6 @@
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha1-LXJLLJkNy4yERAY/NYCpA/bVAMw=",
       "dev": true,
       "license": "MIT",
@@ -2615,7 +2452,6 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "5.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
       "integrity": "sha1-nTTIjAye5iuabk2firjX4paI5rQ=",
       "dev": true,
       "license": "MIT",
@@ -2628,14 +2464,12 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha1-W3SasrFroRNCP+saZKldzTA5hHI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/memcached/-/memcached-2.2.10.tgz",
       "integrity": "sha1-ET+eOkUda14KOCLgbZ/rUuY+lUo=",
       "license": "MIT",
       "dependencies": {
@@ -2644,7 +2478,6 @@
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mysql/-/mysql-2.15.27.tgz",
       "integrity": "sha1-+xOw6GFNOdQvQPOBIX7DIVkV8ek=",
       "license": "MIT",
       "dependencies": {
@@ -2653,7 +2486,6 @@
     },
     "node_modules/@types/node": {
       "version": "26.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha1-Wkh1qGL9qP3Ffej6pXm7gey6FoU=",
       "license": "MIT",
       "dependencies": {
@@ -2662,7 +2494,6 @@
     },
     "node_modules/@types/oracledb": {
       "version": "6.5.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/oracledb/-/oracledb-6.5.2.tgz",
       "integrity": "sha1-GUzQ8TQ2+eHnRKbl4FanykAFNtU=",
       "license": "MIT",
       "dependencies": {
@@ -2671,7 +2502,6 @@
     },
     "node_modules/@types/pg": {
       "version": "8.15.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/pg/-/pg-8.15.6.tgz",
       "integrity": "sha1-TfdZC5rFV8vlR54AdOwVQMvdrZs=",
       "license": "MIT",
       "dependencies": {
@@ -2682,7 +2512,6 @@
     },
     "node_modules/@types/pg-pool": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/pg-pool/-/pg-pool-2.0.7.tgz",
       "integrity": "sha1-wXlFp0Ry2aO+r45m1apvyTgyhzQ=",
       "license": "MIT",
       "dependencies": {
@@ -2691,21 +2520,18 @@
     },
     "node_modules/@types/qs": {
       "version": "6.15.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha1-hgaIQnLGPw25aYa9NUhlDYqTiL8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha1-UK5DU+qt3AQEQnmBL1LIxlhX28s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha1-anhORVQ8GMd0wEm/9tPbrwRcnHQ=",
       "dev": true,
       "license": "MIT",
@@ -2715,7 +2541,6 @@
     },
     "node_modules/@types/serve-static": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha1-1KRHUD6tDRZxEy0atr1YuAXY3mo=",
       "dev": true,
       "license": "MIT",
@@ -2726,7 +2551,6 @@
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha1-hoEY56Z4CCWMBRWOnK2JyliirsE=",
       "license": "MIT",
       "dependencies": {
@@ -2735,7 +2559,6 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
       "license": "MIT",
       "dependencies": {
@@ -2748,7 +2571,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
       "engines": {
@@ -2757,7 +2579,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "license": "MIT",
       "engines": {
@@ -2769,7 +2590,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "license": "MIT",
       "engines": {
@@ -2781,13 +2601,11 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha1-dZxard8v/cTxVPe0k+HIdw+IxNc=",
       "license": "MIT",
       "engines": {
@@ -2796,7 +2614,6 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
       "license": "MIT",
       "dependencies": {
@@ -2820,7 +2637,6 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
       "license": "MIT",
       "engines": {
@@ -2833,7 +2649,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "license": "MIT",
       "dependencies": {
@@ -2842,7 +2657,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
       "license": "MIT",
       "engines": {
@@ -2851,7 +2665,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "license": "MIT",
       "dependencies": {
@@ -2864,7 +2677,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
       "license": "MIT",
       "dependencies": {
@@ -2880,13 +2692,11 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha1-s8pRAYQziSWa3n2Ix3vQbOVYSco=",
       "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "license": "ISC",
       "dependencies": {
@@ -2900,7 +2710,6 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -2909,7 +2718,6 @@
     },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "license": "MIT",
       "dependencies": {
@@ -2924,13 +2732,11 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -2944,7 +2750,6 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -2956,7 +2761,6 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -2973,7 +2777,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "license": "MIT",
       "dependencies": {
@@ -2985,13 +2788,11 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
       "license": "MIT",
       "engines": {
@@ -3004,7 +2805,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
       "license": "MIT",
       "engines": {
@@ -3013,7 +2813,6 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
       "license": "MIT",
       "engines": {
@@ -3022,7 +2821,6 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
       "license": "MIT",
       "engines": {
@@ -3031,7 +2829,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "license": "MIT",
       "dependencies": {
@@ -3045,7 +2842,6 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha1-2P6ysogeak9YwuCKz9Dig04mIi4=",
       "license": "MIT",
       "engines": {
@@ -3054,7 +2850,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
@@ -3071,7 +2866,6 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/depd/-/depd-2.0.0.tgz",
       "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
       "license": "MIT",
       "engines": {
@@ -3080,7 +2874,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "license": "MIT",
       "dependencies": {
@@ -3094,25 +2887,21 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
       "license": "MIT",
       "engines": {
@@ -3121,7 +2910,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "license": "MIT",
       "engines": {
@@ -3130,7 +2918,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "license": "MIT",
       "engines": {
@@ -3139,13 +2926,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
@@ -3157,7 +2942,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
       "dev": true,
       "hasInstallScript": true,
@@ -3199,7 +2983,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "license": "MIT",
       "engines": {
@@ -3208,13 +2991,11 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "license": "MIT",
       "engines": {
@@ -3223,7 +3004,6 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express/-/express-5.2.1.tgz",
       "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
       "license": "MIT",
       "dependencies": {
@@ -3266,13 +3046,11 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha1-8JuNS71Frcbwwgt+eH55PjCdzOk=",
       "funding": [
         {
@@ -3295,7 +3073,6 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
       "license": "MIT",
       "dependencies": {
@@ -3316,7 +3093,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "license": "ISC",
       "dependencies": {
@@ -3332,7 +3108,6 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha1-JIB8McnUAuACqz2McgFEzriEhCM=",
       "license": "MIT",
       "dependencies": {
@@ -3344,7 +3119,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
       "license": "MIT",
       "engines": {
@@ -3353,13 +3127,11 @@
     },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha1-CFEe3aqi3f1WuhETju598RegkyU=",
       "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
       "license": "MIT",
       "engines": {
@@ -3368,7 +3140,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
       "license": "MIT",
@@ -3382,7 +3153,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "license": "MIT",
       "funding": {
@@ -3391,7 +3161,6 @@
     },
     "node_modules/gaxios": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha1-xTEvQlSrwbirU67zDCLFIpuAseE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3406,7 +3175,6 @@
     },
     "node_modules/gcp-metadata": {
       "version": "8.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
       "integrity": "sha1-B/mHJnQxoDrpT3czy9CIv5L60Lk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3420,7 +3188,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "license": "ISC",
       "engines": {
@@ -3429,7 +3196,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "license": "MIT",
       "dependencies": {
@@ -3453,7 +3219,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "license": "MIT",
       "dependencies": {
@@ -3466,7 +3231,6 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-10.5.0.tgz",
       "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -3487,7 +3251,6 @@
     },
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha1-F7cfH5XSZtLd01a48AF4Qz8EGxc=",
       "license": "Apache-2.0",
       "engines": {
@@ -3496,7 +3259,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "license": "MIT",
       "engines": {
@@ -3508,7 +3270,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "license": "MIT",
       "engines": {
@@ -3520,7 +3281,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
@@ -3532,7 +3292,6 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha1-NtL2W8kJyHkAGN02+02T2myq4Gs=",
       "license": "MIT",
       "dependencies": {
@@ -3552,7 +3311,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
@@ -3565,7 +3323,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
       "license": "MIT",
       "dependencies": {
@@ -3581,7 +3338,6 @@
     },
     "node_modules/import-in-the-middle": {
       "version": "3.3.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
       "integrity": "sha1-cUIO1erCSjWGlb/6zXQ1tIbHbWE=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3595,13 +3351,11 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "license": "MIT",
       "engines": {
@@ -3610,7 +3364,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "license": "MIT",
       "engines": {
@@ -3619,19 +3372,16 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3646,7 +3396,6 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha1-rlR4I6wMrYOYZn+M2e9HMPWwH/E=",
       "license": "MIT",
       "dependencies": {
@@ -3655,25 +3404,21 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/long/-/long-5.3.2.tgz",
       "integrity": "sha1-HYRGMJWZkmLX17f4v9SozFUWf4M=",
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "license": "MIT",
       "engines": {
@@ -3682,7 +3427,6 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
       "license": "MIT",
       "engines": {
@@ -3695,7 +3439,6 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
       "license": "MIT",
       "engines": {
@@ -3707,7 +3450,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
       "license": "MIT",
       "engines": {
@@ -3716,7 +3458,6 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
       "license": "MIT",
       "dependencies": {
@@ -3732,7 +3473,6 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "license": "ISC",
       "dependencies": {
@@ -3747,7 +3487,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3756,19 +3495,16 @@
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha1-tmL9zZP2yD0/JSidoM6ByNloW5Q=",
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
       "license": "MIT",
       "engines": {
@@ -3777,7 +3513,6 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha1-aIjbRqH3HAt2s/dVUBa2P+ZHZuU=",
       "deprecated": "Use your platform's native DOMException instead",
       "funding": [
@@ -3797,7 +3532,6 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha1-0eiJus33M7T/OyskPrehKGagt4s=",
       "license": "MIT",
       "dependencies": {
@@ -3815,7 +3549,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
       "license": "MIT",
       "engines": {
@@ -3827,7 +3560,6 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
       "license": "MIT",
       "dependencies": {
@@ -3839,7 +3571,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "license": "ISC",
       "dependencies": {
@@ -3848,13 +3579,11 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "license": "MIT",
       "engines": {
@@ -3863,7 +3592,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
@@ -3872,7 +3600,6 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3888,7 +3615,6 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha1-eVxCDE98pFxbiHNm9iLuDJhSzM0=",
       "license": "MIT",
       "funding": {
@@ -3898,7 +3624,6 @@
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha1-lDvUY79bcbQXARX4D478mgwOt4w=",
       "license": "ISC",
       "engines": {
@@ -3907,13 +3632,11 @@
     },
     "node_modules/pg-protocol": {
       "version": "1.15.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pg-protocol/-/pg-protocol-1.15.0.tgz",
       "integrity": "sha1-dY9sBnnMC79JOGA7dZdwPzMxgMA=",
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha1-LQJQ1jZFT3z6O2rgOC/fqAYyVKM=",
       "license": "MIT",
       "dependencies": {
@@ -3929,7 +3652,6 @@
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha1-SPj84FT7xpZxmZMpuINLdyZS2C4=",
       "license": "MIT",
       "engines": {
@@ -3938,7 +3660,6 @@
     },
     "node_modules/postgres-bytea": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha1-xAs9oCIsUA/x5RxdcBS2C3lpfHo=",
       "license": "MIT",
       "engines": {
@@ -3947,7 +3668,6 @@
     },
     "node_modules/postgres-date": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha1-UbwIYAYAXlBhxZHO5yfyUxv2Qag=",
       "license": "MIT",
       "engines": {
@@ -3956,7 +3676,6 @@
     },
     "node_modules/postgres-interval": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha1-tGDILLFYdQd4iBmgaqD//bNURpU=",
       "license": "MIT",
       "dependencies": {
@@ -3968,7 +3687,6 @@
     },
     "node_modules/protobufjs": {
       "version": "7.6.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/protobufjs/-/protobufjs-7.6.5.tgz",
       "integrity": "sha1-e5JQza9KBhOanw/kaKQNfU/rynE=",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -3991,7 +3709,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
       "license": "MIT",
       "dependencies": {
@@ -4004,7 +3721,6 @@
     },
     "node_modules/qs": {
       "version": "6.15.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/qs/-/qs-6.15.3.tgz",
       "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4020,7 +3736,6 @@
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha1-1/Gb6BK7YnIUcrRdO+IZ7wlXK0c=",
       "license": "MIT",
       "engines": {
@@ -4033,7 +3748,6 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
       "license": "MIT",
       "dependencies": {
@@ -4048,7 +3762,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "license": "MIT",
       "engines": {
@@ -4057,7 +3770,6 @@
     },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
       "integrity": "sha1-294lh/ZpOYYm1WsgyGirh78BzOQ=",
       "license": "MIT",
       "dependencies": {
@@ -4070,7 +3782,6 @@
     },
     "node_modules/rimraf": {
       "version": "5.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha1-I7mEPT3JLbcfluGizpLjn9KoIhw=",
       "license": "ISC",
       "dependencies": {
@@ -4085,7 +3796,6 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/router/-/router-2.2.0.tgz",
       "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
       "license": "MIT",
       "dependencies": {
@@ -4101,13 +3811,11 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/send/-/send-1.2.1.tgz",
       "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
       "license": "MIT",
       "dependencies": {
@@ -4133,7 +3841,6 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
       "license": "MIT",
       "dependencies": {
@@ -4152,13 +3859,11 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "license": "MIT",
       "dependencies": {
@@ -4170,7 +3875,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "license": "MIT",
       "engines": {
@@ -4179,7 +3883,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
@@ -4198,7 +3901,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
@@ -4214,7 +3916,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
       "license": "MIT",
       "dependencies": {
@@ -4232,7 +3933,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
       "license": "MIT",
       "dependencies": {
@@ -4251,7 +3951,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "license": "ISC",
       "engines": {
@@ -4263,7 +3962,6 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
       "license": "MIT",
       "engines": {
@@ -4272,7 +3970,6 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
       "license": "MIT",
       "dependencies": {
@@ -4290,7 +3987,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -4304,7 +4000,6 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -4313,13 +4008,11 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -4331,7 +4024,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "license": "MIT",
       "dependencies": {
@@ -4347,7 +4039,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -4359,7 +4050,6 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -4368,7 +4058,6 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
       "license": "MIT",
       "engines": {
@@ -4377,7 +4066,6 @@
     },
     "node_modules/tsx": {
       "version": "4.23.11",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tsx/-/tsx-4.23.11.tgz",
       "integrity": "sha1-gqfLzOFntXUGDbA+94moTGh8f5c=",
       "dev": true,
       "license": "MIT",
@@ -4396,7 +4084,6 @@
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
       "license": "MIT",
       "dependencies": {
@@ -4414,7 +4101,6 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
       "license": "MIT",
       "engines": {
@@ -4427,13 +4113,11 @@
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "license": "MIT",
       "engines": {
@@ -4442,7 +4126,6 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "license": "MIT",
       "engines": {
@@ -4451,7 +4134,6 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha1-IHO5Gi/bH7+9QB594KyfghTOy0s=",
       "license": "MIT",
       "engines": {
@@ -4460,7 +4142,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "license": "ISC",
       "dependencies": {
@@ -4475,7 +4156,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
       "license": "MIT",
       "dependencies": {
@@ -4493,7 +4173,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "license": "MIT",
       "dependencies": {
@@ -4510,7 +4189,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -4519,7 +4197,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "license": "MIT",
       "dependencies": {
@@ -4534,13 +4211,11 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -4554,7 +4229,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {
@@ -4566,13 +4240,11 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "license": "MIT",
       "engines": {
@@ -4581,7 +4253,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "license": "ISC",
       "engines": {
@@ -4590,7 +4261,6 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "license": "ISC",
       "bin": {
@@ -4605,7 +4275,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "license": "MIT",
       "dependencies": {
@@ -4623,7 +4292,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "license": "ISC",
       "engines": {
@@ -4632,7 +4300,6 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "license": "MIT",
       "engines": {
@@ -4641,13 +4308,11 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "license": "MIT",
       "dependencies": {
@@ -4661,7 +4326,6 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "license": "MIT",
       "dependencies": {

--- a/playground/JavaAppHost/frontend/.npmrc
+++ b/playground/JavaAppHost/frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/JavaAppHost/frontend/package-lock.json
+++ b/playground/JavaAppHost/frontend/package-lock.json
@@ -31,7 +31,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -46,7 +45,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -56,7 +54,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +84,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
       "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
       "dev": true,
       "license": "MIT",
@@ -104,7 +100,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -121,7 +116,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -131,7 +125,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -145,7 +138,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -163,7 +155,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -173,7 +164,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -183,7 +173,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -193,7 +182,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -207,7 +195,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
       "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
       "dev": true,
       "license": "MIT",
@@ -223,7 +210,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -238,7 +224,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
       "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
       "dev": true,
       "license": "MIT",
@@ -257,7 +242,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
       "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
       "dev": true,
       "license": "MIT",
@@ -271,7 +255,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -283,7 +266,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -294,7 +276,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -305,7 +286,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -324,7 +304,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -337,7 +316,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -347,7 +325,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -362,7 +339,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
       "integrity": "sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=",
       "dev": true,
       "license": "Apache-2.0",
@@ -375,7 +351,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -388,7 +363,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=",
       "dev": true,
       "license": "MIT",
@@ -409,7 +383,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -419,7 +392,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -433,7 +405,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -443,7 +414,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -457,7 +427,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -471,7 +440,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -485,7 +453,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -496,7 +463,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "dev": true,
       "license": "MIT",
@@ -507,7 +473,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -517,14 +482,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -535,7 +498,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -554,7 +516,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -564,7 +525,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -581,7 +541,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -598,7 +557,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -615,7 +573,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -632,7 +589,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -649,7 +605,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -666,7 +621,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -683,7 +637,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -700,7 +653,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -717,7 +669,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -734,7 +685,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -751,7 +701,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -768,7 +717,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -787,7 +735,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -804,7 +751,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -821,14 +767,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -839,28 +783,24 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
@@ -870,7 +810,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
@@ -880,7 +819,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
@@ -890,7 +828,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -919,7 +856,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -929,7 +865,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -954,7 +889,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -976,7 +910,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -994,7 +927,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -1011,7 +943,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -1036,7 +967,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -1050,7 +980,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -1078,7 +1007,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -1091,7 +1019,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -1115,7 +1042,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -1133,7 +1059,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -1159,7 +1084,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1172,7 +1096,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1182,7 +1105,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1199,7 +1121,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1209,7 +1130,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
       "integrity": "sha1-fjHYtLqOMkr5mfjzWu3wtBC+pSY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1222,7 +1142,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
@@ -1235,7 +1154,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
       "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
@@ -1269,7 +1187,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -1290,14 +1207,12 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1312,14 +1227,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1337,14 +1250,12 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1354,14 +1265,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.399",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
       "integrity": "sha1-1FIumDONZcpP6kmjySIEdMfAKKc=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1371,7 +1280,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1384,7 +1292,6 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.8.0.tgz",
       "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
@@ -1443,7 +1350,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha1-5nQsrXXZcMCj8w19P6gKR4T1WSc=",
       "dev": true,
       "license": "MIT",
@@ -1463,7 +1369,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.5.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
       "integrity": "sha1-AxEhhjEZP8HqHDdTGh5whagTu2A=",
       "dev": true,
       "license": "MIT",
@@ -1473,7 +1378,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1492,7 +1396,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1505,7 +1408,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1523,7 +1425,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1536,7 +1437,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1549,7 +1449,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1559,7 +1458,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1569,28 +1467,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -1608,7 +1502,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -1621,7 +1514,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1638,7 +1530,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -1652,14 +1543,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1674,7 +1563,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
@@ -1684,7 +1572,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1697,7 +1584,6 @@
     },
     "node_modules/globals": {
       "version": "16.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globals/-/globals-16.5.0.tgz",
       "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
@@ -1710,14 +1596,12 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha1-au7BfRmDtOq/aXIfOqPrcFsX9IA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha1-W+Dkh7IJCIbGK9ihFyTNdm1fVNE=",
       "dev": true,
       "license": "MIT",
@@ -1727,7 +1611,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
@@ -1737,7 +1620,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -1747,7 +1629,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -1757,7 +1638,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -1770,21 +1650,18 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -1797,28 +1674,24 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -1831,7 +1704,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -1841,7 +1713,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -1855,7 +1726,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1885,7 +1755,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1906,7 +1775,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1927,7 +1795,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1948,7 +1815,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -1969,7 +1835,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -1990,7 +1855,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -2011,7 +1875,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2032,7 +1895,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2053,7 +1915,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2074,7 +1935,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -2095,7 +1955,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -2116,7 +1975,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2132,7 +1990,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2142,7 +1999,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2158,14 +2014,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -2184,14 +2038,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -2201,7 +2053,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2219,7 +2070,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2235,7 +2085,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2251,7 +2100,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -2261,7 +2109,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2271,14 +2118,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2291,7 +2136,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "dev": true,
       "funding": [
@@ -2320,7 +2164,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -2330,7 +2173,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2340,7 +2182,6 @@
     },
     "node_modules/react": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
@@ -2349,7 +2190,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
@@ -2361,7 +2201,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -2395,20 +2234,17 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -2418,7 +2254,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -2431,7 +2266,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -2441,7 +2275,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2451,7 +2284,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2300,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -2481,7 +2312,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -2489,7 +2319,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -2502,7 +2331,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2516,7 +2344,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -2540,14 +2367,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -2578,7 +2403,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2588,7 +2412,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.2.tgz",
       "integrity": "sha1-OsKbWGjM8oxZMhORvh6+kG8TXr0=",
       "dev": true,
       "license": "MIT",
@@ -2666,7 +2489,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -2682,7 +2504,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -2692,14 +2513,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -2712,7 +2531,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "dev": true,
       "license": "MIT",
@@ -2722,7 +2540,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha1-vGBeuknOD81ZjBJ/7hwja+PyKRg=",
       "dev": true,
       "license": "MIT",

--- a/playground/PythonAppHost/frontend/.npmrc
+++ b/playground/PythonAppHost/frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/PythonAppHost/frontend/package-lock.json
+++ b/playground/PythonAppHost/frontend/package-lock.json
@@ -31,7 +31,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -46,7 +45,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -56,7 +54,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +84,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
       "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
       "dev": true,
       "license": "MIT",
@@ -104,7 +100,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -121,7 +116,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -131,7 +125,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -145,7 +138,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -163,7 +155,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -173,7 +164,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -183,7 +173,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -193,7 +182,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -207,7 +195,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
       "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
       "dev": true,
       "license": "MIT",
@@ -223,7 +210,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -238,7 +224,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
       "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
       "dev": true,
       "license": "MIT",
@@ -257,7 +242,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.8.tgz",
       "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
       "dev": true,
       "license": "MIT",
@@ -271,7 +255,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -283,7 +266,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -294,7 +276,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -305,7 +286,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -324,7 +304,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -337,7 +316,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -347,7 +325,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -362,7 +339,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
       "integrity": "sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=",
       "dev": true,
       "license": "Apache-2.0",
@@ -375,7 +351,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -388,7 +363,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=",
       "dev": true,
       "license": "MIT",
@@ -409,7 +383,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -419,7 +392,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -433,7 +405,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -443,7 +414,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -457,7 +427,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -471,7 +440,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -485,7 +453,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -496,7 +463,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "dev": true,
       "license": "MIT",
@@ -507,7 +473,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -517,14 +482,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -535,7 +498,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -554,7 +516,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -564,7 +525,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -581,7 +541,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -598,7 +557,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -615,7 +573,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -632,7 +589,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -649,7 +605,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -666,7 +621,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -683,7 +637,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -700,7 +653,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -717,7 +669,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -734,7 +685,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -751,7 +701,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -768,7 +717,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -787,7 +735,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -804,7 +751,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -821,14 +767,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -839,28 +783,24 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
@@ -870,7 +810,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
@@ -880,7 +819,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
@@ -890,7 +828,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -919,7 +856,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -929,7 +865,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -954,7 +889,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -976,7 +910,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -994,7 +927,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -1011,7 +943,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -1036,7 +967,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -1050,7 +980,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -1078,7 +1007,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -1091,7 +1019,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -1115,7 +1042,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -1133,7 +1059,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -1159,7 +1084,6 @@
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -1172,7 +1096,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1182,7 +1105,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1199,7 +1121,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1209,7 +1130,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.11.tgz",
       "integrity": "sha1-fjHYtLqOMkr5mfjzWu3wtBC+pSY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1222,7 +1142,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
@@ -1235,7 +1154,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
       "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
@@ -1269,7 +1187,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -1290,14 +1207,12 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1312,14 +1227,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1337,14 +1250,12 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1354,14 +1265,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.399",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
       "integrity": "sha1-1FIumDONZcpP6kmjySIEdMfAKKc=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1371,7 +1280,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -1384,7 +1292,6 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.8.0.tgz",
       "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
@@ -1443,7 +1350,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha1-5nQsrXXZcMCj8w19P6gKR4T1WSc=",
       "dev": true,
       "license": "MIT",
@@ -1463,7 +1369,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.5.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
       "integrity": "sha1-AxEhhjEZP8HqHDdTGh5whagTu2A=",
       "dev": true,
       "license": "MIT",
@@ -1473,7 +1378,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1492,7 +1396,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1505,7 +1408,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1523,7 +1425,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1536,7 +1437,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1549,7 +1449,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1559,7 +1458,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1569,28 +1467,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -1608,7 +1502,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -1621,7 +1514,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -1638,7 +1530,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -1652,14 +1543,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1674,7 +1563,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
@@ -1684,7 +1572,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -1697,7 +1584,6 @@
     },
     "node_modules/globals": {
       "version": "16.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/globals/-/globals-16.5.0.tgz",
       "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
@@ -1710,14 +1596,12 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha1-au7BfRmDtOq/aXIfOqPrcFsX9IA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha1-W+Dkh7IJCIbGK9ihFyTNdm1fVNE=",
       "dev": true,
       "license": "MIT",
@@ -1727,7 +1611,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
@@ -1737,7 +1620,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -1747,7 +1629,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -1757,7 +1638,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -1770,21 +1650,18 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -1797,28 +1674,24 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -1831,7 +1704,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -1841,7 +1713,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -1855,7 +1726,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1885,7 +1755,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1906,7 +1775,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1927,7 +1795,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1948,7 +1815,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -1969,7 +1835,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -1990,7 +1855,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -2011,7 +1875,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -2032,7 +1895,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -2053,7 +1915,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -2074,7 +1935,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -2095,7 +1955,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -2116,7 +1975,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -2132,7 +1990,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2142,7 +1999,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2158,14 +2014,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -2184,14 +2038,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -2201,7 +2053,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -2219,7 +2070,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -2235,7 +2085,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -2251,7 +2100,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -2261,7 +2109,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -2271,14 +2118,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -2291,7 +2136,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "dev": true,
       "funding": [
@@ -2320,7 +2164,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -2330,7 +2173,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2340,7 +2182,6 @@
     },
     "node_modules/react": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
@@ -2349,7 +2190,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
@@ -2361,7 +2201,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -2395,20 +2234,17 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -2418,7 +2254,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -2431,7 +2266,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -2441,7 +2275,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2451,7 +2284,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -2468,7 +2300,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -2481,7 +2312,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -2489,7 +2319,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -2502,7 +2331,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2516,7 +2344,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -2540,14 +2367,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -2578,7 +2403,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2588,7 +2412,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.2.tgz",
       "integrity": "sha1-OsKbWGjM8oxZMhORvh6+kG8TXr0=",
       "dev": true,
       "license": "MIT",
@@ -2666,7 +2489,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -2682,7 +2504,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -2692,14 +2513,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -2712,7 +2531,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "dev": true,
       "license": "MIT",
@@ -2722,7 +2540,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha1-vGBeuknOD81ZjBJ/7hwja+PyKRg=",
       "dev": true,
       "license": "MIT",

--- a/playground/TypeScriptAppHost/vite-frontend/.npmrc
+++ b/playground/TypeScriptAppHost/vite-frontend/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/playground/TypeScriptAppHost/vite-frontend/package-lock.json
+++ b/playground/TypeScriptAppHost/vite-frontend/package-lock.json
@@ -24,7 +24,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -36,7 +35,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -47,7 +45,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -58,7 +55,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "dev": true,
       "license": "MIT",
@@ -77,7 +73,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha1-zpaQ7IAUS0w43+1E52pnuRHfmso=",
       "dev": true,
       "license": "MIT",
@@ -87,7 +82,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
       "integrity": "sha1-bDHzePQtXqdbN5cNKt1TloImR5I=",
       "cpu": [
         "arm64"
@@ -104,7 +98,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
       "integrity": "sha1-Hbu7rysA0TsyEny/Ojedbvaf1kc=",
       "cpu": [
         "arm64"
@@ -121,7 +114,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
       "integrity": "sha1-O49239Ri4o6JFOfe1jZHGUhmMp8=",
       "cpu": [
         "x64"
@@ -138,7 +130,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
       "integrity": "sha1-fz+Cxqe5/OxOJMKeidg0PJxy1AM=",
       "cpu": [
         "x64"
@@ -155,7 +146,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
       "integrity": "sha1-uu5DXHrd+E5Y/ucscOmKzGA6uj4=",
       "cpu": [
         "arm"
@@ -172,7 +162,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
       "integrity": "sha1-zIxjkTusaL8fSaDQlWNOCQCHQc4=",
       "cpu": [
         "arm64"
@@ -189,7 +178,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
       "integrity": "sha1-qqHQL17nBb1oEv+Eqx93UrpORJc=",
       "cpu": [
         "arm64"
@@ -206,7 +194,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
       "integrity": "sha1-nia7m6KoRgOZAicLd40dO6C2IDM=",
       "cpu": [
         "ppc64"
@@ -223,7 +210,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
       "integrity": "sha1-2exNWxvW+AKQcmcNqfDVjnKOjEQ=",
       "cpu": [
         "s390x"
@@ -240,7 +226,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
       "integrity": "sha1-bMnK1h6gIKwhkQN3VaNvj8+hFDQ=",
       "cpu": [
         "x64"
@@ -257,7 +242,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
       "integrity": "sha1-0j3zmhhL5CeHfak0/Dww4/Jc1oY=",
       "cpu": [
         "x64"
@@ -274,7 +258,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
       "integrity": "sha1-GJ0aBiYk9X+bClL5QWPVG2qmkqs=",
       "cpu": [
         "arm64"
@@ -291,7 +274,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
       "integrity": "sha1-mMY0uRqav13nS4QCqoBj+1BE79Q=",
       "cpu": [
         "wasm32"
@@ -310,7 +292,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
       "integrity": "sha1-HIyFFcgRrij8JjVQebgPYX/d2ws=",
       "cpu": [
         "arm64"
@@ -327,7 +308,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
       "integrity": "sha1-4Use9TRz9RpBgNm0bF8M6p8XE8s=",
       "cpu": [
         "x64"
@@ -344,14 +324,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -362,7 +340,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.8",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
@@ -372,7 +349,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
@@ -382,7 +358,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -408,14 +383,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -425,7 +398,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -443,7 +415,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -458,7 +429,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -488,7 +458,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -509,7 +478,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -530,7 +498,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -551,7 +518,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -572,7 +538,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -593,7 +558,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -614,7 +578,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -635,7 +598,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -656,7 +618,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -677,7 +638,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -698,7 +658,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -719,7 +678,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -738,14 +696,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -758,7 +714,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.23",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha1-NJNVARb0eEhymDAdLC6NxaVuZZQ=",
       "dev": true,
       "funding": [
@@ -787,7 +742,6 @@
     },
     "node_modules/react": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
@@ -796,7 +750,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
@@ -808,7 +761,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha1-fhX7JplzU4CDMBCe9r/9onSqoCc=",
       "dev": true,
       "license": "MIT",
@@ -842,20 +794,17 @@
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -865,7 +814,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -882,7 +830,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -890,7 +837,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -904,7 +850,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/vite/-/vite-8.1.2.tgz",
       "integrity": "sha1-OsKbWGjM8oxZMhORvh6+kG8TXr0=",
       "dev": true,
       "license": "MIT",

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Dotnet/TypeScript/.npmrc
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Dotnet/TypeScript/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Dotnet/TypeScript/package-lock.json
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Dotnet/TypeScript/package-lock.json
@@ -19,7 +19,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
       "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
       "cpu": [
         "ppc64"
@@ -36,7 +35,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
       "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
       "cpu": [
         "arm"
@@ -53,7 +51,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
       "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
       "cpu": [
         "arm64"
@@ -70,7 +67,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
       "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
       "cpu": [
         "x64"
@@ -87,7 +83,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
       "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
       "cpu": [
         "arm64"
@@ -104,7 +99,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
       "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
       "cpu": [
         "x64"
@@ -121,7 +115,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
       "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
       "cpu": [
         "arm64"
@@ -138,7 +131,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
       "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
       "cpu": [
         "x64"
@@ -155,7 +147,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
       "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
       "cpu": [
         "arm"
@@ -172,7 +163,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
       "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
       "cpu": [
         "arm64"
@@ -189,7 +179,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
       "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
       "cpu": [
         "ia32"
@@ -206,7 +195,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
       "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
       "cpu": [
         "loong64"
@@ -223,7 +211,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
       "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
       "cpu": [
         "mips64el"
@@ -240,7 +227,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
       "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
       "cpu": [
         "ppc64"
@@ -257,7 +243,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
       "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
       "cpu": [
         "riscv64"
@@ -274,7 +259,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
       "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
       "cpu": [
         "s390x"
@@ -291,7 +275,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
       "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
       "cpu": [
         "x64"
@@ -308,7 +291,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
       "cpu": [
         "arm64"
@@ -325,7 +307,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
       "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
       "cpu": [
         "x64"
@@ -342,7 +323,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
       "cpu": [
         "arm64"
@@ -359,7 +339,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
       "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
       "cpu": [
         "x64"
@@ -376,7 +355,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
       "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
       "cpu": [
         "arm64"
@@ -393,7 +371,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
       "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
       "cpu": [
         "x64"
@@ -410,7 +387,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
       "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
       "cpu": [
         "arm64"
@@ -427,7 +403,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
       "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
       "cpu": [
         "ia32"
@@ -444,7 +419,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
       "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
       "cpu": [
         "x64"
@@ -461,7 +435,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha1-/Oz1gLpCoNtVz0BMNyyXlzw3bJc=",
       "dev": true,
       "license": "MIT",
@@ -471,7 +444,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "dev": true,
       "license": "ISC",
@@ -485,7 +457,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -495,7 +466,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha1-9uFKl4WNMnJSIAJC1Mz+UixEVSI=",
       "dev": true,
       "license": "MIT",
@@ -508,7 +478,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
       "dev": true,
       "license": "MIT",
@@ -521,7 +490,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/braces/-/braces-3.0.3.tgz",
       "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "dev": true,
       "license": "MIT",
@@ -534,7 +502,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha1-GXxsxmnvKo3F57TZfuTgksPrDVs=",
       "dev": true,
       "license": "MIT",
@@ -559,7 +526,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -577,7 +543,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
       "dev": true,
       "hasInstallScript": true,
@@ -619,7 +584,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "dev": true,
       "license": "MIT",
@@ -632,7 +596,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
       "license": "MIT",
@@ -646,7 +609,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "license": "ISC",
@@ -659,7 +621,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "license": "MIT",
@@ -669,14 +630,12 @@
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "license": "MIT",
@@ -689,7 +648,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -699,7 +657,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "license": "MIT",
@@ -712,7 +669,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true,
       "license": "MIT",
@@ -722,7 +678,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -738,14 +693,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "3.1.14",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nodemon/-/nodemon-3.1.14.tgz",
       "integrity": "sha1-hIfKN5xRUwHSIewAfyfyTsr6K1E=",
       "dev": true,
       "license": "MIT",
@@ -774,7 +727,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
       "license": "MIT",
@@ -784,7 +736,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
@@ -797,14 +748,12 @@
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha1-wkIiT0pnwh9oaDm720rCgrg3PTo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
       "dev": true,
       "license": "MIT",
@@ -817,7 +766,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -830,7 +778,6 @@
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha1-1wuSvat9bZDf1zkxGVowtuPXzrs=",
       "dev": true,
       "license": "MIT",
@@ -843,7 +790,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "license": "MIT",
@@ -856,7 +802,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "license": "MIT",
@@ -869,7 +814,6 @@
     },
     "node_modules/touch": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/touch/-/touch-3.1.1.tgz",
       "integrity": "sha1-CXoj17FhR2Q15cE0SpXA91tKVpQ=",
       "dev": true,
       "license": "ISC",
@@ -879,7 +823,6 @@
     },
     "node_modules/tsx": {
       "version": "4.23.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tsx/-/tsx-4.23.1.tgz",
       "integrity": "sha1-FwPaAC7kQyuaBTkXQx+RRi/KI1s=",
       "dev": true,
       "license": "MIT",
@@ -898,7 +841,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -912,21 +854,18 @@
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha1-OHM7kye9zSJtuIn7cjpu/RYubiw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
       "integrity": "sha1-oyLMDx2X95T/2cTNKomKC94JfzQ=",
       "license": "MIT",
       "engines": {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Rust/TypeScript/.npmrc
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Rust/TypeScript/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Rust/TypeScript/package-lock.json
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Rust/TypeScript/package-lock.json
@@ -19,7 +19,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
       "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
       "cpu": [
         "ppc64"
@@ -36,7 +35,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
       "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
       "cpu": [
         "arm"
@@ -53,7 +51,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
       "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
       "cpu": [
         "arm64"
@@ -70,7 +67,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
       "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
       "cpu": [
         "x64"
@@ -87,7 +83,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
       "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
       "cpu": [
         "arm64"
@@ -104,7 +99,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
       "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
       "cpu": [
         "x64"
@@ -121,7 +115,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
       "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
       "cpu": [
         "arm64"
@@ -138,7 +131,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
       "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
       "cpu": [
         "x64"
@@ -155,7 +147,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
       "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
       "cpu": [
         "arm"
@@ -172,7 +163,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
       "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
       "cpu": [
         "arm64"
@@ -189,7 +179,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
       "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
       "cpu": [
         "ia32"
@@ -206,7 +195,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
       "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
       "cpu": [
         "loong64"
@@ -223,7 +211,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
       "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
       "cpu": [
         "mips64el"
@@ -240,7 +227,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
       "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
       "cpu": [
         "ppc64"
@@ -257,7 +243,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
       "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
       "cpu": [
         "riscv64"
@@ -274,7 +259,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
       "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
       "cpu": [
         "s390x"
@@ -291,7 +275,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
       "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
       "cpu": [
         "x64"
@@ -308,7 +291,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
       "cpu": [
         "arm64"
@@ -325,7 +307,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
       "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
       "cpu": [
         "x64"
@@ -342,7 +323,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
       "cpu": [
         "arm64"
@@ -359,7 +339,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
       "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
       "cpu": [
         "x64"
@@ -376,7 +355,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
       "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
       "cpu": [
         "arm64"
@@ -393,7 +371,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
       "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
       "cpu": [
         "x64"
@@ -410,7 +387,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
       "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
       "cpu": [
         "arm64"
@@ -427,7 +403,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
       "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
       "cpu": [
         "ia32"
@@ -444,7 +419,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
       "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
       "cpu": [
         "x64"
@@ -461,7 +435,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "dev": true,
       "license": "MIT",
@@ -471,7 +444,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
@@ -485,7 +457,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -495,7 +466,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
@@ -508,7 +478,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
       "dev": true,
       "license": "MIT",
@@ -521,7 +490,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
@@ -534,7 +502,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
@@ -559,7 +526,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -577,7 +543,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
       "dev": true,
       "hasInstallScript": true,
@@ -619,7 +584,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
@@ -632,7 +596,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -647,7 +610,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -660,7 +622,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "license": "MIT",
@@ -670,14 +631,12 @@
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
@@ -690,7 +649,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -700,7 +658,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -713,7 +670,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -723,7 +679,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -739,14 +694,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
       "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
@@ -775,7 +728,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
@@ -785,7 +737,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -798,14 +749,12 @@
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
@@ -818,7 +767,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -831,7 +779,6 @@
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
       "license": "MIT",
@@ -844,7 +791,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "license": "MIT",
@@ -857,7 +803,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -870,7 +815,6 @@
     },
     "node_modules/touch": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
       "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
       "dev": true,
       "license": "ISC",
@@ -880,7 +824,6 @@
     },
     "node_modules/tsx": {
       "version": "4.22.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tsx/-/tsx-4.22.3.tgz",
       "integrity": "sha1-fKfLNAKOPiR/H60wDBV+QqkKH1A=",
       "dev": true,
       "license": "MIT",
@@ -899,7 +842,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -913,21 +855,18 @@
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
       "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description

Nine standalone npm projects under `playground/` and `tests/PolyglotAppHosts/` do not inherit the repository `.npmrc` when npm treats each nested directory as the project root. This adds a local `.npmrc` to each project with `omit-lockfile-registry-resolved=true` and regenerates only the adjacent lockfile. The repository `.npmrc` is unchanged.

All lockfiles remain at version 3. Package versions, dependency graphs, integrity values, and platform metadata are unchanged. The only lockfile changes remove 1,461 `resolved` entries, so the files no longer pin Azure DevOps or npm registry hosts.

## Validation

- Confirmed each project reports `true` for `npm config get omit-lockfile-registry-resolved`.
- Regenerated with npm 11.19.0 using `npm install --package-lock-only --ignore-scripts --no-audit --no-fund`.
- Repeated regeneration and confirmed every lockfile was byte-for-byte unchanged.
- Compared parsed lockfiles before and after, excluding `resolved`, and found no metadata changes.
- Confirmed no `resolved`, `pkgs.dev.azure.com`, `pkgs.visualstudio.com`, or `registry.npmjs.org` entries remain in the nine lockfiles.
- Ran `npm ci --no-audit --no-fund` successfully in all nine projects.
- Ran the available frontend builds and lints successfully.
- Confirmed the Java API `tsx` runner starts and reports its version.

The two polyglot fixture type checks need `.aspire/modules/aspire.mjs`, which is generated by `aspire restore --apphost` in the polyglot validation workflow. A direct `npm run build` from a clean checkout stops at that missing generated module.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
