### PR TITLE
Add AppHost-aware integration test scaffolding

### DIFF
--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -350,8 +350,8 @@ path_rules:
     reason: AppHostSdkTargetsTests asserts the per-RID orchestration package reference; TerminalHost exercises packaged DCP
   - paths:
       - src/Aspire.ProjectTemplates/**
-    targets: [test:Aspire.Templates.Tests]
-    reason: Templates.Tests installs the template hive from src/Aspire.ProjectTemplates
+    targets: [test:Aspire.Templates.Tests, test:Aspire.Cli.EndToEnd.Tests]
+    reason: Templates.Tests installs the template hive; CLI EndToEnd tests exercise the packaged templates through an installed CLI
   - paths:
       - src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
       - src/Aspire.ProjectTemplates/templates/aspire-starter/**

--- a/src/Aspire.Cli/CliConfigNames.cs
+++ b/src/Aspire.Cli/CliConfigNames.cs
@@ -8,4 +8,5 @@ internal static class CliConfigNames
 {
     public const string NoLogo = "ASPIRE_CLI_NOLOGO";
     public const string AppHostStartupTimeout = "ASPIRE_CLI_START_TIMEOUT";
+    public const string ShowAllTemplates = "ASPIRE_CLI_SHOW_ALL_TEMPLATES";
 }

--- a/src/Aspire.Cli/CliConfigNames.cs
+++ b/src/Aspire.Cli/CliConfigNames.cs
@@ -8,5 +8,4 @@ internal static class CliConfigNames
 {
     public const string NoLogo = "ASPIRE_CLI_NOLOGO";
     public const string AppHostStartupTimeout = "ASPIRE_CLI_START_TIMEOUT";
-    public const string ShowAllTemplates = "ASPIRE_CLI_SHOW_ALL_TEMPLATES";
 }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -602,9 +602,10 @@ internal sealed class NewCommand : BaseCommand
         // wiring skill — users can still opt into it from the prompt.
         var agentInitResult = await _agentInitCommand.PromptAndChainAsync(InteractionService, templateResult.ExitCode, workspaceRoot, agentInitBinding, skillLocationsBinding, skillsBinding, AgentInitCommand.ExcludeOneTimeSetupSkillsFromDefaults, cancellationToken);
 
-        if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
+        var editorPath = templateResult.EditorPath ?? templateResult.OutputPath;
+        if (editorPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
         {
-            extensionInteractionService.OpenEditor(templateResult.OutputPath);
+            extensionInteractionService.OpenEditor(editorPath);
         }
 
         return CommandResult.FromExitCode(agentInitResult.ExitCode);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -651,7 +651,7 @@ internal sealed class NewCommand : BaseCommand
 
 internal interface INewCommandPrompter
 {
-    Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
+    Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken, PromptBinding<string?>? binding = null);
     Task<string> PromptForProjectNameAsync(string defaultName, ParseResult parseResult, CancellationToken cancellationToken);
     Task<string> PromptForOutputPath(string v, ParseResult parseResult, Func<string, ValidationResult>? validator = null, Func<string, string>? outputPathResolver = null, CancellationToken cancellationToken = default);
 }
@@ -797,12 +797,13 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
             cancellationToken: cancellationToken);
     }
 
-    public virtual async Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
+    public virtual async Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken, PromptBinding<string?>? binding = null)
     {
         return await interactionService.PromptForSelectionAsync(
             NewCommandStrings.SelectAProjectTemplate,
             validTemplates,
             t => t.Description.EscapeMarkup(),
+            binding: binding,
             cancellationToken: cancellationToken
         );
     }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -269,7 +269,8 @@ internal sealed class NewCommand : BaseCommand
                 .ToList();
         }
 
-        // Sort templates alphabetically by description, keeping empty templates at the end
+        // Keep the established AppHost templates first so adding secondary scaffolding templates
+        // does not change the default selection for `aspire new`. Empty templates remain last.
         templates.Sort((a, b) =>
         {
             var aIsEmpty = a.IsEmpty;
@@ -278,6 +279,14 @@ internal sealed class NewCommand : BaseCommand
             if (aIsEmpty != bIsEmpty)
             {
                 return aIsEmpty ? 1 : -1;
+            }
+
+            var aIsIntegrationTest = a.Name.Equals(KnownTemplateId.IntegrationTest, StringComparison.OrdinalIgnoreCase);
+            var bIsIntegrationTest = b.Name.Equals(KnownTemplateId.IntegrationTest, StringComparison.OrdinalIgnoreCase);
+
+            if (aIsIntegrationTest != bIsIntegrationTest)
+            {
+                return aIsIntegrationTest ? 1 : -1;
             }
 
             return string.Compare(a.Description, b.Description, StringComparison.OrdinalIgnoreCase);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -585,7 +585,15 @@ internal sealed class NewCommand : BaseCommand
             Channel = resolvedChannelName,
             Language = selectedLanguageId
         };
-        var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
+        TemplateResult templateResult;
+        try
+        {
+            templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
+        }
+        catch (ProjectLocatorException ex)
+        {
+            return HandleProjectLocatorException(ex, InteractionService, Telemetry);
+        }
 
         // Generated AppHosts can be run directly by dotnet, which cannot trigger lazy bundle
         // extraction. Ensure the bundle is ready instead of relying on best-effort prefetching.

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -1079,7 +1079,7 @@ internal sealed class ProjectLocator(
                     }
                 }
 
-                // If no handler matched, for .cs files check if we should search the parent directory
+                // An invalid apphost.cs can still identify a directory containing a project-based AppHost.
                 if (projectFile.Name.Equals("apphost.cs", StringComparison.OrdinalIgnoreCase) && projectFile.Directory is { } parentDirectory)
                 {
                     // File exists but is not a valid single-file apphost. Search in the parent directory.
@@ -1092,6 +1092,13 @@ internal sealed class ProjectLocator(
                         displayProgress,
                         projectOptionSpecifiedAsDirectory,
                         cancellationToken);
+                }
+
+                if (handler is not null)
+                {
+                    throw new ProjectLocatorException(
+                        ErrorStrings.ProjectFileNotAppHostProject,
+                        ProjectLocatorFailureReason.ProjectFileNotAppHostProject);
                 }
 
                 // No handler can process this file

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -1085,13 +1085,25 @@ internal sealed class ProjectLocator(
                     // File exists but is not a valid single-file apphost. Search in the parent directory.
                     // Propagate displayProgress so callers that opted out of progress UI (e.g. the hidden
                     // `extension get-apphosts` flow) do not start emitting progress on this fallback path.
-                    return await UseOrFindAppHostProjectFileCoreAsync(
-                        new FileInfo(parentDirectory.FullName),
-                        multipleAppHostProjectsFoundBehavior,
-                        createSettingsFile,
-                        displayProgress,
-                        projectOptionSpecifiedAsDirectory,
-                        cancellationToken);
+                    try
+                    {
+                        return await UseOrFindAppHostProjectFileCoreAsync(
+                            new FileInfo(parentDirectory.FullName),
+                            multipleAppHostProjectsFoundBehavior,
+                            createSettingsFile,
+                            displayProgress,
+                            projectOptionSpecifiedAsDirectory,
+                            cancellationToken);
+                    }
+                    catch (ProjectLocatorException ex) when (ex.FailureReason is ProjectLocatorFailureReason.ProjectFileDoesntExist)
+                    {
+                        // The original file exists, so an empty fallback search means it is not a
+                        // valid AppHost rather than that the user supplied a nonexistent path.
+                        logger.LogDebug(ex, "No project-based AppHost was found beside invalid single-file AppHost {ProjectFile}.", projectFile.FullName);
+                        throw new ProjectLocatorException(
+                            ErrorStrings.ProjectFileNotAppHostProject,
+                            ProjectLocatorFailureReason.ProjectFileNotAppHostProject);
+                    }
                 }
 
                 if (handler is not null)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -878,7 +878,25 @@ internal sealed class ProjectLocator(
         return UseOrFindAppHostProjectFileAsync(projectFile, multipleAppHostProjectsFoundBehavior, createSettingsFile, displayProgress: true, cancellationToken);
     }
 
-    public async Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, bool displayProgress, CancellationToken cancellationToken = default)
+    public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, bool displayProgress, CancellationToken cancellationToken = default)
+    {
+        var projectOptionSpecifiedAsDirectory = projectFile is not null && Directory.Exists(projectFile.FullName);
+        return UseOrFindAppHostProjectFileCoreAsync(
+            projectFile,
+            multipleAppHostProjectsFoundBehavior,
+            createSettingsFile,
+            displayProgress,
+            projectOptionSpecifiedAsDirectory,
+            cancellationToken);
+    }
+
+    private async Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileCoreAsync(
+        FileInfo? projectFile,
+        MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior,
+        bool createSettingsFile,
+        bool displayProgress,
+        bool projectOptionSpecifiedAsDirectory,
+        CancellationToken cancellationToken)
     {
         logger.LogDebug("Finding project file in {CurrentDirectory}", executionContext.WorkingDirectory);
         var explicitSelectionWasPrompted = false;
@@ -942,16 +960,25 @@ internal sealed class ProjectLocator(
                     {
                         // Several broken candidates under one directory is a genuine ambiguity rather than
                         // a user selection, so this stays a project-resolution failure.
-                        throw new ProjectLocatorException(ErrorStrings.AppHostsMayNotBeBuildable, ProjectLocatorFailureReason.AppHostsMayNotBeBuildable);
+                        throw new ProjectLocatorException(
+                            ErrorStrings.AppHostsMayNotBeBuildable,
+                            ProjectLocatorFailureReason.AppHostsMayNotBeBuildable,
+                            projectOptionSpecifiedAsDirectory);
                     }
 
                     if (searchResults.UnsupportedProjects.Any(file => IsUnderDirectory(file, directory)))
                     {
-                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.UnsupportedProjects);
+                        throw new ProjectLocatorException(
+                            ErrorStrings.NoProjectFileFound,
+                            ProjectLocatorFailureReason.UnsupportedProjects,
+                            projectOptionSpecifiedAsDirectory);
                     }
 
                     logger.LogError("No AppHost project files found in directory {Directory}", directory.FullName);
-                    throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist, ProjectLocatorFailureReason.ProjectFileDoesntExist);
+                    throw new ProjectLocatorException(
+                        ErrorStrings.ProjectFileDoesntExist,
+                        ProjectLocatorFailureReason.ProjectFileDoesntExist,
+                        projectOptionSpecifiedAsDirectory);
                 }
                 else if (appHostProjects.Count == 1)
                 {
@@ -979,7 +1006,10 @@ internal sealed class ProjectLocator(
                     else if (multipleAppHostProjectsFoundBehavior is MultipleAppHostProjectsFoundBehavior.Throw)
                     {
                         logger.LogError("Multiple AppHost project files found in directory {Directory}, throwing exception", directory.FullName);
-                        throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound, ProjectLocatorFailureReason.MultipleProjectFilesFound);
+                        throw new ProjectLocatorException(
+                            ErrorStrings.MultipleProjectFilesFound,
+                            ProjectLocatorFailureReason.MultipleProjectFilesFound,
+                            projectOptionSpecifiedAsDirectory);
                     }
                 }
             }
@@ -1055,7 +1085,13 @@ internal sealed class ProjectLocator(
                     // File exists but is not a valid single-file apphost. Search in the parent directory.
                     // Propagate displayProgress so callers that opted out of progress UI (e.g. the hidden
                     // `extension get-apphosts` flow) do not start emitting progress on this fallback path.
-                    return await UseOrFindAppHostProjectFileAsync(new FileInfo(parentDirectory.FullName), multipleAppHostProjectsFoundBehavior, createSettingsFile, displayProgress, cancellationToken);
+                    return await UseOrFindAppHostProjectFileCoreAsync(
+                        new FileInfo(parentDirectory.FullName),
+                        multipleAppHostProjectsFoundBehavior,
+                        createSettingsFile,
+                        displayProgress,
+                        projectOptionSpecifiedAsDirectory,
+                        cancellationToken);
                 }
 
                 // No handler can process this file
@@ -1414,9 +1450,14 @@ internal sealed class ProjectLocator(
     }
 }
 
-internal class ProjectLocatorException(string message, ProjectLocatorFailureReason failureReason) : System.Exception(message)
+internal class ProjectLocatorException(
+    string message,
+    ProjectLocatorFailureReason failureReason,
+    bool projectOptionSpecifiedAsDirectory = false) : System.Exception(message)
 {
     public ProjectLocatorFailureReason FailureReason { get; } = failureReason;
+
+    public bool ProjectOptionSpecifiedAsDirectory { get; } = projectOptionSpecifiedAsDirectory;
 }
 
 internal static class ProjectLocatorErrorHelper
@@ -1424,6 +1465,7 @@ internal static class ProjectLocatorErrorHelper
     public static (int ExitCode, string ErrorMessage) GetExitCodeAndMessage(ProjectLocatorException ex, bool projectOptionSpecifiedAsDirectory = false)
     {
         ArgumentNullException.ThrowIfNull(ex);
+        projectOptionSpecifiedAsDirectory |= ex.ProjectOptionSpecifiedAsDirectory;
 
         return ex.FailureReason switch
         {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -61,6 +61,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The path to the Aspire AppHost project file.
+        /// </summary>
+        public static string AppHostProjectOptionDescription {
+            get {
+                return ResourceManager.GetString("AppHostProjectOptionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to AppHost.
         /// </summary>
         public static string AspireAppHost_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -223,6 +223,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net..
+        /// </summary>
+        public static string IntegrationTestFrameworkOptionDescription {
+            get {
+                return ResourceManager.GetString("IntegrationTestFrameworkOptionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Integration tests.
         /// </summary>
         public static string IntegrationTestsTemplate_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -223,7 +223,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net..
+        ///   Looks up a localized string similar to Selects the test framework for the integration test project: MSTest, NUnit, or xUnit..
         /// </summary>
         public static string IntegrationTestFrameworkOptionDescription {
             get {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -241,6 +241,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project..
+        /// </summary>
+        public static string IntegrationTestAppHostReferenceNotSupported {
+            get {
+                return ResourceManager.GetString("IntegrationTestAppHostReferenceNotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Integration tests.
         /// </summary>
         public static string IntegrationTestsTemplate_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -232,6 +232,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Integration test scaffolding can only reference a C# AppHost project (.csproj)..
+        /// </summary>
+        public static string IntegrationTestAppHostMustBeCSharpProject {
+            get {
+                return ResourceManager.GetString("IntegrationTestAppHostMustBeCSharpProject", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Integration tests.
         /// </summary>
         public static string IntegrationTestsTemplate_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The path to the Aspire AppHost project file.
+        ///   Looks up a localized string similar to The path to the Aspire AppHost project file or a directory to search.
         /// </summary>
         public static string AppHostProjectOptionDescription {
             get {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -156,6 +156,9 @@
   <data name="IntegrationTestsTemplate_Description" xml:space="preserve">
     <value>Integration tests</value>
   </data>
+  <data name="AppHostProjectOptionDescription" xml:space="preserve">
+    <value>The path to the Aspire AppHost project file</value>
+  </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>
   </data>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -157,7 +157,7 @@
     <value>Integration tests</value>
   </data>
   <data name="IntegrationTestFrameworkOptionDescription" xml:space="preserve">
-    <value>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</value>
+    <value>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</value>
   </data>
   <data name="AppHostProjectOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -156,6 +156,9 @@
   <data name="IntegrationTestsTemplate_Description" xml:space="preserve">
     <value>Integration tests</value>
   </data>
+  <data name="IntegrationTestFrameworkOptionDescription" xml:space="preserve">
+    <value>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</value>
+  </data>
   <data name="AppHostProjectOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file</value>
   </data>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -163,7 +163,7 @@
     <value>Integration test scaffolding can only reference a C# AppHost project (.csproj).</value>
   </data>
   <data name="AppHostProjectOptionDescription" xml:space="preserve">
-    <value>The path to the Aspire AppHost project file</value>
+    <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -162,6 +162,10 @@
   <data name="IntegrationTestAppHostMustBeCSharpProject" xml:space="preserve">
     <value>Integration test scaffolding can only reference a C# AppHost project (.csproj).</value>
   </data>
+  <data name="IntegrationTestAppHostReferenceNotSupported" xml:space="preserve">
+    <value>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</value>
+    <comment>{0} is a template name, {1} is a package version.</comment>
+  </data>
   <data name="AppHostProjectOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file or a directory to search</value>
   </data>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -159,6 +159,9 @@
   <data name="IntegrationTestFrameworkOptionDescription" xml:space="preserve">
     <value>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</value>
   </data>
+  <data name="IntegrationTestAppHostMustBeCSharpProject" xml:space="preserve">
+    <value>Integration test scaffolding can only reference a C# AppHost project (.csproj).</value>
+  </data>
   <data name="AppHostProjectOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Načítají se šablony...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Integrační testy</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Načítají se šablony...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Vorlagen werden abgerufen...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Integrationstests</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Vorlagen werden abgerufen...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obteniendo plantillas...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Pruebas de integración</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obteniendo plantillas...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obtention des modèles...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Tests d'intégration</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obtention des modèles...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Recupero dei modelli in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Test di integrazione</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Recupero dei modelli in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -92,6 +92,11 @@
         <target state="translated">テンプレートを取得しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">統合テスト</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -92,6 +92,11 @@
         <target state="translated">テンプレートを取得しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -92,6 +92,11 @@
         <target state="translated">템플릿을 가져오는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">통합 테스트</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -92,6 +92,11 @@
         <target state="translated">템플릿을 가져오는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Trwa pobieranie szablonów...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Testy integracji</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Trwa pobieranie szablonów...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obtendo modelos...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Testes de integração</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Obtendo modelos...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Получение шаблонов...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Тесты интеграции</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Получение шаблонов...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Şablonlar alınıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">Tümleştirme testleri</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Şablonlar alınıyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="translated">正在获取模板...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">集成测试</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="translated">正在获取模板...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TemplatingStrings.resx">
     <body>
+      <trans-unit id="AppHostProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file</source>
+        <target state="new">The path to the Aspire AppHost project file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireAppHost_Description">
         <source>AppHost</source>
         <target state="translated">AppHost</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
-        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
-        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="translated">正在取得範本...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestFrameworkOptionDescription">
+        <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</source>
+        <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
         <source>Integration tests</source>
         <target state="translated">整合測試</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="translated">正在取得範本...</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostMustBeCSharpProject">
+        <source>Integration test scaffolding can only reference a C# AppHost project (.csproj).</source>
+        <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="new">Integration test scaffolding can only reference a C# AppHost project (.csproj).</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntegrationTestAppHostReferenceNotSupported">
+        <source>The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</source>
+        <target state="new">The '{0}' template in Aspire.ProjectTemplates {1} does not support AppHost references. Choose a template version that supports AppHost references, or omit --apphost to generate a standalone test project.</target>
+        <note>{0} is a template name, {1} is a package version.</note>
+      </trans-unit>
       <trans-unit id="IntegrationTestFrameworkOptionDescription">
         <source>Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</source>
         <target state="new">Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.</target>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AppHostProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file</source>
-        <target state="new">The path to the Aspire AppHost project file</target>
+        <source>The path to the Aspire AppHost project file or a directory to search</source>
+        <target state="new">The path to the Aspire AppHost project file or a directory to search</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireAppHost_Description">

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -529,9 +529,7 @@ internal class DotNetTemplateFactory(
 
                 if (appHostTargetFramework is not null)
                 {
-                    // The templates map their Framework symbol to dotnet new's conventional
-                    // lowercase --framework option in dotnetcli.host.json.
-                    extraArgs = [.. extraArgs, "--framework", appHostTargetFramework];
+                    extraArgs = [.. extraArgs, "--AppHostTargetFramework", appHostTargetFramework];
                 }
             }
 

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -27,6 +27,7 @@ internal class DotNetTemplateFactory(
     AspireCliTelemetry telemetry,
     ICliHostEnvironment hostEnvironment,
     TemplateNuGetConfigService templateNuGetConfigService,
+    IAppHostInfoResolver appHostInfoResolver,
     IEnvironment environment)
     : ITemplateFactory
 {
@@ -512,6 +513,9 @@ internal class DotNetTemplateFactory(
             var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
             if (appHostProject is not null)
             {
+                var appHostInfo = await appHostInfoResolver.GetAppHostInfoAsync(appHostProject, cancellationToken);
+                var appHostTargetFramework = GetAppHostTargetFramework(appHostInfo);
+
                 extraArgs =
                 [
                     .. extraArgs,
@@ -522,6 +526,13 @@ internal class DotNetTemplateFactory(
                     "--AppHostProjectName",
                     Path.GetFileNameWithoutExtension(appHostProject.Name)
                 ];
+
+                if (appHostTargetFramework is not null)
+                {
+                    // The templates map their Framework symbol to dotnet new's conventional
+                    // lowercase --framework option in dotnetcli.host.json.
+                    extraArgs = [.. extraArgs, "--framework", appHostTargetFramework];
+                }
             }
 
             var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
@@ -641,6 +652,28 @@ internal class DotNetTemplateFactory(
             interactionService.DisplayError(ex.Message);
             return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
+    }
+
+    private static string? GetAppHostTargetFramework(AppHostProjectInfo appHostInfo)
+    {
+        if (appHostInfo.ExitCode != 0)
+        {
+            return null;
+        }
+
+        var targetFrameworks = appHostInfo.TargetFrameworks?.Split(
+            ';',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (targetFrameworks is { Length: > 0 })
+        {
+            // Target the first declared framework so the generated single-target test project
+            // matches an AppHost inner build without guessing which SDK is preferred or installed.
+            return targetFrameworks[0];
+        }
+
+        return string.IsNullOrWhiteSpace(appHostInfo.TargetFramework)
+            ? null
+            : appHostInfo.TargetFramework.Trim();
     }
 
     private static string EscapeMSBuildItemValue(string value)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -215,36 +215,33 @@ internal class DotNetTemplateFactory(
 
         // Prepends a test framework selection step then calls the
         // underlying test template.
-        if (showAllTemplates)
-        {
-            yield return new CallbackTemplate(
-                "aspire-test",
-                TemplatingStrings.IntegrationTestsTemplate_Description,
-                (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
-                command => AddOptionIfMissing(command, _appHostOption),
-                async (template, inputs, parseResult, ct) =>
+        yield return new CallbackTemplate(
+            "aspire-test",
+            TemplatingStrings.IntegrationTestsTemplate_Description,
+            (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
+            command => AddOptionIfMissing(command, _appHostOption),
+            async (template, inputs, parseResult, ct) =>
+            {
+                var appHostProject = parseResult.GetValue(_appHostOption);
+                if (appHostProject is { Exists: false })
                 {
-                    var appHostProject = parseResult.GetValue(_appHostOption);
-                    if (appHostProject is { Exists: false })
-                    {
-                        interactionService.DisplayError(InteractionServiceStrings.ProjectOptionDoesntExist);
-                        return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
-                    }
+                    interactionService.DisplayError(InteractionServiceStrings.ProjectOptionDoesntExist);
+                    return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
+                }
 
-                    var testTemplate = await prompter.PromptForTemplateAsync(
-                        [msTestTemplate, xunitTemplate, nunitTemplate],
-                        ct
-                    );
+                var testTemplate = await prompter.PromptForTemplateAsync(
+                    [msTestTemplate, xunitTemplate, nunitTemplate],
+                    ct
+                );
 
-                    var testCallbackTemplate = (CallbackTemplate)testTemplate;
-                    Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback = testCallbackTemplate.Name == "aspire-xunit"
-                        ? PromptForExtraAspireXUnitOptionsAsync
-                        : (_, _) => Task.FromResult(Array.Empty<string>());
+                var testCallbackTemplate = (CallbackTemplate)testTemplate;
+                Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback = testCallbackTemplate.Name == "aspire-xunit"
+                    ? PromptForExtraAspireXUnitOptionsAsync
+                    : (_, _) => Task.FromResult(Array.Empty<string>());
 
-                    return await ApplyTemplateAsync(testCallbackTemplate, inputs, parseResult, extraArgsCallback, ct, appHostProject);
-                },
-                languageId: KnownLanguageId.CSharp);
-        }
+                return await ApplyTemplateAsync(testCallbackTemplate, inputs, parseResult, extraArgsCallback, ct, appHostProject);
+            },
+            languageId: KnownLanguageId.CSharp);
     }
 
     private CallbackTemplate CreateSingleFileTemplate()

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -183,6 +183,11 @@ internal class DotNetTemplateFactory(
                 );
         }
 
+        if (!showAllTemplates)
+        {
+            yield break;
+        }
+
         // Folded into the last yielded template.
         var msTestTemplate = new CallbackTemplate(
             "aspire-mstest",

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -63,8 +63,7 @@ internal class DotNetTemplateFactory(
             return [];
         }
 
-        var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
-        return GetTemplatesCore(showAllTemplates);
+        return GetTemplatesCore(ShouldShowAllTemplates());
     }
 
     public async Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
@@ -74,8 +73,7 @@ internal class DotNetTemplateFactory(
             return [];
         }
 
-        var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
-        return GetTemplatesCore(showAllTemplates);
+        return GetTemplatesCore(ShouldShowAllTemplates());
     }
 
     public async Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default)
@@ -130,6 +128,15 @@ internal class DotNetTemplateFactory(
         }
 
         return false;
+    }
+
+    private bool ShouldShowAllTemplates()
+    {
+        // This process-scoped switch lets tooling expose gated templates for one CLI invocation
+        // without rewriting user settings or changing configuration-provider precedence.
+        return features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false) ||
+            bool.TryParse(environment.GetEnvironmentVariable(CliConfigNames.ShowAllTemplates), out var showAllTemplates) &&
+            showAllTemplates;
     }
 
     private IEnumerable<ITemplate> GetTemplatesCore(bool showAllTemplates)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -53,7 +53,7 @@ internal class DotNetTemplateFactory(
     };
     private readonly Option<FileInfo?> _appHostOption = new("--apphost")
     {
-        Description = SharedCommandStrings.AppHostOptionDescription
+        Description = TemplatingStrings.AppHostProjectOptionDescription
     };
 
     public IEnumerable<ITemplate> GetTemplates()

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -51,6 +51,10 @@ internal class DotNetTemplateFactory(
     {
         Description = TemplatingStrings.EnterXUnitVersion_Description
     };
+    private readonly Option<FileInfo?> _appHostOption = new("--apphost")
+    {
+        Description = SharedCommandStrings.AppHostOptionDescription
+    };
 
     public IEnumerable<ITemplate> GetTemplates()
     {
@@ -179,7 +183,7 @@ internal class DotNetTemplateFactory(
                 );
         }
 
-        // Folded into the last yieled template.
+        // Folded into the last yielded template.
         var msTestTemplate = new CallbackTemplate(
             "aspire-mstest",
             TemplatingStrings.AspireMSTest_Description,
@@ -217,16 +221,27 @@ internal class DotNetTemplateFactory(
                 "aspire-test",
                 TemplatingStrings.IntegrationTestsTemplate_Description,
                 (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
-                _ => { },
+                command => AddOptionIfMissing(command, _appHostOption),
                 async (template, inputs, parseResult, ct) =>
                 {
+                    var appHostProject = parseResult.GetValue(_appHostOption);
+                    if (appHostProject is { Exists: false })
+                    {
+                        interactionService.DisplayError(InteractionServiceStrings.ProjectOptionDoesntExist);
+                        return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
+                    }
+
                     var testTemplate = await prompter.PromptForTemplateAsync(
                         [msTestTemplate, xunitTemplate, nunitTemplate],
                         ct
                     );
 
                     var testCallbackTemplate = (CallbackTemplate)testTemplate;
-                    return await testCallbackTemplate.ApplyTemplateAsync(inputs, parseResult, ct);
+                    Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback = testCallbackTemplate.Name == "aspire-xunit"
+                        ? PromptForExtraAspireXUnitOptionsAsync
+                        : (_, _) => Task.FromResult(Array.Empty<string>());
+
+                    return await ApplyTemplateAsync(testCallbackTemplate, inputs, parseResult, extraArgsCallback, ct, appHostProject);
                 },
                 languageId: KnownLanguageId.CSharp);
         }
@@ -436,7 +451,13 @@ internal class DotNetTemplateFactory(
         }
     }
 
-    private async Task<TemplateResult> ApplyTemplateAsync(CallbackTemplate template, TemplateInputs inputs, ParseResult parseResult, Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyTemplateAsync(
+        CallbackTemplate template,
+        TemplateInputs inputs,
+        ParseResult parseResult,
+        Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback,
+        CancellationToken cancellationToken,
+        FileInfo? appHostProject = null)
     {
         if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken: cancellationToken))
         {
@@ -451,10 +472,18 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
-        return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken);
+        return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken, appHostProject);
     }
 
-    private async Task<TemplateResult> ApplyTemplateAsync(CallbackTemplate template, TemplateInputs inputs, string name, string outputPath, ParseResult parseResult, Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback, CancellationToken cancellationToken)
+    private async Task<TemplateResult> ApplyTemplateAsync(
+        CallbackTemplate template,
+        TemplateInputs inputs,
+        string name,
+        string outputPath,
+        ParseResult parseResult,
+        Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback,
+        CancellationToken cancellationToken,
+        FileInfo? appHostProject = null)
     {
         try
         {
@@ -472,6 +501,19 @@ internal class DotNetTemplateFactory(
             // Some templates have additional arguments that need to be applied to the `dotnet new` command
             // when it is executed. This callback will get those arguments and potentially prompt for them.
             var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
+            if (appHostProject is not null)
+            {
+                extraArgs =
+                [
+                    .. extraArgs,
+                    "--WithAppHostReference",
+                    "true",
+                    "--AppHostProjectPath",
+                    EscapeMSBuildItemValue(Path.GetRelativePath(outputPath, appHostProject.FullName)),
+                    "--AppHostProjectName",
+                    Path.GetFileNameWithoutExtension(appHostProject.Name)
+                ];
+            }
 
             var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
                 selectedTemplateDetails,
@@ -562,7 +604,10 @@ internal class DotNetTemplateFactory(
 
             interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreatedSuccessfully, outputPath));
 
-            return new TemplateResult(CliExitCodes.Success, outputPath);
+            return new TemplateResult(
+                CliExitCodes.Success,
+                outputPath,
+                appHostProject is null ? null : Path.Combine(outputPath, "IntegrationTest1.cs"));
         }
         catch (OperationCanceledException)
         {
@@ -587,6 +632,22 @@ internal class DotNetTemplateFactory(
             interactionService.DisplayError(ex.Message);
             return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
+    }
+
+    private static string EscapeMSBuildItemValue(string value)
+    {
+        // MSBuild item Include values use %-escaped sequences. Escape existing '%' first so a literal
+        // value like "foo%3Bbar" remains literal instead of being decoded into "foo;bar".
+        return value
+            .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("$", "%24", StringComparison.Ordinal)
+            .Replace("@", "%40", StringComparison.Ordinal)
+            .Replace("'", "%27", StringComparison.Ordinal)
+            .Replace(";", "%3B", StringComparison.Ordinal)
+            .Replace("?", "%3F", StringComparison.Ordinal)
+            .Replace("*", "%2A", StringComparison.Ordinal)
+            .Replace("(", "%28", StringComparison.Ordinal)
+            .Replace(")", "%29", StringComparison.Ordinal);
     }
 
     private async Task<string> GetProjectNameAsync(TemplateInputs inputs, string templateName, ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -32,6 +32,7 @@ internal class DotNetTemplateFactory(
     : ITemplateFactory
 {
     private const string NoTestFramework = "None";
+    private const string IntegrationTestSourceFileName = "IntegrationTest1.cs";
 
     // Template-specific options
     private readonly Option<bool?> _localhostTldOption = new("--localhost-tld")
@@ -186,7 +187,7 @@ internal class DotNetTemplateFactory(
 
         // Folded into the last yielded template.
         var msTestTemplate = new CallbackTemplate(
-            "aspire-mstest",
+            KnownTemplateId.MSTest,
             TemplatingStrings.AspireMSTest_Description,
             (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
@@ -196,7 +197,7 @@ internal class DotNetTemplateFactory(
 
         // Folded into the last yielded template.
         var nunitTemplate = new CallbackTemplate(
-            "aspire-nunit",
+            KnownTemplateId.NUnit,
             TemplatingStrings.AspireNUnit_Description,
             (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
@@ -206,7 +207,7 @@ internal class DotNetTemplateFactory(
 
         // Folded into the last yielded template.
         var xunitTemplate = new CallbackTemplate(
-            "aspire-xunit",
+            KnownTemplateId.XUnit,
             TemplatingStrings.AspireXUnit_Description,
             (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             _ => { },
@@ -217,7 +218,7 @@ internal class DotNetTemplateFactory(
         // Prepends a test framework selection step then calls the
         // underlying test template.
         yield return new CallbackTemplate(
-            "aspire-test",
+            KnownTemplateId.IntegrationTest,
             TemplatingStrings.IntegrationTestsTemplate_Description,
             (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
             command =>
@@ -242,7 +243,7 @@ internal class DotNetTemplateFactory(
                 );
 
                 var testCallbackTemplate = (CallbackTemplate)testTemplate;
-                Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback = testCallbackTemplate.Name == "aspire-xunit"
+                Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback = testCallbackTemplate.Name == KnownTemplateId.XUnit
                     ? PromptForExtraAspireXUnitOptionsAsync
                     : (_, _) => Task.FromResult(Array.Empty<string>());
 
@@ -619,7 +620,7 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(
                 CliExitCodes.Success,
                 outputPath,
-                appHostProject is null ? null : Path.Combine(outputPath, "IntegrationTest1.cs"));
+                appHostProject is null ? null : Path.Combine(outputPath, IntegrationTestSourceFileName));
         }
         catch (OperationCanceledException)
         {

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -64,7 +64,8 @@ internal class DotNetTemplateFactory(
             return [];
         }
 
-        return GetTemplatesCore(ShouldShowAllTemplates());
+        var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
+        return GetTemplatesCore(showAllTemplates);
     }
 
     public async Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
@@ -74,7 +75,8 @@ internal class DotNetTemplateFactory(
             return [];
         }
 
-        return GetTemplatesCore(ShouldShowAllTemplates());
+        var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
+        return GetTemplatesCore(showAllTemplates);
     }
 
     public async Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default)
@@ -131,15 +133,6 @@ internal class DotNetTemplateFactory(
         return false;
     }
 
-    private bool ShouldShowAllTemplates()
-    {
-        // This process-scoped switch lets tooling expose gated templates for one CLI invocation
-        // without rewriting user settings or changing configuration-provider precedence.
-        return features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false) ||
-            bool.TryParse(environment.GetEnvironmentVariable(CliConfigNames.ShowAllTemplates), out var showAllTemplates) &&
-            showAllTemplates;
-    }
-
     private IEnumerable<ITemplate> GetTemplatesCore(bool showAllTemplates)
     {
         yield return new CallbackTemplate(
@@ -189,11 +182,6 @@ internal class DotNetTemplateFactory(
                 ApplyTemplateWithNoExtraArgsAsync,
                 languageId: KnownLanguageId.CSharp
                 );
-        }
-
-        if (!showAllTemplates)
-        {
-            yield break;
         }
 
         // Folded into the last yielded template.

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -49,6 +49,10 @@ internal class DotNetTemplateFactory(
     {
         Description = TemplatingStrings.PromptForTFMOptions_Description
     };
+    private readonly Option<string?> _integrationTestFrameworkOption = new("--test-framework")
+    {
+        Description = TemplatingStrings.IntegrationTestFrameworkOptionDescription
+    };
     private readonly Option<string?> _xunitVersionOption = new("--xunit-version")
     {
         Description = TemplatingStrings.EnterXUnitVersion_Description
@@ -224,7 +228,7 @@ internal class DotNetTemplateFactory(
             command =>
             {
                 AddOptionIfMissing(command, _appHostOption);
-                AddOptionIfMissing(command, _testFrameworkOption);
+                AddOptionIfMissing(command, _integrationTestFrameworkOption);
                 AddOptionIfMissing(command, _xunitVersionOption);
             },
             async (template, inputs, parseResult, ct) =>
@@ -239,7 +243,7 @@ internal class DotNetTemplateFactory(
                 var testTemplate = await prompter.PromptForTemplateAsync(
                     [msTestTemplate, xunitTemplate, nunitTemplate],
                     ct,
-                    PromptBinding.Create(parseResult, _testFrameworkOption)
+                    PromptBinding.Create(parseResult, _integrationTestFrameworkOption)
                 );
 
                 var testCallbackTemplate = (CallbackTemplate)testTemplate;

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -220,7 +220,12 @@ internal class DotNetTemplateFactory(
             "aspire-test",
             TemplatingStrings.IntegrationTestsTemplate_Description,
             (ctx, projectName) => OutputPathHelper.GetUniqueDefaultOutputPath(projectName, ctx.WorkingDirectory.FullName),
-            command => AddOptionIfMissing(command, _appHostOption),
+            command =>
+            {
+                AddOptionIfMissing(command, _appHostOption);
+                AddOptionIfMissing(command, _testFrameworkOption);
+                AddOptionIfMissing(command, _xunitVersionOption);
+            },
             async (template, inputs, parseResult, ct) =>
             {
                 var appHostProject = parseResult.GetValue(_appHostOption);
@@ -232,7 +237,8 @@ internal class DotNetTemplateFactory(
 
                 var testTemplate = await prompter.PromptForTemplateAsync(
                     [msTestTemplate, xunitTemplate, nunitTemplate],
-                    ct
+                    ct,
+                    PromptBinding.Create(parseResult, _testFrameworkOption)
                 );
 
                 var testCallbackTemplate = (CallbackTemplate)testTemplate;

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -237,76 +237,6 @@ internal class DotNetTemplateFactory(
             },
             async (template, inputs, parseResult, ct) =>
             {
-                var specifiedAppHostProject = parseResult.GetValue(_appHostOption);
-                var specifiedAppHostProjectIsDirectory = specifiedAppHostProject is not null
-                    && Directory.Exists(specifiedAppHostProject.FullName);
-                AppHostProjectSearchResult searchResult;
-                try
-                {
-                    // Resolve every candidate before selecting one because the generic locator also
-                    // discovers AppHost types that a C# integration test project cannot reference.
-                    searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
-                        specifiedAppHostProject,
-                        MultipleAppHostProjectsFoundBehavior.None,
-                        createSettingsFile: false,
-                        ct);
-                }
-                catch (ProjectLocatorException ex) when (
-                    specifiedAppHostProject is null &&
-                    ex.FailureReason is ProjectLocatorFailureReason.NoProjectFileFound
-                        or ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
-                        or ProjectLocatorFailureReason.UnsupportedProjects)
-                {
-                    // AppHost discovery improves the generated test project when possible, but the underlying
-                    // templates also support standalone projects. Explicit --apphost errors still surface.
-                    logger.LogDebug(ex, "No compatible AppHost project was discovered. Generating a standalone integration test project.");
-                    searchResult = new AppHostProjectSearchResult(null, []);
-                }
-
-                var appHostProject = searchResult.SelectedProjectFile;
-                if (appHostProject is null || !IsCompatibleIntegrationTestAppHost(appHostProject))
-                {
-                    if (appHostProject is not null)
-                    {
-                        logger.LogDebug(
-                            "The selected AppHost {AppHostProjectPath} cannot be referenced by a C# integration test project. Considering other discovered AppHosts.",
-                            appHostProject.FullName);
-                    }
-
-                    // A workspace setting can select a non-C# AppHost even when the discovery result
-                    // also contains compatible C# projects. Explicit directories can likewise contain
-                    // several AppHost types. Filter the complete candidate set before deciding whether
-                    // to generate standalone, select automatically, prompt, or fail.
-                    var compatibleAppHostProjects = searchResult.AllProjectFileCandidates
-                        .Where(IsCompatibleIntegrationTestAppHost)
-                        .ToList();
-                    appHostProject = compatibleAppHostProjects.Count switch
-                    {
-                        1 => compatibleAppHostProjects[0],
-                        > 1 when hostEnvironment.SupportsInteractiveInput => await interactionService.PromptForSelectionAsync(
-                            InteractionServiceStrings.SelectAppHostToUse,
-                            compatibleAppHostProjects,
-                            projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})",
-                            cancellationToken: ct),
-                        > 1 => throw new ProjectLocatorException(
-                            ErrorStrings.MultipleProjectFilesFound,
-                            ProjectLocatorFailureReason.MultipleProjectFilesFound,
-                            specifiedAppHostProjectIsDirectory),
-                        _ => null
-                    };
-                }
-
-                if (specifiedAppHostProject is not null && appHostProject is null)
-                {
-                    if (searchResult.SelectedProjectFile is null && searchResult.AllProjectFileCandidates.Count == 0)
-                    {
-                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
-                    }
-
-                    interactionService.DisplayError(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject);
-                    return new TemplateResult(CliExitCodes.FailedToFindProject);
-                }
-
                 var testTemplate = await prompter.PromptForTemplateAsync(
                     [msTestTemplate, xunitTemplate, nunitTemplate],
                     ct,
@@ -318,9 +248,135 @@ internal class DotNetTemplateFactory(
                     ? PromptForExtraAspireXUnitOptionsAsync
                     : (_, _) => Task.FromResult(Array.Empty<string>());
 
-                return await ApplyTemplateAsync(testCallbackTemplate, inputs, parseResult, extraArgsCallback, ct, appHostProject);
+                return await ApplyTemplateAsync(testCallbackTemplate, inputs, parseResult, extraArgsCallback, ct, resolveIntegrationTestAppHost: true);
             },
             languageId: KnownLanguageId.CSharp);
+    }
+
+    private async Task<(FileInfo? AppHostProject, TemplateResult? Error)> ResolveIntegrationTestAppHostAsync(
+        string templateName,
+        string templateVersion,
+        string projectName,
+        string outputPath,
+        ParseResult parseResult,
+        CancellationToken cancellationToken)
+    {
+        // Probe the installed template rather than guessing from its version: local builds can
+        // reuse older version numbers, and older daily packages may lack the reference symbols.
+        // "dotnet new aspire-mstest --dry-run --WithAppHostReference false" neither writes files
+        // nor runs post-creation actions, and false avoids needing an AppHost for the probe.
+        var collector = new OutputCollector();
+        var probeExitCode = await runner.NewProjectAsync(
+            templateName,
+            projectName,
+            outputPath,
+            ["--dry-run", "--WithAppHostReference", "false"],
+            new ProcessInvocationOptions
+            {
+                StandardOutputCallback = collector.AppendOutput,
+                StandardErrorCallback = collector.AppendOutput,
+            },
+            cancellationToken);
+
+        var specifiedAppHostProject = parseResult.GetValue(_appHostOption);
+
+        // The only template parameter in the probe is WithAppHostReference. Exit code 127 means
+        // it is unsupported; other failures must still surface instead of becoming standalone.
+        // See https://aka.ms/templating-exit-codes#127.
+        if (probeExitCode == 127)
+        {
+            if (specifiedAppHostProject is not null)
+            {
+                interactionService.DisplayError(string.Format(
+                    CultureInfo.CurrentCulture,
+                    TemplatingStrings.IntegrationTestAppHostReferenceNotSupported,
+                    templateName,
+                    templateVersion));
+                return (null, new TemplateResult(CliExitCodes.FailedToCreateNewProject));
+            }
+
+            logger.LogDebug(
+                "Template {TemplateName} from Aspire.ProjectTemplates {TemplateVersion} does not support AppHost references. Generating a standalone integration test project.",
+                templateName,
+                templateVersion);
+            return (null, null);
+        }
+
+        if (probeExitCode != 0)
+        {
+            return (null, HandleProjectCreationFailure(probeExitCode, collector));
+        }
+
+        var specifiedAppHostProjectIsDirectory = specifiedAppHostProject is not null
+            && Directory.Exists(specifiedAppHostProject.FullName);
+        AppHostProjectSearchResult searchResult;
+        try
+        {
+            // Resolve every candidate before selecting one because the generic locator also
+            // discovers AppHost types that a C# integration test project cannot reference.
+            searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+                specifiedAppHostProject,
+                MultipleAppHostProjectsFoundBehavior.None,
+                createSettingsFile: false,
+                cancellationToken);
+        }
+        catch (ProjectLocatorException ex) when (
+            specifiedAppHostProject is null &&
+            ex.FailureReason is ProjectLocatorFailureReason.NoProjectFileFound
+                or ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
+                or ProjectLocatorFailureReason.UnsupportedProjects)
+        {
+            // AppHost discovery improves the generated test project when possible, but the underlying
+            // templates also support standalone projects. Explicit --apphost errors still surface.
+            logger.LogDebug(ex, "No compatible AppHost project was discovered. Generating a standalone integration test project.");
+            searchResult = new AppHostProjectSearchResult(null, []);
+        }
+
+        var appHostProject = searchResult.SelectedProjectFile;
+        if (appHostProject is null || !IsCompatibleIntegrationTestAppHost(appHostProject))
+        {
+            if (appHostProject is not null)
+            {
+                logger.LogDebug(
+                    "The selected AppHost {AppHostProjectPath} cannot be referenced by a C# integration test project. Considering other discovered AppHosts.",
+                    appHostProject.FullName);
+            }
+
+            // A workspace setting can select a non-C# AppHost even when the discovery result
+            // also contains compatible C# projects. Explicit directories can likewise contain
+            // several AppHost types. Filter the complete candidate set before deciding whether
+            // to generate standalone, select automatically, prompt, or fail.
+            var compatibleAppHostProjects = searchResult.AllProjectFileCandidates
+                .Where(IsCompatibleIntegrationTestAppHost)
+                .ToList();
+            appHostProject = compatibleAppHostProjects.Count switch
+            {
+                1 => compatibleAppHostProjects[0],
+                > 1 when hostEnvironment.SupportsInteractiveInput => await interactionService.PromptForSelectionAsync(
+                    InteractionServiceStrings.SelectAppHostToUse,
+                    compatibleAppHostProjects,
+                    projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})",
+                    cancellationToken: cancellationToken),
+                > 1 => throw new ProjectLocatorException(
+                    ErrorStrings.MultipleProjectFilesFound,
+                    ProjectLocatorFailureReason.MultipleProjectFilesFound,
+                    specifiedAppHostProjectIsDirectory),
+                _ => null
+            };
+        }
+
+        if (specifiedAppHostProject is not null && appHostProject is null)
+        {
+            if (searchResult.SelectedProjectFile is null && searchResult.AllProjectFileCandidates.Count == 0)
+            {
+                throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
+            }
+
+            interactionService.DisplayError(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject);
+            return (null, new TemplateResult(CliExitCodes.FailedToFindProject));
+        }
+
+        return (appHostProject, null);
     }
 
     private static bool IsCompatibleIntegrationTestAppHost(FileInfo appHostProject)
@@ -536,7 +592,7 @@ internal class DotNetTemplateFactory(
         ParseResult parseResult,
         Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback,
         CancellationToken cancellationToken,
-        FileInfo? appHostProject = null)
+        bool resolveIntegrationTestAppHost = false)
     {
         if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken: cancellationToken))
         {
@@ -551,7 +607,7 @@ internal class DotNetTemplateFactory(
             return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
 
-        return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken, appHostProject);
+        return await ApplyTemplateAsync(template, inputs, name, outputPath, parseResult, extraArgsCallback, cancellationToken, resolveIntegrationTestAppHost);
     }
 
     private async Task<TemplateResult> ApplyTemplateAsync(
@@ -562,7 +618,7 @@ internal class DotNetTemplateFactory(
         ParseResult parseResult,
         Func<ParseResult, CancellationToken, Task<string[]>> extraArgsCallback,
         CancellationToken cancellationToken,
-        FileInfo? appHostProject = null)
+        bool resolveIntegrationTestAppHost = false)
     {
         try
         {
@@ -580,6 +636,41 @@ internal class DotNetTemplateFactory(
             // Some templates have additional arguments that need to be applied to the `dotnet new` command
             // when it is executed. This callback will get those arguments and potentially prompt for them.
             var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
+            var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
+                selectedTemplateDetails,
+                sourceOverride: inputs.Source,
+                runner,
+                TemplatingStrings.GettingTemplates,
+                statusEmoji: KnownEmojis.Ice,
+                cancellationToken);
+
+            if (installOutcome.ExitCode != 0)
+            {
+                interactionService.DisplayLines(installOutcome.OutputLines);
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
+                return new TemplateResult(CliExitCodes.FailedToInstallTemplates);
+            }
+
+            interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, installOutcome.TemplateVersion));
+
+            FileInfo? appHostProject = null;
+            if (resolveIntegrationTestAppHost)
+            {
+                var (resolvedAppHostProject, error) = await ResolveIntegrationTestAppHostAsync(
+                    template.Name,
+                    selectedTemplateDetails.Package.Version,
+                    name,
+                    outputPath,
+                    parseResult,
+                    cancellationToken);
+                if (error is not null)
+                {
+                    return error;
+                }
+
+                appHostProject = resolvedAppHostProject;
+            }
+
             if (appHostProject is not null)
             {
                 string? appHostTargetFramework = null;
@@ -590,8 +681,8 @@ internal class DotNetTemplateFactory(
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    // Target-framework alignment is best-effort because --apphost only requires an
-                    // existing project path. Preserve scaffolding when optional MSBuild inspection fails.
+                    // The AppHost has already been selected. Preserve scaffolding when this
+                    // additional, optional MSBuild inspection cannot determine its target framework.
                     logger.LogDebug(ex, "Failed to resolve target framework for AppHost project {AppHostProjectPath}. Using the template default.", appHostProject.FullName);
                 }
 
@@ -611,23 +702,6 @@ internal class DotNetTemplateFactory(
                     extraArgs = [.. extraArgs, "--AppHostTargetFramework", appHostTargetFramework];
                 }
             }
-
-            var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
-                selectedTemplateDetails,
-                sourceOverride: inputs.Source,
-                runner,
-                TemplatingStrings.GettingTemplates,
-                statusEmoji: KnownEmojis.Ice,
-                cancellationToken);
-
-            if (installOutcome.ExitCode != 0)
-            {
-                interactionService.DisplayLines(installOutcome.OutputLines);
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, installOutcome.ExitCode));
-                return new TemplateResult(CliExitCodes.FailedToInstallTemplates);
-            }
-
-            interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, installOutcome.TemplateVersion));
 
             var newProjectCollector = new OutputCollector();
             var newProjectExitCode = await interactionService.ShowStatusAsync(
@@ -653,17 +727,7 @@ internal class DotNetTemplateFactory(
 
             if (newProjectExitCode != 0)
             {
-                // Exit code 73 indicates that the output directory already contains files from a previous project
-                // See: https://github.com/microsoft/aspire/issues/9685
-                if (newProjectExitCode == 73)
-                {
-                    interactionService.DisplayError(TemplatingStrings.ProjectAlreadyExists);
-                    return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
-                }
-
-                interactionService.DisplayLines(newProjectCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode));
-                return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
+                return HandleProjectCreationFailure(newProjectExitCode, newProjectCollector);
             }
 
             // Trust certificates (result not used since we're not launching an AppHost)
@@ -729,6 +793,23 @@ internal class DotNetTemplateFactory(
             interactionService.DisplayError(ex.Message);
             return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
         }
+    }
+
+    private TemplateResult HandleProjectCreationFailure(int exitCode, OutputCollector collector)
+    {
+        // Exit code 73 indicates that the output directory already contains files from a previous project.
+        // See: https://github.com/microsoft/aspire/issues/9685.
+        if (exitCode == 73)
+        {
+            interactionService.DisplayError(TemplatingStrings.ProjectAlreadyExists);
+        }
+        else
+        {
+            interactionService.DisplayLines(collector.GetLines());
+            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, exitCode));
+        }
+
+        return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
     }
 
     private static string? GetAppHostTargetFramework(AppHostProjectInfo appHostInfo)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -14,6 +14,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Aspire.Cli.Templating;
 
@@ -29,6 +30,7 @@ internal class DotNetTemplateFactory(
     ICliHostEnvironment hostEnvironment,
     TemplateNuGetConfigService templateNuGetConfigService,
     IAppHostInfoResolver appHostInfoResolver,
+    IProjectLocator projectLocator,
     IEnvironment environment,
     ILogger<DotNetTemplateFactory> logger)
     : ITemplateFactory
@@ -235,11 +237,75 @@ internal class DotNetTemplateFactory(
             },
             async (template, inputs, parseResult, ct) =>
             {
-                var appHostProject = parseResult.GetValue(_appHostOption);
-                if (appHostProject is { Exists: false })
+                var specifiedAppHostProject = parseResult.GetValue(_appHostOption);
+                var multipleAppHostProjectsFoundBehavior = specifiedAppHostProject is null
+                    ? MultipleAppHostProjectsFoundBehavior.None
+                    : hostEnvironment.SupportsInteractiveInput
+                        ? MultipleAppHostProjectsFoundBehavior.Prompt
+                        : MultipleAppHostProjectsFoundBehavior.Throw;
+                AppHostProjectSearchResult searchResult;
+                try
                 {
-                    interactionService.DisplayError(InteractionServiceStrings.ProjectOptionDoesntExist);
-                    return new TemplateResult(CliExitCodes.FailedToCreateNewProject);
+                    searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+                        specifiedAppHostProject,
+                        multipleAppHostProjectsFoundBehavior,
+                        createSettingsFile: false,
+                        ct);
+                }
+                catch (ProjectLocatorException ex) when (
+                    specifiedAppHostProject is null &&
+                    ex.FailureReason is ProjectLocatorFailureReason.NoProjectFileFound
+                        or ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
+                        or ProjectLocatorFailureReason.UnsupportedProjects)
+                {
+                    // AppHost discovery improves the generated test project when possible, but the underlying
+                    // templates also support standalone projects. Explicit --apphost errors still surface.
+                    logger.LogDebug(ex, "No compatible AppHost project was discovered. Generating a standalone integration test project.");
+                    searchResult = new AppHostProjectSearchResult(null, []);
+                }
+
+                var appHostProject = searchResult.SelectedProjectFile;
+                if (specifiedAppHostProject is not null)
+                {
+                    if (appHostProject is null)
+                    {
+                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
+                    }
+
+                    if (!IsCompatibleIntegrationTestAppHost(appHostProject))
+                    {
+                        interactionService.DisplayError(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject);
+                        return new TemplateResult(CliExitCodes.FailedToFindProject);
+                    }
+                }
+                else if (appHostProject is null || !IsCompatibleIntegrationTestAppHost(appHostProject))
+                {
+                    if (appHostProject is not null)
+                    {
+                        logger.LogDebug(
+                            "The selected AppHost {AppHostProjectPath} cannot be referenced by a C# integration test project. Considering other discovered AppHosts.",
+                            appHostProject.FullName);
+                    }
+
+                    // A workspace setting can select a non-C# AppHost even when the discovery result
+                    // also contains compatible C# projects. Filter the complete candidate set before
+                    // deciding whether to generate standalone, select automatically, prompt, or fail.
+                    var compatibleAppHostProjects = searchResult.AllProjectFileCandidates
+                        .Where(IsCompatibleIntegrationTestAppHost)
+                        .ToList();
+                    appHostProject = compatibleAppHostProjects.Count switch
+                    {
+                        1 => compatibleAppHostProjects[0],
+                        > 1 when hostEnvironment.SupportsInteractiveInput => await interactionService.PromptForSelectionAsync(
+                            InteractionServiceStrings.SelectAppHostToUse,
+                            compatibleAppHostProjects,
+                            projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})",
+                            cancellationToken: ct),
+                        > 1 => throw new ProjectLocatorException(
+                            ErrorStrings.MultipleProjectFilesFound,
+                            ProjectLocatorFailureReason.MultipleProjectFilesFound),
+                        _ => null
+                    };
                 }
 
                 var testTemplate = await prompter.PromptForTemplateAsync(
@@ -257,6 +323,9 @@ internal class DotNetTemplateFactory(
             },
             languageId: KnownLanguageId.CSharp);
     }
+
+    private static bool IsCompatibleIntegrationTestAppHost(FileInfo appHostProject)
+        => string.Equals(appHostProject.Extension, ".csproj", StringComparison.OrdinalIgnoreCase);
 
     private CallbackTemplate CreateSingleFileTemplate()
     {

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -238,17 +238,16 @@ internal class DotNetTemplateFactory(
             async (template, inputs, parseResult, ct) =>
             {
                 var specifiedAppHostProject = parseResult.GetValue(_appHostOption);
-                var multipleAppHostProjectsFoundBehavior = specifiedAppHostProject is null
-                    ? MultipleAppHostProjectsFoundBehavior.None
-                    : hostEnvironment.SupportsInteractiveInput
-                        ? MultipleAppHostProjectsFoundBehavior.Prompt
-                        : MultipleAppHostProjectsFoundBehavior.Throw;
+                var specifiedAppHostProjectIsDirectory = specifiedAppHostProject is not null
+                    && Directory.Exists(specifiedAppHostProject.FullName);
                 AppHostProjectSearchResult searchResult;
                 try
                 {
+                    // Resolve every candidate before selecting one because the generic locator also
+                    // discovers AppHost types that a C# integration test project cannot reference.
                     searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
                         specifiedAppHostProject,
-                        multipleAppHostProjectsFoundBehavior,
+                        MultipleAppHostProjectsFoundBehavior.None,
                         createSettingsFile: false,
                         ct);
                 }
@@ -265,20 +264,7 @@ internal class DotNetTemplateFactory(
                 }
 
                 var appHostProject = searchResult.SelectedProjectFile;
-                if (specifiedAppHostProject is not null)
-                {
-                    if (appHostProject is null)
-                    {
-                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
-                    }
-
-                    if (!IsCompatibleIntegrationTestAppHost(appHostProject))
-                    {
-                        interactionService.DisplayError(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject);
-                        return new TemplateResult(CliExitCodes.FailedToFindProject);
-                    }
-                }
-                else if (appHostProject is null || !IsCompatibleIntegrationTestAppHost(appHostProject))
+                if (appHostProject is null || !IsCompatibleIntegrationTestAppHost(appHostProject))
                 {
                     if (appHostProject is not null)
                     {
@@ -288,8 +274,9 @@ internal class DotNetTemplateFactory(
                     }
 
                     // A workspace setting can select a non-C# AppHost even when the discovery result
-                    // also contains compatible C# projects. Filter the complete candidate set before
-                    // deciding whether to generate standalone, select automatically, prompt, or fail.
+                    // also contains compatible C# projects. Explicit directories can likewise contain
+                    // several AppHost types. Filter the complete candidate set before deciding whether
+                    // to generate standalone, select automatically, prompt, or fail.
                     var compatibleAppHostProjects = searchResult.AllProjectFileCandidates
                         .Where(IsCompatibleIntegrationTestAppHost)
                         .ToList();
@@ -303,9 +290,21 @@ internal class DotNetTemplateFactory(
                             cancellationToken: ct),
                         > 1 => throw new ProjectLocatorException(
                             ErrorStrings.MultipleProjectFilesFound,
-                            ProjectLocatorFailureReason.MultipleProjectFilesFound),
+                            ProjectLocatorFailureReason.MultipleProjectFilesFound,
+                            specifiedAppHostProjectIsDirectory),
                         _ => null
                     };
+                }
+
+                if (specifiedAppHostProject is not null && appHostProject is null)
+                {
+                    if (searchResult.SelectedProjectFile is null && searchResult.AllProjectFileCandidates.Count == 0)
+                    {
+                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
+                    }
+
+                    interactionService.DisplayError(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject);
+                    return new TemplateResult(CliExitCodes.FailedToFindProject);
                 }
 
                 var testTemplate = await prompter.PromptForTemplateAsync(

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Templating;
 
@@ -28,7 +29,8 @@ internal class DotNetTemplateFactory(
     ICliHostEnvironment hostEnvironment,
     TemplateNuGetConfigService templateNuGetConfigService,
     IAppHostInfoResolver appHostInfoResolver,
-    IEnvironment environment)
+    IEnvironment environment,
+    ILogger<DotNetTemplateFactory> logger)
     : ITemplateFactory
 {
     private const string NoTestFramework = "None";
@@ -512,8 +514,18 @@ internal class DotNetTemplateFactory(
             var extraArgs = await extraArgsCallback(parseResult, cancellationToken);
             if (appHostProject is not null)
             {
-                var appHostInfo = await appHostInfoResolver.GetAppHostInfoAsync(appHostProject, cancellationToken);
-                var appHostTargetFramework = GetAppHostTargetFramework(appHostInfo);
+                string? appHostTargetFramework = null;
+                try
+                {
+                    var appHostInfo = await appHostInfoResolver.GetAppHostInfoAsync(appHostProject, cancellationToken);
+                    appHostTargetFramework = GetAppHostTargetFramework(appHostInfo);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Target-framework alignment is best-effort because --apphost only requires an
+                    // existing project path. Preserve scaffolding when optional MSBuild inspection fails.
+                    logger.LogDebug(ex, "Failed to resolve target framework for AppHost project {AppHostProjectPath}. Using the template default.", appHostProject.FullName);
+                }
 
                 extraArgs =
                 [

--- a/src/Aspire.Cli/Templating/ITemplate.cs
+++ b/src/Aspire.Cli/Templating/ITemplate.cs
@@ -73,4 +73,4 @@ internal interface ITemplate
     Task<TemplateResult> ApplyTemplateAsync(TemplateInputs inputs, ParseResult parseResult, CancellationToken cancellationToken);
 }
 
-internal sealed record TemplateResult(int ExitCode, string? OutputPath = null);
+internal sealed record TemplateResult(int ExitCode, string? OutputPath = null, string? EditorPath = null);

--- a/src/Aspire.Cli/Templating/KnownTemplateId.cs
+++ b/src/Aspire.Cli/Templating/KnownTemplateId.cs
@@ -34,6 +34,26 @@ internal static class KnownTemplateId
     public const string TypeScriptStarter = "aspire-ts-starter";
 
     /// <summary>
+    /// The template ID for the grouped integration test template.
+    /// </summary>
+    public const string IntegrationTest = "aspire-test";
+
+    /// <summary>
+    /// The template ID for the MSTest integration test template.
+    /// </summary>
+    public const string MSTest = "aspire-mstest";
+
+    /// <summary>
+    /// The template ID for the NUnit integration test template.
+    /// </summary>
+    public const string NUnit = "aspire-nunit";
+
+    /// <summary>
+    /// The template ID for the xUnit integration test template.
+    /// </summary>
+    public const string XUnit = "aspire-xunit";
+
+    /// <summary>
     /// The template ID for the CLI Java empty AppHost template.
     /// </summary>
     public const string JavaEmptyAppHost = "aspire-java-empty";

--- a/src/Aspire.Cli/Utils/ExtensionHelper.cs
+++ b/src/Aspire.Cli/Utils/ExtensionHelper.cs
@@ -58,11 +58,8 @@ internal static class KnownCapabilities
     // Advertised so tooling can pass `aspire run --launch-profile` only to CLIs that understand it.
     public const string LaunchProfile = "launch-profile.v1";
 
-    // Advertised so tooling can target an AppHost with `aspire new aspire-test --apphost`.
-    public const string AspireTestAppHost = "aspire-test-apphost.v1";
-
     /// <summary>
     /// Gets the set of capabilities this CLI advertises to extensions.
     /// </summary>
-    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, PipelineStepListJson, DescribeIncludeDisabledCommands, LsJsonStream, IsolatedLaunch, LaunchProfile, AspireTestAppHost];
+    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, PipelineStepListJson, DescribeIncludeDisabledCommands, LsJsonStream, IsolatedLaunch, LaunchProfile];
 }

--- a/src/Aspire.Cli/Utils/ExtensionHelper.cs
+++ b/src/Aspire.Cli/Utils/ExtensionHelper.cs
@@ -58,8 +58,11 @@ internal static class KnownCapabilities
     // Advertised so tooling can pass `aspire run --launch-profile` only to CLIs that understand it.
     public const string LaunchProfile = "launch-profile.v1";
 
+    // Advertised so tooling can target an AppHost with `aspire new aspire-test --apphost`.
+    public const string AspireTestAppHost = "aspire-test-apphost.v1";
+
     /// <summary>
     /// Gets the set of capabilities this CLI advertises to extensions.
     /// </summary>
-    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, PipelineStepListJson, DescribeIncludeDisabledCommands, LsJsonStream, IsolatedLaunch, LaunchProfile];
+    public static string[] GetAdvertisedCapabilities() => [DevKit, Project, BuildDotnetUsingCli, Baseline, SecretPrompts, FilePickers, Pipelines, PipelineStepListJson, DescribeIncludeDisabledCommands, LsJsonStream, IsolatedLaunch, LaunchProfile, AspireTestAppHost];
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
       "Framework": {
         "longName": "framework"
       },
+      "AppHostTargetFramework": {
+        "longName": "AppHostTargetFramework",
+        "shortName": ""
+      },
       "skipRestore": {
         "longName": "no-restore",
         "shortName": ""

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/dotnetcli.host.json
@@ -6,7 +6,17 @@
       },
       "AppHostTargetFramework": {
         "longName": "AppHostTargetFramework",
-        "shortName": ""
+        "shortName": "",
+        "isHidden": true
+      },
+      "AppHostProjectPath": {
+        "isHidden": true
+      },
+      "AppHostProjectName": {
+        "isHidden": true
+      },
+      "WithAppHostReference": {
+        "isHidden": true
       },
       "skipRestore": {
         "longName": "no-restore",

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -59,6 +59,43 @@
       "replaces": "net8.0",
       "defaultValue": "net10.0"
     },
+    "AppHostProjectPath": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "AppHostProjectName": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "WithAppHostReference": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "GeneratedAppHostProjectType": {
+      "type": "generated",
+      "generator": "regex",
+      "datatype": "string",
+      "replaces": "GeneratedAppHostProjectType",
+      "parameters": {
+        "source": "AppHostProjectName",
+        "steps": [
+          {
+            "regex": "(((?<=\\.)|^)(?=\\d)|\\W)",
+            "replacement": "_"
+          }
+        ]
+      }
+    },
+    "XmlEncodedAppHostProjectPath": {
+      "type": "derived",
+      "datatype": "string",
+      "replaces": "XmlEncodedAppHostProjectPath",
+      "valueSource": "AppHostProjectPath",
+      "valueTransform": "xmlEncode"
+    },
     "hostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -56,8 +56,12 @@
           "description": "Target net11.0"
         }
       ],
-      "replaces": "net8.0",
       "defaultValue": "net10.0"
+    },
+    "AppHostTargetFramework": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
     },
     "AppHostProjectPath": {
       "type": "parameter",
@@ -73,6 +77,15 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
+    },
+    "TargetFrameworkReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "AppHostTargetFramework",
+        "fallbackVariableName": "Framework"
+      },
+      "replaces": "net8.0"
     },
     "GeneratedAppHostProjectType": {
       "type": "generated",

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -107,7 +107,7 @@
       "datatype": "string",
       "replaces": "XmlEncodedAppHostProjectPath",
       "valueSource": "AppHostProjectPath",
-      "valueTransform": "xmlEncode"
+      "valueTransform": "xmlDoubleQuotedAttributeEncode"
     },
     "hostIdentifier": {
       "type": "bind",
@@ -118,6 +118,20 @@
       "datatype": "bool",
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
+    }
+  },
+  "forms": {
+    "xmlDoubleQuotedAttributeEncode": {
+      "identifier": "chain",
+      "steps": [
+        "xmlEncode",
+        "encodeDoubleQuote"
+      ]
+    },
+    "encodeDoubleQuote": {
+      "identifier": "replace",
+      "pattern": "\"",
+      "replacement": "&quot;"
     }
   },
   "primaryOutputs": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/Aspire.Tests.1.csproj
@@ -15,6 +15,12 @@
     <PackageReference Include="MSTest" Version="3.10.2" />
   </ItemGroup>
 
+  <!--#if (WithAppHostReference) -->
+  <ItemGroup>
+    <ProjectReference Include="XmlEncodedAppHostProjectPath" />
+  </ItemGroup>
+
+  <!--#endif -->
   <ItemGroup>
     <Using Include="System.Net" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/IntegrationTest1.cs
@@ -9,6 +9,18 @@ public class IntegrationTest1
 
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
+#if (WithAppHostReference)
+    [TestMethod]
+    public async Task AppHostBuilds()
+    {
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationTokenSource.Token);
+        cancellationTokenSource.CancelAfter(DefaultTimeout);
+        var cancellationToken = cancellationTokenSource.Token;
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedAppHostProjectType>(cancellationToken);
+
+        await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    }
+#else
     // Instructions:
     // 1. Add a project reference to the target AppHost project, e.g.:
     //
@@ -47,4 +59,5 @@ public class IntegrationTest1
     //     // Assert
     //     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     // }
+#endif
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
       "Framework": {
         "longName": "framework"
       },
+      "AppHostTargetFramework": {
+        "longName": "AppHostTargetFramework",
+        "shortName": ""
+      },
       "skipRestore": {
         "longName": "no-restore",
         "shortName": ""

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/dotnetcli.host.json
@@ -6,7 +6,17 @@
       },
       "AppHostTargetFramework": {
         "longName": "AppHostTargetFramework",
-        "shortName": ""
+        "shortName": "",
+        "isHidden": true
+      },
+      "AppHostProjectPath": {
+        "isHidden": true
+      },
+      "AppHostProjectName": {
+        "isHidden": true
+      },
+      "WithAppHostReference": {
+        "isHidden": true
       },
       "skipRestore": {
         "longName": "no-restore",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -59,6 +59,43 @@
       "replaces": "net8.0",
       "defaultValue": "net10.0"
     },
+    "AppHostProjectPath": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "AppHostProjectName": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "WithAppHostReference": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "GeneratedAppHostProjectType": {
+      "type": "generated",
+      "generator": "regex",
+      "datatype": "string",
+      "replaces": "GeneratedAppHostProjectType",
+      "parameters": {
+        "source": "AppHostProjectName",
+        "steps": [
+          {
+            "regex": "(((?<=\\.)|^)(?=\\d)|\\W)",
+            "replacement": "_"
+          }
+        ]
+      }
+    },
+    "XmlEncodedAppHostProjectPath": {
+      "type": "derived",
+      "datatype": "string",
+      "replaces": "XmlEncodedAppHostProjectPath",
+      "valueSource": "AppHostProjectPath",
+      "valueTransform": "xmlEncode"
+    },
     "hostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -56,8 +56,12 @@
           "description": "Target net11.0"
         }
       ],
-      "replaces": "net8.0",
       "defaultValue": "net10.0"
+    },
+    "AppHostTargetFramework": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
     },
     "AppHostProjectPath": {
       "type": "parameter",
@@ -73,6 +77,15 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
+    },
+    "TargetFrameworkReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "AppHostTargetFramework",
+        "fallbackVariableName": "Framework"
+      },
+      "replaces": "net8.0"
     },
     "GeneratedAppHostProjectType": {
       "type": "generated",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -107,7 +107,7 @@
       "datatype": "string",
       "replaces": "XmlEncodedAppHostProjectPath",
       "valueSource": "AppHostProjectPath",
-      "valueTransform": "xmlEncode"
+      "valueTransform": "xmlDoubleQuotedAttributeEncode"
     },
     "hostIdentifier": {
       "type": "bind",
@@ -118,6 +118,20 @@
       "datatype": "bool",
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
+    }
+  },
+  "forms": {
+    "xmlDoubleQuotedAttributeEncode": {
+      "identifier": "chain",
+      "steps": [
+        "xmlEncode",
+        "encodeDoubleQuote"
+      ]
+    },
+    "encodeDoubleQuote": {
+      "identifier": "replace",
+      "pattern": "\"",
+      "replacement": "&quot;"
     }
   },
   "primaryOutputs": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
@@ -17,6 +17,12 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
+  <!--#if (WithAppHostReference) -->
+  <ItemGroup>
+    <ProjectReference Include="XmlEncodedAppHostProjectPath" />
+  </ItemGroup>
+
+  <!--#endif -->
   <ItemGroup>
     <Using Include="System.Net" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/IntegrationTest1.cs
@@ -10,7 +10,8 @@ public class IntegrationTest1
     [Test]
     public async Task AppHostBuilds()
     {
-        using var cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CurrentContext.CancellationToken);
+        cancellationTokenSource.CancelAfter(DefaultTimeout);
         var cancellationToken = cancellationTokenSource.Token;
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedAppHostProjectType>(cancellationToken);
 
@@ -30,7 +31,8 @@ public class IntegrationTest1
     // public async Task GetWebResourceRootReturnsOkStatusCode()
     // {
     //     // Arrange
-    //     using var cts = new CancellationTokenSource(DefaultTimeout);
+    //     using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CurrentContext.CancellationToken);
+    //     cts.CancelAfter(DefaultTimeout);
     //     var cancellationToken = cts.Token;
     //     var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>();
     //     appHost.Services.AddLogging(logging =>

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/IntegrationTest1.cs
@@ -6,6 +6,17 @@ public class IntegrationTest1
 {
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
+#if (WithAppHostReference)
+    [Test]
+    public async Task AppHostBuilds()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
+        var cancellationToken = cancellationTokenSource.Token;
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedAppHostProjectType>(cancellationToken);
+
+        await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    }
+#else
     // Instructions:
     // 1. Add a project reference to the target AppHost project, e.g.:
     //
@@ -45,4 +56,5 @@ public class IntegrationTest1
     //     // Assert
     //     Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
     // }
+#endif
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
       "Framework": {
         "longName": "framework"
       },
+      "AppHostTargetFramework": {
+        "longName": "AppHostTargetFramework",
+        "shortName": ""
+      },
       "XUnitVersion": {
         "shortName": "",
         "longName": "xunit-version",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/dotnetcli.host.json
@@ -6,7 +6,17 @@
       },
       "AppHostTargetFramework": {
         "longName": "AppHostTargetFramework",
-        "shortName": ""
+        "shortName": "",
+        "isHidden": true
+      },
+      "AppHostProjectPath": {
+        "isHidden": true
+      },
+      "AppHostProjectName": {
+        "isHidden": true
+      },
+      "WithAppHostReference": {
+        "isHidden": true
       },
       "XUnitVersion": {
         "shortName": "",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -59,6 +59,43 @@
       "replaces": "net8.0",
       "defaultValue": "net10.0"
     },
+    "AppHostProjectPath": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "AppHostProjectName": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "WithAppHostReference": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "GeneratedAppHostProjectType": {
+      "type": "generated",
+      "generator": "regex",
+      "datatype": "string",
+      "replaces": "GeneratedAppHostProjectType",
+      "parameters": {
+        "source": "AppHostProjectName",
+        "steps": [
+          {
+            "regex": "(((?<=\\.)|^)(?=\\d)|\\W)",
+            "replacement": "_"
+          }
+        ]
+      }
+    },
+    "XmlEncodedAppHostProjectPath": {
+      "type": "derived",
+      "datatype": "string",
+      "replaces": "XmlEncodedAppHostProjectPath",
+      "valueSource": "AppHostProjectPath",
+      "valueTransform": "xmlEncode"
+    },
     "XUnitVersion": {
       "type": "parameter",
       "description": "The version of xUnit.net to use.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -56,8 +56,12 @@
           "description": "Target net11.0"
         }
       ],
-      "replaces": "net8.0",
       "defaultValue": "net10.0"
+    },
+    "AppHostTargetFramework": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": ""
     },
     "AppHostProjectPath": {
       "type": "parameter",
@@ -73,6 +77,15 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
+    },
+    "TargetFrameworkReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "AppHostTargetFramework",
+        "fallbackVariableName": "Framework"
+      },
+      "replaces": "net8.0"
     },
     "GeneratedAppHostProjectType": {
       "type": "generated",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -107,7 +107,7 @@
       "datatype": "string",
       "replaces": "XmlEncodedAppHostProjectPath",
       "valueSource": "AppHostProjectPath",
-      "valueTransform": "xmlEncode"
+      "valueTransform": "xmlDoubleQuotedAttributeEncode"
     },
     "XUnitVersion": {
       "type": "parameter",
@@ -143,6 +143,20 @@
       "datatype": "bool",
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
+    }
+  },
+  "forms": {
+    "xmlDoubleQuotedAttributeEncode": {
+      "identifier": "chain",
+      "steps": [
+        "xmlEncode",
+        "encodeDoubleQuote"
+      ]
+    },
+    "encodeDoubleQuote": {
+      "identifier": "replace",
+      "pattern": "\"",
+      "replacement": "&quot;"
     }
   },
   "primaryOutputs": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
@@ -20,6 +20,12 @@
     <PackageReference Include="xunit.v3" Version="3.0.1" Condition=" $(XUnitVersion) == 'v3mtp' " />
   </ItemGroup>
 
+  <!--#if (WithAppHostReference) -->
+  <ItemGroup>
+    <ProjectReference Include="XmlEncodedAppHostProjectPath" />
+  </ItemGroup>
+
+  <!--#endif -->
   <ItemGroup>
     <Using Include="System.Net" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/IntegrationTest1.cs
@@ -6,6 +6,22 @@ public class IntegrationTest1
 {
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
+#if (WithAppHostReference)
+    [Fact]
+    public async Task AppHostBuilds()
+    {
+#if (XUnitVersion == "v2")
+        using var cancellationTokenSource = new CancellationTokenSource(DefaultTimeout);
+#else // XunitVersion v3 or v3mtp
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellationTokenSource.CancelAfter(DefaultTimeout);
+#endif
+        var cancellationToken = cancellationTokenSource.Token;
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedAppHostProjectType>(cancellationToken);
+
+        await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    }
+#else
     // Instructions:
     // 1. Add a project reference to the target AppHost project, e.g.:
     //
@@ -49,4 +65,5 @@ public class IntegrationTest1
     //     // Assert
     //     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     // }
+#endif
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -24,14 +24,13 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
-        await auto.RunCommandAsync("aspire config set features.showAllTemplates true -g", counter);
         await auto.RunCommandAsync(
             "aspire new aspire-starter --name IntegrationTestApp --output IntegrationTestApp --non-interactive --suppress-agent-init",
             counter,
             TimeSpan.FromMinutes(5));
 
         await auto.TypeAsync(
-            "aspire new aspire-test " +
+            "ASPIRE_CLI_SHOW_ALL_TEMPLATES=true aspire new aspire-test " +
             "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
             "--name IntegrationTestApp.Tests --output IntegrationTestApp/IntegrationTestApp.Tests --suppress-agent-init");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task CreateAndRunAppHostIntegrationTest()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.RunCommandAsync(
+            "aspire new aspire-starter --name IntegrationTestApp --output IntegrationTestApp --non-interactive --suppress-agent-init",
+            counter,
+            TimeSpan.FromMinutes(5));
+
+        await auto.TypeAsync(
+            "aspire new aspire-test " +
+            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
+            "--name IntegrationTestApp.Tests --output IntegrationTestApp/IntegrationTestApp.Tests --suppress-agent-init");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("> MSTest").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(60),
+            description: "integration test framework selection list (> MSTest)");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+        await auto.RunCommandAsync(
+            "dotnet test IntegrationTestApp/IntegrationTestApp.Tests/IntegrationTestApp.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
+            counter,
+            TimeSpan.FromMinutes(5));
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -24,6 +24,7 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.RunCommandAsync("aspire config set features.showAllTemplates true -g", counter);
         await auto.RunCommandAsync(
             "aspire new aspire-starter --name IntegrationTestApp --output IntegrationTestApp --non-interactive --suppress-agent-init",
             counter,

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -30,7 +30,7 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
             TimeSpan.FromMinutes(5));
 
         await auto.TypeAsync(
-            "ASPIRE_CLI_SHOW_ALL_TEMPLATES=true aspire new aspire-test " +
+            "aspire new aspire-test " +
             "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
             "--name IntegrationTestApp.Tests --output IntegrationTestApp/IntegrationTestApp.Tests --suppress-agent-init");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -31,7 +31,7 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.TypeAsync(
             "aspire new aspire-test " +
-            "--name IntegrationTestApp.Tests --output IntegrationTestApp/IntegrationTestApp.Tests --suppress-agent-init");
+            "--name IntegrationTestApp.Discovered.Tests --output IntegrationTestApp/IntegrationTestApp.Discovered.Tests --suppress-agent-init");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(
             s => new CellPatternSearcher().Find("> MSTest").Search(s).Count > 0,
@@ -41,7 +41,19 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
         await auto.RunCommandAsync(
-            "dotnet test IntegrationTestApp/IntegrationTestApp.Tests/IntegrationTestApp.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
+            "aspire new aspire-test " +
+            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
+            "--test-framework MSTest --name IntegrationTestApp.Explicit.Tests " +
+            "--output IntegrationTestApp/IntegrationTestApp.Explicit.Tests --non-interactive --suppress-agent-init",
+            counter,
+            TimeSpan.FromMinutes(5));
+
+        await auto.RunCommandAsync(
+            "dotnet test IntegrationTestApp/IntegrationTestApp.Discovered.Tests/IntegrationTestApp.Discovered.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
+            counter,
+            TimeSpan.FromMinutes(5));
+        await auto.RunCommandAsync(
+            "dotnet test IntegrationTestApp/IntegrationTestApp.Explicit.Tests/IntegrationTestApp.Explicit.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
             counter,
             TimeSpan.FromMinutes(5));
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -28,6 +28,9 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
             "aspire new aspire-starter --name IntegrationTestApp --output IntegrationTestApp --non-interactive --suppress-agent-init",
             counter,
             TimeSpan.FromMinutes(5));
+        await auto.RunCommandAsync(
+            "echo '// TypeScript AppHost' > IntegrationTestApp/apphost.mts",
+            counter);
 
         await auto.TypeAsync(
             "aspire new aspire-test " +
@@ -42,7 +45,7 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync(
             "aspire new aspire-test " +
-            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
+            "--apphost IntegrationTestApp " +
             "--test-framework MSTest --name IntegrationTestApp.Explicit.Tests " +
             "--output IntegrationTestApp/IntegrationTestApp.Explicit.Tests --non-interactive --suppress-agent-init",
             counter,

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -71,5 +71,36 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
             "dotnet test IntegrationTestApp/IntegrationTestApp.Directory.Tests/IntegrationTestApp.Directory.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
             counter,
             TimeSpan.FromMinutes(5));
+
+        // Older templates should remain standalone even when discovery would find multiple AppHosts.
+        await auto.RunCommandAsync(
+            "mkdir IntegrationTestApp/SecondAppHost && " +
+            "cp IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj IntegrationTestApp/SecondAppHost/SecondAppHost.csproj",
+            counter);
+        await auto.RunCommandAsync(
+            "aspire new aspire-test --version 13.5.3 --source https://api.nuget.org/v3/index.json " +
+            "--test-framework MSTest --name OlderTemplate.Tests --output OlderTemplate.Tests --non-interactive --suppress-agent-init",
+            counter,
+            TimeSpan.FromMinutes(5));
+        await auto.RunCommandAsync(
+            "dotnet build OlderTemplate.Tests/OlderTemplate.Tests.csproj",
+            counter,
+            TimeSpan.FromMinutes(5));
+
+        await auto.TypeAsync(
+            "aspire new aspire-test --version 13.5.3 --source https://api.nuget.org/v3/index.json " +
+            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
+            "--test-framework MSTest --name UnsupportedTemplate.Tests --output UnsupportedTemplate.Tests --non-interactive --suppress-agent-init");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("does not support AppHost references").Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(5),
+            description: "unsupported template AppHost reference diagnostic");
+        var errorPrompt = new CellPatternSearcher().Find($"[{counter.Value} ERR:");
+        await auto.WaitUntilAsync(
+            s => errorPrompt.Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(30),
+            description: "unsupported template command returning a non-zero exit code");
+        counter.Increment();
     }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -31,7 +31,6 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.TypeAsync(
             "aspire new aspire-test " +
-            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
             "--name IntegrationTestApp.Tests --output IntegrationTestApp/IntegrationTestApp.Tests --suppress-agent-init");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(

--- a/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/IntegrationTestScaffoldingTests.cs
@@ -45,9 +45,17 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync(
             "aspire new aspire-test " +
-            "--apphost IntegrationTestApp " +
+            "--apphost IntegrationTestApp/IntegrationTestApp.AppHost/IntegrationTestApp.AppHost.csproj " +
             "--test-framework MSTest --name IntegrationTestApp.Explicit.Tests " +
             "--output IntegrationTestApp/IntegrationTestApp.Explicit.Tests --non-interactive --suppress-agent-init",
+            counter,
+            TimeSpan.FromMinutes(5));
+
+        await auto.RunCommandAsync(
+            "aspire new aspire-test " +
+            "--apphost IntegrationTestApp " +
+            "--test-framework MSTest --name IntegrationTestApp.Directory.Tests " +
+            "--output IntegrationTestApp/IntegrationTestApp.Directory.Tests --non-interactive --suppress-agent-init",
             counter,
             TimeSpan.FromMinutes(5));
 
@@ -57,6 +65,10 @@ public sealed class IntegrationTestScaffoldingTests(ITestOutputHelper output)
             TimeSpan.FromMinutes(5));
         await auto.RunCommandAsync(
             "dotnet test IntegrationTestApp/IntegrationTestApp.Explicit.Tests/IntegrationTestApp.Explicit.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
+            counter,
+            TimeSpan.FromMinutes(5));
+        await auto.RunCommandAsync(
+            "dotnet test IntegrationTestApp/IntegrationTestApp.Directory.Tests/IntegrationTestApp.Directory.Tests.csproj -- --filter-method \"*.AppHostBuilds\"",
             counter,
             TimeSpan.FromMinutes(5));
     }

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -44,12 +44,6 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void ConfigInfo_AdvertisesAspireTestAppHost()
-    {
-        Assert.Contains(KnownCapabilities.AspireTestAppHost, KnownCapabilities.GetAdvertisedCapabilities());
-    }
-
-    [Fact]
     public void ConfigInfoJson_UsesCamelCasePropertyNames()
     {
         var info = new Aspire.Cli.Commands.ConfigInfo(

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -44,6 +44,12 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void ConfigInfo_AdvertisesAspireTestAppHost()
+    {
+        Assert.Contains(KnownCapabilities.AspireTestAppHost, KnownCapabilities.GetAdvertisedCapabilities());
+    }
+
+    [Fact]
     public void ConfigInfoJson_UsesCamelCasePropertyNames()
     {
         var info = new Aspire.Cli.Commands.ConfigInfo(

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTemplateConfigPersistenceTests.cs
@@ -87,11 +87,7 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
         PrDogfoodNewTemplateCase.DotNet(KnownTemplateId.DotNetEmptyAppHost, ["--localhost-tld", "false"]),
         PrDogfoodNewTemplateCase.DotNet("aspire-apphost", ["--localhost-tld", "false"]),
         PrDogfoodNewTemplateCase.DotNet("aspire-servicedefaults"),
-    ];
-
-    private static readonly PrDogfoodNewTemplateExclusion[] s_prDogfoodNewTemplateExclusions =
-    [
-        new("aspire-test", "This wrapper requires an interactive framework sub-template selection before it reaches package resolution.")
+        PrDogfoodNewTemplateCase.DotNet(KnownTemplateId.IntegrationTest, ["--test-framework", "MSTest"]),
     ];
 
     public static TheoryData<PrDogfoodNewTemplateCase> PrDogfoodNewTemplateCases()
@@ -225,12 +221,10 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
             .ToArray();
 
         var accountedForTemplateKeys = s_prDogfoodNewTemplateCases.Select(static testCase => testCase.CoverageKey)
-            .Concat(s_prDogfoodNewTemplateExclusions.Select(static exclusion => exclusion.CoverageKey))
             .OrderBy(static key => key, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         Assert.Equal(accountedForTemplateKeys, registeredTemplateKeys);
-        Assert.All(s_prDogfoodNewTemplateExclusions, static exclusion => Assert.False(string.IsNullOrWhiteSpace(exclusion.Reason)));
     }
 
     /// <summary>
@@ -558,8 +552,6 @@ public class NewCommandTemplateConfigPersistenceTests(ITestOutputHelper outputHe
             return CoverageKey;
         }
     }
-
-    private sealed record PrDogfoodNewTemplateExclusion(string CoverageKey, string Reason);
 
     private sealed record DotNetTemplateInstall(string PackageName, string Version, string? NuGetConfigFile, string? NuGetSource);
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -104,7 +104,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CreateServiceCollection(workspace, options =>
         {
-            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
             options.DotNetCliRunnerFactory = _ => runner;
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
             options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider)

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -104,6 +104,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CreateServiceCollection(workspace, options =>
         {
+            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
             options.DotNetCliRunnerFactory = _ => runner;
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
             options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider)
@@ -160,6 +161,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CreateServiceCollection(workspace, options =>
         {
+            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
             options.DotNetCliRunnerFactory = _ => runner;
             options.InteractionServiceFactory = _ =>
             {
@@ -198,7 +200,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public void NewCommand_IntegrationTestTemplateAppHostOptionDescribesProjectFile()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var services = CreateServiceCollection(workspace);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
+        });
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text.Json;
 using System.Xml.Linq;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Utils;
@@ -82,8 +83,17 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain(command.Options, option => option.Aliases.Contains("--language", StringComparer.OrdinalIgnoreCase));
     }
 
-    [Fact]
-    public async Task NewCommand_IntegrationTestTemplatePassesAppHostToSelectedTemplate()
+    [Theory]
+    [InlineData(0, "net11.0", null, "net11.0")]
+    [InlineData(0, null, "net10.0;net11.0", "net10.0")]
+    [InlineData(0, null, " net11.0 ; net10.0 ", "net11.0")]
+    [InlineData(0, null, null, null)]
+    [InlineData(1, null, null, null)]
+    public async Task NewCommand_IntegrationTestTemplateUsesAppHostTargetFrameworkWhenAvailable(
+        int appHostInfoExitCode,
+        string? targetFramework,
+        string? targetFrameworks,
+        string? expectedTargetFramework)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var appHostDirectory = workspace.CreateDirectory("AppHost_$(literal);100%@'&");
@@ -93,6 +103,26 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         string? selectedTemplate = null;
         string? openedEditorPath = null;
         var runner = CreateTestRunnerWithStandardPackages();
+        runner.GetProjectItemsAndPropertiesAsyncCallbackWithTargets = (_, _, _, _, _, _) =>
+        {
+            if (appHostInfoExitCode != 0)
+            {
+                return (appHostInfoExitCode, null);
+            }
+
+            var output = new
+            {
+                Properties = new
+                {
+                    IsAspireHost = "true",
+                    TargetFramework = targetFramework,
+                    TargetFrameworks = targetFrameworks
+                },
+                Items = new { }
+            };
+
+            return (0, JsonSerializer.SerializeToDocument(output));
+        };
         runner.NewProjectAsyncCallback = (templateName, projectName, generatedPath, _, _) =>
         {
             selectedTemplate = templateName;
@@ -130,16 +160,22 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal("aspire-mstest", selectedTemplate);
         var extraArgs = Assert.IsType<string[]>(runner.LastNewProjectExtraArgs);
-        Assert.Equal(
-            [
-                "--WithAppHostReference",
-                "true",
-                "--AppHostProjectPath",
-                Path.Combine("..", "AppHost_%24%28literal%29%3B100%25%40%27&", "AppHost.csproj"),
-                "--AppHostProjectName",
-                "AppHost"
-            ],
-            extraArgs);
+        var expectedExtraArgs = new List<string>
+        {
+            "--WithAppHostReference",
+            "true",
+            "--AppHostProjectPath",
+            Path.Combine("..", "AppHost_%24%28literal%29%3B100%25%40%27&", "AppHost.csproj"),
+            "--AppHostProjectName",
+            "AppHost"
+        };
+        if (expectedTargetFramework is not null)
+        {
+            expectedExtraArgs.Add("--framework");
+            expectedExtraArgs.Add(expectedTargetFramework);
+        }
+
+        Assert.Equal(expectedExtraArgs, extraArgs);
         Assert.Equal(Path.Combine(outputPath, "IntegrationTest1.cs"), openedEditorPath);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -143,6 +143,58 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommand_IntegrationTestTemplateRejectsMissingAppHostBeforeTemplateSelection()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "Missing.AppHost", "Missing.AppHost.csproj");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var promptedForTemplate = false;
+        var generatedProject = false;
+        TestInteractionService? interactionService = null;
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (_, _, _, _, _) =>
+        {
+            generatedProject = true;
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+            options.NewCommandPrompterFactory = serviceProvider =>
+            {
+                var prompter = new TestNewCommandPrompter(serviceProvider.GetRequiredService<IInteractionService>())
+                {
+                    PromptForTemplateCallback = templates =>
+                    {
+                        promptedForTemplate = true;
+                        return templates[0];
+                    }
+                };
+                return prompter;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new aspire-test --name AppHost.Tests --output \"{outputPath}\" --apphost \"{appHostPath}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
+        Assert.False(promptedForTemplate);
+        Assert.False(generatedProject);
+        Assert.NotNull(interactionService);
+        var error = Assert.Single(interactionService.DisplayedErrors);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionDoesntExist, error);
+    }
+
+    [Fact]
     public void NewCommand_IntegrationTestTemplateAppHostOptionDescribesProjectFile()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -86,7 +86,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommand_IntegrationTestTemplatePassesAppHostToSelectedTemplate()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var appHostDirectory = workspace.CreateDirectory("AppHost");
+        var appHostDirectory = workspace.CreateDirectory("AppHost_$(literal);100%@'&");
         var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
@@ -134,7 +134,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 "--WithAppHostReference",
                 "true",
                 "--AppHostProjectPath",
-                Path.GetRelativePath(outputPath, appHostFile.FullName),
+                Path.Combine("..", "AppHost_%24%28literal%29%3B100%25%40%27&", "AppHost.csproj"),
                 "--AppHostProjectName",
                 "AppHost"
             ],

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -143,6 +143,20 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void NewCommand_IntegrationTestTemplateAppHostOptionDescribesProjectFile()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CreateServiceCollection(workspace);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var integrationTestTemplate = command.Subcommands.Single(subcommand => subcommand.Name == "aspire-test");
+        var appHostOption = integrationTestTemplate.Options.Single(option => option.Name == "--apphost");
+
+        Assert.Equal("The path to the Aspire AppHost project file", appHostOption.Description);
+    }
+
+    [Fact]
     public void NewCommand_WhenIdentityChannelIsStaging_DescribesStagingChannelOption()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -83,6 +83,67 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommand_IntegrationTestTemplatePassesAppHostToSelectedTemplate()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostDirectory = workspace.CreateDirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        string? selectedTemplate = null;
+        string? openedEditorPath = null;
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (templateName, projectName, generatedPath, _, _) =>
+        {
+            selectedTemplate = templateName;
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
+            File.WriteAllText(Path.Combine(generatedPath, "IntegrationTest1.cs"), "public class IntegrationTest1;");
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider)
+            {
+                OpenEditorCallback = path => openedEditorPath = path
+            };
+            options.NewCommandPrompterFactory = serviceProvider =>
+            {
+                var prompter = new TestNewCommandPrompter(serviceProvider.GetRequiredService<IInteractionService>())
+                {
+                    PromptForTemplateCallback = templates => templates.Single(template => template.Name == "aspire-mstest")
+                };
+                return prompter;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"new aspire-test --name AppHost.Tests --output \"{outputPath}\" --apphost \"{appHostFile.FullName}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal("aspire-mstest", selectedTemplate);
+        var extraArgs = Assert.IsType<string[]>(runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+            [
+                "--WithAppHostReference",
+                "true",
+                "--AppHostProjectPath",
+                Path.GetRelativePath(outputPath, appHostFile.FullName),
+                "--AppHostProjectName",
+                "AppHost"
+            ],
+            extraArgs);
+        Assert.Equal(Path.Combine(outputPath, "IntegrationTest1.cs"), openedEditorPath);
+    }
+
+    [Fact]
     public void NewCommand_WhenIdentityChannelIsStaging_DescribesStagingChannelOption()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -85,8 +85,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData(0, "net11.0", null, "net11.0")]
+    [InlineData(0, "net10.0-windows", null, "net10.0-windows")]
     [InlineData(0, null, "net10.0;net11.0", "net10.0")]
     [InlineData(0, null, " net11.0 ; net10.0 ", "net11.0")]
+    [InlineData(0, "   ", null, null)]
     [InlineData(0, null, null, null)]
     [InlineData(1, null, null, null)]
     public async Task NewCommand_IntegrationTestTemplateUsesAppHostTargetFrameworkWhenAvailable(
@@ -171,7 +173,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         };
         if (expectedTargetFramework is not null)
         {
-            expectedExtraArgs.Add("--framework");
+            expectedExtraArgs.Add("--AppHostTargetFramework");
             expectedExtraArgs.Add(expectedTargetFramework);
         }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -244,7 +244,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var starterTestFrameworkOption = starterTemplate.Options.Single(option => option.Name == "--test-framework");
 
         Assert.Equal("The path to the Aspire AppHost project file", appHostOption.Description);
-        Assert.Equal("Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.", integrationTestFrameworkOption.Description);
+        Assert.Equal("Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.", integrationTestFrameworkOption.Description);
         Assert.Equal("Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.", starterTestFrameworkOption.Description);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -227,7 +227,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void NewCommand_IntegrationTestTemplateAppHostOptionDescribesProjectFile()
+    public void NewCommand_TemplateOptionsHaveSpecificDescriptions()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var services = CreateServiceCollection(workspace, options =>
@@ -238,9 +238,14 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var command = provider.GetRequiredService<NewCommand>();
         var integrationTestTemplate = command.Subcommands.Single(subcommand => subcommand.Name == "aspire-test");
+        var starterTemplate = command.Subcommands.Single(subcommand => subcommand.Name == "aspire-starter");
         var appHostOption = integrationTestTemplate.Options.Single(option => option.Name == "--apphost");
+        var integrationTestFrameworkOption = integrationTestTemplate.Options.Single(option => option.Name == "--test-framework");
+        var starterTestFrameworkOption = starterTemplate.Options.Single(option => option.Name == "--test-framework");
 
         Assert.Equal("The path to the Aspire AppHost project file", appHostOption.Description);
+        Assert.Equal("Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.net.", integrationTestFrameworkOption.Description);
+        Assert.Equal("Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.", starterTestFrameworkOption.Description);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -143,19 +143,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 OpenEditorCallback = path => openedEditorPath = path
             };
-            options.NewCommandPrompterFactory = serviceProvider =>
-            {
-                var prompter = new TestNewCommandPrompter(serviceProvider.GetRequiredService<IInteractionService>())
-                {
-                    PromptForTemplateCallback = templates => templates.Single(template => template.Name == "aspire-mstest")
-                };
-                return prompter;
-            };
         });
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse($"new aspire-test --name AppHost.Tests --output \"{outputPath}\" --apphost \"{appHostFile.FullName}\" --suppress-agent-init");
+        var result = command.Parse($"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --apphost \"{appHostFile.FullName}\" --suppress-agent-init");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -249,6 +241,45 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var appHostOption = integrationTestTemplate.Options.Single(option => option.Name == "--apphost");
 
         Assert.Equal("The path to the Aspire AppHost project file", appHostOption.Description);
+    }
+
+    [Theory]
+    [InlineData("MSTest", "aspire-mstest", null)]
+    [InlineData("NUnit", "aspire-nunit", null)]
+    [InlineData("xUnit", "aspire-xunit", "v2")]
+    public async Task NewCommand_IntegrationTestTemplateCanSelectFrameworkNonInteractively(
+        string testFramework,
+        string expectedTemplate,
+        string? xunitVersion)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        string? selectedTemplate = null;
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (templateName, _, generatedPath, _, _) =>
+        {
+            selectedTemplate = templateName;
+            Directory.CreateDirectory(generatedPath);
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var xunitVersionArgument = xunitVersion is null ? string.Empty : $" --xunit-version {xunitVersion}";
+        var result = command.Parse(
+            $"new aspire-test --test-framework {testFramework}{xunitVersionArgument} --name AppHost.Tests " +
+            $"--output \"{outputPath}\" --suppress-agent-init --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal(expectedTemplate, selectedTemplate);
+        Assert.Equal(xunitVersion is null ? [] : ["--xunit-version", xunitVersion], runner.LastNewProjectExtraArgs);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -196,6 +196,244 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.False(requestedCreateSettingsFile);
     }
 
+    [Theory]
+    [InlineData("MSTest", "aspire-mstest", null, "13.5.3", false)]
+    [InlineData("NUnit", "aspire-nunit", null, "13.5.3", false)]
+    [InlineData("xUnit", "aspire-xunit", "v2", "13.5.3", false)]
+    [InlineData("MSTest", "aspire-mstest", null, "13.6.0-preview.1", false)]
+    [InlineData("MSTest", "aspire-mstest", null, "13.5.0-local", true)]
+    [InlineData("MSTest", "aspire-mstest", null, "13.6.0", true)]
+    [InlineData("NUnit", "aspire-nunit", null, "13.6.0", true)]
+    [InlineData("xUnit", "aspire-xunit", "v2", "13.6.0", true)]
+    public async Task NewCommand_IntegrationTestTemplateUsesInstalledTemplateCapabilities(
+        string testFramework,
+        string expectedTemplate,
+        string? xunitVersion,
+        string templateVersion,
+        bool supportsAppHostReference)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostDirectory = workspace.CreateDirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
+        var otherAppHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "OtherAppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+        await File.WriteAllTextAsync(otherAppHostFile.FullName, "<Project />");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var operations = new List<string>();
+        var runner = CreateTestRunnerWithTemplatePackage(templateVersion);
+        runner.InstallTemplateAsyncCallback = (_, version, _, _, _, _, _) =>
+        {
+            operations.Add("Install");
+            Assert.Equal(templateVersion, version);
+            return (0, version);
+        };
+        runner.NewProjectDryRunAsyncCallback = (templateName, _, _, _, _) =>
+        {
+            operations.Add("Probe");
+            Assert.Equal(expectedTemplate, templateName);
+            return supportsAppHostReference ? 0 : 127;
+        };
+        runner.NewProjectAsyncCallback = (templateName, projectName, generatedPath, _, _) =>
+        {
+            operations.Add("Create");
+            Assert.Equal(expectedTemplate, templateName);
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, _, createSettingsFile, _) =>
+                {
+                    operations.Add("Discover");
+                    Assert.Null(projectFile);
+                    Assert.False(createSettingsFile);
+                    return Task.FromResult(new AppHostProjectSearchResult(
+                        supportsAppHostReference ? appHostFile : null,
+                        [appHostFile, otherAppHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var xunitVersionArgument = xunitVersion is null ? string.Empty : $" --xunit-version {xunitVersion}";
+        var result = command.Parse(
+            $"new aspire-test --test-framework {testFramework}{xunitVersionArgument} --version {templateVersion} " +
+            $"--name AppHost.Tests --output \"{outputPath}\" --non-interactive --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal(["--dry-run", "--WithAppHostReference", "false"], Assert.IsType<string[]>(runner.LastNewProjectDryRunExtraArgs));
+        var expectedExtraArgs = new List<string>();
+        if (xunitVersion is not null)
+        {
+            expectedExtraArgs.AddRange(["--xunit-version", xunitVersion]);
+        }
+        if (supportsAppHostReference)
+        {
+            expectedExtraArgs.AddRange(
+            [
+                "--WithAppHostReference",
+                "true",
+                "--AppHostProjectPath",
+                Path.Combine("..", "AppHost", "AppHost.csproj"),
+                "--AppHostProjectName",
+                "AppHost"
+            ]);
+        }
+        Assert.Equal(expectedExtraArgs, runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+            supportsAppHostReference ? ["Install", "Probe", "Discover", "Create"] : ["Install", "Probe", "Create"],
+            operations);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NewCommand_IntegrationTestTemplateRejectsExplicitAppHostForUnsupportedTemplates(bool appHostIsDirectory)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostDirectory = workspace.CreateDirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithTemplatePackage("13.5.3");
+        runner.NewProjectDryRunAsyncCallback = (_, _, _, _, _) => 127;
+        var interactionService = new TestInteractionService();
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                    throw new InvalidOperationException("Unsupported templates must not trigger AppHost discovery.")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var appHostPath = appHostIsDirectory ? appHostDirectory.FullName : appHostFile.FullName;
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --version 13.5.3 --apphost \"{appHostPath}\" " +
+            $"--name AppHost.Tests --output \"{outputPath}\" --non-interactive --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+            string.Format(CultureInfo.CurrentCulture, TemplatingStrings.IntegrationTestAppHostReferenceNotSupported, "aspire-mstest", "13.5.3"),
+            Assert.Single(interactionService.DisplayedErrors));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(73)]
+    [InlineData(103)]
+    public async Task NewCommand_IntegrationTestTemplateSurfacesUnexpectedCapabilityProbeFailures(int probeExitCode)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectDryRunAsyncCallback = (_, _, _, options, _) =>
+        {
+            options.StandardErrorCallback?.Invoke("Template probe failed.");
+            return probeExitCode;
+        };
+        var interactionService = new TestInteractionService();
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                    throw new InvalidOperationException("A failed probe must not trigger AppHost discovery.")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+            probeExitCode == 73
+                ? TemplatingStrings.ProjectAlreadyExists
+                : string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, probeExitCode),
+            Assert.Single(interactionService.DisplayedErrors));
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplatePropagatesCapabilityProbeCancellation()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectDryRunAsyncCallback = (_, _, _, _, cancellationToken) => throw new OperationCanceledException(cancellationToken);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                    throw new InvalidOperationException("A cancelled probe must not trigger AppHost discovery.")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Cancelled, exitCode);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateDoesNotProbeAfterInstallationFailure()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.InstallTemplateAsyncCallback = (_, _, _, _, _, _, _) => (1, null);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                    throw new InvalidOperationException("A failed installation must not trigger AppHost discovery.")
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToInstallTemplates, exitCode);
+        Assert.Null(runner.LastNewProjectDryRunExtraArgs);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+    }
+
     [Fact]
     public async Task NewCommand_IntegrationTestTemplateSelectsCompatibleAppHostFromExplicitDirectory()
     {
@@ -1309,6 +1547,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     private static TestDotNetCliRunner CreateTestRunnerWithStandardPackages()
+        => CreateTestRunnerWithTemplatePackage("9.2.0");
+
+    private static TestDotNetCliRunner CreateTestRunnerWithTemplatePackage(string version)
     {
         var runner = new TestDotNetCliRunner();
         runner.SearchPackagesAsyncCallback = (dir, query, exactMatch, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
@@ -1317,7 +1558,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 Id = "Aspire.ProjectTemplates",
                 Source = "nuget",
-                Version = "9.2.0"
+                Version = version
             };
 
             return (0, new NuGetPackage[] { package });

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1424,6 +1424,54 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithoutTemplateKeepsOriginalTemplateOrder()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        string[]? promptedTemplateNames = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                ConfirmCallback = (_, defaultValue) => defaultValue
+            };
+            options.NewCommandPrompterFactory = sp =>
+            {
+                var prompter = new TestNewCommandPrompter(sp.GetRequiredService<IInteractionService>())
+                {
+                    PromptForTemplateCallback = templates =>
+                    {
+                        promptedTemplateNames = templates.Select(template => template.Name).ToArray();
+                        return templates[0];
+                    }
+                };
+
+                return prompter;
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new --name TestApp --output ./output --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var actualTemplateNames = Assert.IsType<string[]>(promptedTemplateNames);
+        Assert.Equal(
+            [
+                "aspire-starter",
+                "aspire-ts-cs-starter",
+                KnownTemplateId.TypeScriptStarter,
+                KnownTemplateId.PythonStarter,
+                KnownTemplateId.IntegrationTest,
+                KnownTemplateId.CSharpEmptyAppHost,
+            ],
+            actualTemplateNames);
+    }
+
+    [Fact]
     public void NewCommandTemplateSubcommandsListTechnicalNamesForNonInteractiveFlows()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -84,14 +84,16 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(0, "net11.0", null, "net11.0")]
-    [InlineData(0, "net10.0-windows", null, "net10.0-windows")]
-    [InlineData(0, null, "net10.0;net11.0", "net10.0")]
-    [InlineData(0, null, " net11.0 ; net10.0 ", "net11.0")]
-    [InlineData(0, "   ", null, null)]
-    [InlineData(0, null, null, null)]
-    [InlineData(1, null, null, null)]
-    public async Task NewCommand_IntegrationTestTemplateUsesAppHostTargetFrameworkWhenAvailable(
+    [InlineData(false, 0, "net11.0", null, "net11.0")]
+    [InlineData(false, 0, "net10.0-windows", null, "net10.0-windows")]
+    [InlineData(false, 0, null, "net10.0;net11.0", "net10.0")]
+    [InlineData(false, 0, null, " net11.0 ; net10.0 ", "net11.0")]
+    [InlineData(false, 0, "   ", null, null)]
+    [InlineData(false, 0, null, null, null)]
+    [InlineData(false, 1, null, null, null)]
+    [InlineData(true, 0, null, null, null)]
+    public async Task NewCommand_IntegrationTestTemplateUsesAppHostTargetFrameworkWhenAvailableAndFallsBackOtherwise(
+        bool appHostInfoThrows,
         int appHostInfoExitCode,
         string? targetFramework,
         string? targetFrameworks,
@@ -107,6 +109,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var runner = CreateTestRunnerWithStandardPackages();
         runner.GetProjectItemsAndPropertiesAsyncCallbackWithTargets = (_, _, _, _, _, _) =>
         {
+            if (appHostInfoThrows)
+            {
+                throw new InvalidOperationException("Simulated AppHost inspection failure.");
+            }
+
             if (appHostInfoExitCode != 0)
             {
                 return (appHostInfoExitCode, null);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -423,7 +423,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var integrationTestFrameworkOption = integrationTestTemplate.Options.Single(option => option.Name == "--test-framework");
         var starterTestFrameworkOption = starterTemplate.Options.Single(option => option.Name == "--test-framework");
 
-        Assert.Equal("The path to the Aspire AppHost project file", appHostOption.Description);
+        Assert.Equal("The path to the Aspire AppHost project file or a directory to search", appHostOption.Description);
         Assert.Equal("Selects the test framework for the integration test project: MSTest, NUnit, or xUnit.", integrationTestFrameworkOption.Description);
         Assert.Equal("Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.", starterTestFrameworkOption.Description);
     }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -106,6 +106,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
         string? selectedTemplate = null;
         string? openedEditorPath = null;
+        FileInfo? requestedAppHostFile = null;
+        MultipleAppHostProjectsFoundBehavior? requestedMultipleAppHostBehavior = null;
+        bool? requestedCreateSettingsFile = null;
         var runner = CreateTestRunnerWithStandardPackages();
         runner.GetProjectItemsAndPropertiesAsyncCallbackWithTargets = (_, _, _, _, _, _) =>
         {
@@ -145,6 +148,16 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         {
             options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
             options.DotNetCliRunnerFactory = _ => runner;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    requestedAppHostFile = projectFile;
+                    requestedMultipleAppHostBehavior = behavior;
+                    requestedCreateSettingsFile = createSettingsFile;
+                    return Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]));
+                }
+            };
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
             options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider)
             {
@@ -178,59 +191,219 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(expectedExtraArgs, extraArgs);
         Assert.Equal(Path.Combine(outputPath, "IntegrationTest1.cs"), openedEditorPath);
+        Assert.Equal(appHostFile.FullName, requestedAppHostFile?.FullName);
+        Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, requestedMultipleAppHostBehavior);
+        Assert.False(requestedCreateSettingsFile);
     }
 
-    [Fact]
-    public async Task NewCommand_IntegrationTestTemplateRejectsMissingAppHostBeforeTemplateSelection()
+    [Theory]
+    [InlineData(false, nameof(ProjectLocatorFailureReason.NoProjectFileFound))]
+    [InlineData(false, nameof(ProjectLocatorFailureReason.AppHostsMayNotBeBuildable))]
+    [InlineData(false, nameof(ProjectLocatorFailureReason.UnsupportedProjects))]
+    [InlineData(true, nameof(ProjectLocatorFailureReason.NoProjectFileFound))]
+    public async Task NewCommand_IntegrationTestTemplateFallsBackToStandaloneWhenAppHostDiscoveryFails(
+        bool supportsInteractiveInput,
+        string failureReasonName)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "Missing.AppHost", "Missing.AppHost.csproj");
+        var failureReason = Enum.Parse<ProjectLocatorFailureReason>(failureReasonName);
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
-        var promptedForTemplate = false;
-        var generatedProject = false;
-        TestInteractionService? interactionService = null;
+        MultipleAppHostProjectsFoundBehavior? requestedMultipleAppHostBehavior = null;
         var runner = CreateTestRunnerWithStandardPackages();
-        runner.NewProjectAsyncCallback = (_, _, _, _, _) =>
+        runner.NewProjectAsyncCallback = (_, projectName, generatedPath, _, _) =>
         {
-            generatedProject = true;
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
             return 0;
         };
 
         var services = CreateServiceCollection(workspace, options =>
         {
-            options.FeatureFlagsFactory = _ => new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, true);
             options.DotNetCliRunnerFactory = _ => runner;
-            options.InteractionServiceFactory = _ =>
+            options.CliHostEnvironmentFactory = _ => supportsInteractiveInput
+                ? TestHelpers.CreateInteractiveHostEnvironment()
+                : TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
             {
-                interactionService = new TestInteractionService();
-                return interactionService;
-            };
-            options.NewCommandPrompterFactory = serviceProvider =>
-            {
-                var prompter = new TestNewCommandPrompter(serviceProvider.GetRequiredService<IInteractionService>())
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
                 {
-                    PromptForTemplateCallback = templates =>
-                    {
-                        promptedForTemplate = true;
-                        return templates[0];
-                    }
-                };
-                return prompter;
+                    Assert.Null(projectFile);
+                    Assert.False(createSettingsFile);
+                    requestedMultipleAppHostBehavior = behavior;
+                    throw new ProjectLocatorException("Test AppHost resolution failure.", failureReason);
+                }
             };
         });
         using var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse($"new aspire-test --name AppHost.Tests --output \"{outputPath}\" --apphost \"{appHostPath}\" --suppress-agent-init");
+        var nonInteractiveOption = supportsInteractiveInput ? string.Empty : " --non-interactive";
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init{nonInteractiveOption}");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
-        Assert.Equal(CliExitCodes.FailedToCreateNewProject, exitCode);
-        Assert.False(promptedForTemplate);
-        Assert.False(generatedProject);
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Empty(Assert.IsType<string[]>(runner.LastNewProjectExtraArgs));
+        Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, requestedMultipleAppHostBehavior);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateReportsAmbiguousAppHostSelectionNonInteractively()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile1 = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost1", "AppHost1.csproj"));
+        var appHostFile2 = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost2", "AppHost2.csproj"));
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Null(projectFile);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
+                    Assert.False(createSettingsFile);
+                    var unsupportedAppHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+                    return Task.FromResult(new AppHostProjectSearchResult(unsupportedAppHostFile, [unsupportedAppHostFile, appHostFile1, appHostFile2]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateReportsExplicitAppHostResolutionFailure()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MissingAppHost", "AppHost.csproj"));
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Equal(appHostFile.FullName, projectFile?.FullName);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
+                    Assert.False(createSettingsFile);
+                    throw new ProjectLocatorException(
+                        "The specified AppHost project does not exist.",
+                        ProjectLocatorFailureReason.ProjectFileDoesntExist);
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" " +
+            $"--apphost \"{appHostFile.FullName}\" --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Null(runner.LastNewProjectExtraArgs);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateFallsBackToStandaloneWhenDiscoveredAppHostCannotBeReferenced()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (_, projectName, generatedPath, _, _) =>
+        {
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, behavior, _, _) =>
+                {
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
+                    return Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Empty(Assert.IsType<string[]>(runner.LastNewProjectExtraArgs));
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateRejectsExplicitAppHostThatCannotBeReferenced()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        TestInteractionService? interactionService = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Equal(appHostFile.FullName, projectFile?.FullName);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
+                    Assert.False(createSettingsFile);
+                    return Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" " +
+            $"--apphost \"{appHostFile.FullName}\" --non-interactive");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
         Assert.NotNull(interactionService);
-        var error = Assert.Single(interactionService.DisplayedErrors);
-        Assert.Equal(InteractionServiceStrings.ProjectOptionDoesntExist, error);
+        Assert.Equal(TemplatingStrings.IntegrationTestAppHostMustBeCSharpProject, Assert.Single(interactionService.DisplayedErrors));
+        Assert.Null(runner.LastNewProjectExtraArgs);
     }
 
     [Fact]
@@ -265,8 +438,15 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         string? xunitVersion)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostDirectory = workspace.CreateDirectory("AppHost");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "AppHost.csproj"));
+        var unsupportedAppHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
         string? selectedTemplate = null;
+        FileInfo? requestedAppHostFile = null;
+        MultipleAppHostProjectsFoundBehavior? requestedMultipleAppHostBehavior = null;
+        bool? requestedCreateSettingsFile = null;
         var runner = CreateTestRunnerWithStandardPackages();
         runner.NewProjectAsyncCallback = (templateName, _, generatedPath, _, _) =>
         {
@@ -278,6 +458,16 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var services = CreateServiceCollection(workspace, options =>
         {
             options.DotNetCliRunnerFactory = _ => runner;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    requestedAppHostFile = projectFile;
+                    requestedMultipleAppHostBehavior = behavior;
+                    requestedCreateSettingsFile = createSettingsFile;
+                    return Task.FromResult(new AppHostProjectSearchResult(unsupportedAppHostFile, [unsupportedAppHostFile, appHostFile]));
+                }
+            };
         });
         using var provider = services.BuildServiceProvider();
 
@@ -291,7 +481,89 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(expectedTemplate, selectedTemplate);
-        Assert.Equal(xunitVersion is null ? [] : ["--xunit-version", xunitVersion], runner.LastNewProjectExtraArgs);
+        var expectedExtraArgs = new List<string>();
+        if (xunitVersion is not null)
+        {
+            expectedExtraArgs.AddRange(["--xunit-version", xunitVersion]);
+        }
+        expectedExtraArgs.AddRange(
+        [
+            "--WithAppHostReference",
+            "true",
+            "--AppHostProjectPath",
+            Path.Combine("..", "AppHost", "AppHost.csproj"),
+            "--AppHostProjectName",
+            "AppHost"
+        ]);
+        Assert.Equal(expectedExtraArgs, runner.LastNewProjectExtraArgs);
+        Assert.Null(requestedAppHostFile);
+        Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, requestedMultipleAppHostBehavior);
+        Assert.False(requestedCreateSettingsFile);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateRequestsAppHostSelectionWhenInteractive()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var firstAppHostFile = new FileInfo(Path.Combine(workspace.CreateDirectory("AppHost1").FullName, "AppHost1.csproj"));
+        var selectedAppHostFile = new FileInfo(Path.Combine(workspace.CreateDirectory("AppHost2").FullName, "AppHost2.csproj"));
+        var unsupportedAppHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(firstAppHostFile.FullName, "<Project />");
+        await File.WriteAllTextAsync(selectedAppHostFile.FullName, "<Project />");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (_, projectName, generatedPath, _, _) =>
+        {
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
+            return 0;
+        };
+        var interactionService = new TestInteractionService
+        {
+            PromptForSelectionCallback = (prompt, choices, _, _) =>
+            {
+                Assert.Equal(InteractionServiceStrings.SelectAppHostToUse, prompt);
+                Assert.Equal([firstAppHostFile, selectedAppHostFile], choices.Cast<FileInfo>());
+                return selectedAppHostFile;
+            }
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ => interactionService;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Null(projectFile);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
+                    Assert.False(createSettingsFile);
+                    return Task.FromResult(new AppHostProjectSearchResult(unsupportedAppHostFile, [firstAppHostFile, unsupportedAppHostFile, selectedAppHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var extraArgs = Assert.IsType<string[]>(runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+        [
+            "--WithAppHostReference",
+            "true",
+            "--AppHostProjectPath",
+            Path.Combine("..", "AppHost2", "AppHost2.csproj"),
+            "--AppHostProjectName",
+            "AppHost2"
+        ],
+        extraArgs);
     }
 
     [Fact]
@@ -844,6 +1116,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.InteractionServiceFactory = (sp) => {
                 testInteractionService = new TestInteractionService();
                 return testInteractionService;
+            };
+            options.NewCommandPrompterFactory = serviceProvider => new TestNewCommandPrompter(serviceProvider.GetRequiredService<IInteractionService>())
+            {
+                PromptForTemplateCallback = templates =>
+                    templates.Single(template => template.Name.Equals("aspire-starter", StringComparison.OrdinalIgnoreCase))
             };
 
             options.DotNetCliRunnerFactory = (sp) => {

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -192,8 +192,114 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(expectedExtraArgs, extraArgs);
         Assert.Equal(Path.Combine(outputPath, "IntegrationTest1.cs"), openedEditorPath);
         Assert.Equal(appHostFile.FullName, requestedAppHostFile?.FullName);
-        Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, requestedMultipleAppHostBehavior);
+        Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, requestedMultipleAppHostBehavior);
         Assert.False(requestedCreateSettingsFile);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateSelectsCompatibleAppHostFromExplicitDirectory()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostsDirectory = workspace.CreateDirectory("AppHosts");
+        var csharpAppHostDirectory = appHostsDirectory.CreateSubdirectory("CSharpAppHost");
+        var csharpAppHostFile = new FileInfo(Path.Combine(csharpAppHostDirectory.FullName, "CSharpAppHost.csproj"));
+        var typescriptAppHostFile = new FileInfo(Path.Combine(appHostsDirectory.FullName, "apphost.mts"));
+        await File.WriteAllTextAsync(csharpAppHostFile.FullName, "<Project />");
+        await File.WriteAllTextAsync(typescriptAppHostFile.FullName, "// TypeScript AppHost");
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        runner.NewProjectAsyncCallback = (_, projectName, generatedPath, _, _) =>
+        {
+            Directory.CreateDirectory(generatedPath);
+            File.WriteAllText(Path.Combine(generatedPath, $"{projectName}.csproj"), "<Project />");
+            return 0;
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Equal(appHostsDirectory.FullName, projectFile?.FullName);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
+                    Assert.False(createSettingsFile);
+                    return Task.FromResult(new AppHostProjectSearchResult(null, [typescriptAppHostFile, csharpAppHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" " +
+            $"--apphost \"{appHostsDirectory.FullName}\" --non-interactive --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        var extraArgs = Assert.IsType<string[]>(runner.LastNewProjectExtraArgs);
+        Assert.Equal(
+        [
+            "--WithAppHostReference",
+            "true",
+            "--AppHostProjectPath",
+            Path.Combine("..", "AppHosts", "CSharpAppHost", "CSharpAppHost.csproj"),
+            "--AppHostProjectName",
+            "CSharpAppHost"
+        ],
+        extraArgs);
+    }
+
+    [Fact]
+    public async Task NewCommand_IntegrationTestTemplateReportsAmbiguousCompatibleAppHostsInExplicitDirectoryNonInteractively()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostsDirectory = workspace.CreateDirectory("AppHosts");
+        var firstAppHostFile = new FileInfo(Path.Combine(appHostsDirectory.FullName, "AppHost1.csproj"));
+        var secondAppHostFile = new FileInfo(Path.Combine(appHostsDirectory.FullName, "AppHost2.csproj"));
+        var typescriptAppHostFile = new FileInfo(Path.Combine(appHostsDirectory.FullName, "apphost.mts"));
+        var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
+        var runner = CreateTestRunnerWithStandardPackages();
+        TestInteractionService? interactionService = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => runner;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
+            options.ProjectLocatorFactory = _ => new TestProjectLocator
+            {
+                UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
+                {
+                    Assert.Equal(appHostsDirectory.FullName, projectFile?.FullName);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
+                    Assert.False(createSettingsFile);
+                    return Task.FromResult(new AppHostProjectSearchResult(null, [typescriptAppHostFile, firstAppHostFile, secondAppHostFile]));
+                }
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(
+            $"new aspire-test --test-framework MSTest --name AppHost.Tests --output \"{outputPath}\" " +
+            $"--apphost \"{appHostsDirectory.FullName}\" --non-interactive --suppress-agent-init");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.NotNull(interactionService);
+        Assert.Equal(
+            InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts,
+            Assert.Single(interactionService.DisplayedErrors));
+        Assert.Null(runner.LastNewProjectExtraArgs);
     }
 
     [Theory]
@@ -308,7 +414,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
                 {
                     Assert.Equal(appHostFile.FullName, projectFile?.FullName);
-                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
                     Assert.False(createSettingsFile);
                     throw new ProjectLocatorException(
                         ErrorStrings.ProjectFileNotAppHostProject,
@@ -393,7 +499,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
                 {
                     Assert.Equal(appHostFile.FullName, projectFile?.FullName);
-                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
+                    Assert.Equal(MultipleAppHostProjectsFoundBehavior.None, behavior);
                     Assert.False(createSettingsFile);
                     return Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]));
                 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -286,17 +286,23 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NewCommand_IntegrationTestTemplateReportsExplicitAppHostResolutionFailure()
+    public async Task NewCommand_IntegrationTestTemplateReportsExplicitNonAppHostFailure()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MissingAppHost", "AppHost.csproj"));
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "WebApp.csproj"));
         var outputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.Tests");
         var runner = CreateTestRunnerWithStandardPackages();
+        TestInteractionService? interactionService = null;
 
         var services = CreateServiceCollection(workspace, options =>
         {
             options.DotNetCliRunnerFactory = _ => runner;
             options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.InteractionServiceFactory = _ =>
+            {
+                interactionService = new TestInteractionService();
+                return interactionService;
+            };
             options.ProjectLocatorFactory = _ => new TestProjectLocator
             {
                 UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (projectFile, behavior, createSettingsFile, _) =>
@@ -305,8 +311,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     Assert.Equal(MultipleAppHostProjectsFoundBehavior.Throw, behavior);
                     Assert.False(createSettingsFile);
                     throw new ProjectLocatorException(
-                        "The specified AppHost project does not exist.",
-                        ProjectLocatorFailureReason.ProjectFileDoesntExist);
+                        ErrorStrings.ProjectFileNotAppHostProject,
+                        ProjectLocatorFailureReason.ProjectFileNotAppHostProject);
                 }
             };
         });
@@ -320,6 +326,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.NotNull(interactionService);
+        Assert.Equal(InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject, Assert.Single(interactionService.DisplayedErrors));
         Assert.Null(runner.LastNewProjectExtraArgs);
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -521,6 +521,11 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         });
 
         Assert.Equal(ErrorStrings.ProjectFileDoesntExist, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.ProjectFileDoesntExist, ex.FailureReason);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionDoesntExist, errorMessage);
     }
 
     [Fact]
@@ -2044,6 +2049,11 @@ builder.Build().Run();");
         });
 
         Assert.Equal(ErrorStrings.ProjectFileDoesntExist, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.ProjectFileDoesntExist, ex.FailureReason);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionDoesntExist, errorMessage);
     }
 
     [Fact]
@@ -2360,6 +2370,11 @@ builder.Build().Run();");
         });
 
         Assert.Equal(ErrorStrings.ProjectFileDoesntExist, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.ProjectFileDoesntExist, ex.FailureReason);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsNoAppHosts, errorMessage);
     }
 
     [Fact]
@@ -2426,7 +2441,7 @@ builder.Build().Run();");
         Assert.Equal(ErrorStrings.AppHostsMayNotBeBuildable, ex.Message);
         Assert.Equal(ProjectLocatorFailureReason.AppHostsMayNotBeBuildable, ex.FailureReason);
 
-        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex, projectOptionSpecifiedAsDirectory: true);
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
         Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
         Assert.Equal(InteractionServiceStrings.UnbuildableAppHostsDetected, errorMessage);
     }
@@ -2720,6 +2735,44 @@ builder.Build().Run();");
 
         // Should return the first project file (TestInteractionService returns the first choice)
         AssertSameFileSystemPath(projectFile1.FullName, returnedProjectFile!.FullName);
+    }
+
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileThrowsDirectorySpecificDiagnosticWhenDirectoryHasMultipleProjects()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var projectDirectory = workspace.WorkspaceRoot.CreateSubdirectory("MultiProject");
+        var projectFile1 = new FileInfo(Path.Combine(projectDirectory.FullName, "Project1.csproj"));
+        await File.WriteAllTextAsync(projectFile1.FullName, "Not a real project file.");
+        var projectFile2 = new FileInfo(Path.Combine(projectDirectory.FullName, "Project2.csproj"));
+        await File.WriteAllTextAsync(projectFile2.FullName, "Not a real project file.");
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = file => new AppHostValidationResult(
+                IsValid: file.FullName == projectFile1.FullName || file.FullName == projectFile2.FullName)
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+        var directoryAsFileInfo = new FileInfo(projectDirectory.FullName);
+
+        var ex = await Assert.ThrowsAsync<ProjectLocatorException>(async () =>
+        {
+            await projectLocator.UseOrFindAppHostProjectFileAsync(
+                directoryAsFileInfo,
+                MultipleAppHostProjectsFoundBehavior.Throw,
+                createSettingsFile: false,
+                CancellationToken.None).DefaultTimeout();
+        });
+
+        Assert.Equal(ErrorStrings.MultipleProjectFilesFound, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.MultipleProjectFilesFound, ex.FailureReason);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts, errorMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -2052,12 +2052,12 @@ builder.Build().Run();");
             await projectLocator.UseOrFindAppHostProjectFileAsync(appHostFile, createSettingsFile: true, CancellationToken.None).DefaultTimeout();
         });
 
-        Assert.Equal(ErrorStrings.ProjectFileDoesntExist, ex.Message);
-        Assert.Equal(ProjectLocatorFailureReason.ProjectFileDoesntExist, ex.FailureReason);
+        Assert.Equal(ErrorStrings.ProjectFileNotAppHostProject, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.ProjectFileNotAppHostProject, ex.FailureReason);
 
         var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
         Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
-        Assert.Equal(InteractionServiceStrings.ProjectOptionDoesntExist, errorMessage);
+        Assert.Equal(InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject, errorMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -739,8 +739,12 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
                 CancellationToken.None).DefaultTimeout();
         });
 
-        Assert.Equal(ErrorStrings.ProjectFileDoesntExist, ex.Message);
-        Assert.Equal(ProjectLocatorFailureReason.ProjectFileDoesntExist, ex.FailureReason);
+        Assert.Equal(ErrorStrings.ProjectFileNotAppHostProject, ex.Message);
+        Assert.Equal(ProjectLocatorFailureReason.ProjectFileNotAppHostProject, ex.FailureReason);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(ex);
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject, errorMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -273,7 +273,7 @@ public class DotNetTemplateFactoryTests
     }
 
     [Fact]
-    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsStarterAndIntegrationTestTemplates()
+    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsOnlyStarterTemplates()
     {
         // Arrange
         var features = new TestFeatures();
@@ -288,7 +288,7 @@ public class DotNetTemplateFactoryTests
         Assert.DoesNotContain(KnownTemplateId.DotNetEmptyAppHost, templateNames);
         Assert.DoesNotContain("aspire-apphost", templateNames);
         Assert.DoesNotContain("aspire-servicedefaults", templateNames);
-        Assert.Contains("aspire-test", templateNames);
+        Assert.DoesNotContain("aspire-test", templateNames);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -273,7 +273,7 @@ public class DotNetTemplateFactoryTests
     }
 
     [Fact]
-    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsOnlyStarterTemplates()
+    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsStarterAndIntegrationTestTemplates()
     {
         // Arrange
         var features = new TestFeatures();
@@ -288,7 +288,7 @@ public class DotNetTemplateFactoryTests
         Assert.DoesNotContain(KnownTemplateId.DotNetEmptyAppHost, templateNames);
         Assert.DoesNotContain("aspire-apphost", templateNames);
         Assert.DoesNotContain("aspire-servicedefaults", templateNames);
-        Assert.DoesNotContain("aspire-test", templateNames);
+        Assert.Contains("aspire-test", templateNames);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
@@ -397,6 +398,7 @@ public class DotNetTemplateFactoryTests
         var telemetry = TestTelemetryHelper.CreateInitializedTelemetry();
         var hostEnvironment = new FakeCliHostEnvironment(nonInteractive);
         var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, prompter, hostEnvironment);
+        var appHostInfoResolver = new AppHostInfoResolver(runner, new NullAppHostInfoDiskCache());
 
         return new DotNetTemplateFactory(
             interactionService,
@@ -409,6 +411,7 @@ public class DotNetTemplateFactoryTests
             telemetry,
             hostEnvironment,
             templateNuGetConfigService,
+            appHostInfoResolver,
             environment ?? new TestEnvironment());
     }
 

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -292,6 +292,46 @@ public class DotNetTemplateFactoryTests
     }
 
     [Fact]
+    public async Task GetTemplates_WhenCliShowAllTemplatesIsEnabled_ReturnsAllTemplates()
+    {
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            [CliConfigNames.ShowAllTemplates] = "true"
+        });
+        var features = new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, false);
+        var factory = CreateTemplateFactory(features, environment: environment);
+
+        var templates = (await factory.GetTemplatesAsync()).ToList();
+
+        var templateNames = templates.Select(t => t.Name).ToList();
+        Assert.Equal(
+            [
+                "aspire-starter",
+                "aspire-ts-cs-starter",
+                KnownTemplateId.DotNetEmptyAppHost,
+                "aspire-apphost",
+                "aspire-servicedefaults",
+                "aspire-test"
+            ],
+            templateNames);
+    }
+
+    [Fact]
+    public async Task GetTemplates_WhenCliShowAllTemplatesIsDisabled_ReturnsOnlyStarterTemplates()
+    {
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            [CliConfigNames.ShowAllTemplates] = "false"
+        });
+        var factory = CreateTemplateFactory(new TestFeatures(), environment: environment);
+
+        var templates = (await factory.GetTemplatesAsync()).ToList();
+
+        var templateNames = templates.Select(t => t.Name).ToList();
+        Assert.Equal(["aspire-starter", "aspire-ts-cs-starter"], templateNames);
+    }
+
+    [Fact]
     public async Task GetTemplates_SingleFileAppHostIsNotReturned()
     {
         // Arrange
@@ -340,7 +380,11 @@ public class DotNetTemplateFactoryTests
         Assert.Empty(templates);
     }
 
-    private static DotNetTemplateFactory CreateTemplateFactory(TestFeatures features, bool nonInteractive = false, TestDotNetSdkInstaller? sdkInstaller = null)
+    private static DotNetTemplateFactory CreateTemplateFactory(
+        TestFeatures features,
+        bool nonInteractive = false,
+        TestDotNetSdkInstaller? sdkInstaller = null,
+        IEnvironment? environment = null)
     {
         var interactionService = new TestInteractionService();
         var runner = new TestDotNetCliRunner();
@@ -365,7 +409,7 @@ public class DotNetTemplateFactoryTests
             telemetry,
             hostEnvironment,
             templateNuGetConfigService,
-            new HostEnvironment());
+            environment ?? new TestEnvironment());
     }
 
     private sealed class TestInteractionService : IInteractionService

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -267,14 +267,14 @@ public class DotNetTemplateFactoryTests
         // Assert
         var templateNames = templates.Select(t => t.Name).ToList();
         Assert.Contains("aspire-starter", templateNames);
+        Assert.Contains("aspire-test", templateNames);
         Assert.Contains("aspire", templateNames);
         Assert.Contains("aspire-apphost", templateNames);
         Assert.Contains("aspire-servicedefaults", templateNames);
-        Assert.Contains("aspire-test", templateNames);
     }
 
     [Fact]
-    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsOnlyStarterTemplates()
+    public async Task GetTemplates_WhenShowAllTemplatesIsDisabled_ReturnsStarterAndIntegrationTestTemplates()
     {
         // Arrange
         var features = new TestFeatures();
@@ -286,50 +286,10 @@ public class DotNetTemplateFactoryTests
         // Assert
         var templateNames = templates.Select(t => t.Name).ToList();
         Assert.Contains("aspire-starter", templateNames);
+        Assert.Contains("aspire-test", templateNames);
         Assert.DoesNotContain(KnownTemplateId.DotNetEmptyAppHost, templateNames);
         Assert.DoesNotContain("aspire-apphost", templateNames);
         Assert.DoesNotContain("aspire-servicedefaults", templateNames);
-        Assert.DoesNotContain("aspire-test", templateNames);
-    }
-
-    [Fact]
-    public async Task GetTemplates_WhenCliShowAllTemplatesIsEnabled_ReturnsAllTemplates()
-    {
-        var environment = new TestEnvironment(new Dictionary<string, string?>
-        {
-            [CliConfigNames.ShowAllTemplates] = "true"
-        });
-        var features = new TestFeatures().SetFeature(KnownFeatures.ShowAllTemplates, false);
-        var factory = CreateTemplateFactory(features, environment: environment);
-
-        var templates = (await factory.GetTemplatesAsync()).ToList();
-
-        var templateNames = templates.Select(t => t.Name).ToList();
-        Assert.Equal(
-            [
-                "aspire-starter",
-                "aspire-ts-cs-starter",
-                KnownTemplateId.DotNetEmptyAppHost,
-                "aspire-apphost",
-                "aspire-servicedefaults",
-                "aspire-test"
-            ],
-            templateNames);
-    }
-
-    [Fact]
-    public async Task GetTemplates_WhenCliShowAllTemplatesIsDisabled_ReturnsOnlyStarterTemplates()
-    {
-        var environment = new TestEnvironment(new Dictionary<string, string?>
-        {
-            [CliConfigNames.ShowAllTemplates] = "false"
-        });
-        var factory = CreateTemplateFactory(new TestFeatures(), environment: environment);
-
-        var templates = (await factory.GetTemplatesAsync()).ToList();
-
-        var templateNames = templates.Select(t => t.Name).ToList();
-        Assert.Equal(["aspire-starter", "aspire-ts-cs-starter"], templateNames);
     }
 
     [Fact]
@@ -381,11 +341,7 @@ public class DotNetTemplateFactoryTests
         Assert.Empty(templates);
     }
 
-    private static DotNetTemplateFactory CreateTemplateFactory(
-        TestFeatures features,
-        bool nonInteractive = false,
-        TestDotNetSdkInstaller? sdkInstaller = null,
-        IEnvironment? environment = null)
+    private static DotNetTemplateFactory CreateTemplateFactory(TestFeatures features, bool nonInteractive = false, TestDotNetSdkInstaller? sdkInstaller = null)
     {
         var interactionService = new TestInteractionService();
         var runner = new TestDotNetCliRunner();
@@ -412,7 +368,7 @@ public class DotNetTemplateFactoryTests
             hostEnvironment,
             templateNuGetConfigService,
             appHostInfoResolver,
-            environment ?? new TestEnvironment());
+            new HostEnvironment());
     }
 
     private sealed class TestInteractionService : IInteractionService

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -368,7 +368,8 @@ public class DotNetTemplateFactoryTests
             hostEnvironment,
             templateNuGetConfigService,
             appHostInfoResolver,
-            new HostEnvironment());
+            new HostEnvironment(),
+            NullLogger<DotNetTemplateFactory>.Instance);
     }
 
     private sealed class TestInteractionService : IInteractionService

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -368,6 +368,7 @@ public class DotNetTemplateFactoryTests
             hostEnvironment,
             templateNuGetConfigService,
             appHostInfoResolver,
+            new TestProjectLocator(),
             new HostEnvironment(),
             NullLogger<DotNetTemplateFactory>.Instance);
     }

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -495,7 +495,7 @@ public class DotNetTemplateFactoryTests
         public Task<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> PromptForTemplatesVersionAsync(IEnumerable<(Aspire.Shared.NuGetPackageCli Package, PackageChannel Channel)> packages, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<ITemplate> PromptForTemplateAsync(ITemplate[] templates, CancellationToken cancellationToken)
+        public Task<ITemplate> PromptForTemplateAsync(ITemplate[] templates, CancellationToken cancellationToken, PromptBinding<string?>? binding = null)
             => throw new NotImplementedException();
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -24,7 +24,9 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, string[], string[], ProcessInvocationOptions, CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
     public Func<string, string, FileInfo?, string?, bool, ProcessInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, ProcessInvocationOptions, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
+    public Func<string, string, string, ProcessInvocationOptions, CancellationToken, int>? NewProjectDryRunAsyncCallback { get; set; }
     public string[]? LastNewProjectExtraArgs { get; private set; }
+    public string[]? LastNewProjectDryRunExtraArgs { get; private set; }
     public Func<FileInfo, bool, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostCliBackchannel>?, ProcessInvocationOptions, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
     public Func<FileInfo, string, DirectoryInfo, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostCliBackchannel>?, ProcessInvocationOptions, CancellationToken, Task<int>>? RunAppHostCommandAsyncCallback { get; set; }
     public bool InvokeExtensionAppHostLaunchCompletedCallback { get; set; } = true;
@@ -160,6 +162,13 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 
     public Task<int> NewProjectAsync(string templateName, string name, string outputPath, string[] extraArgs, ProcessInvocationOptions options, CancellationToken cancellationToken)
     {
+        // Dry runs must not invoke callbacks that simulate creating project files.
+        if (extraArgs.Contains("--dry-run", StringComparer.Ordinal))
+        {
+            LastNewProjectDryRunExtraArgs = extraArgs.ToArray();
+            return Task.FromResult(NewProjectDryRunAsyncCallback?.Invoke(templateName, name, outputPath, options, cancellationToken) ?? 0);
+        }
+
         LastNewProjectExtraArgs = extraArgs.ToArray();
 
         return NewProjectAsyncCallback != null

--- a/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestNewCommandPrompter.cs
@@ -19,7 +19,7 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
     public Func<string, string>? PromptForOutputPathCallback { get; set; }
     public Func<string, Func<string, ValidationResult>?, string>? PromptForOutputPathWithValidatorCallback { get; set; }
 
-    public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
+    public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken, PromptBinding<string?>? binding = null)
     {
         return PromptForTemplateCallback switch
         {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -634,7 +634,8 @@ internal sealed class CliServiceCollectionTestOptions
         var scaffoldingService = serviceProvider.GetRequiredService<IScaffoldingService>();
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
         var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, new HostEnvironment());
+        var appHostInfoResolver = serviceProvider.GetRequiredService<IAppHostInfoResolver>();
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, new HostEnvironment());
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
         var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, serviceProvider.GetRequiredService<IEnvironment>(), templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -635,9 +635,10 @@ internal sealed class CliServiceCollectionTestOptions
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
         var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
         var appHostInfoResolver = serviceProvider.GetRequiredService<IAppHostInfoResolver>();
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, new HostEnvironment());
+        var environment = serviceProvider.GetRequiredService<IEnvironment>();
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, environment);
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
-        var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, serviceProvider.GetRequiredService<IEnvironment>(), templateNuGetConfigService, cliTemplateLogger);
+        var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, environment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);
     };
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -221,7 +221,7 @@ internal static class CliTestHelper
         // IdentityChannelReader for AspireVersionCheck (doctor) — uses the same
         // pattern as production wiring in Program.cs.
         services.AddSingleton<IIdentityChannelReader>(_ => new IdentityChannelReader(typeof(Program).Assembly));
-        services.AddSingleton<IEnvironment, TestEnvironment>();
+        services.AddSingleton(options.EnvironmentFactory);
         services.AddSingleton<ProfileCaptureState>();
         services.AddSingleton<ProfileCaptureService>();
 
@@ -367,6 +367,12 @@ internal sealed class CliServiceCollectionTestOptions
     public DirectoryInfo WorkingDirectory { get; set; }
 
     public DirectoryInfo? PackagesDirectory { get; set; }
+
+    public Func<IServiceProvider, IEnvironment> EnvironmentFactory { get; set; } = _ =>
+        new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["PATH"] = Environment.GetEnvironmentVariable("PATH")
+        });
 
     public Action<Dictionary<string, string?>> ConfigurationCallback { get; set; } = (Dictionary<string, string?> config) =>
     {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -641,9 +641,10 @@ internal sealed class CliServiceCollectionTestOptions
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
         var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
         var appHostInfoResolver = serviceProvider.GetRequiredService<IAppHostInfoResolver>();
+        var projectLocator = serviceProvider.GetRequiredService<IProjectLocator>();
         var environment = serviceProvider.GetRequiredService<IEnvironment>();
         var dotNetTemplateLogger = serviceProvider.GetRequiredService<ILogger<DotNetTemplateFactory>>();
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, environment, dotNetTemplateLogger);
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, projectLocator, environment, dotNetTemplateLogger);
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
         var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, environment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -642,7 +642,8 @@ internal sealed class CliServiceCollectionTestOptions
         var templateNuGetConfigService = serviceProvider.GetRequiredService<TemplateNuGetConfigService>();
         var appHostInfoResolver = serviceProvider.GetRequiredService<IAppHostInfoResolver>();
         var environment = serviceProvider.GetRequiredService<IEnvironment>();
-        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, environment);
+        var dotNetTemplateLogger = serviceProvider.GetRequiredService<ILogger<DotNetTemplateFactory>>();
+        var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, prompter, executionContext, sdkInstaller, features, telemetry, hostEnvironment, templateNuGetConfigService, appHostInfoResolver, environment, dotNetTemplateLogger);
         var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
         var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, environment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -15,7 +15,8 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
         TestTargetFramework tfm,
         string? error,
         string? appHostDirectoryNamePrefix = null,
-        bool withAppHostReference = true)
+        bool withAppHostReference = true,
+        bool runTests = false)
     {
         var id = GetNewProjectId(prefix: $"new_build_{FixupSymbolName(templateName)}");
         var topLevelDir = Path.Combine(BuildEnvironment.TestRootPath, id + "_root");
@@ -66,12 +67,42 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
                                         withAppHostReference: withAppHostReference);
 
             await project.BuildAsync(extraBuildArgs: [$"-c {config}"], workingDirectory: testProjectDir);
+            if (runTests)
+            {
+                using var testCommand = new DotNetCommand(_testOutput, buildEnv: buildEnvToUse, label: $"test-{templateName}")
+                    .WithWorkingDirectory(testProjectDir)
+                    .WithTimeout(TimeSpan.FromMinutes(3));
+
+                var testResult = await testCommand.ExecuteAsync($"test -c {config} --no-build");
+
+                Assert.Equal(0, testResult.ExitCode);
+                Assert.Matches("Passed! * - Failed: *0, Passed: *1, Skipped: *0, Total: *1", testResult.Output);
+            }
         }
         catch (ToolCommandException tce) when (error is not null)
         {
             Assert.NotNull(tce.Result);
             Assert.Contains(error, tce.Result.Value.Output);
         }
+    }
+}
+
+public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper testOutput) : NewUpAndBuildSupportProjectTemplatesBase(testOutput)
+{
+    [Theory]
+    [InlineData("aspire-mstest", "")]
+    [InlineData("aspire-nunit", "")]
+    [InlineData("aspire-xunit", "--xunit-version v2")]
+    [InlineData("aspire-xunit", "--xunit-version v3mtp")]
+    public Task CanNewAndTestWithAppHostReference(string templateName, string extraTestCreationArgs)
+    {
+        return CanNewAndBuildActual(
+            templateName,
+            extraTestCreationArgs,
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            runTests: true);
     }
 }
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -109,14 +109,15 @@ public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper te
 public class Standalone_NewUpAndBuildSupportProjectTemplatesTests(ITestOutputHelper testOutput) : NewUpAndBuildSupportProjectTemplatesBase(testOutput)
 {
     [Theory]
-    [InlineData("aspire-mstest")]
-    [InlineData("aspire-nunit")]
-    [InlineData("aspire-xunit")]
-    public Task CanNewAndBuildWithoutAppHostReference(string templateName)
+    [InlineData("aspire-mstest", "")]
+    [InlineData("aspire-nunit", "")]
+    [InlineData("aspire-xunit", "")]
+    [InlineData("aspire-xunit", "--xunit-version v3mtp")]
+    public Task CanNewAndBuildWithoutAppHostReference(string templateName, string extraTestCreationArgs)
     {
         return CanNewAndBuildActual(
             templateName,
-            "",
+            extraTestCreationArgs,
             TestSdk.Net10,
             TestTargetFramework.Net10,
             error: null,

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -8,7 +8,14 @@ namespace Aspire.Templates.Tests;
 public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper testOutput) : TemplateTestsBase(testOutput)
 {
     [Trait("category", "basic-build")]
-    protected async Task CanNewAndBuildActual(string templateName, string extraTestCreationArgs, TestSdk sdk, TestTargetFramework tfm, string? error)
+    protected async Task CanNewAndBuildActual(
+        string templateName,
+        string extraTestCreationArgs,
+        TestSdk sdk,
+        TestTargetFramework tfm,
+        string? error,
+        string? appHostDirectoryNamePrefix = null,
+        bool withAppHostReference = true)
     {
         var id = GetNewProjectId(prefix: $"new_build_{FixupSymbolName(templateName)}");
         var topLevelDir = Path.Combine(BuildEnvironment.TestRootPath, id + "_root");
@@ -41,6 +48,12 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
                 addEndpointsHook: false,
                 overrideRootDir: topLevelDir);
             project.AppHostProjectDirectory = Path.Combine(topLevelDir, id + ".AppHost");
+            if (appHostDirectoryNamePrefix is not null)
+            {
+                var specialAppHostDirectory = Path.Combine(topLevelDir, GetNewProjectId(appHostDirectoryNamePrefix));
+                Directory.Move(project.AppHostProjectDirectory, specialAppHostDirectory);
+                project.AppHostProjectDirectory = specialAppHostDirectory;
+            }
 
             var testProjectDir = await CreateAndAddTestTemplateProjectAsync(
                                         id: id,
@@ -49,7 +62,8 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
                                         tfm: tfm,
                                         buildEnvironment: buildEnvToUse,
                                         extraArgs: extraTestCreationArgs,
-                                        overrideRootDir: topLevelDir);
+                                        overrideRootDir: topLevelDir,
+                                        withAppHostReference: withAppHostReference);
 
             await project.BuildAsync(extraBuildArgs: [$"-c {config}"], workingDirectory: testProjectDir);
         }
@@ -58,6 +72,24 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
             Assert.NotNull(tce.Result);
             Assert.Contains(error, tce.Result.Value.Output);
         }
+    }
+}
+
+public class Standalone_NewUpAndBuildSupportProjectTemplatesTests(ITestOutputHelper testOutput) : NewUpAndBuildSupportProjectTemplatesBase(testOutput)
+{
+    [Theory]
+    [InlineData("aspire-mstest")]
+    [InlineData("aspire-nunit")]
+    [InlineData("aspire-xunit")]
+    public Task CanNewAndBuildWithoutAppHostReference(string templateName)
+    {
+        return CanNewAndBuildActual(
+            templateName,
+            "",
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            withAppHostReference: false);
     }
 }
 
@@ -128,5 +160,17 @@ public class MSTest_NewUpAndBuildSupportProjectTemplatesTests(ITestOutputHelper 
     public Task CanNewAndBuild(string templateName, string extraTestCreationArgs, TestSdk sdk, TestTargetFramework tfm, string? error)
     {
         return CanNewAndBuildActual(templateName, extraTestCreationArgs, sdk, tfm, error);
+    }
+
+    [Fact]
+    public Task CanNewAndBuildWithMSBuildSpecialCharactersInAppHostPath()
+    {
+        return CanNewAndBuildActual(
+            "aspire-mstest",
+            "",
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            appHostDirectoryNamePrefix: "AppHost_$(literal);100%@'&");
     }
 }

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml.Linq;
 using Xunit;
 
 namespace Aspire.Templates.Tests;
@@ -16,6 +17,7 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
         string? error,
         string? appHostDirectoryNamePrefix = null,
         bool withAppHostReference = true,
+        bool useAppHostTargetFramework = true,
         bool runTests = false)
     {
         var id = GetNewProjectId(prefix: $"new_build_{FixupSymbolName(templateName)}");
@@ -64,7 +66,8 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
                                         buildEnvironment: buildEnvToUse,
                                         extraArgs: extraTestCreationArgs,
                                         overrideRootDir: topLevelDir,
-                                        withAppHostReference: withAppHostReference);
+                                        withAppHostReference: withAppHostReference,
+                                        useAppHostTargetFramework: useAppHostTargetFramework);
 
             await project.BuildAsync(extraBuildArgs: [$"-c {config}"], workingDirectory: testProjectDir);
             if (runTests)
@@ -103,6 +106,77 @@ public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper te
             TestTargetFramework.Net10,
             error: null,
             runTests: true);
+    }
+
+    [Fact]
+    public Task AppHostTargetFrameworkOverridesExplicitFramework()
+    {
+        return CanNewAndBuildActual(
+            "aspire-mstest",
+            "--framework net11.0",
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            runTests: true);
+    }
+
+    [Fact]
+    public Task MissingAppHostTargetFrameworkFallsBackToExplicitFramework()
+    {
+        return CanNewAndBuildActual(
+            "aspire-mstest",
+            "",
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            useAppHostTargetFramework: false,
+            runTests: true);
+    }
+
+    [Theory]
+    [InlineData("aspire-mstest")]
+    [InlineData("aspire-nunit")]
+    [InlineData("aspire-xunit")]
+    public async Task AppHostTargetFrameworkAcceptsPlatformQualifiedFramework(string templateName)
+    {
+        var buildEnvironment = BuildEnvironment.ForNet10SdkOnly;
+        var id = GetNewProjectId(prefix: $"platform_tfm_{FixupSymbolName(templateName)}");
+        var topLevelDir = Path.Combine(BuildEnvironment.TestRootPath, id + "_root");
+        var testProjectName = $"{id}.Tests";
+        var testProjectDir = Path.Combine(topLevelDir, testProjectName);
+
+        if (Directory.Exists(topLevelDir))
+        {
+            Directory.Delete(topLevelDir, recursive: true);
+        }
+        Directory.CreateDirectory(topLevelDir);
+
+        try
+        {
+            using var newTestCmd = new DotNetNewCommand(
+                _testOutput,
+                label: $"platform-tfm-{templateName}",
+                buildEnv: buildEnvironment)
+                .WithWorkingDirectory(topLevelDir);
+
+            var appHostProjectPath = Path.Combine("..", "AppHost", "AppHost.csproj");
+            var result = await newTestCmd.ExecuteAsync(
+                $"{templateName} -o \"{testProjectName}\" --no-restore " +
+                $"--WithAppHostReference true --AppHostProjectPath \"{appHostProjectPath}\" " +
+                "--AppHostProjectName AppHost --AppHostTargetFramework net10.0-windows");
+            result.EnsureSuccessful();
+
+            var testProjectPath = Assert.Single(Directory.EnumerateFiles(testProjectDir, "*.csproj"));
+            var testProject = XDocument.Load(testProjectPath);
+            Assert.Equal("net10.0-windows", Assert.Single(testProject.Descendants("TargetFramework")).Value);
+        }
+        finally
+        {
+            if (Directory.Exists(topLevelDir))
+            {
+                Directory.Delete(topLevelDir, recursive: true);
+            }
+        }
     }
 }
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -120,14 +120,17 @@ public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper te
             runTests: true);
     }
 
-    [Fact]
-    public Task MissingAppHostTargetFrameworkFallsBackToExplicitFramework()
+    [Theory]
+    [InlineData("aspire-mstest")]
+    [InlineData("aspire-nunit")]
+    [InlineData("aspire-xunit")]
+    public Task MissingAppHostTargetFrameworkFallsBackToExplicitFramework(string templateName)
     {
         return CanNewAndBuildActual(
-            "aspire-mstest",
+            templateName,
             "",
             TestSdk.Net10,
-            TestTargetFramework.Net10,
+            TestTargetFramework.Net9,
             error: null,
             useAppHostTargetFramework: false,
             runTests: true);

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -129,7 +129,7 @@ public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper te
         return CanNewAndBuildActual(
             templateName,
             "",
-            TestSdk.Net10,
+            TestSdk.Net11WithAllSupportedRuntimes,
             TestTargetFramework.Net9,
             error: null,
             useAppHostTargetFramework: false,

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -140,6 +140,22 @@ public class Wired_NewUpAndTestSupportProjectTemplatesTests(ITestOutputHelper te
     [InlineData("aspire-mstest")]
     [InlineData("aspire-nunit")]
     [InlineData("aspire-xunit")]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public Task CanNewAndBuildWithQuoteInAppHostPath(string templateName)
+    {
+        return CanNewAndBuildActual(
+            templateName,
+            "",
+            TestSdk.Net10,
+            TestTargetFramework.Net10,
+            error: null,
+            appHostDirectoryNamePrefix: "AppHost_\"quoted");
+    }
+
+    [Theory]
+    [InlineData("aspire-mstest")]
+    [InlineData("aspire-nunit")]
+    [InlineData("aspire-xunit")]
     public async Task AppHostTargetFrameworkAcceptsPlatformQualifiedFramework(string templateName)
     {
         var buildEnvironment = BuildEnvironment.ForNet10SdkOnly;

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -52,8 +52,8 @@ public abstract partial class PerTestFrameworkTemplatesTests : TemplateTestsBase
 
         var res = await cmd.ExecuteAsync($"test -c {config}");
 
-        Assert.True(res.ExitCode != 0, $"Expected the tests project run to fail");
-        Assert.Matches("Failed! * - Failed: *1, Passed: *0, Skipped: *0, Total: *1", res.Output);
+        Assert.Equal(0, res.ExitCode);
+        Assert.Matches("Passed! * - Failed: *0, Passed: *1, Skipped: *0, Total: *1", res.Output);
 
         async Task AssertBasicTemplateAsync(IBrowserContext context)
         {

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -14,6 +14,9 @@ namespace Aspire.Templates.Tests;
 
 public partial class TemplateTestsBase
 {
+    [GeneratedRegex(@"^\s*//")]
+    private static partial Regex CommentLineRegex();
+
     // Regex is from src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets - _GeneratedClassNameFixupRegex
     [GeneratedRegex(@"(((?<=\.)|^)(?=\d)|\W)")]
     private static partial Regex GeneratedClassNameFixupRegex();
@@ -84,6 +87,20 @@ public partial class TemplateTestsBase
         if (!withAppHostReference)
         {
             Assert.Empty(projectReferences);
+
+            // Standalone templates intentionally emit the sample as comments. Add the same reference users
+            // are instructed to add, then uncomment the sample so the caller's build verifies that guidance.
+            testProject.Root!.Add(
+                new XElement("ItemGroup",
+                    new XElement("ProjectReference",
+                        new XAttribute("Include", EscapeMSBuildItemValue(relativeAppHostProjectPath)))));
+            testProject.Save(testProjectPath);
+
+            UncommentInstructionalSample(
+                Path.Combine(testProjectDir, "IntegrationTest1.cs"),
+                testTemplateName,
+                appHostProjectName);
+
             return testProjectDir;
         }
 
@@ -96,6 +113,41 @@ public partial class TemplateTestsBase
         Assert.Contains($"DistributedApplicationTestingBuilder.CreateAsync<Projects.{appHostProjectType}>", testSource);
 
         return testProjectDir;
+    }
+
+    private static void UncommentInstructionalSample(string testSourcePath, string testTemplateName, string appHostProjectName)
+    {
+        var marker = testTemplateName switch
+        {
+            "aspire-nunit" => "// [Test]",
+            "aspire-mstest" => "// [TestMethod]",
+            "aspire-xunit" => "// [Fact]",
+            _ => throw new NotImplementedException($"Unknown test template: {testTemplateName}")
+        };
+
+        var source = new StringBuilder();
+        var inTest = false;
+        foreach (var line in File.ReadAllLines(testSourcePath))
+        {
+            if (!inTest && line.Contains(marker, StringComparison.Ordinal))
+            {
+                inTest = true;
+            }
+
+            if (inTest && CommentLineRegex().IsMatch(line))
+            {
+                source.AppendLine(CommentLineRegex().Replace(line, "    "));
+                continue;
+            }
+
+            source.AppendLine(line);
+        }
+
+        Assert.True(inTest, $"Expected instructional sample marker '{marker}' in {testSourcePath}");
+
+        var appHostProjectType = GeneratedClassNameFixupRegex().Replace(appHostProjectName, "_");
+        source.Replace("Projects.MyAspireApp_AppHost", $"Projects.{appHostProjectType}");
+        File.WriteAllText(testSourcePath, source.ToString());
     }
 
     private static string UnescapeMSBuildItemValue(string value)

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -54,10 +54,16 @@ public partial class TemplateTestsBase
         BuildEnvironment? buildEnvironment = null,
         string? extraArgs = null,
         string? overrideRootDir = null,
-        bool withAppHostReference = true)
+        bool withAppHostReference = true,
+        bool useAppHostTargetFramework = true)
     {
         buildEnvironment ??= BuildEnvironment.ForDefaultFramework;
-        var tmfArg = tfm is not null ? $"-f {tfm.Value.ToTFMString()}" : "";
+        var targetFramework = tfm?.ToTFMString();
+        var frameworkArg = targetFramework is null
+            ? ""
+            : withAppHostReference && useAppHostTargetFramework
+                ? $"--AppHostTargetFramework {targetFramework}"
+                : $"-f {targetFramework}";
 
         string rootDirToUse = overrideRootDir ?? project.RootDir;
         // Add test project
@@ -74,7 +80,7 @@ public partial class TemplateTestsBase
                                     label: $"new-test-{testTemplateName}",
                                     buildEnv: buildEnvironment)
                                 .WithWorkingDirectory(rootDirToUse);
-        var res = await newTestCmd.ExecuteAsync($"{testTemplateName} {tmfArg} -o \"{testProjectName}\" {extraArgs} {appHostArgs}");
+        var res = await newTestCmd.ExecuteAsync($"{testTemplateName} {frameworkArg} -o \"{testProjectName}\" {extraArgs} {appHostArgs}");
         res.EnsureSuccessful();
 
         Assert.True(Directory.Exists(testProjectDir), $"Expected tests project at {testProjectDir}");
@@ -83,6 +89,11 @@ public partial class TemplateTestsBase
         Assert.True(File.Exists(testProjectPath), $"Expected tests project file at {testProjectPath}");
 
         var testProject = XDocument.Load(testProjectPath);
+        if (targetFramework is not null)
+        {
+            Assert.Equal(targetFramework, Assert.Single(testProject.Descendants("TargetFramework")).Value);
+        }
+
         var projectReferences = testProject.Descendants("ProjectReference").ToArray();
         if (!withAppHostReference)
         {

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -1,9 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml;
+using System.Xml.Linq;
 using Aspire.TestUtilities;
 using Microsoft.Playwright;
 using Xunit;
@@ -13,14 +14,12 @@ namespace Aspire.Templates.Tests;
 
 public partial class TemplateTestsBase
 {
-    [GeneratedRegex(@"^\s*//")]
-    private static partial Regex CommentLineRegex();
-
     // Regex is from src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets - _GeneratedClassNameFixupRegex
     [GeneratedRegex(@"(((?<=\.)|^)(?=\d)|\W)")]
     private static partial Regex GeneratedClassNameFixupRegex();
+    [GeneratedRegex("%(?<value>[0-9A-Fa-f]{2})")]
+    private static partial Regex MSBuildEscapeRegex();
     private static Lazy<IBrowser> Browser => new(CreateBrowser);
-    private static readonly XmlWriterSettings s_xmlWriterSettings = new() { ConformanceLevel = ConformanceLevel.Fragment };
     protected readonly TestOutputWrapper _testOutput;
 
     public static readonly string[] TestFrameworkTypes = ["none", "mstest", "nunit", "xunit.net"];
@@ -51,8 +50,8 @@ public partial class TemplateTestsBase
         TestTargetFramework? tfm = null,
         BuildEnvironment? buildEnvironment = null,
         string? extraArgs = null,
-        Func<AspireProject, Task>? onBuildAspireProject = null,
-        string? overrideRootDir = null)
+        string? overrideRootDir = null,
+        bool withAppHostReference = true)
     {
         buildEnvironment ??= BuildEnvironment.ForDefaultFramework;
         var tmfArg = tfm is not null ? $"-f {tfm.Value.ToTFMString()}" : "";
@@ -60,87 +59,64 @@ public partial class TemplateTestsBase
         string rootDirToUse = overrideRootDir ?? project.RootDir;
         // Add test project
         var testProjectName = $"{id}.{FixupSymbolName(testTemplateName)}Tests";
+        var testProjectDir = Path.Combine(rootDirToUse, testProjectName);
+        var appHostProjectPath = Assert.Single(Directory.EnumerateFiles(project.AppHostProjectDirectory, "*.csproj", SearchOption.TopDirectoryOnly));
+        var appHostProjectName = Path.GetFileNameWithoutExtension(appHostProjectPath);
+        var relativeAppHostProjectPath = Path.GetRelativePath(testProjectDir, appHostProjectPath);
+        var appHostArgs = withAppHostReference
+            ? $"--WithAppHostReference true --AppHostProjectPath \"{EscapeMSBuildItemValue(relativeAppHostProjectPath)}\" --AppHostProjectName \"{appHostProjectName}\""
+            : "";
         using var newTestCmd = new DotNetNewCommand(
                                     _testOutput,
                                     label: $"new-test-{testTemplateName}",
                                     buildEnv: buildEnvironment)
                                 .WithWorkingDirectory(rootDirToUse);
-        var res = await newTestCmd.ExecuteAsync($"{testTemplateName} {tmfArg} -o \"{testProjectName}\" {extraArgs}");
+        var res = await newTestCmd.ExecuteAsync($"{testTemplateName} {tmfArg} -o \"{testProjectName}\" {extraArgs} {appHostArgs}");
         res.EnsureSuccessful();
 
-        var testProjectDir = Path.Combine(rootDirToUse, testProjectName);
         Assert.True(Directory.Exists(testProjectDir), $"Expected tests project at {testProjectDir}");
 
         var testProjectPath = Path.Combine(testProjectDir, testProjectName + ".csproj");
         Assert.True(File.Exists(testProjectPath), $"Expected tests project file at {testProjectPath}");
 
-        var appHostProjectName = Path.GetFileName(project.AppHostProjectDirectory)!;
-        PrepareTestCsFile(
-            id: project.Id,
-            projectDir: testProjectDir,
-            appHostProjectName: appHostProjectName,
-            testTemplateName: testTemplateName);
-        PrepareTestProject(
-            project: project,
-            projectPath: testProjectPath,
-            appHostProjectName: appHostProjectName);
+        var testProject = XDocument.Load(testProjectPath);
+        var projectReferences = testProject.Descendants("ProjectReference").ToArray();
+        if (!withAppHostReference)
+        {
+            Assert.Empty(projectReferences);
+            return testProjectDir;
+        }
+
+        var projectReferencePath = Assert.Single(projectReferences).Attribute("Include")?.Value;
+        Assert.NotNull(projectReferencePath);
+        Assert.Equal(relativeAppHostProjectPath, UnescapeMSBuildItemValue(projectReferencePath));
+        var testSourcePath = Path.Combine(testProjectDir, "IntegrationTest1.cs");
+        var testSource = await File.ReadAllTextAsync(testSourcePath);
+        var appHostProjectType = GeneratedClassNameFixupRegex().Replace(appHostProjectName, "_");
+        Assert.Contains($"DistributedApplicationTestingBuilder.CreateAsync<Projects.{appHostProjectType}>", testSource);
 
         return testProjectDir;
+    }
 
-        static void PrepareTestProject(AspireProject project, string projectPath, string appHostProjectName)
-        {
-            // Insert <ProjectReference Include="$(MSBuildThisFileDirectory)..\aspire-starter0.AppHost\aspire-starter0.AppHost.csproj" /> in the project file
+    private static string UnescapeMSBuildItemValue(string value)
+    {
+        return MSBuildEscapeRegex().Replace(
+            value,
+            match => ((char)Convert.ToByte(match.Groups["value"].Value, 16)).ToString(CultureInfo.InvariantCulture));
+    }
 
-            // taken from https://raw.githubusercontent.com/dotnet/templating/a325ffa18edd1590f9b340cf83d51d8eb567ebdc/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormFactory.cs
-            StringBuilder output = new();
-            using (var w = XmlWriter.Create(output, s_xmlWriterSettings))
-            {
-                w.WriteString(appHostProjectName);
-            }
-            var xmlEncodedId = output.ToString();
-
-            var projectReference = $@"<ProjectReference Include=""$(MSBuildThisFileDirectory)..\{xmlEncodedId}\{xmlEncodedId}.csproj"" />";
-
-            var newContents = File.ReadAllText(projectPath)
-                                    .Replace("</Project>", $"<ItemGroup>{projectReference}</ItemGroup>\n</Project>");
-            File.WriteAllText(projectPath, newContents);
-        }
-
-        static void PrepareTestCsFile(string id, string projectDir, string appHostProjectName, string testTemplateName)
-        {
-            var testCsPath = Path.Combine(projectDir, "IntegrationTest1.cs");
-            var sb = new StringBuilder();
-
-            // Uncomment everything after the marker line
-            var inTest = false;
-            var marker = testTemplateName switch
-            {
-                "aspire-nunit" or "aspire-nunit-9" => "// [Test]",
-                "aspire-mstest" or "aspire-mstest-9" => "// [TestMethod]",
-                "aspire-xunit" or "aspire-xunit-9" => "// [Fact]",
-                _ => throw new NotImplementedException($"Unknown test template: {testTemplateName}")
-            };
-
-            foreach (var line in File.ReadAllLines(testCsPath))
-            {
-                if (!inTest && line.Contains(marker))
-                {
-                    inTest = true;
-                }
-
-                if (inTest && CommentLineRegex().IsMatch(line))
-                {
-                    sb.AppendLine(CommentLineRegex().Replace(line, "    "));
-                    continue;
-                }
-
-                sb.AppendLine(line);
-            }
-
-            var classNameFromId = GeneratedClassNameFixupRegex().Replace(appHostProjectName, "_");
-            sb.Replace("Projects.MyAspireApp_AppHost", $"Projects.{classNameFromId}");
-            File.WriteAllText(testCsPath, sb.ToString());
-        }
+    private static string EscapeMSBuildItemValue(string value)
+    {
+        return value
+            .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("$", "%24", StringComparison.Ordinal)
+            .Replace("@", "%40", StringComparison.Ordinal)
+            .Replace("'", "%27", StringComparison.Ordinal)
+            .Replace(";", "%3B", StringComparison.Ordinal)
+            .Replace("?", "%3F", StringComparison.Ordinal)
+            .Replace("*", "%2A", StringComparison.Ordinal)
+            .Replace("(", "%28", StringComparison.Ordinal)
+            .Replace(")", "%29", StringComparison.Ordinal);
     }
 
     public static Task<IBrowserContext> CreateNewBrowserContextAsync()

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -72,8 +72,13 @@ public partial class TemplateTestsBase
         var appHostProjectPath = Assert.Single(Directory.EnumerateFiles(project.AppHostProjectDirectory, "*.csproj", SearchOption.TopDirectoryOnly));
         var appHostProjectName = Path.GetFileNameWithoutExtension(appHostProjectPath);
         var relativeAppHostProjectPath = Path.GetRelativePath(testProjectDir, appHostProjectPath);
+        // ProcessStartInfo.Arguments parses a quoted path such as:
+        //   --AppHostProjectPath "../quote\"path/AppHost.csproj"
+        // Escape embedded quotes for that command-line layer while preserving the literal quote received by the template.
+        var escapedAppHostProjectPath = EscapeMSBuildItemValue(relativeAppHostProjectPath)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
         var appHostArgs = withAppHostReference
-            ? $"--WithAppHostReference true --AppHostProjectPath \"{EscapeMSBuildItemValue(relativeAppHostProjectPath)}\" --AppHostProjectName \"{appHostProjectName}\""
+            ? $"--WithAppHostReference true --AppHostProjectPath \"{escapedAppHostProjectPath}\" --AppHostProjectName \"{appHostProjectName}\""
             : "";
         using var newTestCmd = new DotNetNewCommand(
                                     _testOutput,

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -942,6 +942,22 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Contains("job:polyglot", r.Jobs);
     }
 
+    [Fact]
+    public void RealMapProjectTemplateChangeRunsTemplateAndCliEndToEndTests()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select(
+            ["src/Aspire.ProjectTemplates/templates/aspire-mstest/IntegrationTest1.cs"],
+            [],
+            new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.Contains("Aspire.Templates.Tests", r.TestProjects);
+        Assert.Contains("Aspire.Cli.EndToEnd.Tests", r.TestProjects);
+    }
+
     // A real src/Aspire.Hosting*/api/<name>.ats.txt baseline for a genuine INTEGRATION (not the
     // codegen engine itself) whose integration also has a tests/PolyglotAppHosts/<name> fixture, so the
     // change exercises the polyglot playground for that integration's exported surface. Computed from the


### PR DESCRIPTION
## Description

Makes the existing integration-test scaffolding a first-class public Aspire CLI flow and adds AppHost-aware wiring to the MSTest, NUnit, and xUnit project templates.

```text
aspire new aspire-test [--apphost <AppHost.csproj>]
```

The grouped `aspire-test` selector is available on the normal `aspire new` surface. The CLI prompts for MSTest, NUnit, or xUnit; automation can select one with `--test-framework <MSTest|NUnit|xUnit> --non-interactive`. No feature flag, persisted configuration change, or process-scoped environment override is required. Existing starter-template menu ordering is preserved.

When `--apphost` is supplied, it must name an existing C# `.csproj` file. Directories and incompatible file types are rejected before framework prompts or template installation. The shared project locator resolves and validates the requested AppHost, and the CLI derives and MSBuild-escapes its relative project-reference path.

When `--apphost` is omitted, AppHost wiring is opportunistic:

- A resolved C# AppHost already selected in workspace settings is reused without scanning for other candidates.
- A single discovered C# AppHost is wired automatically.
- Multiple AppHosts with no resolved selection generate standalone tests in both interactive and non-interactive modes. There is no AppHost-selection prompt or ambiguity error.
- No usable AppHost, or a selected single-file or polyglot AppHost, generates standalone tests. The CLI does not substitute another candidate in a mixed workspace.

Discovery uses the locator's early-exit behavior and does not persist a new workspace selection. The C#-specific reference policy stays in the template factory rather than changing the generic locator's selection rules.

Template compatibility is checked only when a C# AppHost reference would be added. The selected installed template is probed rather than inferring support from a package version. Older templates without reference support still generate standalone projects when `--apphost` is omitted; explicit reference requests fail with actionable guidance. Standalone output that needs no reference skips the probe, and unexpected probe failures or cancellation are not converted into successful fallback.

Wired projects inherit the AppHost target framework when it can be determined, include an XML-attribute-safe project reference, and contain an active typed `AppHostBuilds` test. Otherwise the template's target-framework default is preserved. Extension hosts can open generated `IntegrationTest1.cs` through `TemplateResult.EditorPath`.

Generic agent initialization remains unchanged. `--suppress-agent-init` can still skip it; changing the default specifically for `aspire-test` is tracked separately in #20015.

This is the public CLI/template base layer for the VS Code workflow in #19622; it contains no `extension/**` changes.

### Validation

- Final focused command, template-factory, project-locator, template-configuration-persistence, and init coverage: 383 passed, 5 platform-specific skips.
- Unit coverage asserts operation ordering, zero capability probes for standalone output, early invalid-input rejection, configured AppHost reuse, ambiguity fallback, framework propagation, MSBuild escaping, unexpected probe errors, and cancellation.
- The installed-CLI E2E passed against a locally built Linux ARM64 local-hive archive. It covers interactive framework selection, automatic and explicit C# references, mixed and ambiguous standalone generation, directory rejection, and Aspire.ProjectTemplates 13.5.3 fallback with both a single AppHost and multiple candidates. Generated standalone projects build, and both wired projects run `AppHostBuilds`.
- Template coverage includes MSTest, NUnit, xUnit v2/v3, standalone instructional samples, non-default and platform-qualified target frameworks, and XML/MSBuild-special-character paths.
- Template-only changes select both template tests and CLI E2E tests, with a real-map acceptance test for that routing.

Part of #19409

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No