### PR TITLE
Add --allow-anonymous to aspire start and run

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -79,6 +79,13 @@ internal sealed class AppHostLauncher(
         Description = SharedCommandStrings.LaunchProfileOptionDescription
     };
 
+    // This option explicitly opts into an unsecured dashboard. See the security considerations at
+    // https://aspire.dev/dashboard/security-considerations/ before enabling it outside local development.
+    internal static readonly Option<bool> s_allowAnonymousOption = new("--allow-anonymous")
+    {
+        Description = DashboardCommandStrings.AllowAnonymousOptionDescription
+    };
+
     /// <summary>
     /// Adds the detached launch options to a command so they appear in --help.
     /// Called by both RunCommand and StartCommand to keep options in sync.
@@ -89,6 +96,24 @@ internal sealed class AppHostLauncher(
         command.Options.Add(s_formatOption);
         command.Options.Add(s_isolatedOption);
         command.Options.Add(s_launchProfileOption);
+        command.Options.Add(s_allowAnonymousOption);
+    }
+
+    /// <summary>
+    /// Gets the arguments to pass to the AppHost, including dashboard configuration derived from CLI options.
+    /// </summary>
+    internal static IReadOnlyList<string> GetAppHostArguments(ParseResult parseResult)
+    {
+        var arguments = new List<string>();
+        if (parseResult.GetResult(s_allowAnonymousOption) is { Implicit: false })
+        {
+            var allowAnonymous = parseResult.GetValue(s_allowAnonymousOption);
+            arguments.Add($"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}={allowAnonymous.ToString().ToLowerInvariant()}");
+        }
+
+        arguments.AddRange(parseResult.UnmatchedTokens);
+
+        return arguments;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -329,7 +329,7 @@ internal sealed class RunCommand : BaseCommand
                 StartDebugSession = startDebugSession,
                 LaunchProfile = launchProfile,
                 EnvironmentVariables = new Dictionary<string, string>(),
-                UnmatchedTokens = parseResult.UnmatchedTokens.ToArray(),
+                UnmatchedTokens = [.. AppHostLauncher.GetAppHostArguments(parseResult)],
                 WorkingDirectory = ExecutionContext.WorkingDirectory,
                 BuildCompletionSource = buildCompletionSource,
                 BackchannelCompletionSource = backchannelCompletionSource,
@@ -1200,7 +1200,7 @@ internal sealed class RunCommand : BaseCommand
         var launchProfile = parseResult.GetValue(AppHostLauncher.s_launchProfileOption);
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
-        var appHostArgs = parseResult.UnmatchedTokens;
+        var appHostArgs = AppHostLauncher.GetAppHostArguments(parseResult);
         var additionalArgs = new List<string>();
         var captureProfile = parseResult.GetValue(RootCommand.CaptureProfileOption);
         var stopAfterLaunchDelay = captureProfile

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -59,7 +59,7 @@ internal sealed class StartCommand : BaseCommand
         var isExtensionHost = false;
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
-        var appHostArgs = parseResult.UnmatchedTokens;
+        var appHostArgs = AppHostLauncher.GetAppHostArguments(parseResult);
         var additionalArgs = new List<string>();
         var captureProfile = parseResult.GetValue(RootCommand.CaptureProfileOption);
         var stopAfterLaunchDelay = captureProfile

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -277,6 +277,46 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("E2E", launchProfile);
     }
 
+    [Theory]
+    [InlineData("--allow-anonymous", "true")]
+    [InlineData("--allow-anonymous=false", "false")]
+    public async Task RunCommand_AllowAnonymousOptionIsPassedToAppHost(string option, string expectedValue)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = CreateAppHostFile(workspace);
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+        IReadOnlyList<string>? appHostArguments = null;
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            RunAsyncCallback = (context, _) =>
+            {
+                appHostArguments = context.UnmatchedTokens;
+                context.BuildCompletionSource?.TrySetResult(false);
+                return Task.FromResult(42);
+            }
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => projectLocator;
+            options.AppHostProjectFactory = _ => projectFactory;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(["run", "--apphost", appHostFile.FullName, option]);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(42, exitCode);
+        Assert.Equal(
+            [$"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}={expectedValue}"],
+            appHostArguments);
+    }
+
     [Fact]
     public async Task RunCommand_RejectsInvalidStartupTimeoutEnvironmentVariable()
     {
@@ -1168,6 +1208,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             }
             """);
         var expectedAppHostArguments = new[] { "true", "false", string.Empty, "--detach", "--option-shaped" };
+        string[] expectedForwardedAppHostArguments =
+            [$"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true", .. expectedAppHostArguments];
         var projectLocator = new TestProjectLocator
         {
             UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
@@ -1193,6 +1235,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             "--apphost", appHostFile.FullName,
             "--no-build",
             $"{launchProfileOption}=--no-build",
+            "--allow-anonymous",
             "--",
             .. expectedAppHostArguments
         ]);
@@ -1200,7 +1243,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         Assert.Empty(result.Errors);
         Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, await result.InvokeAsync().DefaultTimeout());
 
-        AssertDetachedChildArguments(command, processFactory.LastArguments, "--no-build", expectedAppHostArguments);
+        AssertDetachedChildArguments(command, processFactory.LastArguments, "--no-build", expectedForwardedAppHostArguments);
     }
 
     [Fact]
@@ -3916,6 +3959,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             "--detach=false",
             "--no-build",
             "--launch-profile", "E2E",
+            "--allow-anonymous",
             "--isolated=false",
             "--format=table",
             "--wait-for-debugger",
@@ -3942,6 +3986,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 "--capture-profile",
                 "--no-build",
                 "--launch-profile", "E2E",
+                "--allow-anonymous",
                 "--isolated", "false",
                 "--wait-for-debugger",
                 "--capture-profile-output", new FileInfo(relativeCapturePath).FullName,

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -206,6 +206,42 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         Assert.Contains("E2E", result.UnmatchedTokens);
     }
 
+    [Fact]
+    public async Task StartCommand_AllowAnonymousOptionIsPassedToAppHost()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var appHostFile = CreateAppHostFile(workspace);
+        var projectLocator = new TestProjectLocator
+        {
+            UseOrFindAppHostProjectFileWithBehaviorAsyncCallback = (_, _, _, _) =>
+                Task.FromResult(new AppHostProjectSearchResult(appHostFile, [appHostFile]))
+        };
+        var processFactory = new TestProcessExecutionFactory
+        {
+            DefaultExitCode = CliExitCodes.FailedToDotnetRunAppHost
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => projectLocator;
+        });
+        services.Replace(ServiceDescriptor.Singleton<IProcessExecutionFactory>(processFactory));
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(["start", "--apphost", appHostFile.FullName, "--allow-anonymous"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, await result.InvokeAsync().DefaultTimeout());
+
+        var forwardedArguments = ExtractForwardedRunArguments(Assert.IsType<string[]>(processFactory.LastArguments));
+        var childParseResult = command.Parse(forwardedArguments);
+
+        Assert.Empty(childParseResult.Errors);
+        Assert.Equal(
+            [$"--{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true"],
+            childParseResult.UnmatchedTokens);
+    }
+
     [Theory]
     [InlineData("--launch-profile")]
     [InlineData("-lp")]
@@ -407,6 +443,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
             "--format=table",
             "--no-build",
             "--launch-profile", "E2E",
+            "--allow-anonymous",
             "--isolated=false",
             "--wait-for-debugger",
             "--non-interactive=false",
@@ -433,6 +470,7 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
                 "--capture-profile",
                 "--no-build",
                 "--launch-profile", "E2E",
+                "--allow-anonymous",
                 "--isolated", "false",
                 "--wait-for-debugger",
                 "--log-level", "Debug",


### PR DESCRIPTION
## Description

`aspire dashboard run` supports opting into anonymous dashboard access, but AppHost users previously had to pass the underlying dashboard configuration setting manually. This change adds the same `--allow-anonymous` option to `aspire start` and `aspire run`.

The shared AppHost launch plumbing translates an explicitly supplied option, including `--allow-anonymous=false`, into `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` for the AppHost. This works for interactive runs, detached runs, background starts, and VS Code delegation while preserving explicit pass-through AppHost arguments.

### User-facing usage

```bash
aspire run --allow-anonymous
aspire start --allow-anonymous
```

The option uses the existing dashboard help text: `Allow anonymous access to the dashboard`.

### Security considerations

This is an explicit opt-in to the dashboard's existing unsecured mode. The option does not change the default authentication behavior, and the dashboard retains its existing anonymous-access warnings and security guidance.

Validation: all 120 `StartCommandTests` and `RunCommandTests` pass.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No