### PR TITLE
Prevent repeated Hot Reload advisory

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -196,6 +196,9 @@
     <trans-unit id="extension.debug.dashboardBrowser">
       <source xml:lang="en">Controls what happens with the Aspire Dashboard when this debug configuration starts. If not set, the global Aspire: Dashboard Browser setting is used.</source>
     </trans-unit>
+    <trans-unit id="configuration.aspire.enableHotReloadNotification">
+      <source xml:lang="en">Controls whether the Aspire extension shows a notification when C# Dev Kit Hot Reload is disabled.</source>
+    </trans-unit>
     <trans-unit id="command.copyAppHostPath">
       <source xml:lang="en">Copy AppHost path</source>
     </trans-unit>

--- a/extension/package.json
+++ b/extension/package.json
@@ -1020,6 +1020,12 @@
           "description": "%configuration.aspire.enableAspireDcpDebugLogging%",
           "scope": "window"
         },
+        "aspire.enableHotReloadNotification": {
+          "type": "boolean",
+          "default": true,
+          "description": "%configuration.aspire.enableHotReloadNotification%",
+          "scope": "window"
+        },
         "aspire.enableAspireDashboardAutoLaunch": {
           "type": "string",
           "enum": [

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -30,6 +30,7 @@
   "configuration.aspire.aspireCliExecutablePath": "The path to the Aspire CLI executable. Use '${workspaceFolder}' for the operation's workspace folder or '${workspaceFolder:name}' for a named folder. If not set, the extension will attempt to use 'aspire' from the system PATH.",
   "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension.",
   "configuration.aspire.enableAspireDcpDebugLogging": "Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace's .aspire/dcp/logs-{debugSessionId} folder.",
+  "configuration.aspire.enableHotReloadNotification": "Controls whether the Aspire extension shows a notification when C# Dev Kit Hot Reload is disabled.",
   "configuration.aspire.enableAspireDashboardAutoLaunch": "Legacy setting for Aspire Dashboard launch behavior. Use Aspire: Dashboard Browser instead. Explicit Aspire: Dashboard Browser none or notification values win. Otherwise, legacy notification or off values override browser-opening choices; launch uses Aspire: Dashboard Browser, falling back to VS Code's integrated browser for compatibility.",
   "configuration.aspire.enableAspireDashboardAutoLaunch.launch": "Use the configured dashboard browser behavior, falling back to VS Code's integrated browser for compatibility.",
   "configuration.aspire.enableAspireDashboardAutoLaunch.notification": "Show a notification with a link to open the dashboard.",

--- a/extension/src/debugger/hotReload.ts
+++ b/extension/src/debugger/hotReload.ts
@@ -7,8 +7,11 @@ const hotReloadConfigurationSection = 'csharp.experimental.debug';
 const hotReloadConfigurationName = 'hotReload';
 const hotReloadOnSaveConfigurationSection = 'csharp.debug';
 const hotReloadOnSaveConfigurationName = 'hotReloadOnSave';
+const aspireConfigurationSection = 'aspire';
+const hotReloadNotificationConfigurationName = 'enableHotReloadNotification';
 const openSettingsCommand = 'workbench.action.openSettings';
 const hotReloadSetting = `${hotReloadConfigurationSection}.${hotReloadConfigurationName}`;
+const hotReloadDisabledAdvisoryShownKey = 'aspire.hotReloadDisabledAdvisoryShown';
 
 export interface HotReloadDiagnostics {
     devKitInstalled: boolean;
@@ -45,17 +48,42 @@ export function logHotReloadDiagnostics(resourceIdentifier: string, diagnostics:
 }
 
 let hotReloadDisabledAdvisoryShown = false;
+let hotReloadAdvisoryWorkspaceState: vscode.Memento | undefined;
+
+export function initializeHotReloadAdvisory(workspaceState: vscode.Memento): void {
+    hotReloadAdvisoryWorkspaceState = workspaceState;
+
+    try {
+        hotReloadDisabledAdvisoryShown = workspaceState.get<boolean>(hotReloadDisabledAdvisoryShownKey, false);
+    }
+    catch (err) {
+        hotReloadDisabledAdvisoryShown = false;
+        extensionLogOutputChannel.warn(`C# Dev Kit Hot Reload advisory persistence failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
 
 export async function showHotReloadDisabledAdvisoryIfNeeded(diagnostics: HotReloadDiagnostics): Promise<void> {
     if (hotReloadDisabledAdvisoryShown
         || !diagnostics.devKitInstalled
         || !diagnostics.settingContributed
-        || diagnostics.settingEnabled) {
+        || diagnostics.settingEnabled
+        || !vscode.workspace
+            .getConfiguration(aspireConfigurationSection)
+            .get<boolean>(hotReloadNotificationConfigurationName, true)) {
         return;
     }
 
     // Set this before showing the message so concurrently launching resources cannot stack notices.
     hotReloadDisabledAdvisoryShown = true;
+
+    try {
+        await hotReloadAdvisoryWorkspaceState?.update(hotReloadDisabledAdvisoryShownKey, true);
+    }
+    catch (err) {
+        // Still show the advisory when persistence fails so this activation retains the existing discoverability.
+        // The in-memory guard continues to prevent concurrent launches from stacking notifications.
+        extensionLogOutputChannel.warn(`C# Dev Kit Hot Reload advisory persistence failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
     try {
         const selection = await vscode.window.showInformationMessage(hotReloadDisabledNotice, openSettingsLabel);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -37,10 +37,13 @@ import { registerInstrumentedCommand } from './activation/instrumentedCommand';
 import { registerCliCommands } from './activation/registerCliCommands';
 import { registerTreeViewCommands } from './activation/registerTreeViewCommands';
 import { registerCodeLensCommands } from './activation/registerCodeLensCommands';
+import { initializeHotReloadAdvisory } from './debugger/hotReload';
 
 let aspireExtensionContext = new AspireExtensionContext();
 
 export async function activate(context: vscode.ExtensionContext) {
+  initializeHotReloadAdvisory(context.workspaceState);
+
   const gitCommitSha = readGitCommitSha(context);
   extensionLogOutputChannel.info(`Activating Aspire extension (commit: ${gitCommitSha})`);
   initializeTelemetry(context);

--- a/extension/src/test-e2e/packageSurface.e2e.test.ts
+++ b/extension/src/test-e2e/packageSurface.e2e.test.ts
@@ -666,6 +666,7 @@ const expectedConfigurationKeys = [
     'aspire.enableCodeLens',
     'aspire.enableDebugConfigEnvironmentLogging',
     'aspire.enableGutterDecorations',
+    'aspire.enableHotReloadNotification',
     'aspire.enableSettingsFileCreationPromptOnStartup',
     'aspire.globalAppHostsPollingInterval',
     'aspire.registerMcpServerInWorkspace',

--- a/extension/src/test/hotReload.test.ts
+++ b/extension/src/test/hotReload.test.ts
@@ -3,15 +3,51 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import {
     getHotReloadDiagnostics,
+    HotReloadDiagnostics,
+    initializeHotReloadAdvisory,
     logHotReloadDiagnostics,
     showHotReloadDisabledAdvisoryIfNeeded
 } from '../debugger/hotReload';
 import { hotReloadDisabledNotice, openSettingsLabel } from '../loc/strings';
 import { extensionLogOutputChannel } from '../utils/logging';
 
+class TestMemento implements vscode.Memento {
+    private readonly values = new Map<string, unknown>();
+
+    keys(): readonly string[] {
+        return [...this.values.keys()];
+    }
+
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return this.values.has(key) ? this.values.get(key) as T : defaultValue;
+    }
+
+    update(key: string, value: unknown): Thenable<void> {
+        if (value === undefined) {
+            this.values.delete(key);
+        }
+        else {
+            this.values.set(key, value);
+        }
+
+        return Promise.resolve();
+    }
+
+    setKeysForSync(): void {
+    }
+}
+
 suite('Hot Reload Tests', () => {
     let restoreTrust: (() => void) | undefined;
+    let workspaceState: TestMemento;
     type HotReloadInspection = NonNullable<ReturnType<vscode.WorkspaceConfiguration['inspect']>>;
+
+    setup(() => {
+        workspaceState = new TestMemento();
+        initializeHotReloadAdvisory(workspaceState);
+    });
 
     teardown(() => {
         restoreTrust?.();
@@ -54,7 +90,27 @@ suite('Hot Reload Tests', () => {
         getConfiguration.withArgs('csharp.debug').returns({
             get: (name: string) => name === 'hotReloadOnSave' ? onSave : undefined
         } as vscode.WorkspaceConfiguration);
+        getConfiguration.withArgs('aspire').returns({
+            get: (name: string, defaultValue?: unknown) => name === 'enableHotReloadNotification' ? true : defaultValue
+        } as vscode.WorkspaceConfiguration);
         getConfiguration.returns({ get: () => undefined } as unknown as vscode.WorkspaceConfiguration);
+    }
+
+    function stubHotReloadNotificationSetting(enabled: boolean): void {
+        const getConfiguration = sinon.stub(vscode.workspace, 'getConfiguration');
+        getConfiguration.withArgs('aspire').returns({
+            get: (name: string, defaultValue?: unknown) => name === 'enableHotReloadNotification' ? enabled : defaultValue
+        } as vscode.WorkspaceConfiguration);
+    }
+
+    function createDisabledHotReloadDiagnostics(): HotReloadDiagnostics {
+        return {
+            devKitInstalled: true,
+            workspaceTrusted: true,
+            settingContributed: true,
+            settingEnabled: false,
+            reloadOnSaveEnabled: true
+        };
     }
 
     test('reports disabled Hot Reload diagnostics', () => {
@@ -163,9 +219,75 @@ suite('Hot Reload Tests', () => {
         assert.strictEqual(notification.called, false);
     });
 
+    test('does not show the advisory when the Aspire Hot Reload notification is disabled', async () => {
+        stubHotReloadNotificationSetting(false);
+        const notification = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+
+        await showHotReloadDisabledAdvisoryIfNeeded(createDisabledHotReloadDiagnostics());
+
+        assert.strictEqual(notification.called, false);
+    });
+
+    test('does not show the advisory again after the extension reloads', async () => {
+        stubHotReloadNotificationSetting(true);
+        const notification = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+        const diagnostics = createDisabledHotReloadDiagnostics();
+
+        await showHotReloadDisabledAdvisoryIfNeeded(diagnostics);
+        initializeHotReloadAdvisory(workspaceState);
+        await showHotReloadDisabledAdvisoryIfNeeded(diagnostics);
+
+        assert.strictEqual(workspaceState.get('aspire.hotReloadDisabledAdvisoryShown'), true);
+        assert.strictEqual(notification.callCount, 1);
+    });
+
+    test('records the advisory before showing the notification', async () => {
+        stubHotReloadNotificationSetting(true);
+        const notification = sinon.stub(vscode.window, 'showInformationMessage').callsFake(() => {
+            assert.strictEqual(workspaceState.get('aspire.hotReloadDisabledAdvisoryShown'), true);
+            return Promise.resolve(undefined);
+        });
+
+        await showHotReloadDisabledAdvisoryIfNeeded(createDisabledHotReloadDiagnostics());
+
+        assert.strictEqual(notification.calledOnce, true);
+    });
+
+    test('shows the advisory once when workspace persistence fails', async () => {
+        stubHotReloadNotificationSetting(true);
+        sinon.stub(workspaceState, 'update').rejects(new Error('write failed'));
+        const notification = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+        const warn = sinon.stub(extensionLogOutputChannel, 'warn');
+        const diagnostics = createDisabledHotReloadDiagnostics();
+
+        await showHotReloadDisabledAdvisoryIfNeeded(diagnostics);
+        await showHotReloadDisabledAdvisoryIfNeeded(diagnostics);
+
+        assert.strictEqual(notification.callCount, 1);
+        assert.strictEqual(warn.calledOnceWithExactly(
+            'C# Dev Kit Hot Reload advisory persistence failed: write failed'), true);
+    });
+
+    test('logs notification failures without breaking launch', async () => {
+        stubHotReloadNotificationSetting(true);
+        sinon.stub(vscode.window, 'showInformationMessage').rejects(new Error('notification failed'));
+        const warn = sinon.stub(extensionLogOutputChannel, 'warn');
+
+        await assert.doesNotReject(
+            showHotReloadDisabledAdvisoryIfNeeded(createDisabledHotReloadDiagnostics()));
+
+        assert.strictEqual(workspaceState.get('aspire.hotReloadDisabledAdvisoryShown'), true);
+        assert.strictEqual(warn.calledOnceWithExactly(
+            'C# Dev Kit Hot Reload advisory failed: notification failed'), true);
+    });
+
     test('opens C# Dev Kit Hot Reload settings without updating configuration', async () => {
         const update = sinon.stub().resolves();
-        const getConfiguration = sinon.stub(vscode.workspace, 'getConfiguration').returns({
+        const getConfiguration = sinon.stub(vscode.workspace, 'getConfiguration');
+        getConfiguration.withArgs('aspire').returns({
+            get: () => true
+        } as unknown as vscode.WorkspaceConfiguration);
+        getConfiguration.returns({
             get: () => false,
             update
         } as unknown as vscode.WorkspaceConfiguration);
@@ -188,7 +310,7 @@ suite('Hot Reload Tests', () => {
         assert.strictEqual(executeCommand.calledOnceWithExactly(
             'workbench.action.openSettings',
             'csharp.experimental.debug.hotReload'), true);
-        assert.strictEqual(getConfiguration.called, false);
+        assert.strictEqual(getConfiguration.calledOnceWithExactly('aspire'), true);
         assert.strictEqual(update.called, false);
     });
 });


### PR DESCRIPTION
## Description

The C# Dev Kit Hot Reload advisory currently reappears after every extension-host reload because its suppression state only lives in memory.

This change records the advisory in workspace state before showing it, so each workspace sees it at most once across extension reloads. It also adds `aspire.enableHotReloadNotification`, which defaults to `true` and lets users disable the notification entirely. Diagnostic logging and debug launch preparation remain unchanged and non-blocking.

### User-facing usage

Users who do not want the advisory can disable it in their VS Code settings:

```json
{
  "aspire.enableHotReloadNotification": false
}
```

### Validation

- `./build.sh`
- `corepack yarn run test` — 2,626 passing, 5 pending
- Compile, lint, and focused Hot Reload/localization tests — 26 passing
- Validated in a real VS Code Extension Host with C# Dev Kit installed: the ordinary .NET resource configuration path showed the advisory once, persisted suppression across an Extension Host reload, honored the disabled setting in fresh storage, and continued logging diagnostics without blocking configuration

A screenshot would only show the existing notification; the changed behavior is that it does not reappear after reload or when disabled. The E2E fixture could not complete AppHost/DCP process execution without a local NuGet package source, so the real-host proof covers resource launch preparation rather than the debug adapter and application process.

Resolves microsoft/aspire#19544

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
