### PR TITLE
ci: run only tests affected by pull request changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,15 +63,16 @@ jobs:
 
       # Compute the selected test subset + non-.NET job booleans. The action reuses this job's checkout
       # (checkout=false) so the BeforeBuildProps.props it may write survives for enumerate-tests below,
-      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'false' keeps this audit-only
-      # (the knob is documented on the action's `enforce` input). No job-level actions/setup-dotnet on
+      # and does its own minimal SDK bootstrap (setupDotNet=true). enforce: 'true' restricts the test
+      # matrix and gates non-.NET jobs (the knob is documented on the action's `enforce` input).
+      # No job-level actions/setup-dotnet on
       # purpose -- global.json declares tools.runtimes, so Arcade always uses repo-local .dotnet.
       - name: Select relevant tests
         id: select_tests
         uses: ./.github/actions/select-tests
         with:
           checkout: 'false'
-          enforce: 'false'
+          enforce: 'true'
           commentFile: ${{ env.SELECT_TESTS_COMMENT_FILE }}
           # Kill switch: the 'run-full-ci' PR label forces the full matrix + all jobs. Read from the event
           # payload snapshot, so adding the label takes effect on the next push (or reopen), not on a
@@ -101,7 +102,7 @@ jobs:
       # enumerate-tests reuses this job's checkout + restore (checkout/restore=false) so the props
       # file the selector wrote survives -- a fresh checkout would git-clean it away. When a
       # restriction was written, beforeBuildPropsPath points enumerate at the selected subset; in
-      # audit mode project_override_props is empty and enumerate builds the full matrix.
+      # an ALL selection project_override_props is empty and enumerate builds the full matrix.
       #
       # Skipped entirely when the selection has no .NET test projects (has_dotnet_tests=false, e.g. an
       # extension-only / polyglot-only change whose only targets are non-.NET jobs). An empty selection

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -9,17 +9,16 @@ Companion documents:
 - [`test-trigger-map.md`](./test-trigger-map.md) — the descriptive path → target map.
 - [`eng/github-ci/test-trigger-map.yml`](../../eng/github-ci/test-trigger-map.yml) — its machine-readable form.
 
-**Status: audit.** `tests.yml`'s `setup_for_tests` runs the `select-tests` action
-*before* `enumerate-tests`. When its `enforce: 'true'` and the selection is
+**Status: enforcing.** `tests.yml`'s `setup_for_tests` runs the `select-tests`
+action *before* `enumerate-tests` with `enforce: 'true'`. When the selection is
 not ALL, the selector writes an `OverrideProjectToBuild` props file so
-`enumerate-tests` builds and enumerates only the selected projects; in audit mode
-(`enforce: 'false'`) it writes no props and `enumerate-tests` produces
-the full matrix unchanged while the summary still reports what enforcing would
-have skipped.
+`enumerate-tests` builds and enumerates only the selected projects. The
+`run-full-ci` label remains a kill switch that forces the full matrix and all
+jobs.
 
-Audit mode does not soften Layer 1 failures. If the affected-projects graph
-cannot be computed, `SelectTests` fails the step because under-selecting would
-silently skip real tests.
+Neither enforcing nor audit mode softens Layer 1 failures. If the
+affected-projects graph cannot be computed, `SelectTests` fails the step because
+under-selecting would silently skip real tests.
 
 ## Goal
 
@@ -453,10 +452,12 @@ The clean wins remain large and safe:
 - Component ↔ component isolation holds: an `Aspire.Npgsql` change does not pull
   unrelated Redis / RabbitMQ / MongoDB / Milvus component tests.
 
-## Audit mode
+## Enforcement and audit mode
 
-Audit mode computes the subset and writes a `$GITHUB_STEP_SUMMARY`, but CI still
-runs the full matrix and all jobs. The summary shows:
+Enforcing mode restricts the .NET matrix and gates non-.NET jobs to the computed
+selection. Audit mode remains available by passing `enforce: 'false'`; it computes
+the subset and writes a `$GITHUB_STEP_SUMMARY`, but CI still runs the full matrix
+and all jobs. The summary shows:
 
 - the invocation mode and change source;
 - selected test projects and triggered jobs, each annotated with **why** it was
@@ -488,9 +489,8 @@ audit mode the comment is advisory — the
 full matrix and all jobs still run — so it is labelled "(audit mode)" and states
 that the lists are what selective CI **would** run under enforcement.
 
-Any audit run where a would-be-skipped test would have failed is a map bug,
-fixed before enforcing. Once audit data shows the skip set is consistently safe,
-flip to enforcing and keep the `run-full-ci` kill switch.
+Any audit run where a would-be-skipped test would have failed is a map bug. Fix
+the map before returning to enforcing mode.
 
 ## Verifier test
 
@@ -596,9 +596,10 @@ run-all fallback exists to prevent.
 
 ## Rollout
 
-1. Run `SelectTests` in audit mode.
-2. Watch the audit summaries and fix unsafe skips in the curated layer.
-3. Flip to enforcing. Keep the kill switch and hard-fail Layer 1 policy.
+1. `SelectTests` ran in audit mode while its summaries were reviewed.
+2. Unsafe skips in the curated layer were fixed.
+3. `tests.yml` now runs in enforcing mode while retaining the `run-full-ci` kill
+   switch and hard-fail Layer 1 policy.
 
 ## Future refinement
 

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsWorkflowTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
+using YamlDotNet.RepresentationModel;
 
 namespace Infrastructure.Tests.TestTriggerMap;
 
@@ -43,6 +44,26 @@ public sealed class SelectTestsWorkflowTests
         Assert.Contains(
             "forceAll: ${{ contains(github.event.pull_request.labels.*.name, 'run-full-ci') }}",
             testsYml);
+    }
+
+    [Fact]
+    public void TestsWorkflowEnforcesSelectedTestSubset()
+    {
+        var yaml = new YamlStream();
+        using var reader = new StringReader(File.ReadAllText(TestsWorkflowPath));
+        yaml.Load(reader);
+
+        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
+        var jobs = (YamlMappingNode)root.Children[new YamlScalarNode("jobs")];
+        var setupForTests = (YamlMappingNode)jobs.Children[new YamlScalarNode("setup_for_tests")];
+        var steps = (YamlSequenceNode)setupForTests.Children[new YamlScalarNode("steps")];
+        var selectTests = Assert.Single(
+            steps.Cast<YamlMappingNode>(),
+            step => step.Children.TryGetValue(new YamlScalarNode("uses"), out var uses) &&
+                    uses.ToString() == "./.github/actions/select-tests");
+        var inputs = (YamlMappingNode)selectTests.Children[new YamlScalarNode("with")];
+
+        Assert.Equal("true", inputs.Children[new YamlScalarNode("enforce")].ToString());
     }
 
     // The comment_selection job posts one comment per pushed commit (createComment for a new commit,


### PR DESCRIPTION
## Description

**Pull request CI currently computes a relevant test subset but still runs the full test matrix and every non-.NET test job.** The selector is explicitly configured with `enforce: 'false'`, leaving conditional test selection in audit mode.

This enables enforcement so `enumerate-tests` builds only selected .NET test projects and the selector gates non-.NET jobs. The `run-full-ci` label remains available as a kill switch that forces the complete matrix and all jobs.

A workflow contract test pins enforcement to prevent an accidental return to audit mode, and the selector design documentation now reflects the active rollout state.

Validation:

```text
dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-namespace "Infrastructure.Tests.TestTriggerMap" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 131, Failed: 0, Skipped: 0
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
