### PR TITLE
Update Nix flake manifest to v13.5.3

### DIFF
--- a/eng/nix/versions.json
+++ b/eng/nix/versions.json
@@ -1,30 +1,30 @@
 {
-  "version": "13.4.6",
-  "releaseTag": "v13.4.6",
+  "version": "13.5.2",
+  "releaseTag": "v13.5.2",
   "systems": {
     "aarch64-darwin": {
       "rid": "osx-arm64",
-      "archiveName": "aspire-cli-osx-arm64-13.4.6.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-osx-arm64-13.4.6.tar.gz",
-      "hash": "sha512-1oM2hmTf5dYlAHawepPisuJK0jl4XL4N0MIcYOpZ1uhu/MBmFUJeds7vGBrkmquCIpuMOL+yrONNIxEnSLEA3g=="
+      "archiveName": "aspire-cli-osx-arm64-13.5.2.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-osx-arm64-13.5.2.tar.gz",
+      "hash": "sha512-ZDqHfHQKSHNyvHFfe6Z5EAqOoS1/Nyp44OcI8D24Ei6O2nlCA2nt+4rJvnFVuRfjo+/NISwcRHrg+43/G261Ww=="
     },
     "aarch64-linux": {
       "rid": "linux-arm64",
-      "archiveName": "aspire-cli-linux-arm64-13.4.6.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-linux-arm64-13.4.6.tar.gz",
-      "hash": "sha512-BabHMBi89LD0o+ic5uvQH/19JcYnR0UBeFveefi0pB6OT2n0lexQgR8i1dUpTbOYEIrw0alnGtjMD5WasCAh0Q=="
+      "archiveName": "aspire-cli-linux-arm64-13.5.2.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-linux-arm64-13.5.2.tar.gz",
+      "hash": "sha512-VeWAhLN3jzkCTQaexW2Go5cl20EK4cw3DDlEj3FVbJcupRYvzXb9/qzLYvMsWdMHGgB5rGOUzWZmvlwtGJaBTg=="
     },
     "x86_64-darwin": {
       "rid": "osx-x64",
-      "archiveName": "aspire-cli-osx-x64-13.4.6.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-osx-x64-13.4.6.tar.gz",
-      "hash": "sha512-Ykf8p4I5cMhQ0F3DS+uVICCobOLZ1WrTx8Guud4c4V4nXtHWNk6A73wGHGWD8jJwI4AhXf3RkwhxHbbcjmPndw=="
+      "archiveName": "aspire-cli-osx-x64-13.5.2.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-osx-x64-13.5.2.tar.gz",
+      "hash": "sha512-5fluPsigyYGgnwhI1nJ5lcI9+HcS+gxhjhEXIxL9tVTLo+v+c4Sp6WZwr4/s7+MflszGXGfJj39USh+IExaZvQ=="
     },
     "x86_64-linux": {
       "rid": "linux-x64",
-      "archiveName": "aspire-cli-linux-x64-13.4.6.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-linux-x64-13.4.6.tar.gz",
-      "hash": "sha512-kYL/Wsf5TjmZRkAScf0dyxAfwp4MiZm2COlH9wI1TTCwnbTes6dunDqx3OBMc2eEe4or50PFjnqjpD5CIw8IRQ=="
+      "archiveName": "aspire-cli-linux-x64-13.5.2.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-linux-x64-13.5.2.tar.gz",
+      "hash": "sha512-KtFW9RLEJY10KxeaTtmc9j7qE02bKDHhHL2qtrpNi/bQZdPQxBp/c9jNv75iodOQfLpHeO06DBid4Re7tsryqg=="
     }
   }
 }

--- a/eng/nix/versions.json
+++ b/eng/nix/versions.json
@@ -1,30 +1,30 @@
 {
-  "version": "13.5.2",
-  "releaseTag": "v13.5.2",
+  "version": "13.5.3",
+  "releaseTag": "v13.5.3",
   "systems": {
     "aarch64-darwin": {
       "rid": "osx-arm64",
-      "archiveName": "aspire-cli-osx-arm64-13.5.2.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-osx-arm64-13.5.2.tar.gz",
-      "hash": "sha512-ZDqHfHQKSHNyvHFfe6Z5EAqOoS1/Nyp44OcI8D24Ei6O2nlCA2nt+4rJvnFVuRfjo+/NISwcRHrg+43/G261Ww=="
+      "archiveName": "aspire-cli-osx-arm64-13.5.3.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.3/aspire-cli-osx-arm64-13.5.3.tar.gz",
+      "hash": "sha512-Y8PYpBzEbpJnrDfnOAGhw0M+LThPBhUFN6+bu1ufC1F2fpZH4cksJ9/rQ13AQXb8aWTUh7s2GNZcicNjNO7P0w=="
     },
     "aarch64-linux": {
       "rid": "linux-arm64",
-      "archiveName": "aspire-cli-linux-arm64-13.5.2.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-linux-arm64-13.5.2.tar.gz",
-      "hash": "sha512-VeWAhLN3jzkCTQaexW2Go5cl20EK4cw3DDlEj3FVbJcupRYvzXb9/qzLYvMsWdMHGgB5rGOUzWZmvlwtGJaBTg=="
+      "archiveName": "aspire-cli-linux-arm64-13.5.3.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.3/aspire-cli-linux-arm64-13.5.3.tar.gz",
+      "hash": "sha512-ReFoW4oObNS3yyqsah98IOExC7p8zvTpzeZrVwroc3KE38uLn4eTolWxz3boXlPr01vXlAwqJNjrVGd/irAbCw=="
     },
     "x86_64-darwin": {
       "rid": "osx-x64",
-      "archiveName": "aspire-cli-osx-x64-13.5.2.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-osx-x64-13.5.2.tar.gz",
-      "hash": "sha512-5fluPsigyYGgnwhI1nJ5lcI9+HcS+gxhjhEXIxL9tVTLo+v+c4Sp6WZwr4/s7+MflszGXGfJj39USh+IExaZvQ=="
+      "archiveName": "aspire-cli-osx-x64-13.5.3.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.3/aspire-cli-osx-x64-13.5.3.tar.gz",
+      "hash": "sha512-UDshdU8yZXY1XRZvRuopQQNHqqcDKRvUW74xnOKJQABWBR1J7ueXxz2DJyVJZCT0mQ+q+fWUoI91CmNfMX0TmQ=="
     },
     "x86_64-linux": {
       "rid": "linux-x64",
-      "archiveName": "aspire-cli-linux-x64-13.5.2.tar.gz",
-      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.2/aspire-cli-linux-x64-13.5.2.tar.gz",
-      "hash": "sha512-KtFW9RLEJY10KxeaTtmc9j7qE02bKDHhHL2qtrpNi/bQZdPQxBp/c9jNv75iodOQfLpHeO06DBid4Re7tsryqg=="
+      "archiveName": "aspire-cli-linux-x64-13.5.3.tar.gz",
+      "url": "https://github.com/microsoft/aspire/releases/download/v13.5.3/aspire-cli-linux-x64-13.5.3.tar.gz",
+      "hash": "sha512-+1n/7mzoIg3sQiAc1xLqKqen5k2sA4OfhNolPKdQzgYr6HhZyNkViZr9T+II9LEnwiqA1UIOKalyTt/9UN9x1g=="
     }
   }
 }


### PR DESCRIPTION
Bumps `eng/nix/versions.json` to the published Aspire CLI `v13.5.3` release assets. Nix consumers of the first-party flake still resolve to `13.4.6`, released 2026-06-20 — the manifest has not moved since it was introduced in #18410, and four stable releases have shipped since.

Retargeted from `v13.5.2` to `v13.5.3` on 2026-08-31, since 13.5.3 was published while this PR was waiting for review.

## Why this is separate from the baseline PRs

The release pipeline already generates this change, but it ships bundled with the `PackageValidationBaselineVersion` bump in `src/Directory.Build.props`:

- #19482 — 13.5.0
- #19558 — 13.5.1
- #19589 — 13.5.2
- #19684 — 13.5.3

All four are still open with red CI, so the Nix manifest has been blocked behind an unrelated concern since 2026-08-18, while `main` itself is largely green.

On the previous head (`v13.5.2`) the manifest-only change passed a full run: 388 checks with a single unrelated `VS Code extension E2E (Linux, discovery-configuration)` failure, against 247 checks with 71 failures on #19589. That places the failures on the `src/Directory.Build.props` half rather than on the Nix change.

## Known blocker

`ManifestVersionMatchesPackageValidationBaselineVersion` in `tests/Infrastructure.Tests/Pipelines/NixCliPackageTests.cs` asserts that the manifest version equals `PackageValidationBaselineVersion`, which this PR deliberately leaves alone. Per the maintainer comment below that coupling looks incidental rather than required, so I have not touched the test pending an answer — happy to drop or redefine it here if that is the direction. #19655 tracks moving future stable-release Nix bumps into dedicated PRs.

## How it was produced

Generated with the in-repo updater against the published release, not hand-edited:

```
eng/nix/update-versions.sh --version 13.5.3
```

The SHA512 digests are read from the official `.sha512` release assets and converted to SRI hashes, exactly as the script documents.

## Verification

All four published archives were downloaded and re-hashed against their `.sha512` sidecars — all match. Built on `x86_64-linux` from this branch:

```
$ nix build github:av-leschinskiy/aspire/nix-manifest-13.5.2#aspire-cli
$ aspire --version
13.5.3+b5f143315ffb6968ea939a9978797a5b20e4c688
```

Only `x86_64-linux` was exercised locally; the other three platforms carry digests taken verbatim from their published `.sha512` assets.

If #19684 merges first this becomes a no-op — close it then.
