### PR TITLE
Avoid live CLI rendering when stdout is redirected

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -476,12 +476,17 @@ internal sealed class RunCommand : BaseCommand
                 }
                 else
                 {
-                    // We want to display resource information in remote environments.
-                    // Resources update over time so we'll use a live display.
-                    // It is used to show discovered endpoints as they come in over the backchannel.
+                    // Remote environments surface endpoints discovered over the backchannel. Interactive
+                    // terminals replace a cumulative snapshot in place, while redirected output appends
+                    // each endpoint transition once without cursor manipulation.
                     var discoveredEndpoints = new List<(string Resource, string Endpoint)>();
                     var endpointsLocalizedString = RunCommandStrings.Endpoints;
                     var showCtrlC = !ExtensionHelper.IsExtensionHost(InteractionService, out _, out _);
+
+                    Markup BuildEndpointMarkup(string resource, string endpoint)
+                    {
+                        return new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] {MarkupHelpers.SafeLink(InteractionService, endpoint)}");
+                    }
 
                     IRenderable BuildLiveRenderable()
                     {
@@ -502,7 +507,7 @@ internal sealed class RunCommand : BaseCommand
                                     i == 0
                                         ? new Align(new Markup($"[bold green]{endpointsLocalizedString}[/]:"), HorizontalAlignment.Right)
                                         : Text.Empty,
-                                    new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] {MarkupHelpers.SafeLink(InteractionService, endpoint)}")
+                                    BuildEndpointMarkup(resource, endpoint)
                                 );
                             }
 
@@ -517,20 +522,60 @@ internal sealed class RunCommand : BaseCommand
                         return rows.Count > 0 ? new Rows(rows) : Text.Empty;
                     }
 
+                    IRenderable BuildStaticEndpointRenderable(string resource, string endpoint, bool isFirstEndpoint)
+                    {
+                        var endpointsGrid = new Grid();
+                        endpointsGrid.AddColumn();
+                        endpointsGrid.AddColumn();
+                        endpointsGrid.Columns[0].Width = longestLocalizedLengthWithColon;
+
+                        if (isFirstEndpoint)
+                        {
+                            endpointsGrid.AddRow(Text.Empty, Text.Empty);
+                        }
+
+                        endpointsGrid.AddRow(
+                            isFirstEndpoint
+                                ? new Align(new Markup($"[bold green]{endpointsLocalizedString}[/]:"), HorizontalAlignment.Right)
+                                : Text.Empty,
+                            BuildEndpointMarkup(resource, endpoint)
+                        );
+
+                        return new Padder(endpointsGrid, new Padding(3, 0));
+                    }
+
+                    async Task ProcessResourceStatesAsync(Action<string, string> endpointWriter)
+                    {
+                        var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
+                        await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
+                        {
+                            ProcessResourceState(resourceState, endpointWriter);
+                        }
+                    }
+
                     try
                     {
-                        await InteractionService.DisplayLiveAsync(BuildLiveRenderable(), async updateTarget =>
+                        if (_hostEnvironment.SupportsInteractiveOutput)
                         {
-                            var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
-                            await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
-                            {
-                                ProcessResourceState(resourceState, (resource, endpoint) =>
+                            await InteractionService.DisplayLiveAsync(
+                                BuildLiveRenderable(),
+                                updateTarget => ProcessResourceStatesAsync((resource, endpoint) =>
                                 {
                                     discoveredEndpoints.Add((resource, endpoint));
                                     updateTarget(BuildLiveRenderable());
-                                });
-                            }
-                        });
+                                }));
+                        }
+                        else
+                        {
+                            AppendCtrlCMessage(longestLocalizedLengthWithColon);
+
+                            var isFirstEndpoint = true;
+                            await ProcessResourceStatesAsync((resource, endpoint) =>
+                            {
+                                InteractionService.DisplayRenderable(BuildStaticEndpointRenderable(resource, endpoint, isFirstEndpoint));
+                                isFirstEndpoint = false;
+                            });
+                        }
                     }
                     catch (ConnectionLostException) when (cancellationToken.IsCancellationRequested)
                     {

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -641,8 +641,9 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
     {
-        // Spectre live rendering requires a usable terminal. Write each update once when output
-        // is redirected so callers can keep processing updates without cursor manipulation.
+        // Spectre live rendering requires a usable terminal. For non-interactive output, append
+        // the initial snapshot and every update so long-running callers still report progress and
+        // leave their final state in logs without cursor manipulation.
         // See https://github.com/microsoft/aspire/issues/19290.
         if (!_hostEnvironment.SupportsInteractiveOutput)
         {

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -641,6 +641,17 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
     {
+        // Spectre live rendering requires a usable terminal. Write each update once when output
+        // is redirected so callers can keep processing updates without cursor manipulation.
+        // See https://github.com/microsoft/aspire/issues/19290.
+        if (!_hostEnvironment.SupportsInteractiveOutput)
+        {
+            var console = MessageConsole;
+            console.Write(initialRenderable);
+            await callback(console.Write);
+            return;
+        }
+
         await MessageConsole.Live(initialRenderable)
             .AutoClear(false)
             .StartAsync(async ctx =>

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -641,16 +641,11 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
     {
-        // Spectre live rendering requires a usable terminal. For non-interactive output, append
-        // the initial snapshot and every update so long-running callers still report progress and
-        // leave their final state in logs without cursor manipulation.
-        // See https://github.com/microsoft/aspire/issues/19290.
         if (!_hostEnvironment.SupportsInteractiveOutput)
         {
-            var console = MessageConsole;
-            console.Write(initialRenderable);
-            await callback(console.Write);
-            return;
+            // The callback supplies replacement snapshots, so appending them would duplicate prior
+            // content. Callers must define incremental static output when a live region is unavailable.
+            throw new InvalidOperationException("Live rendering requires interactive output.");
         }
 
         await MessageConsole.Live(initialRenderable)

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -68,6 +68,11 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
     public bool SupportsAnsi { get; }
 
     public CliHostEnvironment(IConfiguration configuration, bool nonInteractive)
+        : this(configuration, nonInteractive, Console.IsOutputRedirected)
+    {
+    }
+
+    internal CliHostEnvironment(IConfiguration configuration, bool nonInteractive, bool isOutputRedirected)
     {
         // If --non-interactive is explicitly set, disable interactive input and output.
         // ANSI support is still determined from the host configuration so explicit
@@ -88,7 +93,7 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
         else
         {
             SupportsInteractiveInput = DetectInteractiveInput(configuration);
-            SupportsInteractiveOutput = DetectInteractiveOutput(configuration);
+            SupportsInteractiveOutput = DetectInteractiveOutput(configuration, isOutputRedirected);
             SupportsAnsi = DetectAnsiSupport(configuration);
         }
     }
@@ -134,7 +139,7 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
         return true;
     }
 
-    private static bool DetectInteractiveOutput(IConfiguration configuration)
+    private static bool DetectInteractiveOutput(IConfiguration configuration, bool isOutputRedirected)
     {
         // Check if explicitly disabled via configuration
         var nonInteractive = configuration["ASPIRE_NON_INTERACTIVE"];
@@ -147,6 +152,11 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
 
         // Check if running in CI environment (spinners pollute logs)
         if (IsCI(configuration))
+        {
+            return false;
+        }
+
+        if (isOutputRedirected)
         {
             return false;
         }

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -83,11 +83,12 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
             SupportsInteractiveOutput = false;
             SupportsAnsi = DetectAnsiSupport(configuration);
         }
-        // Check if ASPIRE_PLAYGROUND is set to force interactive mode
+        // Playground mode can force interactive input and ANSI output, but a redirected stdout
+        // still cannot support the cursor manipulation required by Spectre live rendering.
         else if (IsPlaygroundMode(configuration))
         {
             SupportsInteractiveInput = true;
-            SupportsInteractiveOutput = true;
+            SupportsInteractiveOutput = !isOutputRedirected;
             SupportsAnsi = true;
         }
         else

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -66,6 +66,80 @@ public sealed class SmokeTests(ITestOutputHelper output)
 
     [CaptureWorkspaceOnFailure]
     [Fact]
+    public async Task RedirectedRemoteSshRunUsesStaticOutput()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        const string projectName = "RemoteSshRedirectedApp";
+        await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
+        await auto.RunCommandAsync($"cd {projectName}", counter);
+
+        var runCommand =
+            "env " +
+            "-u CI -u GITHUB_ACTIONS -u AZURE_PIPELINES -u TF_BUILD -u JENKINS_URL -u GITLAB_CI " +
+            "-u CIRCLECI -u TRAVIS -u BUILDKITE -u APPVEYOR -u TEAMCITY_VERSION " +
+            "-u BITBUCKET_BUILD_NUMBER -u CODEBUILD_BUILD_ID -u ASPIRE_NON_INTERACTIVE " +
+            "-u ASPIRE_PLAYGROUND -u ASPIRE_ANSI_PASS_THRU " +
+            "TERM=dumb LINES=0 COLUMNS=80 " +
+            "VSCODE_IPC_HOOK_CLI=/tmp/vscode-ipc-remote-ssh " +
+            "SSH_CONNECTION='127.0.0.1 12345 127.0.0.1 22' " +
+            $"ASPIRE_CLI_START_TIMEOUT={CliE2EAutomatorHelpers.AspireRunStartupBudgetSeconds} " +
+            "aspire run > remote-ssh.stdout 2> remote-ssh.stderr & echo $! > remote-ssh.pid";
+        await auto.RunCommandAsync(runCommand, counter);
+
+        // Static resource updates are emitted as lines such as:
+        //   worker has endpoint http://localhost:5830
+        await auto.RunCommandAsync(
+            $"endpoint_seen=0; cli_alive=1; " +
+            $"for attempt in $(seq 1 {CliE2EAutomatorHelpers.AspireRunReadyTimeout.TotalSeconds}); do " +
+            "if grep -Fq 'has endpoint' remote-ssh.stdout; then endpoint_seen=1; break; fi; " +
+            "if ! kill -0 \"$(cat remote-ssh.pid)\" 2>/dev/null; then cli_alive=0; break; fi; " +
+            "sleep 1; " +
+            "done; " +
+            "if [ \"$endpoint_seen\" -eq 1 ]; then true; " +
+            "else " +
+            "if [ \"$cli_alive\" -eq 0 ]; then echo 'aspire run exited before an endpoint update' >&2; " +
+            "else echo 'timed out waiting for an endpoint update' >&2; fi; " +
+            "echo '--- remote-ssh.stdout ---' >&2; cat remote-ssh.stdout >&2; " +
+            "echo '--- remote-ssh.stderr ---' >&2; cat remote-ssh.stderr >&2; false; " +
+            "fi",
+            counter,
+            CliE2EAutomatorHelpers.AspireRunReadyTimeout + TimeSpan.FromSeconds(30));
+
+        await auto.RunCommandAsync("kill -0 \"$(cat remote-ssh.pid)\"", counter);
+        await auto.RunCommandAsync("aspire ps --format json > remote-ssh-ps.json", counter);
+        await auto.RunCommandAsync(
+            $"grep -Fq '{projectName}' remote-ssh-ps.json && grep -Fq '\"status\": \"running\"' remote-ssh-ps.json",
+            counter);
+        await auto.RunCommandAsync(
+            "test -f remote-ssh.stdout && test -f remote-ssh.stderr && " +
+            "! grep -F -e 'LiveRenderable' -e 'System.ArgumentException' " +
+            "-e 'An unexpected error occurred' remote-ssh.stdout remote-ssh.stderr",
+            counter);
+        await auto.RunCommandAsync(
+            "test \"$(tr -cd '\\033\\r' < remote-ssh.stdout | wc -c)\" -eq 0",
+            counter);
+        await auto.RunCommandAsync(
+            "cli_pid=$(cat remote-ssh.pid); kill -INT \"$cli_pid\"; wait \"$cli_pid\"; " +
+            "cli_exit=$?; test \"$cli_exit\" -eq 0 && ! kill -0 \"$cli_pid\" 2>/dev/null",
+            counter,
+            TimeSpan.FromMinutes(1));
+    }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
     public async Task CreateAndRunPolyglotAppHostWithDevLocalhostUrls()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -86,12 +86,13 @@ public sealed class SmokeTests(ITestOutputHelper output)
         await auto.AspireNewAsync(projectName, counter, useRedisCache: false);
         await auto.RunCommandAsync($"cd {projectName}", counter);
 
+        // Playground mode normally forces interactive output and takes precedence over ambient CI
+        // markers. Keeping it enabled makes redirected stdout the condition that selects static
+        // rendering, so this test cannot silently pass because a new CI marker was inherited.
         var runCommand =
             "env " +
-            "-u CI -u GITHUB_ACTIONS -u AZURE_PIPELINES -u TF_BUILD -u JENKINS_URL -u GITLAB_CI " +
-            "-u CIRCLECI -u TRAVIS -u BUILDKITE -u APPVEYOR -u TEAMCITY_VERSION " +
-            "-u BITBUCKET_BUILD_NUMBER -u CODEBUILD_BUILD_ID -u ASPIRE_NON_INTERACTIVE " +
-            "-u ASPIRE_PLAYGROUND -u ASPIRE_ANSI_PASS_THRU " +
+            "-u ASPIRE_NON_INTERACTIVE -u ASPIRE_ANSI_PASS_THRU " +
+            "ASPIRE_PLAYGROUND=true " +
             "TERM=dumb LINES=0 COLUMNS=80 " +
             "VSCODE_IPC_HOOK_CLI=/tmp/vscode-ipc-remote-ssh " +
             "SSH_CONNECTION='127.0.0.1 12345 127.0.0.1 22' " +
@@ -99,19 +100,21 @@ public sealed class SmokeTests(ITestOutputHelper output)
             "aspire run > remote-ssh.stdout 2> remote-ssh.stderr & echo $! > remote-ssh.pid";
         await auto.RunCommandAsync(runCommand, counter);
 
-        // Static resource updates are emitted as lines such as:
-        //   worker has endpoint http://localhost:5830
+        // Static resource updates are emitted once as lines such as:
+        //   Endpoints: worker has endpoint http://localhost:5830
+        // Wait for multiple updates so a cumulative-snapshot fallback would be observable.
         await auto.RunCommandAsync(
-            $"endpoint_seen=0; cli_alive=1; " +
+            $"endpoint_count=0; cli_alive=1; " +
             $"for attempt in $(seq 1 {CliE2EAutomatorHelpers.AspireRunReadyTimeout.TotalSeconds}); do " +
-            "if grep -Fq 'has endpoint' remote-ssh.stdout; then endpoint_seen=1; break; fi; " +
+            "endpoint_count=$(grep -Fc 'has endpoint' remote-ssh.stdout || true); " +
+            "if [ \"$endpoint_count\" -ge 2 ]; then break; fi; " +
             "if ! kill -0 \"$(cat remote-ssh.pid)\" 2>/dev/null; then cli_alive=0; break; fi; " +
             "sleep 1; " +
             "done; " +
-            "if [ \"$endpoint_seen\" -eq 1 ]; then true; " +
+            "if [ \"$endpoint_count\" -ge 2 ]; then true; " +
             "else " +
-            "if [ \"$cli_alive\" -eq 0 ]; then echo 'aspire run exited before an endpoint update' >&2; " +
-            "else echo 'timed out waiting for an endpoint update' >&2; fi; " +
+            "if [ \"$cli_alive\" -eq 0 ]; then echo 'aspire run exited before two endpoint updates' >&2; " +
+            "else echo 'timed out waiting for two endpoint updates' >&2; fi; " +
             "echo '--- remote-ssh.stdout ---' >&2; cat remote-ssh.stdout >&2; " +
             "echo '--- remote-ssh.stderr ---' >&2; cat remote-ssh.stderr >&2; false; " +
             "fi",
@@ -129,7 +132,11 @@ public sealed class SmokeTests(ITestOutputHelper output)
             "-e 'An unexpected error occurred' remote-ssh.stdout remote-ssh.stderr",
             counter);
         await auto.RunCommandAsync(
-            "test \"$(tr -cd '\\033\\r' < remote-ssh.stdout | wc -c)\" -eq 0",
+            "test \"$(tr -cd '\\r' < remote-ssh.stdout | wc -c)\" -eq 0",
+            counter);
+        await auto.RunCommandAsync(
+            "test -z \"$(grep -F 'has endpoint' remote-ssh.stdout | sort | uniq -d)\" && " +
+            "test \"$(grep -Foc 'CTRL+C' remote-ssh.stdout)\" -eq 1",
             counter);
         await auto.RunCommandAsync(
             "cli_pid=$(cat remote-ssh.pid); kill -INT \"$cli_pid\"; wait \"$cli_pid\"; " +

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -33,6 +33,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using StreamJsonRpc;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -2060,6 +2061,132 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_InRemoteNonInteractiveHost_DisplaysEachEndpointOnce()
+    {
+        var resourceStatesProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interactionService = new TestInteractionService();
+
+        var backchannelFactory = (IServiceProvider sp) =>
+        {
+            return new TestAppHostBackchannel
+            {
+                GetAppHostLogEntriesAsyncCallback = EmptyLogEntriesAsync,
+                GetDashboardUrlsAsyncCallback = _ => Task.FromResult(new DashboardUrlsState
+                {
+                    DashboardHealthy = true,
+                    BaseUrlWithLoginToken = "http://localhost:5000/login?t=abcd",
+                    CodespacesUrlWithLoginToken = null
+                }),
+                GetResourceStatesAsyncCallback = cancellationToken => GetResourceStatesAsync(resourceStatesProcessed, cancellationToken)
+            };
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+
+                return 0;
+            };
+
+            return runner;
+        };
+
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AppHostBackchannelFactory = backchannelFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.InteractionServiceFactory = _ => interactionService;
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateNonInteractiveHostEnvironment();
+            options.ConfigurationCallback += config =>
+            {
+                config["VSCODE_IPC_HOOK_CLI"] = "test-ipc-hook";
+                config["SSH_CONNECTION"] = "127.0.0.1 1 127.0.0.1 2";
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        using var cts = new CancellationTokenSource();
+        var pendingRun = result.InvokeAsync(cancellationToken: cts.Token);
+
+        try
+        {
+            await resourceStatesProcessed.Task.DefaultTimeout();
+        }
+        finally
+        {
+            cts.Cancel();
+
+            var exitCode = await pendingRun.DefaultTimeout();
+            Assert.Equal(CliExitCodes.Success, exitCode);
+        }
+
+        var renderedOutput = interactionService.DisplayedRenderables.Select(RenderToPlainConsole).ToList();
+
+        Assert.Empty(interactionService.DisplayedLiveRenderables);
+        Assert.Single(renderedOutput, output => output.Contains("frontend has endpoint http://localhost:5000", StringComparison.Ordinal));
+        Assert.Single(renderedOutput, output => output.Contains("backend has endpoint http://localhost:5001", StringComparison.Ordinal));
+        Assert.Single(renderedOutput, output => output.Contains("Endpoints:", StringComparison.Ordinal));
+        Assert.Single(renderedOutput, output => output.Contains("Press CTRL+C to stop the AppHost and exit.", StringComparison.Ordinal));
+
+        static async IAsyncEnumerable<RpcResourceState> GetResourceStatesAsync(
+            TaskCompletionSource resourceStatesProcessed,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            yield return new RpcResourceState
+            {
+                Resource = "frontend",
+                Type = "Project",
+                State = "Running",
+                Endpoints = ["http://localhost:5000"],
+                Health = "Healthy"
+            };
+            yield return new RpcResourceState
+            {
+                Resource = "backend",
+                Type = "Project",
+                State = "Running",
+                Endpoints = ["http://localhost:5001"],
+                Health = "Healthy"
+            };
+
+            resourceStatesProcessed.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        static string RenderToPlainConsole(IRenderable renderable)
+        {
+            var writer = new StringWriter();
+            var console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                Interactive = InteractionSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(writer),
+                Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+            });
+
+            console.Profile.Width = int.MaxValue;
+            console.Profile.Capabilities.Links = false;
+            console.Write(renderable);
+
+            return writer.ToString().Replace("\r\n", "\n");
+        }
+    }
+
+    [Fact]
     public async Task RunCommand_InRemoteExtensionHost_DisplaysDashboardUrlsBeforeLiveEndpointDisplayCompletes()
     {
         var displayLiveStarted = new TaskCompletionSource();
@@ -2099,6 +2226,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.AppHostBackchannelFactory = backchannelFactory;
             options.DotNetCliRunnerFactory = runnerFactory;
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.CliHostEnvironmentFactory = _ => TestHelpers.CreateInteractiveHostEnvironment();
             options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
             options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp)
             {

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -34,6 +34,30 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public async Task DisplayLiveAsync_WhenNonInteractive_WritesRenderablesStatically()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+
+        await interactionService.DisplayLiveAsync(new Text("Initial\n"), update =>
+        {
+            update(new Text("Updated once\n"));
+            update(new Text("Updated twice\n"));
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal("Initial\nUpdated once\nUpdated twice\n", output.ToString(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public async Task PromptForSelectionAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -58,6 +58,33 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
+    public async Task DisplayLiveAsync_WhenInteractive_UsesLiveRendering()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+        console.Profile.Width = int.MaxValue;
+        var interactionService = CreateInteractionService(console);
+
+        await interactionService.DisplayLiveAsync(new Text("Initial\n"), update =>
+        {
+            update(new Text("Updated once\n"));
+            update(new Text("Updated twice\n"));
+            return Task.CompletedTask;
+        });
+
+        var renderedOutput = output.ToString();
+        Assert.Contains("\u001b[?25l", renderedOutput);
+        Assert.Contains("Updated twice", renderedOutput);
+        Assert.Contains("\u001b[?25h", renderedOutput);
+    }
+
+    [Fact]
     public async Task PromptForSelectionAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -34,27 +34,20 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
-    public async Task DisplayLiveAsync_WhenNonInteractive_WritesRenderablesStatically()
+    public async Task DisplayLiveAsync_WhenNonInteractive_ThrowsInvalidOperationException()
     {
-        var output = new StringBuilder();
-        var console = AnsiConsole.Create(new AnsiConsoleSettings
-        {
-            Ansi = AnsiSupport.Yes,
-            ColorSystem = ColorSystemSupport.NoColors,
-            Out = new AnsiConsoleOutput(new StringWriter(output)),
-            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
-        });
-        console.Profile.Width = int.MaxValue;
-        var interactionService = CreateInteractionService(console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
+        var callbackInvoked = false;
+        var interactionService = CreateInteractionService(AnsiConsole.Console, hostEnvironment: TestHelpers.CreateNonInteractiveHostEnvironment());
 
-        await interactionService.DisplayLiveAsync(new Text("Initial\n"), update =>
-        {
-            update(new Text("Updated once\n"));
-            update(new Text("Updated twice\n"));
-            return Task.CompletedTask;
-        });
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            interactionService.DisplayLiveAsync(Text.Empty, _ =>
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }));
 
-        Assert.Equal("Initial\nUpdated once\nUpdated twice\n", output.ToString(), ignoreLineEndingDifferences: true);
+        Assert.Equal("Live rendering requires interactive output.", exception.Message);
+        Assert.False(callbackInvoked);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -46,6 +46,32 @@ public class CliHostEnvironmentTests
         Assert.False(env.SupportsInteractiveOutput);
     }
 
+    [Fact]
+    public void SupportsInteractiveOutput_ReturnsFalse_WhenOutputIsRedirectedInPlaygroundMode()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_PLAYGROUND"] = "true"
+            })
+            .Build();
+
+        var env = new CliHostEnvironment(configuration, nonInteractive: false, isOutputRedirected: true);
+
+        Assert.False(env.SupportsInteractiveOutput);
+    }
+
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    [Fact]
+    public void SupportsInteractiveOutput_ReturnsTrue_WhenOutputIsNotRedirected()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var env = new CliHostEnvironment(configuration, nonInteractive: false, isOutputRedirected: false);
+
+        Assert.True(env.SupportsInteractiveOutput);
+    }
+
     [Theory]
     [InlineData("ASPIRE_NON_INTERACTIVE", "true")]
     [InlineData("ASPIRE_NON_INTERACTIVE", "1")]
@@ -240,7 +266,7 @@ public class CliHostEnvironmentTests
             .Build();
 
         // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: false);
+        var env = new CliHostEnvironment(configuration, nonInteractive: false, isOutputRedirected: false);
 
         // Assert
         Assert.True(env.SupportsInteractiveOutput);
@@ -278,7 +304,7 @@ public class CliHostEnvironmentTests
             .Build();
 
         // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: false);
+        var env = new CliHostEnvironment(configuration, nonInteractive: false, isOutputRedirected: false);
 
         // Assert
         Assert.True(env.SupportsInteractiveOutput);

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -36,6 +36,16 @@ public class CliHostEnvironmentTests
         _ = env.SupportsInteractiveOutput;
     }
 
+    [Fact]
+    public void SupportsInteractiveOutput_ReturnsFalse_WhenOutputIsRedirected()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var env = new CliHostEnvironment(configuration, nonInteractive: false, isOutputRedirected: true);
+
+        Assert.False(env.SupportsInteractiveOutput);
+    }
+
     [Theory]
     [InlineData("ASPIRE_NON_INTERACTIVE", "true")]
     [InlineData("ASPIRE_NON_INTERACTIVE", "1")]


### PR DESCRIPTION
## Description

`aspire run` could enter Spectre live rendering in a Remote SSH session even when stdout was redirected. Resource endpoint updates then crashed the CLI with `System.ArgumentException` from `LiveRenderable.Render`, which also stopped the AppHost.

This change treats redirected stdout as non-interactive. Real terminals keep the existing Spectre live display, which replaces a cumulative endpoint snapshot in place. Redirected or otherwise non-interactive remote runs bypass `DisplayLiveAsync`: they print the CTRL+C hint once and append one line per newly observed endpoint, avoiding both cursor manipulation and duplicate snapshots. `DisplayLiveAsync` now rejects non-interactive calls so future callers must define appropriate static semantics.

### User-facing usage

The reported path now stays running and writes plain endpoint updates:

```bash
TERM=dumb LINES=0 COLUMNS=80 \
VSCODE_IPC_HOOK_CLI=<socket> \
SSH_CONNECTION='<client> <port> <server> <port>' \
aspire run --project playground/DotnetProject/DotnetProject.AppHost/DotnetProject.AppHost.csproj \
  > stdout.log 2> stderr.log
```

Before this change, the command exited with code 2 when the first endpoint updated:

```text
System.ArgumentException: Offset and length were out of bounds...
   at Spectre.Console.LiveRenderable.Render(...)
   at Aspire.Cli.Interaction.ConsoleInteractionService.DisplayLiveAsync(...)
   at Aspire.Cli.Commands.RunCommand.ProcessResourceState(...)
```

After this change, stdout contains one static record per endpoint transition with no carriage-return live redraws, stderr has no Spectre exception, and the AppHost remains running until stopped. The same Remote SSH command under a real PTY continues to use live rendering.

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

The affected surface is redirected stdout rather than a visual terminal layout, so the exact before/after command and output are included above. Interactive PTY rendering was verified separately and remains unchanged.

### Validation

- `RunCommandTests`, `ConsoleInteractionServiceTests`, and `CliHostEnvironmentTests`: 234 passed
- `SmokeTests.RedirectedRemoteSshRunUsesStaticOutput`: 1 passed against a locally built Linux arm64 archive in 2m06s
- `dotnet build src/Aspire.Cli/Aspire.Cli.csproj --no-restore`: 0 warnings, 0 errors
- Redirected Remote SSH path: no carriage-return live redraws, no duplicate endpoint records, no exception, AppHost remained running
- Exact Remote SSH path under a PTY: live endpoint updates remained enabled
- Full four-lane review plus focused blocker re-review: no blocking findings remain

Resolves microsoft/aspire#19290

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

<!-- daily-work-queue:v1 repo=microsoft/aspire pr=19673 head=42148cf682d47a4816f11bc382518c127cc66780 laneType=full-cleanup status=fixed-ci-green timestamp=2026-09-01T00:59:10Z -->