### PR TITLE
Open CLI diagnostic logs in VS Code after failures

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -118,6 +118,22 @@ jobs:
             cliBinary: aspire.exe
             useXvfb: false
           - name: Linux
+            shardName: diagnostic-logs
+            spec: out/test-e2e/test-e2e/diagnosticLogs.e2e.test.js
+            runner: ubuntu-latest
+            rid: linux-x64
+            archivePattern: aspire-cli-linux-x64*.tar.gz
+            cliBinary: aspire
+            useXvfb: true
+          - name: Windows
+            shardName: diagnostic-logs
+            spec: out/test-e2e/test-e2e/diagnosticLogs.e2e.test.js
+            runner: windows-latest
+            rid: win-x64
+            archivePattern: aspire-cli-win-x64*.zip
+            cliBinary: aspire.exe
+            useXvfb: false
+          - name: Linux
             shardName: discovery-configuration
             spec: out/test-e2e/test-e2e/discoveryConfiguration.e2e.test.js
             runner: ubuntu-latest

--- a/extension/src/test-e2e/diagnosticLogs.e2e.test.ts
+++ b/extension/src/test-e2e/diagnosticLogs.e2e.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { getCommandInvocationCount, waitForCommandOutcome, waitForRepositoryIdle, waitForRunningAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
+import { executeE2eControlCommand, runE2eTeardown, stopPrimaryAppHostIfRunning } from './helpers/fixtures';
+import { getPrimaryAppHostProjectPath, getWorkspaceRoot } from './helpers/paths';
+import { openAspireView, waitForNotificationMessage } from './helpers/vscode';
+
+interface CliResult {
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+interface OpenEditor {
+    label: string;
+    uri?: string;
+    text?: string;
+    isPreview: boolean;
+}
+
+suite('CLI diagnostic log editor E2E', function () {
+    this.timeout(420000);
+
+    teardown(async () => {
+        await runE2eTeardown([
+            () => stopPrimaryAppHostIfRunning(),
+            () => executeE2eControlCommand({ name: 'closeAllEditors' }),
+        ], 'CLI diagnostic log editor E2E teardown failed.');
+    });
+
+    test('keeps the failure notification and opens one existing log as a persistent editor', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await executeE2eControlCommand({ name: 'closeAllEditors' });
+
+        const missingAppHost = path.join(getWorkspaceRoot(), 'missing', 'Missing.AppHost.csproj');
+        const status = await executeE2eControlCommand({
+            name: 'runAspireCli',
+            args: ['run', '--apphost', missingAppHost, '--non-interactive'],
+            workingDirectory: '.',
+            allowNonZeroExit: true,
+        }, { timeoutMs: 180000 });
+        const result = status.result as CliResult;
+
+        assert.notStrictEqual(result.exitCode, 0);
+        await waitForNotificationMessage('The --apphost option specified a project that does not exist');
+
+        const editors = await getOpenLogEditors();
+        assert.strictEqual(editors.length, 1);
+        assert.strictEqual(editors[0].isPreview, false);
+    });
+
+    test('opens current and AppHost logs in order as persistent editors', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await waitForWorkspaceAppHost();
+        await executeE2eControlCommand({ name: 'closeAllEditors' });
+
+        const appHostPath = getPrimaryAppHostProjectPath();
+        const runBefore = getCommandInvocationCount('aspire-vscode.runAppHost');
+        await executeE2eControlCommand({ name: 'runAppHost', appHostPath }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.runAppHost', 'success', 180000, runBefore);
+        await waitForRunningAppHost(180000);
+
+        const status = await executeE2eControlCommand({
+            name: 'runAspireCli',
+            args: ['resource', 'e2e-worker', 'missing-command', '--apphost', appHostPath, '--non-interactive'],
+            workingDirectory: '.',
+            allowNonZeroExit: true,
+        }, { timeoutMs: 180000 });
+        const result = status.result as CliResult;
+
+        assert.notStrictEqual(result.exitCode, 0);
+        await waitForNotificationMessage("Failed to execute command 'missing-command'");
+
+        const editors = await getOpenLogEditors();
+        assert.strictEqual(editors.length, 2);
+        assert.ok(editors[0].text?.includes('missing-command'), `Expected the current CLI log first, got '${editors[0].label}'.`);
+        assert.ok(!editors[1].text?.includes('missing-command'), `Expected the AppHost CLI log second, got '${editors[1].label}'.`);
+        assert.deepStrictEqual(editors.map(editor => editor.isPreview), [false, false]);
+    });
+});
+
+async function getOpenLogEditors(): Promise<OpenEditor[]> {
+    const status = await executeE2eControlCommand({ name: 'getOpenEditors' });
+    const editors = status.result as OpenEditor[];
+
+    return editors.filter(editor =>
+        editor.uri !== undefined
+        && path.extname(new URL(editor.uri).pathname) === '.log');
+}

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -543,6 +543,31 @@ suite('InteractionService endpoints', () => {
 		stub.restore();
 	});
 
+	test("openEditor opens multiple files in non-preview editors", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aspire-open-editor-'));
+		const cliLogPath = path.join(tempRoot, 'cli-diagnostics.log');
+		const appHostLogPath = path.join(tempRoot, 'apphost-diagnostics.log');
+		const sandbox = sinon.createSandbox();
+
+		try {
+			const testInfo = await createTestRpcServer();
+			const showTextDocumentStub = sandbox.stub(vscode.window, 'showTextDocument').resolves({} as vscode.TextEditor);
+
+			await testInfo.interactionService.openEditor(cliLogPath);
+			await testInfo.interactionService.openEditor(appHostLogPath);
+
+			assert.strictEqual(showTextDocumentStub.callCount, 2, 'Should open both diagnostic log files');
+			assertPathEqual(showTextDocumentStub.getCall(0).args[0].fsPath, cliLogPath);
+			assert.deepStrictEqual(showTextDocumentStub.getCall(0).args[1], { preview: false });
+			assertPathEqual(showTextDocumentStub.getCall(1).args[0].fsPath, appHostLogPath);
+			assert.deepStrictEqual(showTextDocumentStub.getCall(1).args[1], { preview: false });
+		}
+		finally {
+			sandbox.restore();
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
 	test("openEditor adds folder to existing workspace", async () => {
 		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aspire-open-editor-'));
 		const workspacePath = path.join(tempRoot, 'workspace');

--- a/extension/src/testing/e2eStateFileBridge.ts
+++ b/extension/src/testing/e2eStateFileBridge.ts
@@ -895,6 +895,10 @@ export async function executeE2eControlCommand(
       markStarted();
       return getActiveEditorInfo();
     }
+    case 'getOpenEditors': {
+      markStarted();
+      return getOpenEditorInfo();
+    }
     case 'runAspireCli': {
       if (!Array.isArray(command.args) || !command.args.every(argument => typeof argument === 'string')) {
         throw new Error('Aspire extension E2E runAspireCli args must be an array of strings.');
@@ -907,7 +911,8 @@ export async function executeE2eControlCommand(
         [...command.args],
         workingDirectory,
         timeoutMs,
-        terminalProvider.createEnvironment());
+        terminalProvider.createEnvironment(),
+        { noExtensionVariables: false, rejectOnNonZero: command.allowNonZeroExit !== true });
       markStarted();
       return await commandPromise;
     }
@@ -1373,7 +1378,8 @@ async function proveMauiResourceDebugging(command: MauiResourceDebugProofCommand
       ['resource', resourceName, 'start', '--apphost', appHostPath, '--non-interactive', '--nologo'],
       path.dirname(appHostPath),
       resourceStartTimeoutMs,
-      terminalProvider.createDcpRunSessionEnvironment(aspireDebugSession.debugSessionId, false));
+      terminalProvider.createDcpRunSessionEnvironment(aspireDebugSession.debugSessionId, false),
+      { noExtensionVariables: true, rejectOnNonZero: true });
 
     let stoppedEvent: { stoppedEvent: DebugAdapterStoppedEvent; stackTrace: { stackFrames?: Array<{ source?: { path?: string }; line?: number }> }; matchingFrame: { source?: { path?: string }; line?: number } };
     try {
@@ -1503,7 +1509,8 @@ async function runAspireCliForE2E(
   args: string[],
   workingDirectory: string,
   timeoutMs: number,
-  environment: Record<string, string | undefined>
+  environment: Record<string, string | undefined>,
+  options: { noExtensionVariables: boolean; rejectOnNonZero: boolean }
 ): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
   const cliPath = await terminalProvider.getAspireCliExecutablePath();
   const diagnosticCommand = [cliPath, ...redactCliArgsForLogging(args)].join(' ');
@@ -1535,7 +1542,7 @@ async function runAspireCliForE2E(
         completed = true;
         clearTimeout(timeout);
         const result = { exitCode: code, stdout: stdout.join(''), stderr: stderr.join('') };
-        if (code === 0) {
+        if (code === 0 || !options.rejectOnNonZero) {
           resolve(result);
         } else {
           reject(new Error(`${diagnosticCommand} exited with code ${code}.`));
@@ -1550,7 +1557,7 @@ async function runAspireCliForE2E(
         clearTimeout(timeout);
         reject(error);
       },
-      noExtensionVariables: true,
+      noExtensionVariables: options.noExtensionVariables,
       createProcessGroup: true,
       env: Object.entries(environment)
         .map(([name, value]) => ({ name, value: String(value) }))
@@ -2213,6 +2220,22 @@ function getActiveEditorInfo(): { uri?: string; fileName?: string; text?: string
     fileName: document?.fileName,
     text: document?.getText(),
   };
+}
+
+function getOpenEditorInfo(): Array<{ label: string; uri?: string; text?: string; isPreview: boolean }> {
+  return vscode.window.tabGroups.all.flatMap(group =>
+    group.tabs.map(tab => {
+      const uri = tab.input instanceof vscode.TabInputText ? tab.input.uri : undefined;
+      const document = uri === undefined
+        ? undefined
+        : vscode.workspace.textDocuments.find(candidate => candidate.uri.toString() === uri.toString());
+      return {
+        label: tab.label,
+        uri: uri?.toString(),
+        text: document?.getText(),
+        isPreview: tab.isPreview,
+      };
+    }));
 }
 
 function cloneTerminalCommandEvent(event: AspireTerminalCommandEvent, sequence: number): AspireExtensionE2ETerminalCommand {

--- a/extension/src/types/extensionApi.ts
+++ b/extension/src/types/extensionApi.ts
@@ -255,7 +255,8 @@ export type AspireExtensionE2EControlCommand =
     | { name: 'getWorkspaceFolders' }
     | { name: 'addWorkspaceFolder'; folderPath: string }
     | { name: 'getActiveEditor' }
-    | { name: 'runAspireCli'; args: readonly string[]; workingDirectory: string; timeoutMs?: number }
+    | { name: 'getOpenEditors' }
+    | { name: 'runAspireCli'; args: readonly string[]; workingDirectory: string; timeoutMs?: number; allowNonZeroExit?: boolean }
     | { name: 'getResourceDebuggerExtensions' }
     | { name: 'getSupportedCapabilities' }
     | { name: 'getVisibleExtensionIds' }

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -279,7 +279,7 @@ internal abstract class BaseCommand : Command
     {
         if (interactionService is IExtensionInteractionService extensionInteractionService && File.Exists(logFilePath))
         {
-            extensionInteractionService.OpenEditor(logFilePath);
+            extensionInteractionService.OpenEditor(Path.GetFullPath(logFilePath));
         }
     }
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -223,6 +223,7 @@ internal abstract class BaseCommand : Command
                 string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, MarkupHelpers.SafeFileLink(InteractionService, _executionContext.LogFilePath)),
                 allowMarkup: true,
                 consoleOverride: ConsoleOutput.Error);
+            OpenLogFileInEditorIfAvailable(InteractionService, _executionContext.LogFilePath);
 
             // If we connected to a running app host, also display the log file path of
             // the CLI process that launched it so users can diagnose issues in both processes.
@@ -233,6 +234,7 @@ internal abstract class BaseCommand : Command
                     string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, MarkupHelpers.SafeFileLink(InteractionService, ExecutionContext.AppHostCliLogFilePath)),
                     allowMarkup: true,
                     consoleOverride: ConsoleOutput.Error);
+                OpenLogFileInEditorIfAvailable(InteractionService, ExecutionContext.AppHostCliLogFilePath);
             }
         }
 
@@ -271,6 +273,14 @@ internal abstract class BaseCommand : Command
         }
 
         return false;
+    }
+
+    private static void OpenLogFileInEditorIfAvailable(IInteractionService interactionService, string logFilePath)
+    {
+        if (interactionService is IExtensionInteractionService extensionInteractionService && File.Exists(logFilePath))
+        {
+            extensionInteractionService.OpenEditor(logFilePath);
+        }
     }
 
     private static async Task FlushExtensionInteractionServiceAsync(IInteractionService interactionService)

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -297,6 +297,46 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task BaseCommand_OnFailure_WithExtensionAndRelativeCliLog_OpensAbsoluteEditorPath()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var absoluteCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "relative-cli.log");
+        var relativeCliLogPath = Path.GetRelativePath(Environment.CurrentDirectory, absoluteCliLogPath);
+        File.WriteAllText(absoluteCliLogPath, "Current CLI diagnostics");
+        var backchannelMonitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Something went wrong")
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider);
+            options.AuxiliaryBackchannelMonitorFactory = _ => backchannelMonitor;
+            options.CliExecutionContextFactory = _ => workspace.CreateExecutionContext(logFilePath: relativeCliLogPath);
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var testInteractionService = Assert.IsType<TestExtensionInteractionService>(provider.GetRequiredService<IInteractionService>());
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
+
+        var expectedLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, relativeCliLogPath);
+        Assert.Collection(
+            testInteractionService.DisplayedMessages,
+            message =>
+            {
+                Assert.Equal(expectedLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            });
+        Assert.Equal([absoluteCliLogPath], testInteractionService.OpenEditorPaths);
+    }
+
+    [Fact]
     public async Task BaseCommand_OnFailure_WithExtensionAndExistingCliAndAppHostLogs_DisplaysMessagesAndOpensEditorsInOrder()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -222,7 +222,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task BaseCommand_OnFailure_DisplaysLogFilePathOnStderr()
+    public async Task BaseCommand_OnFailure_WithConsoleInteraction_DisplaysLogFilePathOnStderr()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var testInteractionService = new TestInteractionService();
@@ -248,8 +248,154 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         var executionContext = provider.GetRequiredService<CliExecutionContext>();
         var expectedLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, executionContext.LogFilePath);
-        var logMessage = Assert.Single(testInteractionService.DisplayedMessages, m => m.Message == expectedLogMessage);
-        Assert.Equal(ConsoleOutput.Error, logMessage.ConsoleOverride);
+        Assert.Collection(
+            testInteractionService.DisplayedMessages,
+            message =>
+            {
+                Assert.Equal(expectedLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            });
+    }
+
+    [Fact]
+    public async Task BaseCommand_OnFailure_WithExtensionAndExistingCliLog_DisplaysMessageAndOpensEditor()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var currentCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "current-cli.log");
+        File.WriteAllText(currentCliLogPath, "Current CLI diagnostics");
+        var backchannelMonitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Something went wrong")
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider);
+            options.AuxiliaryBackchannelMonitorFactory = _ => backchannelMonitor;
+            options.CliExecutionContextFactory = _ => workspace.CreateExecutionContext(logFilePath: currentCliLogPath);
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var testInteractionService = Assert.IsType<TestExtensionInteractionService>(provider.GetRequiredService<IInteractionService>());
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
+
+        var expectedLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, currentCliLogPath);
+        Assert.Collection(
+            testInteractionService.DisplayedMessages,
+            message =>
+            {
+                Assert.Equal(expectedLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            });
+        Assert.Equal([currentCliLogPath], testInteractionService.OpenEditorPaths);
+    }
+
+    [Fact]
+    public async Task BaseCommand_OnFailure_WithExtensionAndExistingCliAndAppHostLogs_DisplaysMessagesAndOpensEditorsInOrder()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var currentCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "current-cli.log");
+        var appHostCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost-cli.log");
+        File.WriteAllText(currentCliLogPath, "Current CLI diagnostics");
+        File.WriteAllText(appHostCliLogPath, "AppHost CLI diagnostics");
+        var backchannelMonitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Something went wrong")
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider);
+            options.AuxiliaryBackchannelMonitorFactory = _ => backchannelMonitor;
+            options.CliExecutionContextFactory = _ =>
+            {
+                var executionContext = workspace.CreateExecutionContext(logFilePath: currentCliLogPath);
+                executionContext.AppHostCliLogFilePath = appHostCliLogPath;
+                return executionContext;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var testInteractionService = Assert.IsType<TestExtensionInteractionService>(provider.GetRequiredService<IInteractionService>());
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
+
+        var expectedCliLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, currentCliLogPath);
+        var expectedAppHostLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, appHostCliLogPath);
+        Assert.Collection(
+            testInteractionService.DisplayedMessages,
+            message =>
+            {
+                Assert.Equal(expectedCliLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            },
+            message =>
+            {
+                Assert.Equal(expectedAppHostLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            });
+        Assert.Equal([currentCliLogPath, appHostCliLogPath], testInteractionService.OpenEditorPaths);
+    }
+
+    [Fact]
+    public async Task BaseCommand_OnFailure_WithExtensionAndMissingCliAndAppHostLogs_DisplaysMessagesWithoutOpeningEditors()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var currentCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "missing-current-cli.log");
+        var appHostCliLogPath = Path.Combine(workspace.WorkspaceRoot.FullName, "missing-apphost-cli.log");
+        var backchannelMonitor = new TestAuxiliaryBackchannelMonitor
+        {
+            ScanAsyncCallback = _ => throw new InvalidOperationException("Something went wrong")
+        };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = serviceProvider => new TestExtensionInteractionService(serviceProvider);
+            options.AuxiliaryBackchannelMonitorFactory = _ => backchannelMonitor;
+            options.CliExecutionContextFactory = _ =>
+            {
+                var executionContext = workspace.CreateExecutionContext(logFilePath: currentCliLogPath);
+                executionContext.AppHostCliLogFilePath = appHostCliLogPath;
+                return executionContext;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var testInteractionService = Assert.IsType<TestExtensionInteractionService>(provider.GetRequiredService<IInteractionService>());
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.NotEqual(CliExitCodes.Success, exitCode);
+
+        var expectedCliLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, currentCliLogPath);
+        var expectedAppHostLogMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeAppHostLogsAt, appHostCliLogPath);
+        Assert.Collection(
+            testInteractionService.DisplayedMessages,
+            message =>
+            {
+                Assert.Equal(expectedCliLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            },
+            message =>
+            {
+                Assert.Equal(expectedAppHostLogMessage, message.Message);
+                Assert.Equal(ConsoleOutput.Error, message.ConsoleOverride);
+            });
+        Assert.Empty(testInteractionService.OpenEditorPaths);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -13,6 +13,8 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestExtensionInteractionService(IServiceProvider serviceProvider) : IExtensionInteractionService
 {
+    private readonly object _recordingLock = new();
+
     public ConsoleOutput Console { get; set; }
     public bool SupportsLinks { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
@@ -27,7 +29,9 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     public Func<string, Func<string, ValidationResult>?, bool, bool, PromptBinding<string?>?, CancellationToken, Task<string>>? PromptForStringCallback { get; set; }
     public Func<string, IReadOnlyList<string>, string>? SelectionCallback { get; set; }
     public Func<IRenderable, Func<Action<IRenderable>, Task>, Task>? DisplayLiveAsyncCallback { get; set; }
+    public List<(KnownEmoji Emoji, string Message, ConsoleOutput? ConsoleOverride)> DisplayedMessages { get; } = [];
     public List<(OutputLineStream Stream, string Line)> DisplayedLines { get; } = [];
+    public List<string> OpenEditorPaths { get; } = [];
     public bool FlushAsyncCalled { get; private set; }
 
     public IExtensionBackchannel Backchannel { get; } = serviceProvider.GetRequiredService<IExtensionBackchannel>();
@@ -116,6 +120,10 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false, ConsoleOutput? consoleOverride = null)
     {
+        lock (_recordingLock)
+        {
+            DisplayedMessages.Add((emoji, message, consoleOverride));
+        }
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
@@ -218,6 +226,11 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public void OpenEditor(string projectPath)
     {
+        lock (_recordingLock)
+        {
+            OpenEditorPaths.Add(projectPath);
+        }
+
         OpenEditorCallback?.Invoke(projectPath);
     }
 


### PR DESCRIPTION
## Description

When an Aspire CLI command launched from VS Code fails, the extension shows the existing failure notification but leaves the diagnostic log paths as plain text. This keeps those notifications and also opens each existing CLI diagnostic log in a persistent editor tab. The current CLI log opens first, followed by the AppHost CLI log when both exist.

Missing or stale files are ignored without hiding the original failure. Console-only calls and hidden resource commands keep their existing behavior. This reuses the released `openEditor(path)` RPC and does not add a protocol member.

### User-facing usage

No new command or setting is required. A failing RPC-enabled Aspire command now opens its available diagnostic logs automatically in VS Code.

### Evidence

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class '*.BaseCommandTests' --filter-not-trait 'quarantined=true' --filter-not-trait 'outerloop=true'` — 49 passed
- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class '*.ExtensionE2eWorkflowTests' --filter-not-trait 'quarantined=true' --filter-not-trait 'outerloop=true'` — 2 passed
- `yarn unit-test --run out/test/rpc/interactionServiceTests.test.js --run out/test/resourceCommandExecution.test.js` — 67 passed, including all 18 hidden resource-command tests
- Focused `diagnosticLogs.e2e.test.js` Extension Host run — 2 passed, covering the notification plus one persistent log and ordered current/AppHost persistent logs

The Extension Host assertions inspect the actual open editors, tab order, and preview state. A screenshot would only show local diagnostic documents without proving those behaviors.

Fixes #19511

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
