### PR TITLE
Fix macOS Platform SSO internal detection

### DIFF
--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -84,6 +84,7 @@ ignore:
   - eng/scripts/debug-*.ps1                             # debug-aspire-channel/stable/staging: local channel-switch helpers
   - eng/scripts/debug-*.sh
   - eng/scripts/validate-cli-symbols.ps1                # AzDO native-AOT symbol publish validation; no GH-CI consumer
+  - eng/scripts/validate-mac-platform-sso.sh            # manual managed-Mac validation; no GH-CI consumer
   - eng/generate-catalog.ps1                            # Windows/AzDO template catalog generation; no GH-CI consumer
   - eng/scripts/update-aspire-skills-bundle.ps1         # schedule/dispatch-only bundle updater
   - eng/scripts/verify-aspire-skills-bundle.ps1         # exercised by its dedicated PR workflow

--- a/eng/scripts/validate-mac-platform-sso.sh
+++ b/eng/scripts/validate-mac-platform-sso.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Runs the opt-in live Platform SSO parser test against the current macOS user.
+# The test keeps app-sso output in memory and reports only detection booleans and
+# bounded outcome codes, never aliases, domains, tokens, or raw command output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Error: live Platform SSO validation requires macOS." >&2
+  exit 1
+fi
+
+if [[ ! -x /usr/bin/app-sso ]]; then
+  echo "Error: /usr/bin/app-sso is unavailable." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+./restore.sh
+
+ASPIRE_TEST_LIVE_MAC_PLATFORM_SSO=1 \
+MSBUILDTERMINALLOGGER=false \
+dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj \
+  --no-launch-profile \
+  -- \
+  --filter-method "*.EvaluateMacPlatformSso_LiveManagedMac" \
+  --filter-not-trait "quarantined=true" \
+  --filter-not-trait "outerloop=true"

--- a/eng/scripts/validate-mac-platform-sso.sh
+++ b/eng/scripts/validate-mac-platform-sso.sh
@@ -2,7 +2,7 @@
 
 # Runs the opt-in live Platform SSO parser test against the current macOS user.
 # The test keeps app-sso output in memory and reports only detection booleans and
-# bounded outcome codes, never aliases, domains, tokens, or raw command output.
+# bounded failure codes/stages, never aliases, domains, tokens, or raw command output.
 
 set -euo pipefail
 

--- a/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
+++ b/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
@@ -38,6 +38,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
     private const string CacheFileName = "detector.json";
     private const string VisualStudioMicrosoftTenantProbeName = "Visual Studio Microsoft tenant";
     private const string WslVisualStudioMicrosoftTenantProbeName = "WSL Visual Studio Microsoft tenant";
+    private const string MacPlatformSsoPath = "/usr/bin/app-sso";
     private const int CacheVersion = 6;
     private const int MaxGitHubTokenCandidates = 5;
 
@@ -71,6 +72,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
             logger,
             processExecutionFactory,
             ciEnvironmentDetector,
+            MacPlatformSsoPath,
             probeStages: null)
     {
     }
@@ -83,6 +85,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         ILogger<InternalMicrosoftDetector> logger,
         IProcessExecutionFactory processExecutionFactory,
         ICIEnvironmentDetector ciEnvironmentDetector,
+        string macPlatformSsoPath,
         IReadOnlyList<IReadOnlyList<InternalMicrosoftProbe>>? probeStages,
         HttpMessageHandler? gitHubHttpMessageHandler = null,
         TimeSpan? gitHubCandidateTimeout = null,
@@ -777,6 +780,9 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
 
         return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.IdentityMismatch, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
     }
+
+    private static InternalMicrosoftProbeResult PlatformSsoFailure(string code, string stage)
+        => InternalMicrosoftProbeResult.Failed(new(code, stage));
 
     internal async Task<InternalMicrosoftProbeResult> CheckWindowsWorkplaceJoinAsync(CancellationToken cancellationToken)
     {

--- a/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
+++ b/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
@@ -100,6 +100,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         _logger = logger;
         _ciEnvironmentDetector = ciEnvironmentDetector;
         _probeStageTimeout = probeStageTimeout ?? s_probeStageTimeout;
+        _macPlatformSsoPath = macPlatformSsoPath;
         _probeStages = probeStages;
     }
 
@@ -664,16 +665,10 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         // hide Platform SSO registration from non-interactive CLI invocations.
         if (!File.Exists(_macPlatformSsoPath))
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.CommandMissing);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.CommandMissing, InternalMicrosoftProbeFailureStage.PlatformSso);
         }
 
         var result = await RunProcessAsync(_macPlatformSsoPath, ["platform", "-s"], cancellationToken).ConfigureAwait(false);
-        if (result.TimedOut)
-        {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.TimedOut);
-        }
-
-        var result = await RunProcessAsync("app-sso", ["platform", "-s"], cancellationToken).ConfigureAwait(false);
         if (GetProcessFailure(result, treatNonZeroExitAsFailure: true) is { } processFailure)
         {
             return processFailure;
@@ -700,44 +695,75 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         var userConfiguration = TryParseMacPlatformSsoSection(output, "User Configuration");
         if (deviceConfiguration is null || loginConfiguration is null || userConfiguration is null)
         {
-            return InternalMicrosoftProbeResult.Failed(new(
-                InternalMicrosoftProbeFailureCode.JsonParse,
-                InternalMicrosoftProbeFailureStage.PlatformSso,
-                ExceptionType: InternalMicrosoftProbeExceptionType.Json));
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonParse, InternalMicrosoftProbeFailureStage.PlatformSso);
         }
 
         if (!TryGetBoolean(deviceConfiguration, "registrationCompleted", out var registrationCompleted))
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.MalformedOutput);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoRegistration);
         }
 
         if (!registrationCompleted)
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.IncompleteRegistration);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.RegistrationIncomplete, InternalMicrosoftProbeFailureStage.PlatformSsoRegistration);
         }
 
         var issuer = TryGetAbsoluteUri(loginConfiguration, "issuer");
+        if (issuer is null)
+        {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoIssuer);
+        }
+
+        if (!IsMicrosoftTenantEndpoint(issuer, "/v2.0"))
+        {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.TenantMismatch, InternalMicrosoftProbeFailureStage.PlatformSsoIssuer);
+        }
+
         var keyEndpoint = TryGetAbsoluteUri(loginConfiguration, "keyEndpointURL");
+        if (keyEndpoint is null)
+        {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoKeyEndpoint);
+        }
+
+        if (!IsMicrosoftTenantEndpoint(keyEndpoint, "/getkeydata"))
+        {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.TenantMismatch, InternalMicrosoftProbeFailureStage.PlatformSsoKeyEndpoint);
+        }
+
         var tokenEndpoint = TryGetAbsoluteUri(loginConfiguration, "tokenEndpointURL");
-        if (issuer is null || keyEndpoint is null || tokenEndpoint is null)
+        if (tokenEndpoint is null)
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.MalformedOutput);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoTokenEndpoint);
         }
 
-        if (!IsMicrosoftTenantEndpoint(issuer, "/v2.0") ||
-            !IsMicrosoftTenantEndpoint(keyEndpoint, "/getkeydata") ||
-            !IsMicrosoftTenantEndpoint(tokenEndpoint, "/oauth2/v2.0/token"))
+        if (!IsMicrosoftTenantEndpoint(tokenEndpoint, "/oauth2/v2.0/token"))
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.WrongTenant);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.TenantMismatch, InternalMicrosoftProbeFailureStage.PlatformSsoTokenEndpoint);
         }
 
-        if (userConfiguration["kerberosStatus"] is not JsonArray kerberosStatuses)
+        if (!userConfiguration.TryGetPropertyValue("kerberosStatus", out var kerberosStatusNode) ||
+            kerberosStatusNode is null)
         {
-            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.IncompleteRegistration);
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.RegistrationIncomplete, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
         }
 
-        foreach (var kerberosStatus in kerberosStatuses.OfType<JsonObject>())
+        if (kerberosStatusNode is not JsonArray kerberosStatuses)
         {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
+        }
+
+        if (kerberosStatuses.Count == 0)
+        {
+            return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.RegistrationIncomplete, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
+        }
+
+        foreach (var kerberosStatusNodeEntry in kerberosStatuses)
+        {
+            if (kerberosStatusNodeEntry is not JsonObject kerberosStatus)
+            {
+                return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.JsonShape, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
+            }
+
             var upn = TryGetString(kerberosStatus, "upn");
             var realmDomain = ExtractAdDomainNameFromCorpDnsName(TryGetString(kerberosStatus, "realm"));
             var upnDomain = ExtractAdDomainNameFromAccountIdentifier(upn);
@@ -749,7 +775,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
             }
         }
 
-        return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.NoCorporateIdentity);
+        return PlatformSsoFailure(InternalMicrosoftProbeFailureCode.IdentityMismatch, InternalMicrosoftProbeFailureStage.PlatformSsoIdentity);
     }
 
     internal async Task<InternalMicrosoftProbeResult> CheckWindowsWorkplaceJoinAsync(CancellationToken cancellationToken)
@@ -1122,7 +1148,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
 
             started = true;
             var exitCode = await execution.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
-            return new ProcessResult(exitCode, stdout.ToString(), stderr.ToString(), TimedOut: false);
+            return new ProcessResult(exitCode, stdout.ToString(), stderr.ToString());
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -1820,7 +1846,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
             : null;
     }
 
-    private static bool HasJsonStringProperty(JsonObject json, string propertyName, string expectedValue)
+    private static bool TryGetBoolean(JsonObject json, string propertyName, out bool value)
     {
         value = false;
         return json.TryGetPropertyValue(propertyName, out var node) &&
@@ -1885,8 +1911,6 @@ internal sealed record InternalMicrosoftProbe(
 
 internal readonly record struct InternalMicrosoftProbeResult(bool IsInternalMicrosoft, string? Alias, string? Domain, InternalMicrosoftProbeFailure? Failure = null)
 {
-    public string? DiagnosticOutcome { get; init; }
-
     public static InternalMicrosoftProbeResult NotDetected { get; } = new(IsInternalMicrosoft: false, Alias: null, Domain: null);
 
     public static InternalMicrosoftProbeResult Failed(InternalMicrosoftProbeFailure failure)
@@ -1915,12 +1939,6 @@ internal static class InternalMicrosoftProbeOutcome
     public const string Failed = "failed";
     public const string Cancelled = "cancelled";
     public const string TimedOut = "timed_out";
-    public const string CommandMissing = "command_missing";
-    public const string ProcessFailed = "process_failed";
-    public const string MalformedOutput = "malformed_output";
-    public const string WrongTenant = "wrong_tenant";
-    public const string IncompleteRegistration = "incomplete_registration";
-    public const string NoCorporateIdentity = "no_corporate_identity";
 }
 
 internal sealed record InternalMicrosoftProbeDiagnostic(string Source, string Outcome, TimeSpan Duration, bool HasAlias, bool HasDomain, InternalMicrosoftProbeFailure? Failure = null);
@@ -1934,15 +1952,19 @@ internal sealed record InternalMicrosoftProbeFailure(
 
 internal static class InternalMicrosoftProbeFailureCode
 {
+    public const string CommandMissing = "command_missing";
     public const string Exception = "exception";
     public const string FileUnreadable = "file_unreadable";
     public const string HttpStatus = "http_status";
+    public const string IdentityMismatch = "identity_mismatch";
     public const string JsonParse = "json_parse";
     public const string JsonShape = "json_shape";
     public const string ProcessExit = "process_exit";
     public const string ProcessStart = "process_start";
     public const string ProcessTimeout = "process_timeout";
+    public const string RegistrationIncomplete = "registration_incomplete";
     public const string RequestFailed = "request_failed";
+    public const string TenantMismatch = "tenant_mismatch";
 }
 
 internal static class InternalMicrosoftProbeFailureStage
@@ -1962,6 +1984,11 @@ internal static class InternalMicrosoftProbeFailureStage
     public const string IdTokenTenant = "id_token_payload.tid";
     public const string IdTokenUsername = "id_token_payload.preferred_username";
     public const string PlatformSso = "platform_sso";
+    public const string PlatformSsoIdentity = "platform_sso.identity";
+    public const string PlatformSsoIssuer = "platform_sso.issuer";
+    public const string PlatformSsoKeyEndpoint = "platform_sso.key_endpoint";
+    public const string PlatformSsoRegistration = "platform_sso.registration";
+    public const string PlatformSsoTokenEndpoint = "platform_sso.token_endpoint";
     public const string ProcessExit = "process_exit";
     public const string ProcessStart = "process_start";
     public const string Probe = "probe";

--- a/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
+++ b/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
@@ -60,6 +60,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
     private readonly ICIEnvironmentDetector _ciEnvironmentDetector;
     private readonly IReadOnlyList<IReadOnlyList<InternalMicrosoftProbe>>? _probeStages;
     private readonly TimeSpan _probeStageTimeout;
+    private readonly string _macPlatformSsoPath;
 
     public InternalMicrosoftDetector(CliExecutionContext executionContext, IEnvironment environment, TimeProvider timeProvider, ILogger<InternalMicrosoftDetector> logger, IProcessExecutionFactory processExecutionFactory, ICIEnvironmentDetector ciEnvironmentDetector)
         : this(
@@ -325,7 +326,9 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
             }
         }
 
-        timedOut |= completedResults.Any(result => result.CompletionTimestamp > stageDeadlineTimestamp);
+        timedOut |= completedResults.Any(result =>
+            result.CompletionTimestamp > stageDeadlineTimestamp ||
+            result.Diagnostic.Outcome == InternalMicrosoftProbeOutcome.TimedOut);
         foreach (var probe in probes)
         {
             if (!completedResults.Any(result => result.Source.Equals(probe.Name, StringComparison.Ordinal)))
@@ -655,12 +658,19 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         return DetectVisualStudioMicrosoftTenant(result.Stdout, cancellationToken);
     }
 
-    [SupportedOSPlatform("macos")]
-    private async Task<InternalMicrosoftProbeResult> CheckMacPlatformSsoAsync(CancellationToken cancellationToken)
+    internal async Task<InternalMicrosoftProbeResult> CheckMacPlatformSsoAsync(CancellationToken cancellationToken)
     {
-        if (!CommandExists("app-sso"))
+        // app-sso is a macOS system utility. Use its fixed location so a restricted PATH does not
+        // hide Platform SSO registration from non-interactive CLI invocations.
+        if (!File.Exists(_macPlatformSsoPath))
         {
-            return InternalMicrosoftProbeResult.NotDetected;
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.CommandMissing);
+        }
+
+        var result = await RunProcessAsync(_macPlatformSsoPath, ["platform", "-s"], cancellationToken).ConfigureAwait(false);
+        if (result.TimedOut)
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.TimedOut);
         }
 
         var result = await RunProcessAsync("app-sso", ["platform", "-s"], cancellationToken).ConfigureAwait(false);
@@ -669,12 +679,26 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
             return processFailure;
         }
 
-        // app-sso emits a JSON document similar to:
-        //   {"realm":"REDMOND.CORP.MICROSOFT.COM","upn":"alias@REDMOND.CORP.MICROSOFT.COM",
-        //    "issuer":"https://login.microsoftonline.com/<tenant>/v2.0", ...}
-        // Use JSON APIs for the fixed fields so formatting changes don't affect detection.
-        var json = TryParseJsonObject($"{result.Stdout}{Environment.NewLine}{result.Stderr}");
-        if (json is null)
+        return EvaluateMacPlatformSso($"{result.Stdout}{Environment.NewLine}{result.Stderr}");
+    }
+
+    internal static InternalMicrosoftProbeResult EvaluateMacPlatformSso(string output)
+    {
+        // app-sso platform -s emits diagnostic text containing separate JSON objects:
+        //   Time: 2026-08-25 12:34:56 +0000
+        //   Device Configuration:
+        //    { "registrationCompleted" : true, ... }
+        //   Login Configuration:
+        //    { "issuer" : "https://login.microsoftonline.com/<tenant>/v2.0", ... }
+        //   User Configuration:
+        //    { "kerberosStatus" : [{ "realm" : "...", "upn" : "..." }], ... }
+        // The Platform SSO command has no JSON mode and is explicitly diagnostic, so parse each
+        // labeled object independently and fail closed if its structure changes.
+        // See https://developer.apple.com/documentation/authenticationservices/creating-extensions-that-support-platform-sso.
+        var deviceConfiguration = TryParseMacPlatformSsoSection(output, "Device Configuration");
+        var loginConfiguration = TryParseMacPlatformSsoSection(output, "Login Configuration");
+        var userConfiguration = TryParseMacPlatformSsoSection(output, "User Configuration");
+        if (deviceConfiguration is null || loginConfiguration is null || userConfiguration is null)
         {
             return InternalMicrosoftProbeResult.Failed(new(
                 InternalMicrosoftProbeFailureCode.JsonParse,
@@ -682,21 +706,50 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
                 ExceptionType: InternalMicrosoftProbeExceptionType.Json));
         }
 
-        var expectedIssuer = $"https://login.microsoftonline.com/{MicrosoftTenantId}/v2.0";
-        var expectedKeyEndpoint = $"https://login.microsoftonline.com/{MicrosoftTenantId}/getkeydata";
-        var expectedTokenEndpoint = $"https://login.microsoftonline.com/{MicrosoftTenantId}/oauth2/v2.0/token";
-        var upn = TryGetString(json, "upn");
-        var realmDomain = ExtractAdDomainNameFromCorpDnsName(TryGetString(json, "realm"));
-        var upnDomain = ExtractAdDomainNameFromAccountIdentifier(upn);
-        var domain = realmDomain ?? upnDomain;
+        if (!TryGetBoolean(deviceConfiguration, "registrationCompleted", out var registrationCompleted))
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.MalformedOutput);
+        }
 
-        return HasJsonStringProperty(json, "issuer", expectedIssuer) &&
-            HasJsonStringProperty(json, "keyEndpointURL", expectedKeyEndpoint) &&
-            HasJsonStringProperty(json, "tokenEndpointURL", expectedTokenEndpoint) &&
-            domain is not null &&
-            ExtractAliasFromAccountIdentifier(upn) is { } alias
-                ? Detected(alias, domain)
-                : InternalMicrosoftProbeResult.NotDetected;
+        if (!registrationCompleted)
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.IncompleteRegistration);
+        }
+
+        var issuer = TryGetAbsoluteUri(loginConfiguration, "issuer");
+        var keyEndpoint = TryGetAbsoluteUri(loginConfiguration, "keyEndpointURL");
+        var tokenEndpoint = TryGetAbsoluteUri(loginConfiguration, "tokenEndpointURL");
+        if (issuer is null || keyEndpoint is null || tokenEndpoint is null)
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.MalformedOutput);
+        }
+
+        if (!IsMicrosoftTenantEndpoint(issuer, "/v2.0") ||
+            !IsMicrosoftTenantEndpoint(keyEndpoint, "/getkeydata") ||
+            !IsMicrosoftTenantEndpoint(tokenEndpoint, "/oauth2/v2.0/token"))
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.WrongTenant);
+        }
+
+        if (userConfiguration["kerberosStatus"] is not JsonArray kerberosStatuses)
+        {
+            return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.IncompleteRegistration);
+        }
+
+        foreach (var kerberosStatus in kerberosStatuses.OfType<JsonObject>())
+        {
+            var upn = TryGetString(kerberosStatus, "upn");
+            var realmDomain = ExtractAdDomainNameFromCorpDnsName(TryGetString(kerberosStatus, "realm"));
+            var upnDomain = ExtractAdDomainNameFromAccountIdentifier(upn);
+            if (realmDomain is not null &&
+                upnDomain?.Equals(realmDomain, StringComparison.OrdinalIgnoreCase) == true &&
+                ExtractAliasFromAccountIdentifier(upn) is { } alias)
+            {
+                return Detected(alias, realmDomain);
+            }
+        }
+
+        return InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.NoCorporateIdentity);
     }
 
     internal async Task<InternalMicrosoftProbeResult> CheckWindowsWorkplaceJoinAsync(CancellationToken cancellationToken)
@@ -1069,7 +1122,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
 
             started = true;
             var exitCode = await execution.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
-            return new ProcessResult(exitCode, stdout.ToString(), stderr.ToString());
+            return new ProcessResult(exitCode, stdout.ToString(), stderr.ToString(), TimedOut: false);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -1553,20 +1606,112 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         return _environment.GetEnvironmentVariables();
     }
 
-    private static JsonObject? TryParseJsonObject(string text)
+    private static JsonObject? TryParseMacPlatformSsoSection(string output, string sectionName)
     {
+        var sectionHeader = $"{sectionName}:";
+        var headerIndex = -1;
+        var searchIndex = 0;
+        while (searchIndex < output.Length)
+        {
+            var candidateIndex = output.IndexOf(sectionHeader, searchIndex, StringComparison.Ordinal);
+            if (candidateIndex < 0)
+            {
+                return null;
+            }
+
+            if (candidateIndex == 0 || output[candidateIndex - 1] is '\r' or '\n')
+            {
+                headerIndex = candidateIndex;
+                break;
+            }
+
+            searchIndex = candidateIndex + sectionHeader.Length;
+        }
+
+        if (headerIndex < 0)
+        {
+            return null;
+        }
+
+        var objectStart = headerIndex + sectionHeader.Length;
+        while (objectStart < output.Length && char.IsWhiteSpace(output[objectStart]))
+        {
+            objectStart++;
+        }
+
+        if (objectStart >= output.Length || output[objectStart] != '{')
+        {
+            return null;
+        }
+
+        var objectEnd = FindJsonObjectEnd(output, objectStart);
+        if (objectEnd < 0)
+        {
+            return null;
+        }
+
         try
         {
-            var start = text.IndexOf('{');
-            var end = text.LastIndexOf('}');
-            return start >= 0 && end > start
-                ? JsonNode.Parse(text[start..(end + 1)], documentOptions: new JsonDocumentOptions { AllowTrailingCommas = true }) as JsonObject
-                : null;
+            return JsonNode.Parse(
+                output[objectStart..(objectEnd + 1)],
+                documentOptions: new JsonDocumentOptions { AllowTrailingCommas = true }) as JsonObject;
         }
         catch (JsonException)
         {
             return null;
         }
+    }
+
+    private static int FindJsonObjectEnd(string text, int objectStart)
+    {
+        var depth = 0;
+        var insideString = false;
+        var escaped = false;
+        for (var index = objectStart; index < text.Length; index++)
+        {
+            var character = text[index];
+            if (insideString)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                }
+                else if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == '"')
+                {
+                    insideString = false;
+                }
+
+                continue;
+            }
+
+            if (character == '"')
+            {
+                insideString = true;
+            }
+            else if (character == '{')
+            {
+                depth++;
+            }
+            else if (character == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return index;
+                }
+
+                if (depth < 0)
+                {
+                    return -1;
+                }
+            }
+        }
+
+        return -1;
     }
 
     private static InternalMicrosoftProbeResult Detected(string? alias, string? domain = null)
@@ -1677,7 +1822,29 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
 
     private static bool HasJsonStringProperty(JsonObject json, string propertyName, string expectedValue)
     {
-        return TryGetString(json, propertyName)?.Equals(expectedValue, StringComparison.OrdinalIgnoreCase) == true;
+        value = false;
+        return json.TryGetPropertyValue(propertyName, out var node) &&
+            node is JsonValue jsonValue &&
+            jsonValue.TryGetValue(out value);
+    }
+
+    private static Uri? TryGetAbsoluteUri(JsonObject json, string propertyName)
+    {
+        return Uri.TryCreate(TryGetString(json, propertyName), UriKind.Absolute, out var uri)
+            ? uri
+            : null;
+    }
+
+    private static bool IsMicrosoftTenantEndpoint(Uri uri, string expectedSuffix)
+    {
+        var expectedPath = $"/{MicrosoftTenantId}{expectedSuffix}";
+        return uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+            uri.Host.Equals("login.microsoftonline.com", StringComparison.OrdinalIgnoreCase) &&
+            uri.IsDefaultPort &&
+            string.IsNullOrEmpty(uri.UserInfo) &&
+            string.IsNullOrEmpty(uri.Query) &&
+            string.IsNullOrEmpty(uri.Fragment) &&
+            uri.AbsolutePath.TrimEnd('/').Equals(expectedPath, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? TryGetString(JsonObject json, string propertyName)
@@ -1718,6 +1885,8 @@ internal sealed record InternalMicrosoftProbe(
 
 internal readonly record struct InternalMicrosoftProbeResult(bool IsInternalMicrosoft, string? Alias, string? Domain, InternalMicrosoftProbeFailure? Failure = null)
 {
+    public string? DiagnosticOutcome { get; init; }
+
     public static InternalMicrosoftProbeResult NotDetected { get; } = new(IsInternalMicrosoft: false, Alias: null, Domain: null);
 
     public static InternalMicrosoftProbeResult Failed(InternalMicrosoftProbeFailure failure)
@@ -1746,6 +1915,12 @@ internal static class InternalMicrosoftProbeOutcome
     public const string Failed = "failed";
     public const string Cancelled = "cancelled";
     public const string TimedOut = "timed_out";
+    public const string CommandMissing = "command_missing";
+    public const string ProcessFailed = "process_failed";
+    public const string MalformedOutput = "malformed_output";
+    public const string WrongTenant = "wrong_tenant";
+    public const string IncompleteRegistration = "incomplete_registration";
+    public const string NoCorporateIdentity = "no_corporate_identity";
 }
 
 internal sealed record InternalMicrosoftProbeDiagnostic(string Source, string Outcome, TimeSpan Duration, bool HasAlias, bool HasDomain, InternalMicrosoftProbeFailure? Failure = null);

--- a/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
+++ b/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
@@ -369,11 +369,13 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
                 cancellationToken.ThrowIfCancellationRequested();
                 var result = await probe.DetectAsync(cancellationToken).ConfigureAwait(false);
                 stopwatch.Stop();
-                var outcome = result.Failure is not null
-                    ? InternalMicrosoftProbeOutcome.Failed
-                    : result.IsInternalMicrosoft
-                        ? InternalMicrosoftProbeOutcome.Detected
-                        : InternalMicrosoftProbeOutcome.NotDetected;
+                var outcome = result.Failure?.Code == InternalMicrosoftProbeFailureCode.ProcessTimeout
+                    ? InternalMicrosoftProbeOutcome.TimedOut
+                    : result.Failure is not null
+                        ? InternalMicrosoftProbeOutcome.Failed
+                        : result.IsInternalMicrosoft
+                            ? InternalMicrosoftProbeOutcome.Detected
+                            : InternalMicrosoftProbeOutcome.NotDetected;
                 return new InternalMicrosoftProbeRunResult(
                     probe,
                     probe.Name,

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -729,6 +729,198 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         Assert.Equal("dsregcmd", processFactory.LastFileName);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("/")]
+    [InlineData("///")]
+    public void EvaluateMacPlatformSso_DetectsManagedMicrosoftFixture(string trailingSeparators)
+    {
+        var output = MacPlatformSsoOutputFixture
+            .Replace("/v2.0\"", $"/v2.0{trailingSeparators}\"", StringComparison.Ordinal)
+            .Replace("/getkeydata\"", $"/getkeydata{trailingSeparators}\"", StringComparison.Ordinal)
+            .Replace("/oauth2/v2.0/token\"", $"/oauth2/v2.0/token{trailingSeparators}\"", StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.True(result.IsInternalMicrosoft);
+        Assert.Equal("test.alias", result.Alias);
+        Assert.Equal("REDMOND", result.Domain);
+        Assert.Null(result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public void EvaluateMacPlatformSso_RejectsOtherTenant()
+    {
+        var output = MacPlatformSsoOutputFixture.Replace(
+            MicrosoftTenantIdForTests,
+            "0dde70e6-f430-449f-8bce-f4d0a9eca2a4",
+            StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.WrongTenant, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public void EvaluateMacPlatformSso_RejectsIncompleteRegistration()
+    {
+        var output = MacPlatformSsoOutputFixture.Replace(
+            "\"registrationCompleted\" : true",
+            "\"registrationCompleted\" : false",
+            StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.IncompleteRegistration, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public void EvaluateMacPlatformSso_RejectsMalformedEndpoint()
+    {
+        var output = MacPlatformSsoOutputFixture.Replace(
+            $"https://login.microsoftonline.com/{MicrosoftTenantIdForTests}/getkeydata",
+            "not a URI",
+            StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.MalformedOutput, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public void EvaluateMacPlatformSso_RequiresRealmAndUpnFromSameKerberosEntry()
+    {
+        var output = MacPlatformSsoOutputFixture.Replace(
+            "test.alias@REDMOND.CORP.MICROSOFT.COM",
+            "test.alias@EUROPE.CORP.MICROSOFT.COM",
+            StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.NoCorporateIdentity, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public void EvaluateMacPlatformSso_RejectsTruncatedSection()
+    {
+        var output = MacPlatformSsoOutputFixture.Replace(
+            """
+            Login Configuration:
+             {
+            """,
+            """
+            Login Configuration:
+             [
+            """,
+            StringComparison.Ordinal);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.MalformedOutput, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public async Task CheckMacPlatformSsoAsync_UsesConfiguredSystemPathAndParsesStderr()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appSsoPath = Path.Combine(workspace.Path, "usr", "bin", "app-sso");
+        Directory.CreateDirectory(Path.GetDirectoryName(appSsoPath)!);
+        await File.WriteAllTextAsync(appSsoPath, string.Empty);
+        var processFactory = new TestProcessExecutionFactory
+        {
+            CreateExecutionWithFileNameCallback = (fileName, arguments, environment, _, options) =>
+                new TestProcessExecution(
+                    fileName,
+                    arguments,
+                    environment,
+                    options,
+                    (_, _, _) => Task.FromResult((0, (string?)null)),
+                    () => 1)
+                {
+                    WaitForExitAsyncCallback = (invocationOptions, _) =>
+                    {
+                        invocationOptions.StandardErrorCallback?.Invoke(MacPlatformSsoOutputFixture);
+                        return Task.FromResult(0);
+                    }
+                }
+        };
+        var detector = CreateDetector(
+            Path.Combine(workspace.Path, "cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            probeStages: [],
+            processFactory: processFactory,
+            macPlatformSsoPath: appSsoPath);
+
+        var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
+
+        Assert.True(result.IsInternalMicrosoft);
+        Assert.Equal(appSsoPath, processFactory.LastFileName);
+        Assert.Equal(["platform", "-s"], Assert.IsType<string[]>(processFactory.LastArguments));
+    }
+
+    [Fact]
+    public async Task CheckMacPlatformSsoAsync_ReportsMissingCommand()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var detector = CreateDetector(
+            Path.Combine(workspace.Path, "cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            probeStages: [],
+            macPlatformSsoPath: Path.Combine(workspace.Path, "missing-app-sso"));
+
+        var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.CommandMissing, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public async Task CheckMacPlatformSsoAsync_ReportsProcessTimeout()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appSsoPath = Path.Combine(workspace.Path, "app-sso");
+        await File.WriteAllTextAsync(appSsoPath, string.Empty);
+        var processFactory = new TestProcessExecutionFactory
+        {
+            CreateExecutionWithFileNameCallback = (fileName, arguments, environment, _, _) =>
+                new StartCancellingProcessExecution(fileName, arguments, environment)
+        };
+        var detector = CreateDetector(
+            Path.Combine(workspace.Path, "cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            probeStages: [],
+            processFactory: processFactory,
+            macPlatformSsoPath: appSsoPath);
+
+        var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeOutcome.TimedOut, result.DiagnosticOutcome);
+    }
+
+    [Fact]
+    public async Task IsInternalMicrosoftMachineAsync_ReportsProbeSpecificOutcome()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var detector = CreateDetector(
+            Path.Combine(workspace.Path, "cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            [[new InternalMicrosoftProbe("Mac Platform SSO", _ => Task.FromResult(
+                InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.WrongTenant)))]]);
+
+        var result = await detector.IsInternalMicrosoftMachineAsync();
+
+        Assert.False(result.IsInternalMicrosoft);
+        var diagnostic = Assert.Single(result.ProbeDiagnostics);
+        Assert.Equal("Mac Platform SSO", diagnostic.Source);
+        Assert.Equal(InternalMicrosoftProbeOutcome.WrongTenant, diagnostic.Outcome);
+    }
+
     [Fact]
     public async Task CheckWindowsWorkplaceJoinAsync_ReturnsOnlyNonSensitiveProcessExitCode()
     {
@@ -1388,6 +1580,46 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         => $"gho_{index:D2}{new string('a', 24)}";
 
     private const string MicrosoftTenantIdForTests = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+    private const string MacPlatformSsoOutputFixture = """
+        Time: 2026-08-25 12:34:56 +0000
+
+        Device Configuration:
+         {
+          "formatNote" : "Braces { } and text such as Login Configuration: do not end a section.",
+          "registrationCompleted" : true
+        }
+
+        Login Configuration:
+         {
+          "issuer" : "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0",
+          "keyEndpointURL" : "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/getkeydata",
+          "tokenEndpointURL" : "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token"
+        }
+
+        User Configuration:
+         {
+          "kerberosStatus" : [
+            {
+              "realm" : "KERBEROS.MICROSOFTONLINE.COM",
+              "upn" : "test.alias@microsoft.com@KERBEROS.MICROSOFTONLINE.COM"
+            },
+            {
+              "realm" : "REDMOND.CORP.MICROSOFT.COM",
+              "upn" : "test.alias@REDMOND.CORP.MICROSOFT.COM"
+            }
+          ],
+          "state" : "POUserStateNormal (0)",
+          "userLoginConfiguration" : {
+            "loginUserName" : "test.alias@microsoft.com"
+          }
+        }
+
+        SSO Tokens:
+        Received:
+        2026-08-25T12:34:56Z
+        Expiration:
+        2026-09-08T12:34:56Z (Not Expired)
+        """;
 
     private static string CreateJwt(string tenantId, string userName)
     {

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -904,6 +904,47 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
     }
 
     [Fact]
+    public async Task EvaluateMacPlatformSso_LiveManagedMac()
+    {
+        Assert.SkipUnless(OperatingSystem.IsMacOS(), "Live Platform SSO validation requires macOS.");
+        Assert.SkipUnless(
+            Environment.GetEnvironmentVariable("ASPIRE_TEST_LIVE_MAC_PLATFORM_SSO") == "1",
+            "Run eng/scripts/validate-mac-platform-sso.sh on a managed Mac to enable this test.");
+
+        var startInfo = new ProcessStartInfo("/usr/bin/app-sso")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("platform");
+        startInfo.ArgumentList.Add("-s");
+
+        using var process = new Process { StartInfo = startInfo };
+        Assert.True(process.Start(), "Failed to start /usr/bin/app-sso.");
+
+        // Read both streams concurrently to avoid deadlock if a future app-sso version writes enough
+        // diagnostic data to fill either pipe.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await process.WaitForExitAsync(timeout.Token);
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        Assert.Equal(0, process.ExitCode);
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso($"{stdout}{Environment.NewLine}{stderr}");
+        outputHelper.WriteLine(
+            $"Detected={result.IsInternalMicrosoft}; HasAlias={result.Alias is not null}; HasDomain={result.Domain is not null}; Outcome={result.DiagnosticOutcome ?? "<none>"}");
+
+        Assert.True(
+            result.IsInternalMicrosoft,
+            $"Platform SSO did not detect a managed Microsoft identity. Outcome: {result.DiagnosticOutcome ?? InternalMicrosoftProbeOutcome.NotDetected}.");
+        Assert.NotNull(result.Alias);
+        Assert.NotNull(result.Domain);
+    }
+
+    [Fact]
     public async Task IsInternalMicrosoftMachineAsync_ReportsProbeSpecificOutcome()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -745,7 +745,7 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         Assert.True(result.IsInternalMicrosoft);
         Assert.Equal("test.alias", result.Alias);
         Assert.Equal("REDMOND", result.Domain);
-        Assert.Null(result.DiagnosticOutcome);
+        Assert.Null(result.Failure);
     }
 
     [Fact]
@@ -759,7 +759,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.WrongTenant, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.TenantMismatch, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoIssuer, result.Failure?.Stage);
     }
 
     [Fact]
@@ -773,7 +774,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.IncompleteRegistration, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.RegistrationIncomplete, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoRegistration, result.Failure?.Stage);
     }
 
     [Fact]
@@ -787,7 +789,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.MalformedOutput, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.JsonShape, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoKeyEndpoint, result.Failure?.Stage);
     }
 
     [Fact]
@@ -801,7 +804,22 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.NoCorporateIdentity, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.IdentityMismatch, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoIdentity, result.Failure?.Stage);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("[\"unexpected\"]")]
+    public void EvaluateMacPlatformSso_RejectsMalformedKerberosStatus(string replacement)
+    {
+        var output = ReplaceMacPlatformSsoKerberosStatus(replacement);
+
+        var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.JsonShape, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoIdentity, result.Failure?.Stage);
     }
 
     [Fact]
@@ -821,7 +839,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso(output);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.MalformedOutput, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.JsonParse, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSso, result.Failure?.Stage);
     }
 
     [Fact]
@@ -859,6 +878,7 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
 
         Assert.True(result.IsInternalMicrosoft);
+        Assert.Null(result.Failure);
         Assert.Equal(appSsoPath, processFactory.LastFileName);
         Assert.Equal(["platform", "-s"], Assert.IsType<string[]>(processFactory.LastArguments));
     }
@@ -876,7 +896,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.CommandMissing, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.CommandMissing, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSso, result.Failure?.Stage);
     }
 
     [Fact]
@@ -900,7 +921,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.Equal(InternalMicrosoftProbeOutcome.TimedOut, result.DiagnosticOutcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.ProcessTimeout, result.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessStart, result.Failure?.Stage);
     }
 
     [Fact]
@@ -923,43 +945,60 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         using var process = new Process { StartInfo = startInfo };
         Assert.True(process.Start(), "Failed to start /usr/bin/app-sso.");
 
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         // Read both streams concurrently to avoid deadlock if a future app-sso version writes enough
         // diagnostic data to fill either pipe.
-        var stdoutTask = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
-        var stderrTask = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await process.WaitForExitAsync(timeout.Token);
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+        var stderrTask = process.StandardError.ReadToEndAsync(timeout.Token);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+            await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(timeout.Token);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+
         var stdout = await stdoutTask;
         var stderr = await stderrTask;
 
         Assert.Equal(0, process.ExitCode);
         var result = InternalMicrosoftDetector.EvaluateMacPlatformSso($"{stdout}{Environment.NewLine}{stderr}");
         outputHelper.WriteLine(
-            $"Detected={result.IsInternalMicrosoft}; HasAlias={result.Alias is not null}; HasDomain={result.Domain is not null}; Outcome={result.DiagnosticOutcome ?? "<none>"}");
+            $"Detected={result.IsInternalMicrosoft}; HasAlias={result.Alias is not null}; HasDomain={result.Domain is not null}; FailureCode={result.Failure?.Code ?? "<none>"}; FailureStage={result.Failure?.Stage ?? "<none>"}");
 
         Assert.True(
             result.IsInternalMicrosoft,
-            $"Platform SSO did not detect a managed Microsoft identity. Outcome: {result.DiagnosticOutcome ?? InternalMicrosoftProbeOutcome.NotDetected}.");
+            $"Platform SSO did not detect a managed Microsoft identity. Failure: {result.Failure?.Code ?? InternalMicrosoftProbeOutcome.NotDetected} at {result.Failure?.Stage ?? "<none>"}.");
         Assert.NotNull(result.Alias);
         Assert.NotNull(result.Domain);
     }
 
     [Fact]
-    public async Task IsInternalMicrosoftMachineAsync_ReportsProbeSpecificOutcome()
+    public async Task IsInternalMicrosoftMachineAsync_ReportsPlatformSsoFailure()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var detector = CreateDetector(
             Path.Combine(workspace.Path, "cache", "detector.json"),
             new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
             [[new InternalMicrosoftProbe("Mac Platform SSO", _ => Task.FromResult(
-                InternalMicrosoftProbeResult.NotDetectedWithOutcome(InternalMicrosoftProbeOutcome.WrongTenant)))]]);
+                InternalMicrosoftProbeResult.Failed(new(
+                    InternalMicrosoftProbeFailureCode.TenantMismatch,
+                    InternalMicrosoftProbeFailureStage.PlatformSsoIssuer))))]]);
 
         var result = await detector.IsInternalMicrosoftMachineAsync();
 
         Assert.False(result.IsInternalMicrosoft);
         var diagnostic = Assert.Single(result.ProbeDiagnostics);
         Assert.Equal("Mac Platform SSO", diagnostic.Source);
-        Assert.Equal(InternalMicrosoftProbeOutcome.WrongTenant, diagnostic.Outcome);
+        Assert.Equal(InternalMicrosoftProbeOutcome.Failed, diagnostic.Outcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.TenantMismatch, diagnostic.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.PlatformSsoIssuer, diagnostic.Failure?.Stage);
     }
 
     [Fact]
@@ -1619,6 +1658,22 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
 
     private static string CreateGitHubToken(int index)
         => $"gho_{index:D2}{new string('a', 24)}";
+
+    private static string ReplaceMacPlatformSsoKerberosStatus(string replacement)
+    {
+        const string propertyPrefix = "\"kerberosStatus\" : ";
+        const string followingProperty = ",\n  \"state\"";
+        var propertyIndex = MacPlatformSsoOutputFixture.IndexOf(propertyPrefix, StringComparison.Ordinal);
+        Assert.True(propertyIndex >= 0);
+        var valueStart = propertyIndex + propertyPrefix.Length;
+        var valueEnd = MacPlatformSsoOutputFixture.IndexOf(followingProperty, valueStart, StringComparison.Ordinal);
+        Assert.True(valueEnd >= 0);
+
+        return string.Concat(
+            MacPlatformSsoOutputFixture.AsSpan(0, valueStart),
+            replacement,
+            MacPlatformSsoOutputFixture.AsSpan(valueEnd));
+    }
 
     private const string MicrosoftTenantIdForTests = "72f988bf-86f1-41af-91ab-2d7cd011db47";
     private const string MacPlatformSsoOutputFixture = """

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -1662,12 +1662,13 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
     private static string ReplaceMacPlatformSsoKerberosStatus(string replacement)
     {
         const string propertyPrefix = "\"kerberosStatus\" : ";
-        const string followingProperty = ",\n  \"state\"";
         var propertyIndex = MacPlatformSsoOutputFixture.IndexOf(propertyPrefix, StringComparison.Ordinal);
         Assert.True(propertyIndex >= 0);
         var valueStart = propertyIndex + propertyPrefix.Length;
-        var valueEnd = MacPlatformSsoOutputFixture.IndexOf(followingProperty, valueStart, StringComparison.Ordinal);
-        Assert.True(valueEnd >= 0);
+        var followingPropertyIndex = MacPlatformSsoOutputFixture.IndexOf("\"state\"", valueStart, StringComparison.Ordinal);
+        Assert.True(followingPropertyIndex >= 0);
+        var valueEnd = MacPlatformSsoOutputFixture.LastIndexOf(',', followingPropertyIndex);
+        Assert.True(valueEnd >= valueStart);
 
         return string.Concat(
             MacPlatformSsoOutputFixture.AsSpan(0, valueStart),

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -906,10 +906,32 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var appSsoPath = Path.Combine(workspace.Path, "app-sso");
         await File.WriteAllTextAsync(appSsoPath, string.Empty);
+        var timeoutObserved = false;
         var processFactory = new TestProcessExecutionFactory
         {
-            CreateExecutionWithFileNameCallback = (fileName, arguments, environment, _, _) =>
-                new StartCancellingProcessExecution(fileName, arguments, environment)
+            CreateExecutionWithFileNameCallback = (fileName, arguments, environment, _, options) =>
+                new TestProcessExecution(
+                    fileName,
+                    arguments,
+                    environment,
+                    options,
+                    (_, _, _) => Task.FromResult((0, (string?)null)),
+                    () => 1)
+                {
+                    WaitForExitAsyncCallback = async (_, cancellationToken) =>
+                    {
+                        try
+                        {
+                            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                            return 0;
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            timeoutObserved = true;
+                            throw;
+                        }
+                    }
+                }
         };
         var detector = CreateDetector(
             Path.Combine(workspace.Path, "cache", "detector.json"),
@@ -921,8 +943,9 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
 
         Assert.False(result.IsInternalMicrosoft);
+        Assert.True(timeoutObserved);
         Assert.Equal(InternalMicrosoftProbeFailureCode.ProcessTimeout, result.Failure?.Code);
-        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessStart, result.Failure?.Stage);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessExit, result.Failure?.Stage);
     }
 
     [Fact]
@@ -1622,7 +1645,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         TimeSpan? probeStageTimeout = null,
         TestEnvironment? environment = null,
         DirectoryInfo? homeDirectory = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        string? macPlatformSsoPath = null)
     {
         var executionContext = Utils.TestExecutionContextHelper.CreateExecutionContext(
             new DirectoryInfo(Path.GetDirectoryName(cacheFilePath) ?? AppContext.BaseDirectory),
@@ -1641,6 +1665,7 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
             NullLogger<InternalMicrosoftDetector>.Instance,
             processFactory ?? new TestProcessExecutionFactory(),
             ciEnvironmentDetector,
+            macPlatformSsoPath ?? "/usr/bin/app-sso",
             probeStages,
             gitHubHttpMessageHandler,
             gitHubCandidateTimeout,

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -940,12 +940,26 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
             processFactory: processFactory,
             macPlatformSsoPath: appSsoPath);
 
-        var result = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
+        var probeResult = await detector.CheckMacPlatformSsoAsync(CancellationToken.None);
+
+        Assert.False(probeResult.IsInternalMicrosoft);
+        Assert.True(timeoutObserved);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.ProcessTimeout, probeResult.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessExit, probeResult.Failure?.Stage);
+
+        var fullDetector = CreateDetector(
+            Path.Combine(workspace.Path, "full-detector-cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            [[new InternalMicrosoftProbe("Mac Platform SSO", _ => Task.FromResult(probeResult))]]);
+
+        var result = await fullDetector.IsInternalMicrosoftMachineAsync();
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.True(timeoutObserved);
-        Assert.Equal(InternalMicrosoftProbeFailureCode.ProcessTimeout, result.Failure?.Code);
-        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessExit, result.Failure?.Stage);
+        Assert.Equal(InternalMicrosoftDetectorOutcome.TimedOut, result.Outcome);
+        var diagnostic = Assert.Single(result.ProbeDiagnostics);
+        Assert.Equal(InternalMicrosoftProbeOutcome.TimedOut, diagnostic.Outcome);
+        Assert.Equal(InternalMicrosoftProbeFailureCode.ProcessTimeout, diagnostic.Failure?.Code);
+        Assert.Equal(InternalMicrosoftProbeFailureStage.ProcessExit, diagnostic.Failure?.Stage);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -902,6 +902,23 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
             r.Jobs.Order(StringComparer.Ordinal));
     }
 
+    [Fact]
+    public void RealMapManualMacPlatformSsoValidationDoesNotSelectCi()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select(
+            ["eng/scripts/validate-mac-platform-sso.sh"],
+            [],
+            new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.Empty(r.TestProjects);
+        Assert.Empty(r.Jobs);
+        Assert.Empty(r.UnmatchedFiles);
+    }
+
     // An integration's checked-in *.ats.txt baseline tracks its exported [AspireExport] surface -- the
     // same surface the per-language polyglot playground scripts regenerate and compile
     // (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). A change to that


### PR DESCRIPTION
## Description

The macOS Platform SSO internal detector has produced no positive telemetry because `/usr/bin/app-sso platform -s` emits diagnostic text containing three separately labeled JSON objects, while the existing parser expects one JSON document. On a managed Microsoft Mac, the required tenant and identity signals are present but the parser rejects the output before inspecting them.

This PR is stacked on #19653 and uses its bounded probe failure diagnostics. It:

- Parses the `Device Configuration`, `Login Configuration`, and `User Configuration` objects independently.
- Requires completed Platform SSO registration, Microsoft tenant HTTPS endpoints, and matching corporate realm/UPN evidence from the same Kerberos entry.
- Uses the fixed macOS system path instead of relying on `PATH`.
- Distinguishes command missing, process failure, malformed output, wrong tenant, incomplete registration, timeout, and missing corporate identity using bounded failure codes and stages without emitting raw output or identity data.
- Adds sanitized fixture coverage and an opt-in live test for future validation on managed Macs.

### Live validation

On a managed Microsoft Mac, run:

```bash
./eng/scripts/validate-mac-platform-sso.sh
```

The script invokes the real system utility and passes its in-memory output to the production parser. It reports only detection booleans and bounded failure codes/stages.

Validation:

```text
InternalMicrosoftDetectorTests + AspireCliTelemetryTests: 175 passed, 1 opt-in test skipped
validate-mac-platform-sso.sh: 1 passed on a managed Microsoft Mac
```

Fixes #19649

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No