### PR TITLE
Fix VS Code debugger guidance E2E contract

### DIFF
--- a/extension/src/test-e2e/edgeCases.e2e.test.ts
+++ b/extension/src/test-e2e/edgeCases.e2e.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { AspireExtensionE2ECodeLensProbeResult, AspireExtensionE2EControlCommand } from '../types/extensionApi';
+import type { AspireExtensionE2EControlCommand } from '../types/extensionApi';
 import { getCommandInvocationCount, getDebugLaunchCount, isSamePath, waitForCommandOutcome, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForSelectedWorkspaceAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
 import { createEmptyAppHostProject, createExternalSingleFileAppHost, executeE2eControlCommand, getGeneratedAppHostPath, getGeneratedProjectRoot, isProcessAlive, removeExternalSingleFileAppHost, removeGeneratedProject, restoreWorkspaceAppHostConfig, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setDebugLaunchSuppressedForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, waitForKnownProcessExit, writeFileWithRetry, writeWorkspaceAppHostConfigForPath } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath, getWorkspaceRoot } from './helpers/paths';
@@ -212,20 +212,6 @@ builder.Build().Run();`));
             'Set up Python debugging support to debug resources in this app.',
             60000);
         await notification.dismiss();
-
-        const timeoutMs = 60000;
-        const started = Date.now();
-        let lastResult: AspireExtensionE2ECodeLensProbeResult | undefined;
-        while (Date.now() - started < timeoutMs) {
-            lastResult = (await executeE2eControlCommand({ name: 'getCodeLenses', filePath: appHostPath })).result as AspireExtensionE2ECodeLensProbeResult;
-            if (lastResult.commandTitles.some(title => title.includes('Set up Python debugger'))) {
-                return;
-            }
-
-            await delay(500);
-        }
-
-        throw new Error(`Timed out after ${timeoutMs}ms waiting for the Python debugger CodeLens. Last provider result: ${JSON.stringify(lastResult)}`);
     });
 
     test('process-owner cleanup stops the owned CLI and AppHost process tree', async () => {
@@ -258,7 +244,3 @@ builder.Build().Run();`));
         await waitForNoRunningAppHost(120000, appHostPath);
     });
 });
-
-function delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -1078,8 +1078,9 @@ suite('E2E launch profile', () => {
         assert.ok(!workspaceTargetProofSource.includes('const wrapperPath = path.join(folderPath, `aspire-${folderName}`);'));
 
         const edgeCases = getTestBlock(edgeCasesSource, 'shows debugger install guidance while the Aspire panel and AppHost source are closed');
-        assert.ok(edgeCases.includes("executeE2eControlCommand({ name: 'getCodeLenses', filePath: appHostPath })"));
-        assert.ok(edgeCases.includes("title.includes('Set up Python debugger')"));
+        assert.ok(edgeCases.includes("waitForNotificationMessage("));
+        assert.ok(edgeCases.includes("'Set up Python debugging support to debug resources in this app.'"));
+        assert.ok(!edgeCases.includes("name: 'getCodeLenses'"));
         assert.ok(!edgeCases.includes("waitForCodeLensText("));
         assert.ok(!edgeCases.includes("name: 'openFile'"));
         assert.ok(!edgeCases.includes("waitForWorkbenchText('Set up Python debugger'"));


### PR DESCRIPTION
## Description

The Windows `edge-cases` shard repeatedly confirms the Python debugger setup notification, then times out waiting for CodeLens commands on a closed AppHost document. CodeLens materialization in a closed editor is not part of this scenario's contract.

This keeps the user-facing notification assertion and removes the invalid follow-up CodeLens probe. The source-contract unit test now requires the notification proof and prevents the closed-document probe from being reintroduced.

This reproduced in four consecutive main runs: 32885558008, 32898142217, 32909638198, and 32917733900.

Validation:

- `corepack yarn compile-tests`
- Focused `e2eLaunchProfile` unit test
- `corepack yarn compile-e2e`
- `corepack yarn lint`

Fixes #19547

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
