### PR TITLE
Harden Markdown URL validation

### DIFF
--- a/src/Aspire.Dashboard/Model/Markdown/MarkdownHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Markdown/MarkdownHelpers.cs
@@ -85,9 +85,15 @@ public static class MarkdownHelpers
 
         static LinkType DetectLink(string? url, HashSet<string>? allowedUrlSchemes)
         {
-            if (url == null || !Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+            if (url is null)
             {
                 return LinkType.None;
+            }
+
+            // Browsers and protocol handlers can accept URLs rejected by System.Uri, so don't render an unclassified URL.
+            if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                return LinkType.Prohibited;
             }
 
             if (!uri.IsAbsoluteUri)

--- a/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
@@ -262,6 +262,29 @@ public class MarkdownProcessorTests
     }
 
     [Theory]
+    [InlineData("vscode://%0alocalhost:8080")]
+    [InlineData("http://%0alocalhost:8080")]
+    public void ToHtml_UrlThatCannotBeParsed_UrlRemoved(string url)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor(safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes);
+
+        var markdown =
+            $"""
+            [test]({url})
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            """
+            <p><a href="">test</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
     [InlineData("http://contoso.com:8080", "http://contoso.com:8080")]
     [InlineData("https://contoso.com:8081", "https://contoso.com:8081")]
     [InlineData("mailto:test@test.com", "test@test.com")]


### PR DESCRIPTION
## Description

Markdown links that `System.Uri` can't parse were previously left unclassified. Browsers and registered protocol handlers can accept URLs that `System.Uri` rejects, so an unparseable URL could still be rendered instead of being removed.

This change classifies unparseable URLs as prohibited. It adds regression coverage for encoded-newline URLs using both `vscode` and HTTP schemes.

### Security considerations

This tightens the trust boundary for Markdown links: URLs must be successfully classified before they can be rendered. The change has not had a formal threat model or security review.

Validation:

```text
MarkdownProcessorTests: 28 passed, 0 failed, 0 skipped
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No