### PR TITLE
test: Quarantine flaky CI tests

### DIFF
--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Templates.Tests;
+using Aspire.TestUtilities;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
@@ -85,6 +86,7 @@ public class PRScriptShellTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18732")]
     public async Task MockGhApiWorkflowWithoutJqFailsLoudly()
     {
         using var env = new TestEnvironment();

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs
@@ -17,6 +17,7 @@ using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Shared;
 using Aspire.Tests;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -123,6 +124,7 @@ public class AppHostServerSessionTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/19150")]
     public async Task GetRpcClientAsync_WhenServerExitsBeforeSocketIsAvailable_FailsWithoutWaitingForConnectionTimeout()
     {
         // RecordingAppHostServerProject spawns `dotnet --version`, which exits almost immediately

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.DotNet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using static Aspire.Cli.Tests.TestServices.ProcessTestHelpers;
@@ -138,6 +139,7 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18880")]
     public async Task LaunchAsync_WithGracefulServices_BlockingSignalerDoesNotConsumeGracefulBudget()
     {
         // Regression coverage for DCP's stop-process-tree behavior: the graceful signaler can

--- a/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Lifecycle;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -631,6 +632,7 @@ public class MauiBuildQueueTests
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18592")]
     public async Task ReleaseSemaphoreAfterLaunchAsync_SkipsReplayStateAndReleasesOnStableState()
     {
         await using var env = await BuildQueueTestEnvironment.CreateAsync();

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.Tasks;
+using Aspire.TestUtilities;
 using Xunit;
 
 namespace Aspire.Hosting.Sdk.Tests;
@@ -775,6 +776,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/19517")]
     public async Task RunAspireCliCommandKillsCommandShimProcessTreeOnTimeoutInFullFrameworkMsBuild()
     {
         Assert.SkipUnless(OperatingSystem.IsWindows(), "This test validates the net472 task under full-framework MSBuild.");


### PR DESCRIPTION
[automated] 

## Description

Quarantines five intermittently-failing tests by adding the `[QuarantinedTest]` attribute so they run in the scheduled `Quarantine` workflow (`tests-quarantine.yml`) instead of the regular `tests.yml` workflow. This keeps PR CI green while the underlying flakiness is investigated. Test logic is unchanged; each attribute links its tracking issue.

Attributes were added with `tools/QuarantineTools` (one invocation per canonical method); no attributes were hand-edited.

### Quarantined tests

| Test | Source | Issue |
|------|--------|-------|
| `MauiBuildQueueTests.ReleaseSemaphoreAfterLaunchAsync_SkipsReplayStateAndReleasesOnStableState` | `tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs` | #18592 |
| `PRScriptShellTests.MockGhApiWorkflowWithoutJqFailsLoudly` | `tests/Aspire.Acquisition.Tests/Scripts/PRScriptShellTests.cs` | #18732 |
| `ProcessGuestLauncherTests.LaunchAsync_WithGracefulServices_BlockingSignalerDoesNotConsumeGracefulBudget` | `tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs` | #18880 |
| `AppHostServerSessionTests.GetRpcClientAsync_WhenServerExitsBeforeSocketIsAvailable_FailsWithoutWaitingForConnectionTimeout` | `tests/Aspire.Cli.Tests/Projects/AppHostServerSessionTests.cs` | #19150 |
| `AppHostSdkTargetsTests.RunAspireCliCommandKillsCommandShimProcessTreeOnTimeoutInFullFrameworkMsBuild` | `tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs` | #19517 |

### Verification

Restored the local SDK, then built each affected project (all `0 Warning(s), 0 Error(s)`) and confirmed each quarantined method is excluded when the quarantine trait is filtered out, using MTP-native filters:

```
dotnet build tests/Aspire.Acquisition.Tests/Aspire.Acquisition.Tests.csproj
dotnet build tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj
dotnet build tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
dotnet build tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj

dotnet test <project> --no-build --no-launch-profile -- \
  --filter-method "*.<Method>" \
  --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
# => "Zero tests ran" for each quarantined method (excluded by the quarantined=true trait)
```

`git diff --check` reports no whitespace errors. `QuarantineTools` prepended a UTF-8 BOM and appended an out-of-order `using`; both were cleaned so each file's diff is exactly the `[QuarantinedTest]` attribute plus a correctly-sorted `using Aspire.TestUtilities;`.

On merge, the `quarantined-test` label is added only to the successfully quarantined linked issues (#18592, #18732, #18880, #19150, #19517).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

Addresses #18592
Addresses #18732
Addresses #18880
Addresses #19150
Addresses #19517