### PR TITLE
[automated] fix(ci): select installer jobs and loose CI dependencies correctly

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -116,6 +116,28 @@ Use the impact analysis to drive coverage review. A PR can have many tests and s
 
 When the impact analysis is useful to explain a test finding, present it concisely in the finding: identify the impacted code path, the regression risk, and the missing test shape. For example: "This changes `DcpExecutor.PrepareServices()` port allocation timing, but there is no regression test showing a dependent resource can resolve the endpoint before workload creation."
 
+### Conditional Test Selection Impact
+
+Apply the repository-wide Conditional Test Selection rules in `AGENTS.md`.
+Trace new test projects, CI jobs, workflows, scripts, and loose inputs to their
+actual consumers before deciding whether the map needs to change.
+
+Flag concrete selection gaps:
+
+- Treat files evaluated by the `Aspire.slnx` ProjectGraph as Layer 1-owned and
+  projects outside that graph as Layer 2 blind spots.
+- Route Layer 2 inputs to their precise consumer, to `ALL` for broad impact, or
+  explicitly outside the selector. Do not allow `ignore` or prefilter entries
+  to hide a real PR-CI consumer.
+- Require `run_*` wiring for gated `job:` targets, advisory classification for
+  targets outside the regular PR matrix or job gates, and routing from reusable
+  workflow implementations to the jobs they implement.
+
+Selector behavior changes must keep the action, workflow gates, tool, map,
+tests, and canonical documentation synchronized. Require real-map tests for
+curated routing changes and focused synthetic-map tests for engine or CLI
+behavior. See `docs/ci/test-trigger-map.md` for the complete contract.
+
 ### Test Coverage Review
 
 Every review must evaluate whether the PR has appropriate tests for the type of behavior being changed. Do not require tests for purely mechanical refactors, comments, or documentation-only changes, but do flag missing or insufficient coverage when production behavior changes and there is no explicit, convincing justification in the PR. Regression coverage is especially important: bug fixes and behavior changes should include tests that would have failed before the fix, not just broad happy-path coverage or regenerated snapshots.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,28 @@ Instructions for GitHub Copilot and other AI coding agents working with the Aspi
 
 ## Code Review Instructions
 
+### Conditional Test Selection
+
+When reviewing a pull request, check whether `eng/github-ci/test-trigger-map.yml`
+needs to change if the diff:
+
+* Adds, removes, or renames a test project.
+* Adds or changes a CI job, reusable workflow, or `run_*` selection gate.
+* Adds or changes a script, configuration file, or other loose input consumed by
+  CI or tests but not represented by an MSBuild project reference.
+
+Do not request manual mappings for files evaluated by projects in the
+`Aspire.slnx`-rooted ProjectGraph; Layer 1 owns them. For Layer 2 blind spots,
+verify that the map routes each path to its actual consumer, uses `ALL` for
+broad shared inputs, or explicitly classifies paths handled by unconditional or
+dedicated workflows and paths with no PR-CI consumer. A gated job implemented by
+a reusable workflow must route changes to that workflow file to the job target
+and keep its `run_*` output wiring consistent.
+
+Selector behavior changes should include focused coverage in
+`tests/Infrastructure.Tests/TestTriggerMap/`. See
+`docs/ci/test-trigger-map.md` for the map vocabulary and maintenance guidance.
+
 ### API Files and Public API Surface
 
 The API files located in `*/api/*.cs` (e.g., `src/Aspire.Hosting/api/Aspire.Hosting.cs`) track the public API surface that has already been shipped in the latest release. These files are auto-generated and serve as a baseline for API compatibility checks.

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -76,18 +76,12 @@ The map stays small by keeping each dependency in the layer that can prove it:
 | `job:winget-installer` | `tests.yml` `prepare_winget_installer_artifacts` |
 | `job:homebrew-installer` | `tests.yml` `prepare_homebrew_installer_artifacts` |
 | `job:nix-package` | `tests.yml` `nix_package` |
-| `job:api-diffs` | [`generate-api-diffs.yml`](../../.github/workflows/generate-api-diffs.yml) — *schedule-only today* |
-| `job:ats-diffs` | [`generate-ats-diffs.yml`](../../.github/workflows/generate-ats-diffs.yml) — *schedule-only today* |
 | `job:deployment-e2e` | [`deployment-tests.yml`](../../.github/workflows/deployment-tests.yml) — *schedule/dispatch-only today* |
-| `ALL` | full test matrix + all jobs |
+| `ALL` | every selector target; PR CI runs the full PR test matrix and all PR-gated jobs, while independently scheduled, dispatched, or outerloop targets remain advisory |
 | `<GROUP_NAME>` | a named group (see `groups:`) expanding **recursively** to its `test:`/`job:` members |
 
-Base builds (packages, CLI native archives, installer artifacts, the CLI E2E
-image) are not modelled as targets. They are upstream `needs:` of the targets
-above and run whenever any dependent target runs.
-
-Their **workflow files** are in the catch-all `path_rules` entry (target `ALL`)
-because a change to *how* they build can affect every consumer.
+Unconditional baseline builds are not selector targets. Gated reusable
+workflows are routed to the target they implement or serve.
 
 ## Rule categories
 
@@ -158,6 +152,10 @@ src/Components/Common/**                          # link-compiled into many comp
 src/Vendoring/OpenTelemetry.Instrumentation.*/**  # glob-compiled into Redis/Kafka components; Layer 1 covers
 ```
 
+This also includes paths already exercised by unconditional or dedicated
+workflows, schedule/dispatch-only inputs, and paths with no PR-CI consumer.
+Each entry's YAML comment records which case applies.
+
 ### Path rules (`path_rules`)
 
 The one general path-glob → targets matcher. `targets` may be `test:` / `job:` /
@@ -215,24 +213,59 @@ This is how a job fires based on *which tests run*, not on which file changed:
 
 ## Maintenance
 
-The map is hand-curated; there is no generator. The verifier tests
-(`Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs`) keep it honest
-and tell you exactly what to fix when the repo changes.
+The map is hand-curated; there is no generator. Do not add a rule only because a
+file changed or a verifier failed. First trace the file to the work that consumes
+it.
 
-Steady state:
+1. **Decide which layer owns the dependency.**
+   - If a project in the `Aspire.slnx`-rooted `ProjectGraph` evaluates the file
+     and MSBuild expresses the dependency, Layer 1 owns it. Do not add a manual
+     rule for a new `ProjectReference`, linked file, or ordinary project input.
+   - Otherwise it is a Layer 2 blind spot. Common examples are workflow
+     implementations, scripts invoked by CI, and configuration read directly by
+     a test or job.
+2. **Identify the actual consumer.** Follow script invocations, reusable-workflow
+   calls, project imports, and job `needs:` edges. Determine whether the consumer
+   is a selector-gated PR test/job, an unconditional or dedicated workflow, a
+   schedule/dispatch-only workflow, or has no CI consumer.
+3. **Choose the narrowest accurate representation.**
+   - use `path_rules` for a path with specific `test:` or `job:` consumers;
+   - use `ALL` only for inputs shared broadly enough to invalidate precise
+     routing;
+   - use `ignore` when Layer 2 must account for a path but the selector has no
+     target to schedule; record why in the adjacent YAML comment;
+   - add a top-level skip pattern only when the path cannot affect main CI, or a
+     dedicated workflow fully validates it; preserve any `keep_routed` carve-out;
+   - use `affected_project_rules` only when an affected production project
+     implies work beyond the graph-selected tests, and `derived_targets` only
+     when selecting one test inherently requires another target.
+4. **Wire jobs end to end.** A selector-gated `job:` target needs a matching
+   `run_*` output in `tests.yml`, a gate that consumes that output, and a route
+   from any reusable workflow that implements the job. Targets outside those PR
+   gates must remain advisory rather than appearing as PR-runnable work.
+5. **Add a regression that would catch both under- and over-selection.**
+   - curated routing changes use the real map in `TestTriggerMapTests.cs` and
+     compare the complete selected target sets;
+   - selector-engine behavior uses focused synthetic maps in
+     `SelectTestsAcceptanceTests.cs`;
+   - CLI rendering and side-channel behavior belongs in
+     `SelectTestsCliTests.cs`;
+   - action or workflow-gate contracts belong in `SelectTestsWorkflowTests.cs`
+     or an exact real-workflow invariant.
 
-1. Make the change. The graph closure (Layer 1) tracks itself — you do **not**
-   edit the map for a new `ProjectReference`, a new `src` project in
-   `Aspire.slnx`, or a new linked-file edge.
-2. Run the verifier. Each failure names the offending path/project/target:
-   - new `src` project neither in `Aspire.slnx` nor matched by a rule → add a
-     `path_rules` entry, or add it to the solution;
-   - a convention-miss dir whose non-MSBuild changes should run a specific test
-     → add a `path_rules` entry;
-   - renamed/removed test project, job, or path → fix the name/glob.
-3. Check the selector's audit summary for **unattributed changed files**. A new
-   non-.NET job or runtime file read shows up there, prompting a `path_rules`
-   addition.
+After restoring the repository, run the focused selector suite:
+
+```bash
+dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj \
+  --no-launch-profile -- \
+  --filter-namespace "Infrastructure.Tests.TestTriggerMap" \
+  --filter-not-trait "quarantined=true" \
+  --filter-not-trait "outerloop=true"
+```
+
+Finally, inspect the PR audit comment or job summary. Confirm that every changed
+file is attributed, the selected PR tests/jobs are the expected complete sets,
+and independently scheduled targets appear only as advisory impact.
 
 The hand-owned knowledge (`conventions`, `ignore`, `path_rules`,
 `derived_targets`) encodes dependencies a fresh codebase read cannot recover, so
@@ -255,9 +288,14 @@ carry it forward. Never silently regenerate it.
 - **Safety vs. selectivity.** The catch-all `ALL` rule, the run-all fallback, and
   the kill switch err toward `ALL`; otherwise the selector relies on Layer 1 for
   `src` coverage and the convention backstop for non-MSBuild files.
-- **Schedule/outerloop-only targets.** `api-diffs`, `ats-diffs`,
-  `deployment-e2e`, and `Aspire.EndToEnd.Tests` are not in the regular PR matrix
-  today; their rules give the *would-be* trigger paths.
+- **Independent workflow targets.** `deployment-e2e`,
+  `Aspire.Deployment.EndToEnd.Tests`, `Aspire.EndToEnd.Tests`, and
+  `Aspire.Oracle.EntityFrameworkCore.Tests` are not in the regular PR matrix
+  today; their rules give the *would-be* trigger paths. Their own schedules,
+  dispatches, or narrow PR workflow triggers decide whether they run. Comments
+  and job summaries list them separately from work the PR selector can actually
+  run. The API/ATS baseline regeneration workflows are independently scheduled
+  or dispatched and ignored as selector targets, as described in `ignore` above.
 - **Integration dirs with no test.** `src/Aspire.Hosting.Orleans`,
   `Aspire.Hosting.AppHost`, and `Aspire.Hosting.Tasks` have no dedicated test
   project. Their MSBuild files are owned by Layer 1, and their non-MSBuild files

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -14,8 +14,9 @@ Companion documents:
 not ALL, the selector writes an `OverrideProjectToBuild` props file so
 `enumerate-tests` builds and enumerates only the selected projects; in audit mode
 (`enforce: 'false'`) it writes no props and `enumerate-tests` produces
-the full matrix unchanged while the summary still reports what enforcing would
-have skipped.
+the regular PR matrix unchanged while the summary still reports what enforcing
+would have skipped. Schedule/dispatch-only jobs and outerloop-only tests are
+reported separately because the PR selector cannot cause them to run.
 
 Audit mode does not soften Layer 1 failures. If the affected-projects graph
 cannot be computed, `SelectTests` fails the step because under-selecting would
@@ -239,7 +240,7 @@ load-bearing at the design level:
   Layer 2 run-all fallback, while Layer 1 still attributes an `ignore`d file.
 - **`affected_project_rules`** matches Layer 1's affected **production** project
   names only; affected matrix *test* projects are filtered out first, so a
-  test-only change cannot fire production jobs (`ats-diffs`, `extension-e2e`, …)
+  test-only change cannot fire production jobs (`typescript-api-compat`, `extension-e2e`, …)
   through a glob like `Aspire.Hosting*`.
 
 ## The tool (`tools/SelectTests`)
@@ -456,21 +457,24 @@ The clean wins remain large and safe:
 ## Audit mode
 
 Audit mode computes the subset and writes a `$GITHUB_STEP_SUMMARY`, but CI still
-runs the full matrix and all jobs. The summary shows:
+runs the regular PR matrix and PR-gated jobs. The summary shows:
 
 - the invocation mode and change source;
-- selected test projects and triggered jobs, each annotated with **why** it was
-  selected — the changed file, affected project, graph edge, or selected test
-  that pulled it in, plus the curated rule's `reason` text;
+- selected PR test projects and triggered PR jobs, each annotated with **why**
+  it was selected — the changed file, affected project, graph edge, or selected
+  test that pulled it in, plus the curated rule's `reason` text;
+- schedule/dispatch-only jobs and outerloop-only tests as advisory impact, not
+  as work the PR selector would run;
 - the would-have-been-skipped list;
 - any `ALL` or kill-switch escalation and why;
 - unattributed changed files that may need curated rules.
 
 The PR comment carries the same selection in a more scannable form. It leads
-with **what runs** — the flat list of selected test projects and the flat list
-of selected jobs (test projects first, since they are the primary review
-signal) — so a reviewer sees the full impact at a glance even when many files
-changed. It then explains **how** the selection was reached in a collapsed
+with **what runs** — the flat list of selected PR test projects, the flat list
+of selected PR jobs, and a separate advisory schedule/outerloop section (test
+projects first, since they are the primary review signal) — so a reviewer sees
+the full impact at a glance even when many files changed. It then explains
+**how** the selection was reached in a collapsed
 `<details>` (the heading is the `<summary>`, so the rationale stays out of the
 way until expanded), grouping the selected projects under each trigger (changed
 file, affected project, or derived test) that pulled them in: a changed file
@@ -484,9 +488,10 @@ commit updates that commit's comment in place (no duplicate — re-runs are
 common), a new commit posts a fresh comment at the bottom, and comments from
 superseded commits are collapsed (minimized, never deleted) so the latest
 selection surfaces at the bottom while the per-push history is preserved. In
-audit mode the comment is advisory — the
-full matrix and all jobs still run — so it is labelled "(audit mode)" and states
-that the lists are what selective CI **would** run under enforcement.
+audit mode the comment is advisory — the regular PR matrix and PR-gated jobs
+still run — so it is labelled "(audit mode)" and states that the PR lists are
+what selective CI **would** run under enforcement. Advisory-only targets remain
+explicitly labelled as schedule/outerloop impact.
 
 Any audit run where a would-be-skipped test would have failed is a map bug,
 fixed before enforcing. Once audit data shows the skip set is consistently safe,
@@ -503,7 +508,6 @@ flip to enforcing and keep the `run-full-ci` kill switch.
 - **Coverage:** every test project and every `src` project is reachable by some
   rule or by `Aspire.slnx`, so a newly added, unmapped project fails loudly
   instead of silently never running.
-
 A convention-miss dir with no same-named test is intentionally not asserted.
 Its MSBuild files are owned by Layer 1, and a non-MSBuild change there safely
 hits a curated rule, the convention backstop, or the run-all fallback.

--- a/eng/github-ci/ci-skip-entirely-patterns.txt
+++ b/eng/github-ci/ci-skip-entirely-patterns.txt
@@ -43,6 +43,10 @@ Aspire-Core.slnf
 .github/instructions/**
 .agents/skills/**
 
+# Copilot canvas extensions have a dedicated PR workflow that validates module syntax,
+# manifests, imports, and tests without running the main build/test matrix.
+.github/extensions/**
+
 # GitHub workflow files that do not affect the CI build or test process
 .github/workflows/apply-test-attributes.yml
 .github/workflows/backmerge-release.yml
@@ -75,6 +79,10 @@ start-code.sh
 localhive.*
 dogfood.sh
 
+# Developer-only workspace settings with no build or CI consumer.
+.vscode/settings.json
+pyrightconfig.json
+
 # Repository metadata with no build or test impact. Without these, a PR touching only one of them
 # would fall through the selective-CI run-all fallback and force the FULL test matrix (the fallback
 # escalates any file it cannot attribute -- see tools/SelectTests/TestSelector.cs). Issue forms,
@@ -88,4 +96,6 @@ dogfood.sh
 # the conventions route to their projects -- they must not skip CI.
 .gitignore
 .github/CODEOWNERS
+.github/dependabot.yml
 .github/ISSUE_TEMPLATE/**
+.github/policies/**

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -22,8 +22,6 @@
 #   job:winget-installer       tests.yml prepare_winget_installer_artifacts
 #   job:homebrew-installer     tests.yml prepare_homebrew_installer_artifacts
 #   job:nix-package            tests.yml nix_package
-#   job:api-diffs              generate-api-diffs.yml    (schedule-only today)
-#   job:ats-diffs              generate-ats-diffs.yml    (schedule-only today)
 #   job:deployment-e2e         deployment-tests.yml      (schedule/dispatch-only today)
 #   ALL                        full test matrix + all jobs
 #   <GROUP_NAME>               a named group (see groups:) expanding recursively to its members
@@ -70,6 +68,12 @@ prefilter:
 ignore:
   - src/Components/Common/**                            # link-compiled into many components; Layer 1 covers
   - src/Vendoring/OpenTelemetry.Instrumentation.*/**    # glob-compiled into the Redis/Kafka components; Layer 1 covers
+  # These verifiers run in every unconditional native CLI archive build. Selecting a test target for
+  # them would add no coverage; accounting for them here avoids an unrelated full test matrix.
+  - eng/scripts/verify-cli-npm-package.ps1
+  - eng/scripts/verify-cli-tool-nupkg.ps1
+  # The stabilization job invokes this script independently of the tests selector.
+  - eng/scripts/stabilization-smoke-init-restore.sh
   # Dev/AzDO-only eng/scripts with NO test consumer and no GH-CI build/test path: local debug-channel
   # helpers and the AzDO native-symbol validator. Listed so they do not show as unattributed audit noise.
   # (verify-cli-archive.ps1 and validate-npm-release-aliases.ps1 are NOT here -- they have test consumers
@@ -77,7 +81,11 @@ ignore:
   - eng/scripts/debug-*.ps1                             # debug-aspire-channel/stable/staging: local channel-switch helpers
   - eng/scripts/debug-*.sh
   - eng/scripts/validate-cli-symbols.ps1                # AzDO native-AOT symbol publish validation; no GH-CI consumer
-  # Schedule-only workflows that regenerate API/ATS surface baselines; no PR-CI path.
+  - eng/generate-catalog.ps1                            # Windows/AzDO template catalog generation; no GH-CI consumer
+  - eng/scripts/cli-starter-validation.ps1              # exercised by unconditional cross-platform CLI starter PR jobs
+  - eng/scripts/update-aspire-skills-bundle.ps1         # schedule/dispatch-only bundle updater
+  - eng/scripts/verify-aspire-skills-bundle.ps1         # exercised by its dedicated PR workflow
+  # Schedule/dispatch-only workflows that regenerate API/ATS surface baselines; no PR-CI path.
   - .github/workflows/generate-api-diffs.yml
   - .github/workflows/generate-ats-diffs.yml
   # NOTE: src/Shared/**/*.cs and tests/Shared/**/*.cs are deliberately NOT ignored -- Layer 1 attributes
@@ -94,6 +102,7 @@ path_rules:
   - paths:
       - global.json
       - NuGet.config
+      - .gitattributes
       - .config/dotnet-tools.json
       - Directory.Build.props
       - Directory.Build.targets
@@ -134,11 +143,14 @@ path_rules:
                              # leftovers, but route them to ALL explicitly so the intent is recorded
                              # and pinned by TestTriggerMapTests.EveryLocalActionUsedByAWorkflowIsRoutedToAll.
       - eng/scripts/split-test-matrix-by-deps.ps1
+      - eng/scripts/split-test-projects-for-ci.ps1   # discovers every split project's partitions/classes
+      - eng/scripts/gha-testreport.ps1   # invoked by the shared MTP targets after every GitHub test run
       - eng/scripts/build-test-matrix.ps1   # canonical-matrix builder; a bug skews every PR's matrix -> err toward ALL (also runs its BuildTestMatrixTests verifier)
       - eng/scripts/expand-test-matrix-github.ps1   # GitHub matrix expansion; a bug skews every PR's matrix -> err toward ALL (also runs its ExpandTestMatrixGitHubTests verifier)
       - eng/scripts/write-class-mode-test-props.ps1   # enumerate-tests class-mode restriction; a bug skews every PR's matrix -> err toward ALL (also runs its WriteClassModeTestPropsTests verifier)
       - eng/scripts/scan-test-partitions-from-source.ps1   # source partition discovery in the runsheet builder; a bug skews every split project's enumeration -> err toward ALL
       - eng/TestEnumerationRunsheetBuilder/**
+      - tools/ExtractTestPartitions/**   # compiled partition extractor used for every split test project
       - eng/testing/CITestsProperties.props
       - .github/workflows/tests.yml
       - .github/workflows/run-tests.yml
@@ -195,9 +207,13 @@ path_rules:
       - src/Aspire.Hosting*/api/*.ats.txt
     targets: [job:typescript-api-compat, job:polyglot]
     reason: an integration's *.ats.txt baseline tracks its exported ATS surface; the polyglot playground regenerates+compiles that surface per language, so a baseline change must run polyglot too
-  - paths: [extension/**]
+  - paths:
+      - extension/**
+      - .vscode/launch.json
+      - .vscode/tasks.json
+      - .github/scripts/assert-extension-e2e-bridge-vsix.ps1
     targets: [job:extension-unit]
-    reason: extension_tests_win + extension_bootstrap_linux run yarn build/test in extension/
+    reason: extension_tests_win validates the root launch/task workspace wiring and extension tests; extension_bootstrap_linux builds the extension and validates the e2e bridge VSIX
   - paths:
       - extension/**
       - src/Aspire.Cli/**
@@ -223,6 +239,10 @@ path_rules:
       - .github/workflows/deployment-tests.yml
     targets: [job:deployment-e2e]
     reason: SCHEDULE/DISPATCH-ONLY today; ProjectTemplates is a Layer-1 blind spot; Azure/Cli/TypeSystem/Managed production projects are in affected_project_rules
+  - paths:
+      - .github/workflows/prepare-installer-artifacts.yml
+    targets: [job:winget-installer, job:homebrew-installer]
+    reason: the reusable workflow implements both gated installer artifact jobs
 
   # --- outerloop / e2e test targets: loose paths (production projects in affected_project_rules) --------
   - paths:
@@ -246,8 +266,9 @@ path_rules:
     reason: Cli.Tests/Npm/AspireJsLauncherTests reads eng/clipack/npm/aspire.js; Infrastructure.Tests reads eng/clipack/*; CLI archive consumed by e2e and packaged into the WinGet/Homebrew installer artifacts
   - paths:
       - .github/workflows/build-cli-e2e-image.yml
+      - eng/scripts/load-cli-e2e-images.sh
     targets: [test:Aspire.Cli.EndToEnd.Tests]
-    reason: builds the CLI E2E Docker image consumed only by the requiresCliArchive test shards (Aspire.Cli.EndToEnd.Tests, the sole RequiresCliArchive=true project); the build_cli_e2e_image job self-gates on tests_matrix_requires_cli_archive, so it only runs when that test is selected anyway -> route there, not ALL
+    reason: builds or loads the CLI E2E images consumed only by Aspire.Cli.EndToEnd.Tests
   - paths:
       - eng/scripts/pack-cli-npm-package.ps1
     targets: [test:Aspire.Cli.Tests, test:Infrastructure.Tests]
@@ -275,6 +296,11 @@ path_rules:
     targets: [test:Infrastructure.Tests]
     reason: Infrastructure.Tests/PowerShellScripts validates these CLI-archive/npm packaging scripts (DownloadNativeArchivesTests, StageNativeCliToolPackagesTests, ValidateNpmPackageSignaturesTests, ValidateNpmReleaseAliasesTests; ReleasePublishNugetPipelineTests reads validate-npm-release-aliases.ps1); the build jobs that run them are unconditional needs, so the unit verifier is the trigger that must fire
   - paths:
+      - eng/scripts/aspire-skills-bundle.common.ps1
+      - eng/test-retry-patterns.json
+    targets: [test:Infrastructure.Tests]
+    reason: Infrastructure.Tests validates the shared Aspire skills bundle helpers and transient retry-pattern configuration
+  - paths:
       - eng/scripts/verify-cli-archive.ps1
     targets: [test:Aspire.Acquisition.Tests]
     reason: Aspire.Acquisition.Tests/Scripts/VerifyCliArchivePowerShellTests invokes eng/scripts/verify-cli-archive.ps1
@@ -283,9 +309,17 @@ path_rules:
     targets: [test:Aspire.Acquisition.Tests, job:winget-installer]
     reason: WinGet manifest generation; prepare_winget_installer_artifacts builds from eng/winget, Acquisition.Tests exercises installer-mode
   - paths:
+      - eng/scripts/smoke-installed-cli.ps1
+    targets: [job:winget-installer]
+    reason: the WinGet installer artifact job invokes this installed-CLI smoke test
+  - paths:
       - eng/homebrew/**
     targets: [test:Aspire.Acquisition.Tests, job:homebrew-installer]
     reason: Homebrew cask generation; prepare_homebrew_installer_artifacts builds from eng/homebrew, Acquisition.Tests exercises installer-mode
+  - paths:
+      - eng/scripts/smoke-installed-cli.sh
+    targets: [job:homebrew-installer]
+    reason: the Homebrew installer artifact job invokes this installed-CLI smoke test
   - paths:
       - eng/dashboardpack/**
     targets: [test:Aspire.Hosting.Sdk.Tests]

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -771,7 +771,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     // projects. affected_project_rules key off project NAME globs and must match only PRODUCTION names.
     // A matrix test project ("Aspire.Hosting.Foo.Tests") matches a production glob ("Aspire.Hosting*"),
     // so without the production-only filter a TEST-ONLY change would spuriously fire that rule's
-    // production jobs (ats-diffs / extension-e2e / typescript-api-compat / deployment-e2e).
+    // production jobs (extension-e2e / typescript-api-compat / deployment-e2e).
     [Fact]
     public void AffectedProjectRulesMatchProductionProjectsNotTestProjects()
     {
@@ -822,11 +822,19 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.True(filter.IsExcluded(".gitignore"));                    // repo-ROOT .gitignore (anchored)
         Assert.True(filter.IsExcluded(".github/CODEOWNERS"));
         Assert.True(filter.IsExcluded(".github/ISSUE_TEMPLATE/10_bug_report.yml"));
+        Assert.True(filter.IsExcluded(".github/dependabot.yml"));
+        Assert.True(filter.IsExcluded(".github/policies/labelManagement.prOpened.yml"));
+        Assert.True(filter.IsExcluded(".github/extensions/aspire-team-app/extension.mjs"));
+        Assert.True(filter.IsExcluded(".vscode/settings.json"));
+        Assert.True(filter.IsExcluded("pyrightconfig.json"));
 
         // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore
-        // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), and
-        // .editorconfig / .gitattributes affect the build and checkout.
+        // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), root
+        // launch/task files are validated by extension tests, and .editorconfig / .gitattributes affect the
+        // build and checkout.
         Assert.False(filter.IsExcluded("src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore"));
+        Assert.False(filter.IsExcluded(".vscode/launch.json"));
+        Assert.False(filter.IsExcluded(".vscode/tasks.json"));
         Assert.False(filter.IsExcluded(".editorconfig"));
         Assert.False(filter.IsExcluded(".gitattributes"));
 

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -156,16 +156,16 @@ public sealed class SelectTestsCliTests
                 var comment = File.ReadAllText(commentPath);
                 Assert.StartsWith("## Tests selector", comment);
                 Assert.DoesNotContain("audit mode", comment);
-                Assert.Contains("### Selected test projects (1 / 2)", comment);
+                Assert.Contains("### Selected PR test projects (1 / 2)", comment);
                 Assert.Contains("`Aspire.Hosting.Tests`", comment);
-                Assert.Contains("### Selected jobs (1)", comment);
+                Assert.Contains("### Selected PR jobs (1)", comment);
                 Assert.Contains("`extension-e2e`", comment);
                 // Test projects are the primary signal, so their section must come BEFORE the jobs
                 // section. Falsifies a revert to the old jobs-first ordering.
                 Assert.True(
-                    comment.IndexOf("### Selected test projects", StringComparison.Ordinal)
-                        < comment.IndexOf("### Selected jobs", StringComparison.Ordinal),
-                    "Selected test projects must be listed before Selected jobs.");
+                    comment.IndexOf("### Selected PR test projects", StringComparison.Ordinal)
+                        < comment.IndexOf("### Selected PR jobs", StringComparison.Ordinal),
+                    "Selected PR test projects must be listed before selected PR jobs.");
                 // The rationale is collapsed by default behind a <details> so the comment leads with
                 // what runs; the heading is the <summary>. Falsifies a revert to a plain "### How these
                 // were chosen" heading that is always expanded.
@@ -315,7 +315,7 @@ public sealed class SelectTestsCliTests
         }, slnx: slnx, map: map);
     }
 
-    // In audit mode the comment is advisory: the full matrix and all jobs still run, and the lists
+    // In audit mode the comment is advisory: regular PR tests and PR-gated jobs still run, and the lists
     // describe what selective CI WOULD run under enforcement. Pin the "(audit mode)" title qualifier
     // and the explanatory line so the advisory framing can't silently disappear — without it a reader
     // could mistake the selected subset for what actually ran.
@@ -337,12 +337,203 @@ public sealed class SelectTestsCliTests
                 Assert.StartsWith("## Tests selector (audit mode)", comment);
                 Assert.Contains("**would**", comment);
                 Assert.Contains("under enforcement", comment);
+                Assert.Contains("regular PR test matrix and PR-gated jobs", comment);
+                Assert.Contains("Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates", comment);
+                Assert.DoesNotContain("do not run on PRs", comment);
             }
             finally
             {
                 Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
             }
         });
+    }
+
+    [Fact]
+    public void CommentAndSummarySeparatePrSelectionFromAdvisoryOnlyTargets()
+    {
+        const string slnx = """
+            <Solution>
+              <Project Path="tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj" />
+              <Project Path="tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj" />
+            </Solution>
+            """;
+        const string map = """
+            version: 1
+            path_rules:
+              - paths: [trigger.txt]
+                targets:
+                  - test:Aspire.Hosting.Tests
+                  - test:Aspire.EndToEnd.Tests
+                  - job:extension-e2e
+                  - job:deployment-e2e
+            """;
+
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var commentPath = Path.Combine(repoRoot, "comment.md");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", commentPath);
+            try
+            {
+                var changed = WriteChangedFiles(repoRoot, "trigger.txt");
+
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: false));
+
+                var comment = File.ReadAllText(commentPath);
+                Assert.Contains("### Selected PR test projects (1 / 1)", comment);
+                Assert.Contains("### Selected PR jobs (1)", comment);
+                Assert.Contains("### Advisory workflow impact (2)", comment);
+                Assert.Contains("`Aspire.EndToEnd.Tests` *(outerloop-only)*", comment);
+                Assert.Contains("`deployment-e2e` *(schedule/dispatch-only)*", comment);
+
+                var summary = File.ReadAllText(Path.Combine(repoRoot, "summary"));
+                Assert.Contains("- selected PR test projects: 1 / 1", summary);
+                Assert.Contains("- triggered PR jobs: job:extension-e2e", summary);
+                Assert.Contains("- advisory-only targets: test:Aspire.EndToEnd.Tests, job:deployment-e2e", summary);
+                Assert.Contains("<details><summary>Advisory test projects (1)</summary>", summary);
+                Assert.DoesNotContain("Advisory outerloop test projects", summary);
+                Assert.Contains(
+                    "- mode: audit (advisory: the regular test matrix + selector-gated jobs run regardless of the selection below; advisory-only targets are reported but scheduled independently)",
+                    summary);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
+            }
+        }, slnx: slnx, map: map);
+    }
+
+    [Fact]
+    public void AuditAllCommentKeepsAdvisoryTargetsOutsideRegularGates()
+    {
+        const string slnx = """
+            <Solution>
+              <Project Path="tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj" />
+              <Project Path="tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj" />
+            </Solution>
+            """;
+        const string map = """
+            version: 1
+            path_rules:
+              - paths: [trigger.txt]
+                targets: [ALL]
+              - paths: [deployment.txt]
+                targets: [job:deployment-e2e]
+            """;
+
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var commentPath = Path.Combine(repoRoot, "comment.md");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", commentPath);
+            try
+            {
+                var changed = WriteChangedFiles(repoRoot, "trigger.txt");
+
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: false));
+
+                var comment = File.ReadAllText(commentPath);
+                Assert.Contains("**Selects the full PR test matrix + all PR-gated jobs (ALL)**", comment);
+                Assert.Contains("### Advisory workflow impact (2)", comment);
+                Assert.Contains("Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates", comment);
+                Assert.DoesNotContain("do not run on PRs", comment);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
+            }
+        }, slnx: slnx, map: map);
+    }
+
+    [Fact]
+    public void AdvisoryTestClassificationMatchesProjectsExcludedFromRegularPrRunsheets()
+    {
+        var solution = File.ReadAllText(Path.Combine(RepoRoot.Path, "Aspire.slnx"));
+        var testProjectPaths = System.Text.RegularExpressions.Regex
+            .Matches(solution, "Path=\"(tests/[^\"]+\\.Tests\\.csproj)\"")
+            .Select(match => match.Groups[1].Value)
+            .ToList();
+        var expectedAdvisoryProjects = testProjectPaths
+            .Where(projectPath =>
+            {
+                var project = File.ReadAllText(Path.Combine(RepoRoot.Path, projectPath));
+                return project.Contains("<SkipTests", StringComparison.Ordinal) &&
+                    project.Contains("RunOuterloopTests", StringComparison.Ordinal) &&
+                    !project.Contains("IsGithubPullRequest", StringComparison.Ordinal);
+            })
+            .Select(Path.GetFileNameWithoutExtension)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var runsheetTargets = File.ReadAllText(Path.Combine(
+            RepoRoot.Path,
+            "eng",
+            "TestEnumerationRunsheetBuilder",
+            "TestEnumerationRunsheetBuilder.targets"));
+        var deploymentProject = System.Text.RegularExpressions.Regex.Match(
+            runsheetTargets,
+            @"OnlyDeploymentTests\)' != 'true'.*MSBuildProjectName\)' == '(?<name>[^']+)'");
+        Assert.True(deploymentProject.Success, "The deployment-only runsheet exclusion was not found.");
+        expectedAdvisoryProjects.Add(deploymentProject.Groups["name"].Value);
+
+        Assert.Contains("Aspire.EndToEnd.Tests", expectedAdvisoryProjects);
+        Assert.Contains("Aspire.Oracle.EntityFrameworkCore.Tests", expectedAdvisoryProjects);
+        Assert.Contains("Aspire.Deployment.EndToEnd.Tests", expectedAdvisoryProjects);
+        Assert.Equal(
+            expectedAdvisoryProjects.Order(StringComparer.Ordinal),
+            GetSelectionTargetKeys("s_advisoryTestTargets").Order(StringComparer.Ordinal));
+
+        var slnx = "<Solution>\n"
+            + "  <Project Path=\"tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj\" />\n"
+            + string.Join(
+                "\n",
+                expectedAdvisoryProjects.Order(StringComparer.Ordinal)
+                    .Select(name => $"  <Project Path=\"tests/{name}/{name}.csproj\" />"))
+            + "\n</Solution>";
+        var map = "version: 1\npath_rules:\n  - paths: [trigger.txt]\n    targets:\n"
+            + "      - test:Aspire.Hosting.Tests\n"
+            + string.Join(
+                "\n",
+                expectedAdvisoryProjects.Order(StringComparer.Ordinal)
+                    .Select(name => $"      - test:{name}"))
+            + "\n";
+
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var commentPath = Path.Combine(repoRoot, "comment.md");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", commentPath);
+            try
+            {
+                var changed = WriteChangedFiles(repoRoot, "trigger.txt");
+
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, enforce: false));
+
+                var comment = File.ReadAllText(commentPath);
+                Assert.Contains("### Selected PR test projects (1 / 1)", comment);
+                Assert.Contains(
+                    $"### Advisory workflow impact ({expectedAdvisoryProjects.Count})",
+                    comment);
+                foreach (var project in expectedAdvisoryProjects)
+                {
+                    Assert.Contains($"`{project}`", comment);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_COMMENT_FILE", previous);
+            }
+        }, slnx: slnx, map: map);
+    }
+
+    private static IReadOnlyList<string> GetSelectionTargetKeys(string fieldName)
+    {
+        var field = typeof(Selection).GetField(
+            fieldName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(field);
+
+        var targets = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(field.GetValue(null));
+        return targets.Keys.ToList();
     }
 
     // The JSON selection artifact (SELECT_TESTS_JSON_FILE) is the durable, machine-readable record of a
@@ -682,7 +873,7 @@ public sealed class SelectTestsCliTests
             // ALL selected -> enforce writes no restriction props, so enumerate-tests runs everything.
             Assert.False(File.Exists(propsPath));
 
-            // The fallback is recorded in the run summary (the durable record the weekly audit reads),
+            // The fallback is recorded in the run summary (the durable record historical audits read),
             // naming the merge-base as the cause.
             var summary = File.ReadAllText(Path.Combine(repoRoot, "summary"));
             Assert.Contains("fail-safe run-all because", summary);
@@ -696,7 +887,7 @@ public sealed class SelectTestsCliTests
     // ("fail-safe run-all because ...") rather than the run-full-ci kill switch, so a systemic
     // shallow-history regression can't hide behind a green-but-full-matrix run no matter which surface a
     // reader consults:
-    //   - the step summary (the weekly audit reads it, not the raw logs),
+    //   - the step summary (historical audits read it, not the raw logs),
     //   - the PR comment (what a contributor sees on the PR), and
     //   - the JSON artifact (the durable, machine-readable record).
     // The reason flows through SelectorOptions.ForceAllReason into SelectionResult.EscalationReason, which
@@ -724,11 +915,11 @@ public sealed class SelectTestsCliTests
                 var summary = File.ReadAllText(Path.Combine(repoRoot, "summary"));
                 Assert.Contains($"force-all: True — fail-safe run-all because {reason}", summary);
                 Assert.DoesNotContain("force-all: True (kill switch)", summary);
-                Assert.Contains($"**selects ALL** — {reason}", summary);
+                Assert.Contains($"**selects ALL PR test projects + jobs** — {reason}", summary);
 
                 // The PR comment's ALL banner names the same reason, not the run-full-ci kill switch.
                 var comment = File.ReadAllText(commentPath);
-                Assert.Contains($"**Runs the full test matrix + all jobs (ALL)** — {reason}", comment);
+                Assert.Contains($"**Selects the full PR test matrix + all PR-gated jobs (ALL)** — {reason}", comment);
                 Assert.DoesNotContain("the run-full-ci label forces the full matrix", comment);
 
                 // The durable JSON artifact records the same reason under escalationReason.

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.SelectTests;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Xunit;
 
@@ -262,10 +263,11 @@ public sealed class TestTriggerMapTests
     [Fact]
     public void EveryJobTargetMapsToAnExistingWorkflowOrJob()
     {
-        // The job: vocabulary is small and curated. Each one resolves either to a standalone
-        // workflow file or to job id(s) in tests.yml (see the Target vocabulary table in
-        // test-trigger-map.md). Assert the map references only known jobs, and that the thing
-        // each one points at still exists — so a renamed/removed workflow or job fails loudly.
+        // The job: vocabulary is small and curated, and must exactly match the targets referenced by
+        // the map. Each token resolves either to a standalone workflow file or to job id(s) in
+        // tests.yml (see the Target vocabulary table in test-trigger-map.md). Assert the map references
+        // only known jobs, and that the thing each one points at still exists — so a renamed/removed
+        // workflow or job fails loudly.
         var workflowsDir = Path.Combine(RepoRoot.Path, ".github", "workflows");
         var testsYml = File.ReadAllText(Path.Combine(workflowsDir, "tests.yml"));
 
@@ -283,22 +285,133 @@ public sealed class TestTriggerMapTests
             ["job:winget-installer"] = () => JobExists("prepare_winget_installer_artifacts"),
             ["job:homebrew-installer"] = () => JobExists("prepare_homebrew_installer_artifacts"),
             ["job:nix-package"] = () => JobExists("nix_package"),
-            ["job:api-diffs"] = () => WorkflowExists("generate-api-diffs.yml"),
-            ["job:ats-diffs"] = () => WorkflowExists("generate-ats-diffs.yml"),
             ["job:deployment-e2e"] = () => WorkflowExists("deployment-tests.yml"),
         };
 
         var referenced = s_map.AllReferencedTargets()
             .Where(t => t.StartsWith("job:", StringComparison.Ordinal))
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
+            .ToHashSet(StringComparer.Ordinal);
 
         var unknown = referenced.Where(j => !expected.ContainsKey(j)).Order(StringComparer.Ordinal).ToList();
         Assert.True(unknown.Count == 0, $"job: targets not in the known vocabulary: {string.Join(", ", unknown)}");
 
+        var unreferenced = expected.Keys.Except(referenced).Order(StringComparer.Ordinal).ToList();
+        Assert.True(unreferenced.Count == 0, $"known job: targets not referenced by the map: {string.Join(", ", unreferenced)}");
+
         var broken = expected.Where(kvp => referenced.Contains(kvp.Key) && !kvp.Value())
             .Select(kvp => kvp.Key).Order(StringComparer.Ordinal).ToList();
         Assert.True(broken.Count == 0, $"job: targets whose workflow/job no longer exists: {string.Join(", ", broken)}");
+    }
+
+    [Fact]
+    public void DocumentedJobTargetVocabularyMatchesReferencedMapJobs()
+    {
+        var referenced = s_map.AllReferencedTargets()
+            .Where(t => t.StartsWith("job:", StringComparison.Ordinal))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var documentation = File.ReadAllText(Path.Combine(RepoRoot.Path, "docs", "ci", "test-trigger-map.md"));
+        var targetVocabulary = TextBetween(documentation, "## Target vocabulary", "## Rule categories");
+        var documented = System.Text.RegularExpressions.Regex
+            .Matches(targetVocabulary, @"^\| `(job:[a-z0-9-]+)` \|", System.Text.RegularExpressions.RegexOptions.Multiline)
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var map = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
+        var mapVocabulary = TextBetween(map, "# Target vocabulary:", "version: 1");
+        var documentedInMap = System.Text.RegularExpressions.Regex
+            .Matches(mapVocabulary, @"^#\s+(job:[a-z0-9-]+)\s+", System.Text.RegularExpressions.RegexOptions.Multiline)
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(referenced.Order(StringComparer.Ordinal), documented.Order(StringComparer.Ordinal));
+        Assert.Equal(referenced.Order(StringComparer.Ordinal), documentedInMap.Order(StringComparer.Ordinal));
+    }
+
+    public static TheoryData<string, string[]> AuditedLoosePathCases => new()
+    {
+        {
+            ".github/workflows/prepare-installer-artifacts.yml",
+            ["test:Infrastructure.Tests", "job:winget-installer", "job:homebrew-installer"]
+        },
+        {
+            ".github/scripts/assert-extension-e2e-bridge-vsix.ps1",
+            ["job:extension-unit"]
+        },
+        {
+            ".vscode/launch.json",
+            ["job:extension-unit"]
+        },
+        {
+            ".vscode/tasks.json",
+            ["job:extension-unit"]
+        },
+        {
+            "eng/test-retry-patterns.json",
+            ["test:Infrastructure.Tests"]
+        },
+        {
+            "eng/scripts/aspire-skills-bundle.common.ps1",
+            ["test:Infrastructure.Tests"]
+        },
+        {
+            "eng/scripts/smoke-installed-cli.ps1",
+            ["job:winget-installer"]
+        },
+        {
+            "eng/scripts/smoke-installed-cli.sh",
+            ["job:homebrew-installer"]
+        },
+        {
+            "eng/scripts/load-cli-e2e-images.sh",
+            ["test:Aspire.Cli.EndToEnd.Tests"]
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(AuditedLoosePathCases))]
+    public void AuditedLoosePathSelectsExactConsumerSetWithoutRunAllFallback(string path, string[] expectedTargets)
+    {
+        var result = SelectWithRealMap(path);
+
+        Assert.False(result.SelectsAll, $"{path} unexpectedly selected ALL: {result.EscalationReason}");
+        Assert.Empty(result.UnmatchedFiles);
+
+        var actualTargets = result.TestProjects.Select(name => $"test:{name}")
+            .Concat(result.Jobs)
+            .Order(StringComparer.Ordinal);
+        Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+    }
+
+    [Theory]
+    [InlineData(".gitattributes")]
+    [InlineData("eng/scripts/gha-testreport.ps1")]
+    [InlineData("eng/scripts/split-test-projects-for-ci.ps1")]
+    [InlineData("tools/ExtractTestPartitions/Program.cs")]
+    public void BroadCiInputHasAnExplicitRunAllRule(string path)
+    {
+        var result = SelectWithRealMap(path);
+
+        Assert.True(result.SelectsAll);
+        Assert.Empty(result.UnmatchedFiles);
+    }
+
+    [Theory]
+    [InlineData("eng/scripts/verify-cli-npm-package.ps1")]
+    [InlineData("eng/scripts/verify-cli-tool-nupkg.ps1")]
+    [InlineData("eng/scripts/stabilization-smoke-init-restore.sh")]
+    [InlineData("eng/generate-catalog.ps1")]
+    [InlineData("eng/scripts/update-aspire-skills-bundle.ps1")]
+    [InlineData("eng/scripts/verify-aspire-skills-bundle.ps1")]
+    [InlineData("eng/scripts/cli-starter-validation.ps1")]
+    public void PathHandledOutsideSelectorDoesNotForceTestSelection(string path)
+    {
+        var result = SelectWithRealMap(path);
+
+        Assert.False(result.SelectsAll);
+        Assert.Empty(result.UnmatchedFiles);
+        Assert.Empty(result.TestProjects);
+        Assert.Empty(result.Jobs);
     }
 
     [Fact]
@@ -332,10 +445,23 @@ public sealed class TestTriggerMapTests
             .Where(t => t.StartsWith("job:", StringComparison.Ordinal))
             .Select(t => "run_" + t["job:".Length..].Replace('-', '_'))
             .ToHashSet(StringComparer.Ordinal);
+        var expectedAdvisoryJobs = s_map.AllReferencedTargets()
+            .Where(t => t.StartsWith("job:", StringComparison.Ordinal))
+            .Where(t => !declared.Contains("run_" + t["job:".Length..].Replace('-', '_')))
+            .ToHashSet(StringComparer.Ordinal);
+        var advisoryJobField = typeof(Selection).GetField(
+            "s_advisoryJobTargets",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(advisoryJobField);
+        var configuredAdvisoryJobs = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(
+            advisoryJobField.GetValue(null));
 
         // Sanity: the regexes actually matched, so a pattern slip can't make the asserts vacuously pass.
         Assert.Contains("run_winget_installer", declared);
         Assert.Contains("run_winget_installer", consumed);
+        Assert.Equal(
+            expectedAdvisoryJobs.Order(StringComparer.Ordinal),
+            configuredAdvisoryJobs.Keys.Order(StringComparer.Ordinal));
 
         // Finding 1: every unpacked output is a key the tool emits. A typo'd fromJSON property or a
         // renamed/removed map token leaves the output permanently empty (job silently skipped).
@@ -454,9 +580,10 @@ public sealed class TestTriggerMapTests
         // fallback treats them as owned — they need no curated rule) and non-source build/fixture infra
         // (props/targets/packages/Docker/Playwright/certs -> ALL). A tests/Shared file that is NEITHER a
         // *.cs NOR matched by an ALL path rule NOR a doc (excluded by the prefilter) would silently select
-        // nothing: it is not under a project dir (so directory containment can't attribute a loose file
-        // there) and the run-all fallback is src/-only. Pin the invariant so a new file type added under
-        // tests/Shared can't quietly fall through. (.md files are dropped by the prefilter's **.md.)
+        // no targeted work: it is not under a project dir (so directory containment can't attribute a
+        // loose file there) and would force the run-all fallback. Pin the invariant so a new file type
+        // added under tests/Shared can't quietly expand to ALL. (.md files are dropped by the prefilter's
+        // **.md.)
         var allGlobs = s_map.PathRules
             .Where(r => r.Targets.Contains("ALL", StringComparer.Ordinal))
             .SelectMany(r => r.Paths)
@@ -481,12 +608,11 @@ public sealed class TestTriggerMapTests
     public void EveryLocalActionUsedByAWorkflowIsRoutedToAll()
     {
         // A local composite action (.github/actions/<name>) is not a project, so Layer 1 never attributes
-        // a change to it, and the run-all fallback in TestSelector escalates only src/** files. So a
-        // changed action that no path rule matches selects NOTHING in enforce mode -- a PR editing a
-        // CI-critical action (the skip gate, the macOS keychain unlock, enumerate-tests, ...) would
-        // silently skip all tests. The map routes .github/actions/** -> ALL to cover this; pin the
-        // invariant so a new action referenced from a workflow can't fall through if that rule is ever
-        // narrowed. Failure mode: drop the .github/actions/** ALL rule and this goes red.
+        // a change to it. An action that no path rule matches therefore forces the run-all fallback, but
+        // its CI-wide impact should be explicit rather than appearing as an unattributed audit warning.
+        // The map routes .github/actions/** -> ALL to cover this; pin the invariant so a new action
+        // referenced from a workflow can't lose that explicit ownership if the rule is narrowed.
+        // Failure mode: drop the .github/actions/** ALL rule and this goes red.
         var allGlobs = s_map.PathRules
             .Where(r => r.Targets.Contains("ALL", StringComparer.Ordinal))
             .SelectMany(r => r.Paths)
@@ -517,7 +643,35 @@ public sealed class TestTriggerMapTests
 
         Assert.True(unrouted.Count == 0,
             $"local actions referenced by a workflow but not routed to ALL (a change to them would select " +
-            $"nothing in enforce mode): {string.Join(", ", unrouted)}");
+            $"ALL only through the unattributed fallback): {string.Join(", ", unrouted)}");
+    }
+
+    private static SelectionResult SelectWithRealMap(string path)
+    {
+        var projectPaths = LoadSolutionProjectPaths();
+        var testProjects = projectPaths
+            .Where(projectPath => projectPath.StartsWith("tests/", StringComparison.Ordinal))
+            .Select(projectPath => Path.GetFileNameWithoutExtension(projectPath)!)
+            .Where(name => name.EndsWith(".Tests", StringComparison.Ordinal))
+            .ToHashSet(StringComparer.Ordinal);
+        var projectDirectories = projectPaths
+            .Select(projectPath => Path.GetDirectoryName(projectPath)!.Replace('\\', '/'))
+            .ToHashSet(StringComparer.Ordinal);
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, testProjects, projectDirectories);
+
+        return selector.Select([path], [], new SelectorOptions());
+    }
+
+    private static string TextBetween(string text, string startMarker, string endMarker)
+    {
+        var start = text.IndexOf(startMarker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Start marker not found: {startMarker}");
+
+        var end = text.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
+        Assert.True(end >= 0, $"End marker not found after {startMarker}: {endMarker}");
+
+        return text[start..end];
     }
 
     // Text of a top-level tests.yml job block: from "\n  <id>:" up to the next line indented exactly

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -63,7 +63,7 @@ var forceAllReasonOption = new Option<string?>("--force-all-reason")
 {
     Description = "Human-readable reason recorded in the run summary when --force-all is a fail-SAFE " +
                   "fallback (e.g. the CI checkout couldn't reach the merge-base) rather than the kill " +
-                  "switch. Lets the weekly audit -- which reads the summary, not the raw logs -- tell a " +
+                  "switch. Lets a later audit -- which reads the summary, not the raw logs -- tell a " +
                   "systemic regression apart from an intentional run-full-ci full run."
 };
 
@@ -128,6 +128,22 @@ internal sealed record RunOptions(
 
 internal static class Selection
 {
+    private static readonly IReadOnlyDictionary<string, string> s_advisoryTestTargets =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Aspire.Deployment.EndToEnd.Tests"] = "deployment workflow-only",
+            ["Aspire.EndToEnd.Tests"] = "outerloop-only",
+            ["Aspire.Oracle.EntityFrameworkCore.Tests"] = "outerloop-only",
+        };
+
+    private static readonly IReadOnlyDictionary<string, string> s_advisoryJobTargets =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["job:deployment-e2e"] = "schedule/dispatch-only",
+        };
+
+    private sealed record AdvisoryTarget(string Token, string DisplayName, string Qualifier);
+
     public static int Run(RunOptions options)
     {
         var trace = new SelectionTrace();
@@ -720,53 +736,93 @@ internal static class Selection
 
         if (!options.Enforce)
         {
-            // Audit mode runs the full matrix and every job regardless of the selection, so the lists
-            // below are advisory: they are what selective CI WOULD run once ENFORCE_SELECTION is on.
-            // Say so explicitly, otherwise a reader could mistake the subset for what actually ran.
-            sb.AppendLine("_The full test matrix and all jobs still run in audit mode. The tests and jobs below are what selective CI **would** run under enforcement._");
+            // Audit mode runs all regular PR work regardless of the selection. Schedule/outerloop-only
+            // targets are reported separately because the PR selector cannot cause them to run.
+            sb.AppendLine("_The regular PR test matrix and PR-gated jobs still run in audit mode. The PR tests and jobs below are what selective CI **would** run under enforcement. Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates; independent workflows may still run them for a PR._");
             sb.AppendLine();
-        }
-
-        if (result.SelectsAll)
-        {
-            sb.AppendLine(CultureInfo.InvariantCulture, $"**Runs the full test matrix + all jobs (ALL)** — {result.EscalationReason}");
-            sb.AppendLine();
-            WriteCommentFile(commentPath, sb.ToString());
-            return;
         }
 
         var tests = result.TestProjects.OrderBy(p => p, StringComparer.Ordinal).ToList();
         // Keep the full job: tokens for cause lookup; strip the prefix only for display.
         var jobs = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
+        var prTests = tests.Where(test => !s_advisoryTestTargets.ContainsKey(test)).ToList();
+        var prJobs = jobs.Where(job => !s_advisoryJobTargets.ContainsKey(job)).ToList();
+        var advisoryTargets = GetAdvisoryTargets(tests, jobs);
+        var allPrTestProjects = allTestProjects.Count(test => !s_advisoryTestTargets.ContainsKey(test));
+
+        if (result.SelectsAll)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"**Selects the full PR test matrix + all PR-gated jobs (ALL)** — {result.EscalationReason}");
+            sb.AppendLine();
+            AppendAdvisoryTargets(sb, advisoryTargets);
+            WriteCommentFile(commentPath, sb.ToString());
+            return;
+        }
 
         var fileWord = changedFiles.Count == 1 ? "changed file" : "changed files";
-        var jobWord = jobs.Count == 1 ? "job" : "jobs";
+        var jobWord = prJobs.Count == 1 ? "job" : "jobs";
+        var advisoryWord = advisoryTargets.Count == 1 ? "target" : "targets";
         sb.AppendLine(CultureInfo.InvariantCulture,
-            $"**{tests.Count} / {allTestProjects.Count} test projects · {jobs.Count} {jobWord}**, from {changedFiles.Count} {fileWord}.");
+            $"**{prTests.Count} / {allPrTestProjects} PR test projects · {prJobs.Count} PR {jobWord} · {advisoryTargets.Count} advisory-only {advisoryWord}**, from {changedFiles.Count} {fileWord}.");
         sb.AppendLine();
 
         // WHAT runs -- the flat lists up front. A reviewer scanning a large selection sees the complete
         // set of projects and jobs without reading the per-trigger breakdown below. Test projects come
         // first because they are the primary thing a reviewer cares about; the non-.NET jobs follow.
-        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected test projects ({tests.Count} / {allTestProjects.Count})");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected PR test projects ({prTests.Count} / {allPrTestProjects})");
         sb.AppendLine();
-        sb.AppendLine(tests.Count == 0
-            ? "_none — no .NET test projects run for this change._"
-            : string.Join(", ", tests.Select(t => $"`{t}`")));
+        sb.AppendLine(prTests.Count == 0
+            ? "_none — no PR-gated .NET test projects run for this change._"
+            : string.Join(", ", prTests.Select(t => $"`{t}`")));
         sb.AppendLine();
 
-        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected jobs ({jobs.Count})");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"### Selected PR jobs ({prJobs.Count})");
         sb.AppendLine();
-        sb.AppendLine(jobs.Count == 0
+        sb.AppendLine(prJobs.Count == 0
             ? "_none_"
-            : string.Join(", ", jobs.Select(j => $"`{StripJobPrefix(j)}`")));
+            : string.Join(", ", prJobs.Select(j => $"`{StripJobPrefix(j)}`")));
         sb.AppendLine();
+
+        AppendAdvisoryTargets(sb, advisoryTargets);
 
         // HOW it was chosen -- the per-trigger grouping.
         AppendSelectionRationale(sb, result, tests, jobs);
 
         sb.AppendLine();
         WriteCommentFile(commentPath, sb.ToString());
+    }
+
+    private static IReadOnlyList<AdvisoryTarget> GetAdvisoryTargets(
+        IReadOnlyList<string> tests,
+        IReadOnlyList<string> jobs)
+    {
+        var targets = tests
+            .Where(s_advisoryTestTargets.ContainsKey)
+            .Select(test => new AdvisoryTarget($"test:{test}", test, s_advisoryTestTargets[test]))
+            .ToList();
+        targets.AddRange(jobs
+            .Where(s_advisoryJobTargets.ContainsKey)
+            .Select(job => new AdvisoryTarget(job, StripJobPrefix(job), s_advisoryJobTargets[job])));
+
+        return targets;
+    }
+
+    private static void AppendAdvisoryTargets(StringBuilder sb, IReadOnlyList<AdvisoryTarget> targets)
+    {
+        sb.AppendLine(CultureInfo.InvariantCulture, $"### Advisory workflow impact ({targets.Count})");
+        sb.AppendLine();
+        if (targets.Count == 0)
+        {
+            sb.AppendLine("_none_");
+        }
+        else
+        {
+            foreach (var target in targets)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{target.DisplayName}` *({target.Qualifier})*");
+            }
+        }
+        sb.AppendLine();
     }
 
     // Renders the "how these were chosen" section: every selected test project grouped under each
@@ -1036,8 +1092,11 @@ internal static class Selection
         var source = options.ChangedFilesPath is not null
             ? $"changed-files {options.ChangedFilesPath}"
             : $"git diff {options.From}{(options.To is null ? " (working tree)" : $"..{options.To}")}";
+        var mode = options.Enforce
+            ? "enforcing"
+            : "audit (advisory: the regular test matrix + selector-gated jobs run regardless of the selection below; advisory-only targets are reported but scheduled independently)";
         sb.AppendLine("### Options");
-        sb.AppendLine(CultureInfo.InvariantCulture, $"- mode: {(options.Enforce ? "enforcing" : "audit (advisory: the full matrix + all jobs run regardless of the selection below)")}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"- mode: {mode}");
         sb.AppendLine(CultureInfo.InvariantCulture, $"- change source: {source}");
         var forceAllDetail = options.ForceAll && options.ForceAllReason is not null
             ? $"True — fail-safe run-all because {options.ForceAllReason}"
@@ -1099,36 +1158,58 @@ internal static class Selection
         sb.AppendLine();
 
         sb.AppendLine("### Selection");
+        var selected = result.TestProjects.OrderBy(p => p, StringComparer.Ordinal).ToList();
+        var jobTokens = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
+        var selectedPrTests = selected.Where(test => !s_advisoryTestTargets.ContainsKey(test)).ToList();
+        var prJobTokens = jobTokens.Where(job => !s_advisoryJobTargets.ContainsKey(job)).ToList();
+        var advisoryTargets = GetAdvisoryTargets(selected, jobTokens);
+        var allPrTestProjects = allTestProjects.Count(test => !s_advisoryTestTargets.ContainsKey(test));
+
         if (result.SelectsAll)
         {
-            sb.AppendLine(CultureInfo.InvariantCulture, $"- **selects ALL** — {result.EscalationReason}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- **selects ALL PR test projects + jobs** — {result.EscalationReason}");
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"- advisory-only targets: {(advisoryTargets.Count == 0 ? "(none)" : string.Join(", ", advisoryTargets.Select(target => target.Token)))}");
             WriteOut(sb);
             return;
         }
 
-        var selected = result.TestProjects.OrderBy(p => p, StringComparer.Ordinal).ToList();
         var skipped = allTestProjects.Except(result.TestProjects, StringComparer.Ordinal)
+            .Where(test => !s_advisoryTestTargets.ContainsKey(test))
             .OrderBy(p => p, StringComparer.Ordinal)
             .ToList();
-        var jobTokens = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
 
-        sb.AppendLine(CultureInfo.InvariantCulture, $"- selected test projects: {selected.Count} / {allTestProjects.Count}");
-        sb.AppendLine(CultureInfo.InvariantCulture, $"- triggered jobs: {(jobTokens.Count == 0 ? "(none)" : string.Join(", ", jobTokens))}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"- selected PR test projects: {selectedPrTests.Count} / {allPrTestProjects}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"- triggered PR jobs: {(prJobTokens.Count == 0 ? "(none)" : string.Join(", ", prJobTokens))}");
+        sb.AppendLine(CultureInfo.InvariantCulture,
+            $"- advisory-only targets: {(advisoryTargets.Count == 0 ? "(none)" : string.Join(", ", advisoryTargets.Select(target => target.Token)))}");
         sb.AppendLine();
 
         // Each selected test project / job is listed with the full set of reasons it was selected
         // (the changed file, affected project, graph edge, or selected test that pulled it in, plus
         // the curated rule's reason text). This is the "why" an auditor needs to trust the selection.
-        AppendCauseList(sb, "Selected test projects", selected, p => p, result.TestCauses);
+        AppendCauseList(sb, "Selected PR test projects", selectedPrTests, p => p, result.TestCauses);
         AppendCauseList(
             sb,
-            "Triggered jobs",
-            jobTokens,
+            "Triggered PR jobs",
+            prJobTokens,
             t => t.StartsWith("job:", StringComparison.Ordinal) ? t["job:".Length..] : t,
+            result.JobCauses);
+        AppendCauseList(
+            sb,
+            "Advisory test projects",
+            selected.Where(s_advisoryTestTargets.ContainsKey).ToList(),
+            p => p,
+            result.TestCauses);
+        AppendCauseList(
+            sb,
+            "Advisory schedule/dispatch jobs",
+            jobTokens.Where(s_advisoryJobTargets.ContainsKey).ToList(),
+            StripJobPrefix,
             result.JobCauses);
         // In enforcing mode the unselected projects are actually skipped; in audit mode the full matrix
         // still runs, so they only "would have been" skipped.
-        AppendProjectList(sb, options.Enforce ? "Skipped (not run)" : "Would have been skipped", skipped);
+        AppendProjectList(sb, options.Enforce ? "Skipped PR test projects (not run)" : "PR test projects that would have been skipped", skipped);
 
         WriteOut(sb);
 

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -268,7 +268,7 @@ public sealed class TestSelector
         // Match ONLY production project names: Layer 1 reports production AND test projects, and the
         // affected test projects are already selected via the intersection above. Without this filter
         // an affected matrix test name (e.g. "Aspire.Hosting.Python.Tests") would match a production
-        // glob like "Aspire.Hosting*" and spuriously fire production jobs (ats-diffs / extension-e2e /
+        // glob like "Aspire.Hosting*" and spuriously fire production jobs (extension-e2e /
         // typescript-api-compat / deployment-e2e) for a TEST-ONLY change. See test-trigger-map.yml's
         // affected_project_rules comment ("matched against the affected PRODUCTION projects").
         var affectedProductionProjects = layer1Affected


### PR DESCRIPTION
## Description

[automated] **Conditional-test audit results can currently miss gated installer jobs, force unnecessary full matrices, and present schedule/outerloop-only targets as PR-runnable work.** For example, an edit to the reusable installer workflow selects `Infrastructure.Tests` but not the WinGet or Homebrew jobs it implements. Several loose CI inputs instead report:

```text
run-all fallback: 'eng/generate-catalog.ps1' is neither Layer-1-owned nor matched by a Layer 2 rule
```

The curated map did not cover every runtime script/config dependency, and the audit renderer treated every selected token as work that PR enforcement could run.

This change routes confirmed loose inputs to their actual consumers, makes CI-wide inputs explicit `ALL`, and explicitly accounts for paths already exercised by baseline or dedicated workflows as well as paths with no PR-CI consumer. Audit comments and job summaries now separate PR-gated work from advisory workflow impact that is scheduled independently of the regular selector gates.

Repository-wide code-review guidance now prompts reviewers to check selector routing when PRs add test projects, CI jobs/workflows, or loose CI inputs, while avoiding manual mappings for ProjectGraph-owned .NET changes.

Native CLI archive verifier scripts remain in the main CI workflow but no longer select tests because the unconditional archive jobs already execute them. The Windows-only template catalog generator and schedule-only skills updater are classified outside PR CI. The cross-platform CLI starter validator is also outside selector targets because unconditional PR jobs already execute it. The bundle verifier remains covered by its dedicated PR workflow. Root VS Code settings and Pyright configuration skip the main matrix because they have no CI consumer; root VS Code launch and task configuration route to the extension unit job. Copilot canvas extension changes skip the main matrix and continue through their dedicated validation workflow.

Selector enforcement remains disabled (`enforce: 'false'`). Unowned source and shared-file changes still fail safe to `ALL`.

Validation:

```text
dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-namespace "Infrastructure.Tests.TestTriggerMap" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 154, Failed: 0, Skipped: 0
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
