### PR TITLE
Extend DCP initialization timeout through API readiness

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -271,7 +271,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             return ExecuteWithRetry(
                 DcpApiOperationType.Watch,
                 T.ObjectKind,
-                (kubernetes) =>
+                async (kubernetes, operationCancellationToken) =>
                 {
                     var responseTask = string.IsNullOrEmpty(namespaceParameter)
                         ? kubernetes.CustomObjects.ListClusterCustomObjectWithHttpMessagesAsync(
@@ -279,14 +279,17 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                             GroupVersion.Version,
                             resourceType,
                             watch: true,
-                            cancellationToken: restartCancellationToken)
+                            cancellationToken: operationCancellationToken)
                         : kubernetes.CustomObjects.ListNamespacedCustomObjectWithHttpMessagesAsync(
                             GroupVersion.Group,
                             GroupVersion.Version,
                             namespaceParameter,
                             resourceType,
                             watch: true,
-                            cancellationToken: restartCancellationToken);
+                            cancellationToken: operationCancellationToken);
+
+                    // KubernetesClient's lazy WatchAsync does not await the HTTP response until enumeration starts.
+                    await responseTask.ConfigureAwait(false);
 
                     // TODO: KubernetesClient v18 marked WatchAsync extension method as obsolete.
                     // The new pattern uses Watcher<T> directly, but requires significant refactoring.
@@ -449,21 +452,6 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         }
 
         return kindWithResource.Resource;
-    }
-
-    private Task<TResult> ExecuteWithRetry<TResult>(
-        DcpApiOperationType operationType,
-        string resourceType,
-        Func<DcpKubernetesClient, TResult> operation,
-        Func<Exception, bool> isRetryable,
-        CancellationToken cancellationToken)
-    {
-        return ExecuteWithRetry<TResult>(
-            operationType,
-            resourceType,
-            (DcpKubernetesClient kubernetes, CancellationToken _) => Task.FromResult(operation(kubernetes)),
-            isRetryable,
-            cancellationToken);
     }
 
     private async Task<TResult> ExecuteWithRetry<TResult>(

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -88,11 +88,12 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
     private readonly SemaphoreSlim _kubeconfigReadSemaphore = new(1);
 
     private DcpKubernetesClient? _kubernetes;
+    private int _kubernetesApiReady;
     private ResiliencePipeline? _resiliencePipeline;
     private bool _disposed;
 
     public TimeSpan MaxRetryDuration { get; set; } = TimeSpan.FromSeconds(20);
-    public TimeSpan KubernetesConfigInitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
+    public TimeSpan KubernetesInitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
     public Task<T> GetAsync<T>(string name, string? namespaceParameter = null, CancellationToken cancellationToken = default)
         where T : CustomResource, IKubernetesStaticMetadata
@@ -102,7 +103,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
             DcpApiOperationType.Get,
             T.ObjectKind,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 var response = string.IsNullOrEmpty(namespaceParameter)
                 ? await kubernetes.CustomObjects.GetClusterCustomObjectWithHttpMessagesAsync(
@@ -110,14 +111,14 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     GroupVersion.Version,
                     resourceType,
                     name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false)
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false)
                 : await kubernetes.CustomObjects.GetNamespacedCustomObjectWithHttpMessagesAsync(
                     GroupVersion.Group,
                     GroupVersion.Version,
                     namespaceParameter,
                     resourceType,
                     name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false);
 
                 return KubernetesJson.Deserialize<T>(response.Body.ToString());
             },
@@ -135,7 +136,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
            DcpApiOperationType.Create,
            T.ObjectKind,
-           async (kubernetes) =>
+           async (kubernetes, operationCancellationToken) =>
            {
                var response = string.IsNullOrEmpty(namespaceParameter)
                 ? await kubernetes.CustomObjects.CreateClusterCustomObjectWithHttpMessagesAsync(
@@ -143,14 +144,14 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     GroupVersion.Group,
                     GroupVersion.Version,
                     resourceType,
-                    cancellationToken: cancellationToken).ConfigureAwait(false)
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false)
                 : await kubernetes.CustomObjects.CreateNamespacedCustomObjectWithHttpMessagesAsync(
                     obj,
                     GroupVersion.Group,
                     GroupVersion.Version,
                     namespaceParameter,
                     resourceType,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false);
 
                return KubernetesJson.Deserialize<T>(response.Body.ToString());
            },
@@ -168,7 +169,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
            DcpApiOperationType.Patch,
            T.ObjectKind,
-           async (kubernetes) =>
+           async (kubernetes, operationCancellationToken) =>
            {
                var response = string.IsNullOrEmpty(namespaceParameter)
                 ? await kubernetes.CustomObjects.PatchClusterCustomObjectWithHttpMessagesAsync(
@@ -177,7 +178,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     GroupVersion.Version,
                     resourceType,
                     obj.Metadata.Name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false)
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false)
                 : await kubernetes.CustomObjects.PatchNamespacedCustomObjectWithHttpMessagesAsync(
                     patch,
                     GroupVersion.Group,
@@ -185,7 +186,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     namespaceParameter,
                     resourceType,
                     obj.Metadata.Name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false);
 
                return KubernetesJson.Deserialize<T>(response.Body.ToString());
            },
@@ -202,20 +203,20 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
             DcpApiOperationType.List,
             T.ObjectKind,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 var response = string.IsNullOrEmpty(namespaceParameter)
                     ? await kubernetes.CustomObjects.ListClusterCustomObjectWithHttpMessagesAsync(
                         GroupVersion.Group,
                         GroupVersion.Version,
                         resourceType,
-                        cancellationToken: cancellationToken).ConfigureAwait(false)
+                        cancellationToken: operationCancellationToken).ConfigureAwait(false)
                     : await kubernetes.CustomObjects.ListNamespacedCustomObjectWithHttpMessagesAsync(
                         GroupVersion.Group,
                         GroupVersion.Version,
                         namespaceParameter,
                         resourceType,
-                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                        cancellationToken: operationCancellationToken).ConfigureAwait(false);
 
                 return KubernetesJson.Deserialize<CustomResourceList<T>>(response.Body.ToString()).Items;
             },
@@ -232,7 +233,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
             DcpApiOperationType.Delete,
             T.ObjectKind,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 var response = string.IsNullOrEmpty(namespaceParameter)
                 ? await kubernetes.CustomObjects.DeleteClusterCustomObjectWithHttpMessagesAsync(
@@ -240,14 +241,14 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     GroupVersion.Version,
                     resourceType,
                     name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false)
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false)
                 : await kubernetes.CustomObjects.DeleteNamespacedCustomObjectWithHttpMessagesAsync(
                     GroupVersion.Group,
                     GroupVersion.Version,
                     namespaceParameter,
                     resourceType,
                     name,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: operationCancellationToken).ConfigureAwait(false);
 
                 return KubernetesJson.Deserialize<T>(response.Body.ToString());
             },
@@ -295,7 +296,8 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 #pragma warning restore CS0618 // Type or member is obsolete
                 },
                 RetryOnConnectivityAndConflictErrors,
-                restartCancellationToken);
+                restartCancellationToken,
+                marksApiReady: false);
         };
 
         await foreach (var item in PeriodicRestartAsyncEnumerable.CreateAsync(innerWatchFactory, restartInterval: TimeSpan.FromMinutes(5), cancellationToken: cancellationToken).ConfigureAwait(false))
@@ -343,7 +345,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
             DcpApiOperationType.GetLogSubresource,
             T.ObjectKind,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 var response = await kubernetes.ReadSubResourceAsStreamAsync(
                     GroupVersion.Group,
@@ -353,7 +355,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                     Logs.SubResourceName,
                     obj.Metadata.Namespace(),
                     queryParams,
-                    cancellationToken
+                    operationCancellationToken
                 ).ConfigureAwait(false);
 
                 return response.Body;
@@ -370,7 +372,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         return ExecuteWithRetry(
             DcpApiOperationType.ServerStop,
             DcpExecutionResourceType,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 await kubernetes.PatchExecutionDocumentAsync(
                     new ApiServerExecution
@@ -378,7 +380,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                         ApiServerStatus = ApiServerStatus.Stopping,
                         ShutdownResourceCleanup = ResourceCleanup.Full
                     },
-                    cancellationToken
+                    operationCancellationToken
                     ).ConfigureAwait(false);
                 return (object?)null;
             },
@@ -394,7 +396,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         var executionDoc = await ExecuteWithRetry(
             DcpApiOperationType.ResourceCleanup,
             DcpExecutionResourceType,
-            async (kubernetes) =>
+            async (kubernetes, operationCancellationToken) =>
             {
                 return await kubernetes.PatchExecutionDocumentAsync(
                     new ApiServerExecution
@@ -402,7 +404,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                         ApiServerStatus = ApiServerStatus.CleaningResources,
                         ShutdownResourceCleanup = ResourceCleanup.Full
                     },
-                    cancellationToken
+                    operationCancellationToken
                     ).ConfigureAwait(false);
             },
             RetryOnConnectivityErrors,
@@ -429,7 +431,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 
         await retryPipeline.ExecuteAsync(async cancellationContext =>
         {
-            return await _kubernetes!.GetExecutionDocumentAsync(cancellationToken).ConfigureAwait(false);
+            return await _kubernetes!.GetExecutionDocumentAsync(cancellationContext).ConfigureAwait(false);
         }, cancellationToken).ConfigureAwait(false);
     }
 
@@ -455,25 +457,29 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         string resourceType,
         Func<DcpKubernetesClient, TResult> operation,
         Func<Exception, bool> isRetryable,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool marksApiReady = true)
     {
         return ExecuteWithRetry<TResult>(
             operationType,
             resourceType,
-            (DcpKubernetesClient kubernetes) => Task.FromResult(operation(kubernetes)),
+            (DcpKubernetesClient kubernetes, CancellationToken _) => Task.FromResult(operation(kubernetes)),
             isRetryable,
-            cancellationToken);
+            cancellationToken,
+            marksApiReady);
     }
 
     private async Task<TResult> ExecuteWithRetry<TResult>(
         DcpApiOperationType operationType,
         string resourceType,
-        Func<DcpKubernetesClient, Task<TResult>> operation,
+        Func<DcpKubernetesClient, CancellationToken, Task<TResult>> operation,
         Func<Exception, bool> isRetryable,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool marksApiReady = true)
     {
         using var activity = ProfilingTelemetry.StartDcpKubernetesApi(configuration, operationType, resourceType);
         var retryCount = 0;
+        var useInitializationTimeout = Volatile.Read(ref _kubernetesApiReady) == 0;
 
         try
         {
@@ -491,19 +497,30 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                 // The first DCP request must also wait for DCP to create its kubeconfig. Give that initialization
                 // its own budget so slower hosts do not consume the shorter already-running API retry budget.
                 var initializationPipeline = CreateKubernetesCallResiliencePipeline(
-                    KubernetesConfigInitializationTimeout,
+                    KubernetesInitializationTimeout,
                     RetryOnConnectivityErrors,
                     activity,
                     () => retryCount++);
                 await initializationPipeline.ExecuteAsync(EnsureKubernetesClientAsync, cancellationToken).ConfigureAwait(false);
             }
 
-            var resiliencePipeline = CreateKubernetesCallResiliencePipeline(MaxRetryDuration, isRetryable, activity, () => retryCount++);
+            // A parsed kubeconfig does not guarantee that DCP can process requests yet. Keep using the startup
+            // budget until an API operation succeeds, then fail steady-state API calls on the normal budget.
+            var retryDuration = useInitializationTimeout
+                ? KubernetesInitializationTimeout
+                : MaxRetryDuration;
+
+            var resiliencePipeline = CreateKubernetesCallResiliencePipeline(retryDuration, isRetryable, activity, () => retryCount++);
             return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
             {
                 // Keep connection establishment inside the retry loop so kubeconfig read failures remain retryable.
                 await EnsureKubernetesClientAsync(cancellationToken).ConfigureAwait(false);
-                return await operation(_kubernetes!).ConfigureAwait(false);
+                var result = await operation(_kubernetes!, cancellationToken).ConfigureAwait(false);
+                if (marksApiReady)
+                {
+                    Volatile.Write(ref _kubernetesApiReady, 1);
+                }
+                return result;
             }, cancellationToken).ConfigureAwait(false);
         }
         finally

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -88,7 +88,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
     private readonly SemaphoreSlim _kubeconfigReadSemaphore = new(1);
 
     private DcpKubernetesClient? _kubernetes;
-    private int _kubernetesApiReady;
+    private bool _kubernetesApiReady;
     private ResiliencePipeline? _resiliencePipeline;
     private bool _disposed;
 
@@ -296,8 +296,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 #pragma warning restore CS0618 // Type or member is obsolete
                 },
                 RetryOnConnectivityAndConflictErrors,
-                restartCancellationToken,
-                marksApiReady: false);
+                restartCancellationToken);
         };
 
         await foreach (var item in PeriodicRestartAsyncEnumerable.CreateAsync(innerWatchFactory, restartInterval: TimeSpan.FromMinutes(5), cancellationToken: cancellationToken).ConfigureAwait(false))
@@ -457,16 +456,14 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         string resourceType,
         Func<DcpKubernetesClient, TResult> operation,
         Func<Exception, bool> isRetryable,
-        CancellationToken cancellationToken,
-        bool marksApiReady = true)
+        CancellationToken cancellationToken)
     {
         return ExecuteWithRetry<TResult>(
             operationType,
             resourceType,
             (DcpKubernetesClient kubernetes, CancellationToken _) => Task.FromResult(operation(kubernetes)),
             isRetryable,
-            cancellationToken,
-            marksApiReady);
+            cancellationToken);
     }
 
     private async Task<TResult> ExecuteWithRetry<TResult>(
@@ -474,12 +471,10 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         string resourceType,
         Func<DcpKubernetesClient, CancellationToken, Task<TResult>> operation,
         Func<Exception, bool> isRetryable,
-        CancellationToken cancellationToken,
-        bool marksApiReady = true)
+        CancellationToken cancellationToken)
     {
         using var activity = ProfilingTelemetry.StartDcpKubernetesApi(configuration, operationType, resourceType);
         var retryCount = 0;
-        var useInitializationTimeout = Volatile.Read(ref _kubernetesApiReady) == 0;
 
         try
         {
@@ -506,9 +501,9 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
 
             // A parsed kubeconfig does not guarantee that DCP can process requests yet. Keep using the startup
             // budget until an API operation succeeds, then fail steady-state API calls on the normal budget.
-            var retryDuration = useInitializationTimeout
-                ? KubernetesInitializationTimeout
-                : MaxRetryDuration;
+            var retryDuration = Volatile.Read(ref _kubernetesApiReady)
+                ? MaxRetryDuration
+                : KubernetesInitializationTimeout;
 
             var resiliencePipeline = CreateKubernetesCallResiliencePipeline(retryDuration, isRetryable, activity, () => retryCount++);
             return await resiliencePipeline.ExecuteAsync(async (cancellationToken) =>
@@ -516,10 +511,8 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                 // Keep connection establishment inside the retry loop so kubeconfig read failures remain retryable.
                 await EnsureKubernetesClientAsync(cancellationToken).ConfigureAwait(false);
                 var result = await operation(_kubernetes!, cancellationToken).ConfigureAwait(false);
-                if (marksApiReady)
-                {
-                    Volatile.Write(ref _kubernetesApiReady, 1);
-                }
+                Volatile.Write(ref _kubernetesApiReady, true);
+
                 return result;
             }, cancellationToken).ConfigureAwait(false);
         }

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -133,6 +133,40 @@ public class KubernetesServiceTests
         await server.WaitForRequestCancellationAsync(cts.Token);
     }
 
+    [Fact]
+    public async Task WatchAsync_DoesNotMarkApiReady_WhileHttpResponseIsPending()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+
+        var (service, kubeconfigPath, fileSystem) = CreateService(
+            maxRetryDuration: TimeSpan.FromMilliseconds(500),
+            kubernetesInitializationTimeout: TimeSpan.FromSeconds(5));
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
+        server.BlockWatchResponses();
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        await using var watchEnumerator = service.WatchAsync<Container>(cancellationToken: watchCts.Token).GetAsyncEnumerator();
+        var watchTask = watchEnumerator.MoveNextAsync().AsTask();
+        await server.WaitForWatchRequestAsync(cts.Token);
+
+        // Three conflict retries take longer than the steady-state budget but remain within the initialization budget.
+        server.FailNextRequests(3);
+        try
+        {
+            Assert.Empty(await service.ListAsync<Container>(cancellationToken: cts.Token));
+        }
+        finally
+        {
+            watchCts.Cancel();
+            await server.WaitForRequestCancellationAsync(cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => watchTask);
+        }
+    }
+
     // Verifies that establishing the connection survives a partially-written kubeconfig: when the file exists
     // but DCP has only flushed part of it (so it does not yet parse as a valid kubeconfig), the read is retried
     // and the operation succeeds once the complete, valid kubeconfig is written.
@@ -359,6 +393,16 @@ public class KubernetesServiceTests
             Interlocked.Exchange(ref _responseState.ResponseDelayTicks, delay.Ticks);
         }
 
+        public void BlockWatchResponses()
+        {
+            Volatile.Write(ref _responseState.BlockWatchResponses, true);
+        }
+
+        public Task WaitForWatchRequestAsync(CancellationToken cancellationToken)
+        {
+            return _responseState.WatchRequestArrived.Task.WaitAsync(cancellationToken);
+        }
+
         public Task WaitForRequestCancellationAsync(CancellationToken cancellationToken)
         {
             return _responseState.RequestCancellationObserved.Task.WaitAsync(cancellationToken);
@@ -383,6 +427,22 @@ public class KubernetesServiceTests
 
             app.Run(async context =>
             {
+                var isWatchRequest = context.Request.Query.TryGetValue("watch", out var watchValues)
+                    && string.Equals(watchValues.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+                if (isWatchRequest && Volatile.Read(ref responseState.BlockWatchResponses))
+                {
+                    responseState.WatchRequestArrived.TrySetResult(true);
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, context.RequestAborted);
+                    }
+                    catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+                    {
+                        responseState.RequestCancellationObserved.TrySetResult(true);
+                        throw;
+                    }
+                }
+
                 var responseDelayTicks = Interlocked.Read(ref responseState.ResponseDelayTicks);
                 if (responseDelayTicks > 0)
                 {
@@ -425,11 +485,14 @@ public class KubernetesServiceTests
 
         private sealed class ResponseState
         {
+            public bool BlockWatchResponses;
             public int RequestCount;
             public TaskCompletionSource<bool> RequestCancellationObserved { get; } =
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
             public long ResponseDelayTicks;
             public int SuccessfulRequestNumber;
+            public TaskCompletionSource<bool> WatchRequestArrived { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/KubernetesServiceTests.cs
@@ -68,25 +68,69 @@ public class KubernetesServiceTests
     }
 
     [Fact]
-    public async Task ExecuteWithRetry_UsesApiRetryDuration_AfterKubernetesClientInitialization()
+    public async Task ExecuteWithRetry_UsesInitializationTimeout_UntilFirstApiOperationSucceeds()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
 
         var (service, kubeconfigPath, fileSystem) = CreateService(
             maxRetryDuration: TimeSpan.FromMilliseconds(500),
-            kubernetesConfigInitializationTimeout: TimeSpan.FromSeconds(5));
+            kubernetesInitializationTimeout: TimeSpan.FromSeconds(5));
         using var disposableFileSystem = fileSystem;
         using var disposableService = service;
 
         // The fourth API request succeeds after exponential retry delays of 100, 200, and 400 milliseconds.
-        // It is reachable under the initialization budget but not the 500-millisecond API budget.
+        // It is reachable under the initialization budget but not the 500-millisecond steady-state budget.
         await using var server = await TestDcpApiServer.StartAsync(cts.Token, successfulRequestNumber: 4);
         var listTask = service.ListAsync<Container>(cancellationToken: cts.Token);
 
         await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
         WriteKubeconfig(kubeconfigPath, server.Port);
 
-        await Assert.ThrowsAsync<TimeoutRejectedException>(() => listTask);
+        var result = await listTask;
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetry_UsesApiRetryDuration_AfterFirstApiOperationSucceeds()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService(
+            maxRetryDuration: TimeSpan.FromMilliseconds(500),
+            kubernetesInitializationTimeout: TimeSpan.FromSeconds(5));
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
+        WriteKubeconfig(kubeconfigPath, server.Port);
+
+        var result = await service.ListAsync<Container>(cancellationToken: cts.Token);
+        Assert.Empty(result);
+
+        server.FailNextRequests(3);
+        await Assert.ThrowsAsync<TimeoutRejectedException>(
+            () => service.ListAsync<Container>(cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetry_CancelsApiRequest_WhenRetryDurationExpires()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        var (service, kubeconfigPath, fileSystem) = CreateService(
+            maxRetryDuration: TimeSpan.FromMilliseconds(500),
+            kubernetesInitializationTimeout: TimeSpan.FromSeconds(5));
+        using var disposableFileSystem = fileSystem;
+        using var disposableService = service;
+
+        await using var server = await TestDcpApiServer.StartAsync(cts.Token);
+        WriteKubeconfig(kubeconfigPath, server.Port);
+        Assert.Empty(await service.ListAsync<Container>(cancellationToken: cts.Token));
+
+        server.DelayResponses(TimeSpan.FromSeconds(2));
+        await Assert.ThrowsAsync<TimeoutRejectedException>(
+            () => service.ListAsync<Container>(cancellationToken: cts.Token));
+        await server.WaitForRequestCancellationAsync(cts.Token);
     }
 
     // Verifies that establishing the connection survives a partially-written kubeconfig: when the file exists
@@ -120,7 +164,7 @@ public class KubernetesServiceTests
 
     private static (KubernetesService Service, string KubeconfigPath, IDisposable FileSystem) CreateService(
         TimeSpan? maxRetryDuration = null,
-        TimeSpan? kubernetesConfigInitializationTimeout = null)
+        TimeSpan? kubernetesInitializationTimeout = null)
     {
         var configuration = new ConfigurationBuilder().Build();
 
@@ -141,7 +185,7 @@ public class KubernetesServiceTests
             {
                 // Generous enough that the test can flip the kubeconfig before the retry budget is exhausted.
                 MaxRetryDuration = maxRetryDuration ?? TimeSpan.FromSeconds(30),
-                KubernetesConfigInitializationTimeout = kubernetesConfigInitializationTimeout ?? TimeSpan.FromSeconds(60),
+                KubernetesInitializationTimeout = kubernetesInitializationTimeout ?? TimeSpan.FromSeconds(60),
             };
 
             return (service, locations.DcpKubeconfigPath, fileSystem);
@@ -290,14 +334,35 @@ public class KubernetesServiceTests
     private sealed class TestDcpApiServer : IAsyncDisposable
     {
         private readonly WebApplication _app;
+        private readonly ResponseState _responseState;
 
-        private TestDcpApiServer(WebApplication app, int port)
+        private TestDcpApiServer(WebApplication app, int port, ResponseState responseState)
         {
             _app = app;
+            _responseState = responseState;
             Port = port;
         }
 
         public int Port { get; }
+
+        public void FailNextRequests(int count)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            Volatile.Write(
+                ref _responseState.SuccessfulRequestNumber,
+                Volatile.Read(ref _responseState.RequestCount) + count + 1);
+        }
+
+        public void DelayResponses(TimeSpan delay)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(delay, TimeSpan.Zero);
+            Interlocked.Exchange(ref _responseState.ResponseDelayTicks, delay.Ticks);
+        }
+
+        public Task WaitForRequestCancellationAsync(CancellationToken cancellationToken)
+        {
+            return _responseState.RequestCancellationObserved.Task.WaitAsync(cancellationToken);
+        }
 
         public static async Task<TestDcpApiServer> StartAsync(
             CancellationToken cancellationToken = default,
@@ -311,11 +376,28 @@ public class KubernetesServiceTests
             builder.WebHost.UseUrls("http://127.0.0.1:0");
 
             var app = builder.Build();
+            var responseState = new ResponseState
+            {
+                SuccessfulRequestNumber = successfulRequestNumber,
+            };
 
-            var requestCount = 0;
             app.Run(async context =>
             {
-                if (Interlocked.Increment(ref requestCount) < successfulRequestNumber)
+                var responseDelayTicks = Interlocked.Read(ref responseState.ResponseDelayTicks);
+                if (responseDelayTicks > 0)
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromTicks(responseDelayTicks), context.RequestAborted);
+                    }
+                    catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+                    {
+                        responseState.RequestCancellationObserved.TrySetResult(true);
+                        throw;
+                    }
+                }
+
+                if (Interlocked.Increment(ref responseState.RequestCount) < Volatile.Read(ref responseState.SuccessfulRequestNumber))
                 {
                     context.Response.StatusCode = StatusCodes.Status409Conflict;
                     return;
@@ -332,13 +414,22 @@ public class KubernetesServiceTests
             var address = app.Urls.First();
             var port = new Uri(address).Port;
 
-            return new TestDcpApiServer(app, port);
+            return new TestDcpApiServer(app, port, responseState);
         }
 
         public async ValueTask DisposeAsync()
         {
             await _app.StopAsync().ConfigureAwait(false);
             await _app.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private sealed class ResponseState
+        {
+            public int RequestCount;
+            public TaskCompletionSource<bool> RequestCancellationObserved { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public long ResponseDelayTicks;
+            public int SuccessfulRequestNumber;
         }
     }
 }


### PR DESCRIPTION
## Description

#19636 gave initial DCP kubeconfig discovery and client creation a separate 60-second timeout, but its first CI run still timed out in the first DCP API operation after the client was initialized. A parsed kubeconfig does not mean DCP is ready to process requests yet.

This keeps the startup timeout through the first successful eager DCP API operation. Calls that start before readiness retain that startup budget; later calls use the existing 20-second retry budget. Lazy watches do not publish readiness, and Polly's timeout token now reaches the underlying Kubernetes requests so stalled requests are canceled.

The regression coverage now checks delayed kubeconfig creation, delayed first API success, the transition back to the steady-state timeout, and cancellation of a stalled HTTP request.

Follow-up to #19636.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
