### PR TITLE
Normalize Foundry hosted agent environment variable names

### DIFF
--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentConfiguration.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentConfiguration.cs
@@ -117,8 +117,9 @@ public partial class HostedAgentConfiguration(string image)
     /// </summary>
     internal ProjectsAgentVersionCreationOptions ToProjectsAgentVersionCreationOptions(string targetResourceName)
     {
-        ValidateEnvironmentVariableNames(EnvironmentVariables.Keys, targetResourceName);
-        ValidateEnvironmentVariableNamesAreNotReserved(EnvironmentVariables.Keys, targetResourceName);
+        var environmentVariables = NormalizeEnvironmentVariableNames(targetResourceName);
+        ValidateEnvironmentVariableNames(environmentVariables.Keys, targetResourceName);
+        ValidateEnvironmentVariableNamesAreNotReserved(environmentVariables.Keys, targetResourceName);
         ValidateProtocolVersions(targetResourceName);
 
         var def = new HostedAgentDefinition(
@@ -139,7 +140,7 @@ public partial class HostedAgentConfiguration(string image)
         {
             def.Tools.Add(tool);
         }
-        foreach (var envVar in EnvironmentVariables)
+        foreach (var envVar in environmentVariables)
         {
             def.EnvironmentVariables[envVar.Key] = envVar.Value;
         }
@@ -152,6 +153,26 @@ public partial class HostedAgentConfiguration(string image)
             options.Metadata[kvp.Key] = kvp.Value;
         }
         return options;
+    }
+
+    private Dictionary<string, string> NormalizeEnvironmentVariableNames(string targetResourceName)
+    {
+        var normalizedEnvironmentVariables = new Dictionary<string, string>(EnvironmentVariables.Count);
+        foreach (var (name, value) in EnvironmentVariables)
+        {
+            // Aspire resource names allow hyphens, so generated connection string and service
+            // discovery keys can contain them. Foundry Hosted Agents only accept letters, digits,
+            // and underscores in environment variable names.
+            var normalizedName = name.Replace('-', '_');
+            if (!normalizedEnvironmentVariables.TryAdd(normalizedName, value))
+            {
+                throw new DistributedApplicationException(
+                    $"Foundry hosted agent for target resource '{targetResourceName}' contains environment variable names that become duplicates when '-' is replaced with '_'. " +
+                    $"Duplicate name: '{normalizedName}'");
+            }
+        }
+
+        return normalizedEnvironmentVariables;
     }
 
     private void ValidateProtocolVersions(string? targetResourceName)

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentConfigurationTests.cs
@@ -152,7 +152,38 @@ public class HostedAgentConfigurationTests
         var ex = Assert.Throws<DistributedApplicationException>(() => config.ToProjectsAgentVersionCreationOptions("target"));
 
         Assert.Equal(
-            "Foundry hosted agent for target resource 'target' contains environment variable names that are not supported by Foundry Hosted Agents. Environment variable names must contain only ASCII letters, digits, or underscores. Invalid name(s): 'INVALID-NAME', 'invalid.name'",
+            "Foundry hosted agent for target resource 'target' contains environment variable names that are not supported by Foundry Hosted Agents. Environment variable names must contain only ASCII letters, digits, or underscores. Invalid name(s): 'invalid.name'",
+            ex.Message);
+    }
+
+    [Fact]
+    public void ToProjectsAgentVersionCreationOptions_ReplacesHyphensInEnvironmentVariableNames()
+    {
+        var config = new HostedAgentConfiguration("myimage:latest");
+        config.ProtocolVersions.Add(new ProtocolVersionRecord(ProjectsAgentProtocol.Responses, "2.0.0"));
+        config.EnvironmentVariables["ConnectionStrings__ai-light-model"] = "connection-string";
+        config.EnvironmentVariables["services__analytics-api__https__0"] = "https://analytics.example.com";
+
+        var options = config.ToProjectsAgentVersionCreationOptions("target");
+        var payload = JsonNode.Parse(ModelReaderWriter.Write(options, ModelReaderWriterOptions.Json).ToString())!;
+        var environmentVariables = payload["definition"]!["environment_variables"]!;
+
+        Assert.Equal("connection-string", environmentVariables["ConnectionStrings__ai_light_model"]!.GetValue<string>());
+        Assert.Equal("https://analytics.example.com", environmentVariables["services__analytics_api__https__0"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToProjectsAgentVersionCreationOptions_ThrowsWhenNormalizedEnvironmentVariableNamesConflict()
+    {
+        var config = new HostedAgentConfiguration("myimage:latest");
+        config.ProtocolVersions.Add(new ProtocolVersionRecord(ProjectsAgentProtocol.Responses, "2.0.0"));
+        config.EnvironmentVariables["DUPLICATE-NAME"] = "first";
+        config.EnvironmentVariables["DUPLICATE_NAME"] = "second";
+
+        var ex = Assert.Throws<DistributedApplicationException>(() => config.ToProjectsAgentVersionCreationOptions("target"));
+
+        Assert.Equal(
+            "Foundry hosted agent for target resource 'target' contains environment variable names that become duplicates when '-' is replaced with '_'. Duplicate name: 'DUPLICATE_NAME'",
             ex.Message);
     }
 


### PR DESCRIPTION
## Description

Foundry Hosted Agents reject environment variable names containing hyphens, while Aspire resource names allow them and generate keys such as `ConnectionStrings__ai-light-model` and `services__analytics-api__https__0`. This prevents hosted agents that reference hyphenated resources from deploying.

This change normalizes hyphens to underscores when creating the Foundry deployment payload, while preserving validation for other unsupported characters. It also reports normalization collisions instead of silently overwriting one of the conflicting values.

### User-facing usage

No AppHost changes are required. Generated environment variable names are translated automatically:

```text
ConnectionStrings__ai-light-model -> ConnectionStrings__ai_light_model
services__analytics-api__https__0 -> services__analytics_api__https__0
```

Added unit coverage for normalization, unsupported characters, and duplicate names after normalization.

Fixes #19674

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No