### PR TITLE
Fix broken `main` CI

### DIFF
--- a/.github/workflows/prepare-installer-artifacts.yml
+++ b/.github/workflows/prepare-installer-artifacts.yml
@@ -27,6 +27,28 @@ jobs:
           path: ${{ github.workspace }}/native-archives
           merge-multiple: false
 
+      - name: Download NuGet packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/built-nugets
+
+      - name: Configure CLI package override
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $templatePackages = @(
+            Get-ChildItem -Path "$env:GITHUB_WORKSPACE/built-nugets" -Recurse -File -Filter 'Aspire.ProjectTemplates.*.nupkg' |
+              Where-Object { $_.Directory.Name -eq 'Shipping' }
+          )
+          if ($templatePackages.Count -ne 1) {
+            throw "Expected exactly one Shipping/Aspire.ProjectTemplates.*.nupkg in the built-nugets artifact, found $($templatePackages.Count)."
+          }
+
+          $packageDirectory = $templatePackages[0].Directory.FullName
+          "ASPIRE_CLI_PACKAGES=$packageDirectory" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Using same-run Aspire packages from '$packageDirectory'."
+
       - name: Prepare WinGet manifest artifact
         if: ${{ inputs.installer == 'winget' }}
         shell: pwsh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -328,6 +328,7 @@ jobs:
     uses: ./.github/workflows/prepare-installer-artifacts.yml
     needs: [
       setup_for_tests,
+      build_packages,
       build_cli_archive_windows,
       build_cli_archive_windows_arm64,
     ]
@@ -340,6 +341,7 @@ jobs:
     uses: ./.github/workflows/prepare-installer-artifacts.yml
     needs: [
       setup_for_tests,
+      build_packages,
       build_cli_archive_macos,
       build_cli_archive_macos_x64,
     ]

--- a/tests/Infrastructure.Tests/WorkflowScripts/CiWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CiWorkflowTests.cs
@@ -7,19 +7,68 @@ namespace Infrastructure.Tests;
 
 public sealed class CiWorkflowTests
 {
+    [Theory]
+    [InlineData("prepare_winget_installer_artifacts")]
+    [InlineData("prepare_homebrew_installer_artifacts")]
+    public void InstallerJobsDependOnBuiltPackages(string jobName)
+    {
+        var workflow = ReadWorkflow("tests.yml");
+        var job = GetJob(workflow, jobName);
+
+        Assert.Contains("      build_packages,", job);
+    }
+
+    [Fact]
+    public void InstallerWorkflowStagesSameRunTemplatePackages()
+    {
+        var workflow = ReadWorkflow("prepare-installer-artifacts.yml");
+        var job = GetJob(workflow, "prepare_installer_artifacts");
+        var downloadStep = GetStep(job, "Download NuGet packages");
+        var configureStep = GetStep(job, "Configure CLI package override");
+
+        Assert.Contains("name: built-nugets", downloadStep);
+        Assert.Contains("path: ${{ github.workspace }}/built-nugets", downloadStep);
+        Assert.Contains("Aspire.ProjectTemplates.*.nupkg", configureStep);
+        Assert.Contains("Where-Object { $_.Directory.Name -eq 'Shipping' }", configureStep);
+        Assert.Contains("ASPIRE_CLI_PACKAGES=$packageDirectory", configureStep);
+        Assert.Contains("$env:GITHUB_ENV", configureStep);
+    }
+
     [Fact]
     public void CiFailureTrackerCheckoutDoesNotPinMain()
     {
-        var workflow = File.ReadAllText(Path.Combine(RepoRoot.Path, ".github", "workflows", "ci.yml"));
-        var job = System.Text.RegularExpressions.Regex.Match(workflow, "(?ms)^  ci_failure_tracker:\\n(?<body>.*?)(?=^  [A-Za-z0-9_-]+:\\n|\\z)");
-        Assert.True(job.Success, "Could not find the ci_failure_tracker job in ci.yml.");
+        var workflow = ReadWorkflow("ci.yml");
+        var job = GetJob(workflow, "ci_failure_tracker");
 
-        var checkout = System.Text.RegularExpressions.Regex.Match(job.Value, "(?ms)^      - uses: actions/checkout@.*?(?=^      - |\\z)");
+        var checkout = System.Text.RegularExpressions.Regex.Match(job, "(?ms)^      - uses: actions/checkout@.*?(?=^      - |\\z)");
         Assert.True(checkout.Success, "Could not find the ci_failure_tracker checkout step.");
 
         // Push CI also runs on release/**. Pinning this checkout to main makes the
         // tracker execute main's reporter instead of the workflow code from the branch
         // whose run is being evaluated.
         Assert.DoesNotContain("ref: main", checkout.Value);
+    }
+
+    private static string ReadWorkflow(string fileName)
+        => File.ReadAllText(Path.Combine(RepoRoot.Path, ".github", "workflows", fileName));
+
+    private static string GetJob(string workflow, string jobName)
+    {
+        var job = System.Text.RegularExpressions.Regex.Match(
+            workflow,
+            $@"(?ms)^  {System.Text.RegularExpressions.Regex.Escape(jobName)}:\n(?<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\z)");
+        Assert.True(job.Success, $"Could not find the {jobName} job.");
+
+        return job.Value;
+    }
+
+    private static string GetStep(string job, string stepName)
+    {
+        var step = System.Text.RegularExpressions.Regex.Match(
+            job,
+            $@"(?ms)^      - name: {System.Text.RegularExpressions.Regex.Escape(stepName)}\n.*?(?=^      - |\z)");
+        Assert.True(step.Success, $"Could not find the {stepName} step.");
+
+        return step.Value;
     }
 }


### PR DESCRIPTION
## Description

**Homebrew and WinGet installer artifact jobs fail during `aspire new`:**

```text
No matching local Aspire.ProjectTemplates package was found for Aspire CLI version '13.6.0-ci'.
```

Exact local template selection now requires the installed CI CLI to resolve templates with the same version. The installer jobs downloaded only native CLI archives, leaving `Aspire.ProjectTemplates.13.6.0-ci.nupkg` unavailable even though `build_packages` published it in the `built-nugets` artifact.

This makes both installer jobs depend on `build_packages`, downloads `built-nugets` in the reusable installer workflow, and exports the directory containing the single Shipping template package through `ASPIRE_CLI_PACKAGES`. Workflow-contract tests keep the producer dependency and package override wired together.

Both installer jobs now wait for the package build as well as their platform archives. That dependency is required so the installed CLI and templates always come from the same CI build.

Validation:

- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.CiWorkflowTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Parsed both changed workflows as YAML.
- Ran `actionlint` on `.github/workflows/prepare-installer-artifacts.yml`.
- Exercised the package-discovery step against a failed-run `built-nugets` artifact and resolved `Debug/Shipping/Aspire.ProjectTemplates.13.6.0-ci.nupkg`.

Fixes #19596

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
