### PR TITLE
Add Azure Files support for AKS volumes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.SignalR" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Sql" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.2" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.2.0-beta.1" />
     <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.6" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.4.0" />

--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <!-- Transitive through Azure.Provisioning.Storage; remove when 1.2.0 ships stable. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
     <PackageTags>aspire integration hosting azure container cloud appcontainers</PackageTags>
     <Description>Azure container apps resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
+++ b/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <!-- Transitive through Aspire.Hosting.Azure.Storage; remove when Azure.Provisioning.Storage 1.2.0 ships stable. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
     <PackageTags>aspire integration hosting azure eventhubs messaging eventing cloud</PackageTags>
     <Description>Azure Event Hubs resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureEventHubs_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
+++ b/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <!-- Transitive through Aspire.Hosting.Azure.Storage; remove when Azure.Provisioning.Storage 1.2.0 ships stable. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
     <!-- Disable package validation as this package hasn't shipped stable yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
     <PackageTags>aspire integration hosting azure functions serverless cloud</PackageTags>

--- a/src/Aspire.Hosting.Azure.Kubernetes/AksWorkloadIdentityBinding.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AksWorkloadIdentityBinding.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Kubernetes;
+
+/// <summary>
+/// Describes a federated identity credential that connects a Kubernetes service account to an Azure identity.
+/// </summary>
+internal sealed record AksWorkloadIdentityBinding(
+    string ServiceAccountName,
+    string FederatedCredentialName,
+    IAppIdentityResource IdentityResource);

--- a/src/Aspire.Hosting.Azure.Kubernetes/AksWorkloadIdentityBindingKey.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AksWorkloadIdentityBindingKey.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Kubernetes;
+
+/// <summary>
+/// Uniquely identifies a workload identity binding without relying on ambiguous concatenated resource names.
+/// </summary>
+internal readonly record struct AksWorkloadIdentityBindingKey(string WorkloadName, string? VolumeName);

--- a/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Azure.Kubernetes/Aspire.Hosting.Azure.Kubernetes.csproj
@@ -22,10 +22,12 @@
     <PackageReference Include="Azure.Provisioning.ContainerService" />
     <PackageReference Include="Azure.Provisioning.Network" />
     <PackageReference Include="Azure.Provisioning.OperationalInsights" />
+    <PackageReference Include="Azure.Provisioning.Storage" />
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure.ContainerRegistry\Aspire.Hosting.Azure.ContainerRegistry.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure.Network\Aspire.Hosting.Azure.Network.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Kubernetes\Aspire.Hosting.Kubernetes.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureFileSharePersistentVolumeAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureFileSharePersistentVolumeAnnotation.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.Kubernetes;
+
+/// <summary>
+/// Associates an Azure Files persistent volume with the identity used by its authorized workloads.
+/// </summary>
+internal sealed class AzureFileSharePersistentVolumeAnnotation(
+    AzureFileStorageShareResource share,
+    AzureUserAssignedIdentityResource identity) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the Azure file share that backs the persistent volume.
+    /// </summary>
+    public AzureFileStorageShareResource Share { get; } = share;
+
+    /// <summary>
+    /// Gets the user-assigned identity used to mount the persistent volume.
+    /// </summary>
+    public AzureUserAssignedIdentityResource Identity { get; } = identity;
+}

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -606,6 +606,14 @@ public static class AzureKubernetesEnvironmentExtensions
             };
         }
 
+        if (aksResource.AzureFileStorageAccounts.Count > 0)
+        {
+            aks.StorageProfile = new ManagedClusterStorageProfile
+            {
+                IsFileCsiDriverEnabled = true
+            };
+        }
+
         // Private cluster
         if (aksResource.IsPrivateCluster)
         {

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -834,21 +834,34 @@ public static class AzureKubernetesEnvironmentExtensions
             // Dynamic (parameter-based) namespaces are not supported for federated
             // credentials since Azure AD needs a fixed subject at provision time.
             var nsFormat = nsAnnotation.Namespace.Format;
-            if (!string.IsNullOrEmpty(nsFormat) && !nsFormat.Contains('{'))
+            if (aksResource.WorkloadIdentities.Count > 0 &&
+                !string.IsNullOrEmpty(nsFormat) &&
+                nsFormat.Contains('{'))
+            {
+                throw new InvalidOperationException(
+                    "AKS workload identity requires a literal Kubernetes namespace because the federated identity subject is provisioned before deploy-time parameters are resolved.");
+            }
+
+            if (!string.IsNullOrEmpty(nsFormat))
             {
                 k8sNamespace = nsFormat;
             }
         }
 
-        foreach (var (resourceName, identityResource) in aksResource.WorkloadIdentities)
+        var precedingCredentialByIdentity = new Dictionary<IAppIdentityResource, FederatedIdentityCredential>(ReferenceEqualityComparer.Instance);
+        foreach (var (bindingKey, binding) in aksResource.WorkloadIdentities)
         {
-            var saName = $"{resourceName}-sa";
-            var sanitizedName = Infrastructure.NormalizeBicepIdentifier(resourceName);
+            // Aspire resource names cannot contain underscores, so the double underscore keeps
+            // the workload/volume boundary unambiguous after Bicep identifier normalization.
+            var bindingName = bindingKey.VolumeName is null
+                ? bindingKey.WorkloadName
+                : $"{bindingKey.WorkloadName}__{bindingKey.VolumeName}";
+            var sanitizedName = Infrastructure.NormalizeBicepIdentifier(bindingName);
             var identityParamName = $"identityName_{sanitizedName}";
 
             var identityNameParam = new ProvisioningParameter(identityParamName, typeof(string));
             infrastructure.Add(identityNameParam);
-            aksResource.Parameters[identityParamName] = identityResource.PrincipalName;
+            aksResource.Parameters[identityParamName] = binding.IdentityResource.PrincipalName;
 
             var existingIdentity = UserAssignedIdentity.FromExisting($"identity_{sanitizedName}");
             existingIdentity.Name = identityNameParam;
@@ -857,16 +870,22 @@ public static class AzureKubernetesEnvironmentExtensions
             var fedCred = new FederatedIdentityCredential($"fedcred_{sanitizedName}")
             {
                 Parent = existingIdentity,
-                Name = $"{resourceName}-fedcred",
+                Name = binding.FederatedCredentialName,
                 IssuerUri = new MemberExpression(
                     new MemberExpression(
                         new MemberExpression(new IdentifierExpression(aks.BicepIdentifier), "properties"),
                         "oidcIssuerProfile"),
                     "issuerURL"),
-                Subject = $"system:serviceaccount:{k8sNamespace}:{saName}",
+                Subject = $"system:serviceaccount:{k8sNamespace}:{binding.ServiceAccountName}",
                 Audiences = { "api://AzureADTokenExchange" }
             };
+            if (precedingCredentialByIdentity.TryGetValue(binding.IdentityResource, out var precedingCredential))
+            {
+                // ARM can reject concurrent child-resource writes against the same UAMI.
+                fedCred.DependsOn.Add(precedingCredential);
+            }
             infrastructure.Add(fedCred);
+            precedingCredentialByIdentity[binding.IdentityResource] = fedCred;
         }
     }
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES001 // Pipeline step types used for push/deploy dependency wiring
 #pragma warning disable ASPIREPIPELINES002 // IDeploymentStateManager is experimental
 #pragma warning disable ASPIREAZURE001 // AzureEnvironmentResource.ProvisionInfrastructureStepName for pipeline ordering
+#pragma warning disable ASPIRECOMPUTE002 // Kubernetes persistent-volume resources are experimental
 #pragma warning disable ASPIREFILESYSTEM001 // IFileSystemService/TempDirectory are experimental
 
 using System.Text;
@@ -11,6 +12,8 @@ using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Kubernetes.Annotations;
+using Aspire.Hosting.Kubernetes.Extensions;
 using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
@@ -56,6 +59,17 @@ public partial class AzureKubernetesEnvironmentResource
         // The system pool should only run system pods; application workloads
         // need a user pool.
         var defaultUserPool = EnsureDefaultUserNodePool(this, appModel);
+        var workloadIdentityScope = ResolveWorkloadIdentityScope();
+        foreach (var volume in appModel.Resources.OfType<KubernetesPersistentVolumeResource>())
+        {
+            if (ReferenceEquals(volume.Parent.OwningComputeEnvironment, this) &&
+                volume.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles))
+            {
+                // Scope is finalized only after all fluent configuration has run, so repeat the
+                // eager assignment here to keep WithAzureFileShare/AsExisting call order irrelevant.
+                azureFiles.Identity.Scope = workloadIdentityScope;
+            }
+        }
 
         foreach (var r in appModel.GetComputeResources())
         {
@@ -74,70 +88,120 @@ public partial class AzureKubernetesEnvironmentResource
                 r.Annotations.Add(new KubernetesNodePoolAnnotation(defaultUserPool));
             }
 
-            // Wire workload identity: if the resource has an AppIdentityAnnotation
-            // (auto-created by AzureResourcePreparer or explicit via WithAzureUserAssignedIdentity),
-            // generate a ServiceAccount and wire the pod spec.
-            if (r.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentity))
+            r.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentity);
+            var azureFileVolumes = GetAzureFileVolumes(r);
+
+            // Azure resource references use the workload's app identity. Azure Files volumes use
+            // a volume-specific identity because one static PV has one fixed CSI client ID.
+            if (appIdentity is not null || azureFileVolumes.Count > 0)
             {
-                // Ensure OIDC + workload identity are enabled on the cluster
+                // Ensure OIDC + workload identity are enabled on the cluster.
                 OidcIssuerEnabled = true;
                 WorkloadIdentityEnabled = true;
 
-                var saName = $"{r.Name}-sa";
-                var identityClientId = appIdentity.IdentityResource.ClientId;
+                var saName = $"{r.Name.ToKubernetesResourceName()}-sa";
 
-                // Use KubernetesServiceCustomizationAnnotation to inject SA + pod spec changes
-                // during Helm chart generation.
+                // A bare service account is sufficient for CSI token requests. Add the Azure
+                // Workload Identity annotations only when the application itself uses an identity.
                 r.Annotations.Add(new KubernetesServiceCustomizationAnnotation(kubeResource =>
                 {
-                    // Create ServiceAccount with workload identity annotations
-                    var serviceAccount = new ServiceAccountV1();
-                    serviceAccount.Metadata.Name = saName;
-                    serviceAccount.Metadata.Annotations["azure.workload.identity/client-id"] =
-                        $"{{{{ .Values.parameters.{r.Name}.identityClientId }}}}";
-                    serviceAccount.Metadata.Labels["azure.workload.identity/use"] = "true";
-                    kubeResource.AdditionalResources.Add(serviceAccount);
+                    var existingPodSpec = kubeResource.Workload?.PodTemplate.Spec;
+                    var configuredServiceAccount = !string.IsNullOrEmpty(existingPodSpec?.ServiceAccountName)
+                        ? existingPodSpec.ServiceAccountName
+                        : existingPodSpec?.ServiceAccount;
+                    if (!string.IsNullOrEmpty(configuredServiceAccount) &&
+                        !string.Equals(configuredServiceAccount, saName, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Resource '{r.Name}' uses service account '{configuredServiceAccount}', but Azure workload identity requires the Aspire-managed service account '{saName}'.");
+                    }
 
-                    // Add a placeholder parameter for the identity clientId
-                    // so it appears in values.yaml under parameters.<name>.identityClientId.
-                    // The actual value is resolved at deploy time via CapturedHelmValueProviders.
-                    kubeResource.Parameters["identityClientId"] = new KubernetesResource.HelmValue(
-                        $"{{{{ .Values.parameters.{r.Name}.identityClientId }}}}",
-                        string.Empty);
+                    var serviceAccount = kubeResource.AdditionalResources
+                        .OfType<ServiceAccountV1>()
+                        .SingleOrDefault(resource => string.Equals(resource.Metadata.Name, saName, StringComparison.Ordinal));
+                    if (serviceAccount is null)
+                    {
+                        serviceAccount = new ServiceAccountV1();
+                        serviceAccount.Metadata.Name = saName;
+                        kubeResource.AdditionalResources.Add(serviceAccount);
+                    }
 
-                    // Set serviceAccountName on pod spec and add workload identity label
+                    if (appIdentity is not null)
+                    {
+                        var identityClientIdExpression = "identityClientId".ToHelmParameterExpression(r.Name);
+                        serviceAccount.Metadata.Annotations["azure.workload.identity/client-id"] =
+                            identityClientIdExpression;
+                        serviceAccount.Metadata.Labels["azure.workload.identity/use"] = "true";
+                        kubeResource.Parameters["identityClientId"] = new KubernetesResource.HelmValue(
+                            identityClientIdExpression,
+                            string.Empty);
+                    }
+
                     if (kubeResource.Workload?.PodTemplate is { } podTemplate)
                     {
                         if (podTemplate.Spec is { } podSpec)
                         {
                             podSpec.ServiceAccountName = saName;
+                            podSpec.ServiceAccount = null;
                         }
 
-                        // The workload identity webhook requires this label on the POD
-                        // to inject AZURE_CLIENT_ID, token volume mounts, etc.
-                        podTemplate.Metadata.Labels["azure.workload.identity/use"] = "true";
+                        if (appIdentity is not null)
+                        {
+                            // The webhook injects the application identity environment and token mount.
+                            podTemplate.Metadata.Labels["azure.workload.identity/use"] = "true";
+                        }
                     }
                 }));
 
-                // Wire the identity clientId as a deferred Helm value so it gets
-                // resolved from the Bicep output at deploy time. The SA annotation
-                // references {{ .Values.parameters.<name>.identityClientId }}.
-                if (identityClientId is IValueProvider clientIdProvider)
+                if (appIdentity is not null)
                 {
-                    KubernetesEnvironment.CapturedHelmValueProviders.Add(
-                        new KubernetesEnvironmentResource.CapturedHelmValueProvider(
-                            "parameters",
-                            r.Name,
-                            "identityClientId",
-                            clientIdProvider));
+                    if (appIdentity.IdentityResource.ClientId is IValueProvider clientIdProvider)
+                    {
+                        KubernetesEnvironment.CapturedHelmValueProviders.Add(
+                            new KubernetesEnvironmentResource.CapturedHelmValueProvider(
+                                "parameters",
+                                r.Name.ToHelmValuesSectionName(),
+                                "identityClientId",
+                                clientIdProvider));
+                    }
+
+                    WorkloadIdentities[new AksWorkloadIdentityBindingKey(r.Name, null)] = new AksWorkloadIdentityBinding(
+                        saName,
+                        $"{r.Name}-fedcred",
+                        appIdentity.IdentityResource);
                 }
 
-                // Store the identity reference for federated credential Bicep generation
-                WorkloadIdentities[r.Name] = appIdentity.IdentityResource;
+                foreach (var (volume, volumeIdentity) in azureFileVolumes)
+                {
+                    WorkloadIdentities[new AksWorkloadIdentityBindingKey(r.Name, volume.Name)] = new AksWorkloadIdentityBinding(
+                        saName,
+                        $"{r.Name}-fedcred",
+                        volumeIdentity);
+                }
             }
         }
 
         return Task.CompletedTask;
+    }
+
+    private static List<(KubernetesPersistentVolumeResource Volume, AzureUserAssignedIdentityResource Identity)> GetAzureFileVolumes(IResource resource)
+    {
+        var volumes = new List<(KubernetesPersistentVolumeResource, AzureUserAssignedIdentityResource)>();
+        if (!resource.TryGetAnnotationsOfType<KubernetesPersistentVolumeBindingAnnotation>(out var bindings))
+        {
+            return volumes;
+        }
+
+        foreach (var binding in bindings)
+        {
+            if (binding.Volume.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles) &&
+                !volumes.Any(entry => ReferenceEquals(entry.Item1, binding.Volume)))
+            {
+                volumes.Add((binding.Volume, azureFiles.Identity));
+            }
+        }
+
+        return volumes;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.cs
@@ -166,6 +166,11 @@ public partial class AzureKubernetesEnvironmentResource :
     internal AzureContainerRegistryResource? DefaultContainerRegistry { get; set; }
 
     /// <summary>
+    /// Gets the Azure Storage accounts that back static Azure Files persistent volumes.
+    /// </summary>
+    internal Dictionary<string, AzureStorageResource> AzureFileStorageAccounts { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets the load balancer resources registered against this AKS environment via
     /// <see cref="AzureKubernetesEnvironmentExtensions.AddLoadBalancer"/>. Used by
     /// the Bicep emission to synthesize per-LB role assignments granting the

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Pipelines;
 
@@ -145,10 +146,10 @@ public partial class AzureKubernetesEnvironmentResource :
     internal Dictionary<string, BicepOutputReference> NodePoolSubnets { get; } = [];
 
     /// <summary>
-    /// Gets the workload identity mappings. Key is the resource name, value is the identity resource.
+    /// Gets the workload identity mappings. The key uniquely identifies the identity and service-account binding.
     /// Used to generate federated identity credentials in Bicep.
     /// </summary>
-    internal Dictionary<string, IAppIdentityResource> WorkloadIdentities { get; } = [];
+    internal Dictionary<AksWorkloadIdentityBindingKey, AksWorkloadIdentityBinding> WorkloadIdentities { get; } = [];
 
     /// <summary>
     /// Gets or sets the network profile for the AKS cluster.
@@ -169,6 +170,37 @@ public partial class AzureKubernetesEnvironmentResource :
     /// Gets the Azure Storage accounts that back static Azure Files persistent volumes.
     /// </summary>
     internal Dictionary<string, AzureStorageResource> AzureFileStorageAccounts { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves the resource-group scope used for generated workload identities.
+    /// </summary>
+    internal AzureBicepResourceScope? ResolveWorkloadIdentityScope()
+    {
+        if (Scope is not null)
+        {
+            return Scope;
+        }
+
+        if (!this.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existing) ||
+            existing.ResourceGroup is null)
+        {
+            return null;
+        }
+
+        return existing.Subscription is { } subscription
+            ? new AzureBicepResourceScope(existing.ResourceGroup, subscription)
+            : new AzureBicepResourceScope(existing.ResourceGroup);
+    }
+
+    /// <inheritdoc/>
+    public override string GetBicepTemplateString()
+    {
+        // AKS workload-identity FICs are materialized by a pipeline preparation step, which can
+        // run after dependency discovery first requests the template. Always render current state.
+        using var template = GetBicepTemplateFile();
+
+        return File.ReadAllText(template.Path);
+    }
 
     /// <summary>
     /// Gets the load balancer resources registered against this AKS environment via

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesPersistentVolumeExtensions.cs
@@ -3,8 +3,14 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Kubernetes;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Kubernetes.Annotations;
+using Azure.Provisioning;
+using Azure.Provisioning.Authorization;
+using Azure.Provisioning.Expressions;
+using Azure.Provisioning.Storage;
 
 namespace Aspire.Hosting;
 
@@ -15,6 +21,9 @@ namespace Aspire.Hosting;
 [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public static class AzureKubernetesPersistentVolumeExtensions
 {
+    private const string AzureFileCsiDriver = "file.csi.azure.com";
+    private const string StorageFileDataSmbMiAdminRoleId = "a235d3ee-5935-4cfb-8cc5-a3303ad5995e";
+
     /// <summary>
     /// Adds a Kubernetes PersistentVolumeClaim resource to the application model for the
     /// specified AKS environment.
@@ -59,5 +68,128 @@ public static class AzureKubernetesPersistentVolumeExtensions
 
         var k8sEnvBuilder = builder.ApplicationBuilder.CreateResourceBuilder(builder.Resource.KubernetesEnvironment);
         return k8sEnvBuilder.AddPersistentVolume(name);
+    }
+
+    /// <summary>
+    /// Configures an AKS persistent volume to use an existing Azure file share with
+    /// managed identity authentication.
+    /// </summary>
+    /// <ats-summary>Backs an AKS persistent volume with an Azure file share</ats-summary>
+    /// <param name="builder">The persistent volume resource builder.</param>
+    /// <param name="share">The Azure file share resource builder.</param>
+    /// <returns>The same persistent volume builder for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// The generated Kubernetes persistent volume uses the Azure Files CSI driver and
+    /// authenticates with the AKS kubelet managed identity. No Kubernetes Secret or
+    /// storage account key is generated.
+    /// </para>
+    /// <para>
+    /// The AKS cluster must use Kubernetes 1.34 or later on Linux nodes. Aspire grants
+    /// the kubelet identity the <c>Storage File Data SMB MI Admin</c> role on the storage
+    /// account. Storage accounts provisioned by Aspire enable SMB OAuth and disable shared
+    /// key authentication when Azure Files is added. Existing storage accounts must already
+    /// have those settings configured.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var files = builder.AddAzureStorage("storage").AddFiles("files");
+    /// var share = files.AddFileShare("media-share", "media");
+    ///
+    /// var volume = aks.AddPersistentVolume("media-volume")
+    ///     .WithAzureFileShare(share)
+    ///     .WithCapacity("100Gi");
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<KubernetesPersistentVolumeResource> WithAzureFileShare(
+        this IResourceBuilder<KubernetesPersistentVolumeResource> builder,
+        IResourceBuilder<AzureFileStorageShareResource> share)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(share);
+
+        if (!ReferenceEquals(builder.ApplicationBuilder, share.ApplicationBuilder))
+        {
+            throw new ArgumentException("The persistent volume and Azure file share must belong to the same distributed application.", nameof(share));
+        }
+
+        if (builder.Resource.Parent.OwningComputeEnvironment is not AzureKubernetesEnvironmentResource aks)
+        {
+            throw new InvalidOperationException(
+                $"Persistent volume '{builder.Resource.Name}' must belong to an Azure Kubernetes Service environment before it can use an Azure file share.");
+        }
+
+        var storage = share.Resource.Parent.Parent;
+        if (aks.AzureFileStorageAccounts.TryAdd(storage.Name, storage))
+        {
+            ConfigureKubeletIdentityRoleAssignment(
+                share.ApplicationBuilder.CreateResourceBuilder(storage),
+                aks);
+        }
+
+        var volumeHandle = ReferenceExpression.Create(
+            $"{storage.ResourceGroupName}#{storage.NameOutputReference}#{share.Resource.FileShareName}");
+        var volumeAttributes = new Dictionary<string, ReferenceExpression>(StringComparer.Ordinal)
+        {
+            ["resourceGroup"] = ReferenceExpression.Create($"{storage.ResourceGroupName}"),
+            ["storageAccount"] = ReferenceExpression.Create($"{storage.NameOutputReference}"),
+            ["shareName"] = ReferenceExpression.Create($"{share.Resource.FileShareName}"),
+            ["protocol"] = ReferenceExpression.Create($"smb"),
+            ["mountWithManagedIdentity"] = ReferenceExpression.Create($"true"),
+        };
+
+        builder.WithAnnotation(
+            new KubernetesCsiPersistentVolumeSourceAnnotation(
+                driver: AzureFileCsiDriver,
+                volumeHandle,
+                volumeAttributes,
+                mountOptions:
+                [
+                    "dir_mode=0777",
+                    "file_mode=0777",
+                    "uid=0",
+                    "gid=0",
+                    "mfsymlinks",
+                    "cache=strict",
+                    "nosharesock",
+                    "actimeo=30",
+                    "nobrl",
+                ],
+                defaultStorageClassName: "azurefile-csi",
+                defaultAccessMode: PersistentVolumeAccessMode.ReadWriteMany),
+            ResourceAnnotationMutationBehavior.Replace);
+
+        return builder;
+    }
+
+    private static void ConfigureKubeletIdentityRoleAssignment(
+        IResourceBuilder<AzureStorageResource> storage,
+        AzureKubernetesEnvironmentResource aks)
+    {
+        var normalizedAksName = Infrastructure.NormalizeBicepIdentifier(aks.Name);
+        var principalIdParameterName = $"aksKubeletPrincipalId_{normalizedAksName}";
+        storage.Resource.Parameters[principalIdParameterName] = aks.KubeletIdentityObjectId;
+
+        storage.ConfigureInfrastructure(infrastructure =>
+        {
+            var storageAccount = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
+            var principalId = new ProvisioningParameter(principalIdParameterName, typeof(string));
+            infrastructure.Add(principalId);
+
+            var roleDefinitionId = BicepFunction.GetSubscriptionResourceId(
+                "Microsoft.Authorization/roleDefinitions",
+                StorageFileDataSmbMiAdminRoleId);
+            var roleAssignment = new RoleAssignment($"aksFilesRole_{normalizedAksName}")
+            {
+                Name = BicepFunction.CreateGuid(storageAccount.Id, principalId, roleDefinitionId),
+                Scope = new IdentifierExpression(storageAccount.BicepIdentifier),
+                RoleDefinitionId = roleDefinitionId,
+                PrincipalId = principalId,
+                PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
+            };
+            infrastructure.Add(roleAssignment);
+        });
     }
 }

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesPersistentVolumeExtensions.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.IO.Hashing;
+using System.Text;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -23,6 +26,8 @@ public static class AzureKubernetesPersistentVolumeExtensions
 {
     private const string AzureFileCsiDriver = "file.csi.azure.com";
     private const string StorageFileDataSmbMiAdminRoleId = "a235d3ee-5935-4cfb-8cc5-a3303ad5995e";
+    private const int MaxAspireResourceNameLength = 64;
+    private static readonly TimeSpan s_workloadIdentityHelmTimeout = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// Adds a Kubernetes PersistentVolumeClaim resource to the application model for the
@@ -81,15 +86,24 @@ public static class AzureKubernetesPersistentVolumeExtensions
     /// <remarks>
     /// <para>
     /// The generated Kubernetes persistent volume uses the Azure Files CSI driver and
-    /// authenticates with the AKS kubelet managed identity. No Kubernetes Secret or
-    /// storage account key is generated.
+    /// authenticates with a user-assigned managed identity created for the persistent volume.
+    /// Each workload that mounts the volume is federated to that identity through its Kubernetes
+    /// service account. No Kubernetes Secret or storage account key is generated.
     /// </para>
     /// <para>
-    /// The AKS cluster must use Kubernetes 1.34 or later on Linux nodes. Aspire grants
-    /// the kubelet identity the <c>Storage File Data SMB MI Admin</c> role on the storage
-    /// account. Storage accounts provisioned by Aspire enable SMB OAuth and disable shared
-    /// key authentication when Azure Files is added. Existing storage accounts must already
-    /// have those settings configured.
+    /// The AKS cluster must use Azure Files CSI driver version 1.35.0 or later on Linux nodes.
+    /// Aspire grants the persistent volume identity the <c>Storage File Data SMB MI Admin</c>
+    /// data-plane role scoped to the storage account. This role does not grant Azure Resource
+    /// Manager control-plane permissions, but it applies to every file share in the account.
+    /// Storage accounts provisioned by Aspire enable SMB OAuth and disable shared key
+    /// authentication when Azure Files is added. Existing storage accounts must already have
+    /// those settings configured.
+    /// </para>
+    /// <para>
+    /// Azure infrastructure deployments are incremental. Removing the persistent volume or
+    /// retargeting it to another storage account does not delete the previously provisioned
+    /// identity or role assignment. Remove those resources explicitly, or use
+    /// <c>aspire destroy</c> when the deployment resource group is owned by the application.
     /// </para>
     /// </remarks>
     /// <example>
@@ -122,12 +136,44 @@ public static class AzureKubernetesPersistentVolumeExtensions
         }
 
         var storage = share.Resource.Parent.Parent;
-        if (aks.AzureFileStorageAccounts.TryAdd(storage.Name, storage))
+        aks.AzureFileStorageAccounts.TryAdd(storage.Name, storage);
+        if (aks.KubernetesEnvironment.HelmDeploymentTimeout is not { } timeout ||
+            timeout < s_workloadIdentityHelmTimeout)
         {
-            ConfigureKubeletIdentityRoleAssignment(
-                share.ApplicationBuilder.CreateResourceBuilder(storage),
-                aks);
+            // A newly created federated credential can take longer than Helm's five-minute
+            // default to propagate. The pod cannot become ready until CSI can mount the share.
+            aks.KubernetesEnvironment.HelmDeploymentTimeout = s_workloadIdentityHelmTimeout;
         }
+
+        AzureUserAssignedIdentityResource identity;
+        if (builder.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var existing))
+        {
+            if (!ReferenceEquals(existing.Share, share.Resource))
+            {
+                throw new InvalidOperationException(
+                    $"Persistent volume '{builder.Resource.Name}' is already configured to use Azure file share '{existing.Share.Name}'.");
+            }
+
+            identity = existing.Identity;
+        }
+        else
+        {
+            var identityBuilder = builder.ApplicationBuilder.AddAzureUserAssignedIdentity(GetIdentityResourceName(builder.Resource.Name));
+            identity = identityBuilder.Resource;
+            identity.Scope = aks.ResolveWorkloadIdentityScope();
+            builder.WithAnnotation(
+                new AzureFileSharePersistentVolumeAnnotation(share.Resource, identity),
+                ResourceAnnotationMutationBehavior.Replace);
+
+            ConfigurePersistentVolumeIdentityRoleAssignment(
+                share.ApplicationBuilder.CreateResourceBuilder(storage),
+                identity,
+                builder.Resource.Name);
+        }
+
+        // Dependency discovery can run before workload consumers are converted into FIC
+        // bindings, so record the PV identity relationship eagerly.
+        aks.References.Add(identity);
 
         var volumeHandle = ReferenceExpression.Create(
             $"{storage.ResourceGroupName}#{storage.NameOutputReference}#{share.Resource.FileShareName}");
@@ -137,7 +183,8 @@ public static class AzureKubernetesPersistentVolumeExtensions
             ["storageAccount"] = ReferenceExpression.Create($"{storage.NameOutputReference}"),
             ["shareName"] = ReferenceExpression.Create($"{share.Resource.FileShareName}"),
             ["protocol"] = ReferenceExpression.Create($"smb"),
-            ["mountWithManagedIdentity"] = ReferenceExpression.Create($"true"),
+            ["clientID"] = ReferenceExpression.Create($"{identity.ClientId}"),
+            ["mountWithWorkloadIdentityToken"] = ReferenceExpression.Create($"true"),
         };
 
         builder.WithAnnotation(
@@ -164,24 +211,45 @@ public static class AzureKubernetesPersistentVolumeExtensions
         return builder;
     }
 
-    private static void ConfigureKubeletIdentityRoleAssignment(
-        IResourceBuilder<AzureStorageResource> storage,
-        AzureKubernetesEnvironmentResource aks)
+    private static string GetIdentityResourceName(string volumeName)
     {
-        var normalizedAksName = Infrastructure.NormalizeBicepIdentifier(aks.Name);
-        var principalIdParameterName = $"aksKubeletPrincipalId_{normalizedAksName}";
-        storage.Resource.Parameters[principalIdParameterName] = aks.KubeletIdentityObjectId;
+        const string suffix = "-identity";
+        var identityName = $"{volumeName}{suffix}";
+        if (identityName.Length <= MaxAspireResourceNameLength)
+        {
+            return identityName;
+        }
+
+        // Keep derived resource names deterministic and globally distinguishable when the PV
+        // already uses the full Aspire resource-name budget.
+        var hash = XxHash3.HashToUInt64(Encoding.UTF8.GetBytes(volumeName))
+            .ToString("x16", CultureInfo.InvariantCulture)[..8];
+        var prefixLength = MaxAspireResourceNameLength - suffix.Length - hash.Length - 1;
+        var prefix = volumeName[..prefixLength].TrimEnd('-');
+        return $"{prefix}-{hash}{suffix}";
+    }
+
+    private static void ConfigurePersistentVolumeIdentityRoleAssignment(
+        IResourceBuilder<AzureStorageResource> storage,
+        AzureUserAssignedIdentityResource identity,
+        string volumeName)
+    {
+        var normalizedVolumeName = Infrastructure.NormalizeBicepIdentifier(volumeName);
+        var principalIdParameterName = $"azureFilesIdentityPrincipalId_{normalizedVolumeName}";
+        storage.Resource.Parameters[principalIdParameterName] = identity.PrincipalId;
 
         storage.ConfigureInfrastructure(infrastructure =>
         {
-            var storageAccount = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
+            var storageAccount = infrastructure.GetProvisionableResources()
+                .OfType<StorageAccount>()
+                .Single();
             var principalId = new ProvisioningParameter(principalIdParameterName, typeof(string));
             infrastructure.Add(principalId);
 
             var roleDefinitionId = BicepFunction.GetSubscriptionResourceId(
                 "Microsoft.Authorization/roleDefinitions",
                 StorageFileDataSmbMiAdminRoleId);
-            var roleAssignment = new RoleAssignment($"aksFilesRole_{normalizedAksName}")
+            var roleAssignment = new RoleAssignment($"azureFilesRole_{normalizedVolumeName}")
             {
                 Name = BicepFunction.CreateGuid(storageAccount.Id, principalId, roleDefinitionId),
                 Scope = new IdentifierExpression(storageAccount.BicepIdentifier),

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -68,8 +68,9 @@ When no storage class is specified, the generated claim uses the cluster's defau
 #### Azure file shares
 
 Use a statically provisioned Azure file share for shared, persistent storage. This
-uses the AKS kubelet managed identity and does not create a Kubernetes Secret or
-use a storage account key.
+creates one managed identity per persistent volume and federates each consuming
+workload's Kubernetes service account to it. It does not create a Kubernetes Secret,
+grant storage access to the kubelet identity, or use a storage account key.
 
 **C#**
 
@@ -98,10 +99,18 @@ await media.withCapacity("100Gi");
 await myService.withKubernetesPersistentVolumeMount(media, "/srv/media");
 ```
 
-Managed identity mounts require AKS 1.34 or later on Linux nodes. Storage accounts
-created by Aspire enable SMB OAuth and disable shared key authentication. Existing
-storage accounts and file shares are not modified and must already meet those
-authentication requirements.
+Workload identity mounts require Azure Files CSI driver version 1.35.0 or later on
+Linux nodes. Aspire grants the volume identity a data-plane-only role at storage-account
+scope; the role has no Azure Resource Manager control-plane permissions but applies to every
+file share in that account. Use separate storage accounts when volumes require independent
+data-access boundaries. Storage accounts created by Aspire enable SMB OAuth and disable shared
+key authentication. Existing storage accounts and file shares are not modified and must already
+meet those authentication requirements.
+
+Azure infrastructure deployments are incremental. Removing a persistent volume or retargeting
+it to another storage account does not remove its previous managed identity or role assignment.
+Remove those resources explicitly, or run `aspire destroy` when the application owns the
+deployment resource group.
 
 ## Additional documentation
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/README.md
+++ b/src/Aspire.Hosting.Azure.Kubernetes/README.md
@@ -65,6 +65,44 @@ await myService.withKubernetesPersistentVolumeMount(data, "/data");
 
 When no storage class is specified, the generated claim uses the cluster's default storage class. A standard AKS cluster dynamically provisions an Azure managed disk. To request Premium SSD storage explicitly, call `WithStorageClass("managed-csi-premium")` in C# or `withStorageClass("managed-csi-premium")` in TypeScript.
 
+#### Azure file shares
+
+Use a statically provisioned Azure file share for shared, persistent storage. This
+uses the AKS kubelet managed identity and does not create a Kubernetes Secret or
+use a storage account key.
+
+**C#**
+
+```csharp
+var files = builder.AddAzureStorage("storage").AddFiles("files");
+var share = files.AddFileShare("media-share", "media");
+
+var media = aks.AddPersistentVolume("media-volume")
+    .WithAzureFileShare(share)
+    .WithCapacity("100Gi");
+
+myService.WithPersistentVolume(media, "/srv/media");
+```
+
+**TypeScript**
+
+```typescript
+const storage = await builder.addAzureStorage("storage");
+const files = await storage.addFiles("files");
+const share = await files.addFileShare("media-share", { fileShareName: "media" });
+
+const media = await aks.addPersistentVolume("media-volume");
+await media.withAzureFileShare(share);
+await media.withCapacity("100Gi");
+
+await myService.withKubernetesPersistentVolumeMount(media, "/srv/media");
+```
+
+Managed identity mounts require AKS 1.34 or later on Linux nodes. Storage accounts
+created by Aspire enable SMB OAuth and disable shared key authentication. Existing
+storage accounts and file shares are not modified and must already meet those
+authentication requirements.
+
 ## Additional documentation
 
 * https://aspire.dev/integrations/gallery/

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -4,6 +4,8 @@
     <!-- This project needs to multi-target to net9.0 as well to avoid hitting NuGet Restore issues when package is restored from a net9+ project and avoid NU1605 downgrade errors. -->
     <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <!-- Transitive through Aspire.Hosting.Azure.Storage; remove when Azure.Provisioning.Storage 1.2.0 ships stable. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
     <PackageTags>aspire integration hosting azure sql database data cloud</PackageTags>
     <Description>Azure SQL Database resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSqlServer_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure storage blob queue table cloud</PackageTags>
+    <PackageTags>aspire integration hosting azure storage blob files queue table cloud</PackageTags>
     <Description>Azure Storage resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureStorageContainer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <!-- Remove when Azure.Provisioning.Storage 1.2.0 ships stable. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
     <PackageTags>aspire integration hosting azure storage blob files queue table cloud</PackageTags>
     <Description>Azure Storage resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureStorageContainer_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure.Storage/AzureFileStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureFileStorageResource.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents the Azure Files service in an Azure Storage account.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="storage">The Azure Storage account that contains the Files service.</param>
+public class AzureFileStorageResource(string name, AzureStorageResource storage) : Resource(name),
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureStorageResource>,
+    IAzurePrivateEndpointTarget
+{
+    /// <summary>
+    /// Gets the parent Azure Storage account.
+    /// </summary>
+    public AzureStorageResource Parent => storage ?? throw new ArgumentNullException(nameof(storage));
+
+    /// <summary>
+    /// Gets the connection URI expression for the Azure Files service.
+    /// </summary>
+    public ReferenceExpression UriExpression => Parent.FileUriExpression;
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure Files service.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.GetFileConnectionString();
+
+    internal ReferenceExpression GetConnectionString(string? fileShareName)
+    {
+        if (string.IsNullOrEmpty(fileShareName))
+        {
+            return ConnectionStringExpression;
+        }
+
+        ReferenceExpressionBuilder builder = new();
+        builder.Append($"Endpoint={ConnectionStringExpression}");
+        builder.Append($";FileShareName={fileShareName}");
+
+        return builder.Build();
+    }
+
+    BicepOutputReference IAzurePrivateEndpointTarget.Id => Parent.Id;
+
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateLinkGroupIds() => ["file"];
+
+    IEnumerable<string> IAzurePrivateEndpointTarget.GetPrivateDnsZoneNames() => ["privatelink.file.core.windows.net"];
+
+    IEnumerable<KeyValuePair<string, ReferenceExpression>> IResourceWithConnectionString.GetConnectionProperties()
+    {
+        yield return new("Uri", UriExpression);
+    }
+}

--- a/src/Aspire.Hosting.Azure.Storage/AzureFileStorageShareResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureFileStorageShareResource.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning;
+using ProvisioningFileShare = Azure.Provisioning.Storage.FileShare;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an Azure file share.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="fileShareName">The name of the Azure file share.</param>
+/// <param name="parent">The Azure Files service that contains the share.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, FileShare = {FileShareName}")]
+public class AzureFileStorageShareResource(string name, string fileShareName, AzureFileStorageResource parent) : Resource(name),
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureFileStorageResource>
+{
+    /// <summary>
+    /// Gets the name of the Azure file share.
+    /// </summary>
+    public string FileShareName { get; } = ThrowIfNullOrEmpty(fileShareName);
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure file share.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.GetConnectionString(FileShareName);
+
+    /// <summary>
+    /// Gets the parent Azure Files service.
+    /// </summary>
+    public AzureFileStorageResource Parent => parent ?? throw new ArgumentNullException(nameof(parent));
+
+    internal ProvisioningFileShare ToProvisioningEntity(bool isExisting)
+    {
+        var identifier = Infrastructure.NormalizeBicepIdentifier(Name);
+        var fileShare = isExisting
+            ? ProvisioningFileShare.FromExisting(identifier)
+            : new ProvisioningFileShare(identifier);
+        fileShare.Name = FileShareName;
+
+        return fileShare;
+    }
+
+    private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+        return argument;
+    }
+
+    IEnumerable<KeyValuePair<string, ReferenceExpression>> IResourceWithConnectionString.GetConnectionProperties()
+    {
+        foreach (var property in ((IResourceWithConnectionString)Parent).GetConnectionProperties())
+        {
+            yield return property;
+        }
+
+        yield return new("FileShareName", ReferenceExpression.Create($"{FileShareName}"));
+    }
+}

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -7,6 +7,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Storage;
 using Azure.Provisioning;
+using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
@@ -20,20 +21,24 @@ namespace Aspire.Hosting;
 public static class AzureStorageExtensions
 {
     private const string SkipApiVersionCheckArgument = "--skipApiVersionCheck";
+    private static readonly RoleDefinition s_fileStorageContributorRole = new(
+        StorageBuiltInRole.StorageFileDataSmbShareContributor.ToString(),
+        StorageBuiltInRole.GetBuiltInRoleName(StorageBuiltInRole.StorageFileDataSmbShareContributor));
 
     /// <summary>
-    /// Adds an Azure Storage resource to the application model. This resource can be used to create Azure blob, table, and queue resources.
+    /// Adds an Azure Storage resource to the application model. This resource can be used to create Azure Blob, Files, Queue, Table, and Data Lake resources.
     /// </summary>
     /// <param name="builder">The builder for the distributed application.</param>
     /// <param name="name">The name of the resource.</param>
     /// <returns></returns>
     /// <remarks>
-    /// By default references to the Azure Storage resource will be assigned the following roles:
-    /// 
-    /// - <see cref="StorageBuiltInRole.StorageBlobDataContributor"/>
-    /// - <see cref="StorageBuiltInRole.StorageTableDataContributor"/>
-    /// - <see cref="StorageBuiltInRole.StorageQueueDataContributor"/>
-    ///
+    /// By default, references to the Azure Storage resource are assigned the following roles:
+    /// <list type="bullet">
+    /// <item><description><see cref="StorageBuiltInRole.StorageBlobDataContributor"/></description></item>
+    /// <item><description><see cref="StorageBuiltInRole.StorageTableDataContributor"/></description></item>
+    /// <item><description><see cref="StorageBuiltInRole.StorageQueueDataContributor"/></description></item>
+    /// </list>
+    /// Adding an Azure Files resource also adds <see cref="StorageBuiltInRole.StorageFileDataSmbShareContributor"/>.
     /// These can be replaced by calling <see cref="WithRoleAssignments{T}(IResourceBuilder{T}, IResourceBuilder{AzureStorageResource}, StorageBuiltInRole[])"/>.
     /// </remarks>
     /// <ats-remarks />
@@ -84,6 +89,17 @@ public static class AzureStorageExtensions
                         AllowSharedKeyAccess = false,
                         Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
                     };
+
+                    if (azureResource.IsFileStorageEnabled)
+                    {
+                        // Azure Files managed identity authentication requires SMB OAuth on the
+                        // account. Shared key access remains disabled by the account default above.
+                        storageAccount.AzureFilesIdentityBasedAuthentication = new FilesIdentityBasedAuthentication
+                        {
+                            DirectoryServiceOptions = DirectoryServiceOption.None,
+                            IsSmbOAuthEnabled = true
+                        };
+                    }
 
                     // When using private endpoints, completely disable public network access.
                     if (hasPrivateEndpoint)
@@ -136,6 +152,22 @@ public static class AzureStorageExtensions
                 }
             }
 
+            if (azureResource.FileShares.Count > 0)
+            {
+                var fileService = storageAccount.IsExistingResource
+                    ? FileService.FromExisting("files")
+                    : new FileService("files");
+                fileService.Parent = storageAccount;
+                infrastructure.Add(fileService);
+
+                foreach (var share in azureResource.FileShares)
+                {
+                    var provisionedShare = share.ToProvisioningEntity(storageAccount.IsExistingResource);
+                    provisionedShare.Parent = fileService;
+                    infrastructure.Add(provisionedShare);
+                }
+            }
+
             // TODO: When Tables are added, change this check to use Count > 0
             if (azureResource.TableStorageBuilder is not null)
             {
@@ -151,9 +183,11 @@ public static class AzureStorageExtensions
             infrastructure.Add(new ProvisioningOutput("dataLakeEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.DfsUri.ToBicepExpression() });
             infrastructure.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.QueueUri.ToBicepExpression() });
             infrastructure.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.TableUri.ToBicepExpression() });
+            infrastructure.Add(new ProvisioningOutput("fileEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.FileUri.ToBicepExpression() });
 
             // We need to output name to externalize role assignments.
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = storageAccount.Name.ToBicepExpression() });
+            infrastructure.Add(new ProvisioningOutput("resourceGroupName", typeof(string)) { Value = BicepFunction.GetResourceGroup().Name });
             infrastructure.Add(new ProvisioningOutput("id", typeof(string)) { Value = storageAccount.Id });
         };
 
@@ -185,6 +219,10 @@ public static class AzureStorageExtensions
         if (builder.Resource.IsHnsEnabled)
         {
             throw new InvalidOperationException("Emulator currently does not support data lake.");
+        }
+        if (builder.Resource.IsFileStorageEnabled)
+        {
+            throw new InvalidOperationException("Emulator currently does not support file storage.");
         }
 
         if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
@@ -432,6 +470,47 @@ public static class AzureStorageExtensions
     }
 
     /// <summary>
+    /// Adds an Azure Files service resource to the application model.
+    /// </summary>
+    /// <param name="builder">The Azure Files resource builder.</param>
+    /// <param name="name">The name of the Azure Files resource.</param>
+    /// <returns>A builder for the Azure Files resource.</returns>
+    /// <remarks>
+    /// Storage accounts provisioned by Aspire enable SMB OAuth and disable shared key access.
+    /// Existing storage accounts are not modified and must already have the required authentication settings.
+    /// The local Azure Storage emulator does not support Azure Files.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var files = builder.AddAzureStorage("storage")
+    ///     .AddFiles("files");
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<AzureFileStorageResource> AddFiles(
+        this IResourceBuilder<AzureStorageResource> builder,
+        [ResourceName] string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        if (builder.Resource.IsEmulator)
+        {
+            throw new InvalidOperationException("Emulator currently does not support file storage.");
+        }
+
+        builder.Resource.IsFileStorageEnabled = true;
+        AddFileStorageDefaultRoleAssignment(builder);
+
+        if (string.Equals(name, builder.Resource.Name + "-files", StringComparisons.ResourceName))
+        {
+            return GetFileService(builder);
+        }
+
+        return CreateFileService(builder, name);
+    }
+
+    /// <summary>
     /// Creates a builder for the <see cref="AzureBlobStorageResource"/> which can be referenced to get the Azure Storage blob endpoint for the storage account.
     /// </summary>
     /// <param name="builder">The <see cref="IResourceBuilder{T}"/> for <see cref="AzureStorageResource"/>.</param>
@@ -470,6 +549,15 @@ public static class AzureStorageExtensions
         var name = builder.Resource.Name + "-data-lake";
 
         return builder.Resource.DataLakeStorageBuilder ??= CreateDataLakeService(builder, name);
+    }
+
+    private static IResourceBuilder<AzureFileStorageResource> GetFileService(this IResourceBuilder<AzureStorageResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var name = builder.Resource.Name + "-files";
+
+        return builder.Resource.FileStorageBuilder ??= CreateFileService(builder, name);
     }
 
     /// <summary>
@@ -535,6 +623,47 @@ public static class AzureStorageExtensions
         var parentBuilder = builder.Resource.ImplicitDataLakeService ??= GetDataLakeService(builder);
         AzureDataLakeStorageFileSystemResource resource = new(name, dataLakeFileSystemName, parentBuilder.Resource);
         builder.Resource.DataLakeFileSystems.Add(resource);
+
+        return builder.ApplicationBuilder
+            .AddResource(resource)
+            .WithIconName("FolderOpen");
+    }
+
+    /// <summary>
+    /// Adds an Azure file share resource to the application model.
+    /// </summary>
+    /// <param name="builder">The Azure Storage resource builder.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="fileShareName">The name of the Azure file share. Defaults to <paramref name="name"/>.</param>
+    /// <returns>A builder for the Azure file share resource.</returns>
+    /// <remarks>
+    /// When the parent storage account is configured as an existing resource, the generated infrastructure references an existing file share with <paramref name="fileShareName"/> instead of creating one.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var files = builder.AddAzureStorage("storage")
+    ///     .AddFiles("files");
+    /// var share = files.AddFileShare("media");
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<AzureFileStorageShareResource> AddFileShare(
+        this IResourceBuilder<AzureFileStorageResource> builder,
+        [ResourceName] string name,
+        string? fileShareName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        if (builder.Resource.Parent.IsEmulator)
+        {
+            throw new InvalidOperationException("Emulator currently does not support file storage.");
+        }
+
+        fileShareName ??= name;
+
+        AzureFileStorageShareResource resource = new(name, fileShareName, builder.Resource);
+        builder.Resource.Parent.FileShares.Add(resource);
 
         return builder.ApplicationBuilder
             .AddResource(resource)
@@ -826,6 +955,36 @@ public static class AzureStorageExtensions
         return builder.ApplicationBuilder
             .AddResource(resource)
             .WithIconName("HardDrive");
+    }
+
+    private static IResourceBuilder<AzureFileStorageResource> CreateFileService(IResourceBuilder<AzureStorageResource> builder, string name)
+    {
+        var resource = new AzureFileStorageResource(name, builder.Resource);
+
+        return builder.ApplicationBuilder
+            .AddResource(resource)
+            .WithIconName("Folder");
+    }
+
+    private static void AddFileStorageDefaultRoleAssignment(IResourceBuilder<AzureStorageResource> builder)
+    {
+        var annotations = builder.Resource.Annotations
+            .OfType<DefaultRoleAssignmentsAnnotation>()
+            .ToList();
+        if (annotations.Count == 0 || annotations[^1].Roles.Contains(s_fileStorageContributorRole))
+        {
+            return;
+        }
+
+        var roles = annotations[^1].Roles.ToHashSet();
+        roles.Add(s_fileStorageContributorRole);
+
+        foreach (var annotation in annotations)
+        {
+            builder.Resource.Annotations.Remove(annotation);
+        }
+
+        builder.Resource.Annotations.Add(new DefaultRoleAssignmentsAnnotation(roles));
     }
 
     private static IResourceBuilder<AzureTableStorageResource> CreateTableService(IResourceBuilder<AzureStorageResource> builder, string name)

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -30,13 +30,13 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     internal IResourceBuilder<AzureQueueStorageResource>? QueueStorageBuilder { get; set; }
     internal IResourceBuilder<AzureTableStorageResource>? TableStorageBuilder { get; set; }
     internal IResourceBuilder<AzureDataLakeStorageResource>? DataLakeStorageBuilder { get; set; }
+    internal IResourceBuilder<AzureFileStorageResource>? FileStorageBuilder { get; set; }
 
-    // Implicit parent selection for child resources (containers, queues, file systems)
-    // added without an explicit parent service. Set to the first blob/queue/data-lake
-    // service created via AddBlobs/AddQueues/AddDataLake, regardless of whether the
-    // user chose a custom name or the default. Used so that AddBlobContainer /
-    // AddQueue / AddDataLakeFileSystem don't auto-create a duplicate default-named
-    // service when the user has already added their own.
+    // Implicit parent selection for child resources (containers, queues, file systems,
+    // and file shares) added without an explicit parent service. Set to the first
+    // corresponding service created by the user, regardless of whether they chose a
+    // custom name or the default. This prevents child helpers from auto-creating a
+    // duplicate default-named service.
     internal IResourceBuilder<AzureBlobStorageResource>? ImplicitBlobService { get; set; }
     internal IResourceBuilder<AzureQueueStorageResource>? ImplicitQueueService { get; set; }
     internal IResourceBuilder<AzureDataLakeStorageResource>? ImplicitDataLakeService { get; set; }
@@ -47,7 +47,11 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
 
     internal List<AzureQueueStorageQueueResource> Queues { get; } = [];
 
+    internal List<AzureFileStorageShareResource> FileShares { get; } = [];
+
     internal bool IsHnsEnabled { get; set; }
+
+    internal bool IsFileStorageEnabled { get; set; }
 
     /// <summary>
     /// Gets the "blobEndpoint" output reference from the bicep template for the Azure Storage resource.
@@ -70,6 +74,11 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     public BicepOutputReference DataLakeEndpoint => new("dataLakeEndpoint", this);
 
     /// <summary>
+    /// Gets the "fileEndpoint" output reference from the Bicep template for the Azure Storage resource.
+    /// </summary>
+    public BicepOutputReference FileEndpoint => new("fileEndpoint", this);
+
+    /// <summary>
     /// Gets the "id" output reference for the resource.
     /// </summary>
     public BicepOutputReference Id => new("id", this);
@@ -78,6 +87,11 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     /// Gets the "name" output reference for the resource.
     /// </summary>
     public BicepOutputReference NameOutputReference => new("name", this);
+
+    /// <summary>
+    /// Gets the resource group name output reference for the Azure Storage account.
+    /// </summary>
+    public BicepOutputReference ResourceGroupName => new("resourceGroupName", this);
 
     /// <summary>
     /// Gets a value indicating whether the Azure Storage resource is running in the local emulator.
@@ -103,6 +117,16 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     public ReferenceExpression DataLakeUriExpression => IsEmulator
         ? throw new InvalidOperationException("Emulator currently does not support data lake.")
         : ReferenceExpression.Create($"{DataLakeEndpoint}");
+
+    /// <summary>
+    /// Gets the connection URI expression for the Azure Files service.
+    /// </summary>
+    /// <remarks>
+    /// Format: <c>{fileEndpoint}</c> for Azure. The local storage emulator does not support Azure Files.
+    /// </remarks>
+    public ReferenceExpression FileUriExpression => IsEmulator
+        ? throw new InvalidOperationException("Emulator currently does not support file storage.")
+        : ReferenceExpression.Create($"{FileEndpoint}");
 
     /// <summary>
     /// Gets the connection URI expression for the queue storage service.
@@ -147,6 +171,10 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     internal ReferenceExpression GetDataLakeConnectionString() => IsEmulator
         ? throw new InvalidOperationException("Emulator currently does not support data lake.")
         : ReferenceExpression.Create($"{DataLakeEndpoint}");
+
+    internal ReferenceExpression GetFileConnectionString() => IsEmulator
+        ? throw new InvalidOperationException("Emulator currently does not support file storage.")
+        : ReferenceExpression.Create($"{FileEndpoint}");
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
     {

--- a/src/Aspire.Hosting.Azure.Storage/README.md
+++ b/src/Aspire.Hosting.Azure.Storage/README.md
@@ -33,7 +33,7 @@ aspire secret set Azure:Location "<azure location>"
 
 ## Usage example
 
-In the AppHost, add a Blob (can use tables or queues also) Storage connection and reference it from another resource with either C# or TypeScript:
+In the AppHost, add a Blob (files, tables, or queues can also be used) Storage connection and reference it from another resource with either C# or TypeScript:
 
 **C#**
 
@@ -87,6 +87,34 @@ builder.AddProject<Projects.MyService>()
 
 This approach allows you to define and reference specific blob containers and queues as first-class resources in your AppHost model.
 
+## Creating and using Azure Files
+
+Azure Files uses managed identity authentication by default. Newly provisioned storage accounts enable SMB OAuth and disable shared key access.
+
+```csharp
+var storage = builder.AddAzureStorage("storage");
+var files = storage.AddFiles("files");
+var share = files.AddFileShare("media");
+```
+
+```typescript
+const storage = await builder.addAzureStorage("storage");
+const files = await storage.addFiles("files");
+const share = await files.addFileShare("media");
+```
+
+The Files service and file share can be referenced independently:
+
+```csharp
+api.WithReference(files).WithReference(share);
+```
+
+```typescript
+await api.withReference(files).withReference(share);
+```
+
+The local Azure Storage emulator does not support Azure Files.
+
 ## Creating and using data lake
 ```csharp
 var storage = builder.AddAzureStorage("azure-storage");
@@ -134,6 +162,24 @@ The Data Lake Storage resource exposes the following connection properties:
 | `Uri` | The URI of the data lake storage service, with the format `https://mystorageaccount.dfs.core.windows.net/` |
 
 Emulator currently does not support data lake storage.
+
+### Azure Files
+
+The Azure Files resource exposes the following connection properties:
+
+| Property Name | Description |
+|---------------|-------------|
+| `Uri` | The URI of the Azure Files service, with the format `https://mystorageaccount.file.core.windows.net/` |
+
+The local Azure Storage emulator does not support Azure Files.
+
+### Azure File Share
+
+The Azure File Share resource inherits all properties from its parent `AzureFileStorageResource` and adds:
+
+| Property Name | Description |
+|---------------|-------------|
+| `FileShareName` | The name of the Azure file share |
 
 ### Data Lake File System
 

--- a/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesCsiPersistentVolumeSourceAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesCsiPersistentVolumeSourceAnnotation.cs
@@ -24,7 +24,7 @@ namespace Aspire.Hosting.Kubernetes.Annotations;
 /// reference infrastructure outputs without materializing them into published artifacts.
 /// </remarks>
 [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-public sealed class KubernetesCsiPersistentVolumeSourceAnnotation(
+internal sealed class KubernetesCsiPersistentVolumeSourceAnnotation(
     string driver,
     ReferenceExpression volumeHandle,
     IReadOnlyDictionary<string, ReferenceExpression> volumeAttributes,

--- a/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesCsiPersistentVolumeSourceAnnotation.cs
+++ b/src/Aspire.Hosting.Kubernetes/Annotations/KubernetesCsiPersistentVolumeSourceAnnotation.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Kubernetes.Annotations;
+
+/// <summary>
+/// Configures a <see cref="KubernetesPersistentVolumeResource"/> with a statically
+/// provisioned Container Storage Interface (CSI) backing volume.
+/// </summary>
+/// <param name="driver">The CSI driver name.</param>
+/// <param name="volumeHandle">The unique volume identifier understood by the CSI driver.</param>
+/// <param name="volumeAttributes">Driver-specific volume attributes.</param>
+/// <param name="mountOptions">Options passed to the filesystem mount operation.</param>
+/// <param name="reclaimPolicy">The reclaim policy for the generated persistent volume.</param>
+/// <param name="readOnly">Whether the CSI volume is read-only.</param>
+/// <param name="fileSystemType">The filesystem type to mount, or <see langword="null"/> to let the driver choose.</param>
+/// <param name="defaultStorageClassName">The storage class name used when the volume resource does not specify one.</param>
+/// <param name="defaultAccessMode">The access mode used when the volume resource does not specify one.</param>
+/// <remarks>
+/// Values remain deferred until deployment, allowing deployment-target integrations to
+/// reference infrastructure outputs without materializing them into published artifacts.
+/// </remarks>
+[Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class KubernetesCsiPersistentVolumeSourceAnnotation(
+    string driver,
+    ReferenceExpression volumeHandle,
+    IReadOnlyDictionary<string, ReferenceExpression> volumeAttributes,
+    IReadOnlyList<string>? mountOptions = null,
+    PersistentVolumeReclaimPolicy reclaimPolicy = PersistentVolumeReclaimPolicy.Retain,
+    bool readOnly = false,
+    string? fileSystemType = null,
+    string? defaultStorageClassName = null,
+    PersistentVolumeAccessMode? defaultAccessMode = null) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the CSI driver name.
+    /// </summary>
+    public string Driver { get; } = string.IsNullOrWhiteSpace(driver)
+        ? throw new ArgumentException("The CSI driver name cannot be empty.", nameof(driver))
+        : driver;
+
+    /// <summary>
+    /// Gets the unique volume identifier understood by the CSI driver.
+    /// </summary>
+    public ReferenceExpression VolumeHandle { get; } = volumeHandle ?? throw new ArgumentNullException(nameof(volumeHandle));
+
+    /// <summary>
+    /// Gets the driver-specific volume attributes.
+    /// </summary>
+    public IReadOnlyDictionary<string, ReferenceExpression> VolumeAttributes { get; } =
+        ValidateVolumeAttributes(volumeAttributes);
+
+    /// <summary>
+    /// Gets the options passed to the filesystem mount operation.
+    /// </summary>
+    public IReadOnlyList<string> MountOptions { get; } = mountOptions?.ToArray() ?? [];
+
+    /// <summary>
+    /// Gets the reclaim policy for the generated persistent volume.
+    /// </summary>
+    public PersistentVolumeReclaimPolicy ReclaimPolicy { get; } = reclaimPolicy;
+
+    /// <summary>
+    /// Gets a value indicating whether the CSI volume is read-only.
+    /// </summary>
+    public bool ReadOnly { get; } = readOnly;
+
+    /// <summary>
+    /// Gets the filesystem type to mount, or <see langword="null"/> to let the driver choose.
+    /// </summary>
+    public string? FileSystemType { get; } = fileSystemType;
+
+    /// <summary>
+    /// Gets the storage class name used when the volume resource does not specify one.
+    /// </summary>
+    public string? DefaultStorageClassName { get; } = defaultStorageClassName;
+
+    /// <summary>
+    /// Gets the access mode used when the volume resource does not specify one.
+    /// </summary>
+    public PersistentVolumeAccessMode? DefaultAccessMode { get; } = defaultAccessMode;
+
+    private static IReadOnlyDictionary<string, ReferenceExpression> ValidateVolumeAttributes(
+        IReadOnlyDictionary<string, ReferenceExpression> volumeAttributes)
+    {
+        ArgumentNullException.ThrowIfNull(volumeAttributes);
+
+        var result = new Dictionary<string, ReferenceExpression>(StringComparer.Ordinal);
+        foreach (var (key, value) in volumeAttributes)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(key);
+            ArgumentNullException.ThrowIfNull(value);
+            result.Add(key, value);
+        }
+
+        return result;
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/Deployment/HelmDeploymentEngine.cs
+++ b/src/Aspire.Hosting.Kubernetes/Deployment/HelmDeploymentEngine.cs
@@ -437,6 +437,10 @@ internal static partial class HelmDeploymentEngine
                 arguments.Append(CultureInfo.InvariantCulture, $" --namespace {@namespace}");
                 arguments.Append(" --create-namespace");
                 arguments.Append(" --wait");
+                if (environment.HelmDeploymentTimeout is { } timeout)
+                {
+                    arguments.Append(CultureInfo.InvariantCulture, $" --timeout {(long)Math.Ceiling(timeout.TotalSeconds)}s");
+                }
 
                 if (environment.KubeConfigPath is not null)
                 {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -69,6 +69,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     internal string HelmChartDescription { get; set; } = "Aspire Helm Chart";
 
     /// <summary>
+    /// Gets or sets an optional timeout for Helm deployment readiness.
+    /// </summary>
+    internal TimeSpan? HelmDeploymentTimeout { get; set; }
+
+    /// <summary>
     /// Determines whether to include an Aspire dashboard for telemetry visualization in this environment.
     /// </summary>
     public bool DashboardEnabled { get; set; } = true;

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -600,8 +600,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     }
 
     /// <summary>
-    /// Resolves a <see cref="ReferenceExpression"/> for inclusion in a Kubernetes manifest
-    /// produced by an ingress or gateway resource. When the expression wraps one or more
+    /// Resolves a <see cref="ReferenceExpression"/> for inclusion in a generated Kubernetes
+    /// manifest. When the expression wraps one or more
     /// <see cref="ParameterResource"/> instances that must remain deploy-time inputs
     /// (for example, secrets or parameters without published defaults), the expression is
     /// rendered with Helm template placeholders (such as <c>{{ .Values.parameters.ingress.ingressclass }}</c>)
@@ -609,14 +609,16 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     /// </summary>
     /// <param name="expression">The reference expression to resolve.</param>
     /// <param name="owningResourceName">
-    /// The name of the resource (ingress or gateway) that owns this expression. Used as the
+    /// The name of the resource that owns this expression. Used as the
     /// scoping segment in the generated Helm parameter path so multiple ingress/gateway resources
     /// can reuse the same parameter name without collision.
     /// </param>
     /// <param name="cancellationToken">The cancellation token.</param>
     private async Task<string> ResolveExpressionAsync(ReferenceExpression expression, string owningResourceName, CancellationToken cancellationToken)
     {
-        if (!expression.ValueProviders.OfType<ParameterResource>().Any(ShouldCaptureAsHelmValue))
+        var hasDeferredValueProvider = expression.ValueProviders.Any(IsDeferredValueProvider);
+        if (!hasDeferredValueProvider &&
+            !expression.ValueProviders.OfType<ParameterResource>().Any(ShouldCaptureAsHelmValue))
         {
             try
             {
@@ -685,6 +687,32 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 : valueKey.ToHelmParameterExpression(owningResourceName);
         }
 
+        if (IsDeferredValueProvider(valueProvider) &&
+            valueProvider is IManifestExpressionProvider expressionProvider)
+        {
+            var valueKey = expressionProvider.ValueExpression
+                .Replace(HelmExtensions.StartDelimiter, string.Empty)
+                .Replace(HelmExtensions.EndDelimiter, string.Empty)
+                .Replace("{", string.Empty)
+                .Replace("}", string.Empty)
+                .Replace(".", "_")
+                .ToHelmValuesSectionName();
+
+            if (!CapturedHelmValueProviders.Any(c =>
+                    c.Section == HelmExtensions.ConfigKey &&
+                    c.ResourceKey == owningResourceKey &&
+                    c.ValueKey == valueKey))
+            {
+                CapturedHelmValueProviders.Add(new CapturedHelmValueProvider(
+                    HelmExtensions.ConfigKey,
+                    owningResourceKey,
+                    valueKey,
+                    valueProvider));
+            }
+
+            return valueKey.ToHelmConfigExpression(owningResourceName);
+        }
+
         // For non-ParameterResource providers (string literals, endpoint references, etc.)
         // resolve normally. If a nested provider throws MissingParameterValueException
         // we intentionally let it propagate: silently substituting an empty string here
@@ -696,6 +724,12 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
     private static bool ShouldCaptureAsHelmValue(ParameterResource parameter)
         => parameter.Secret || parameter.Default is null;
+
+    private static bool IsDeferredValueProvider(IValueProvider valueProvider)
+        => valueProvider is IManifestExpressionProvider
+            and not ParameterResource
+            and not EndpointReference
+            and not EndpointReferenceExpression;
 
     private async Task<List<string>> ResolveHostnamesAsync(
         IEnumerable<ReferenceExpression> hostnames,
@@ -989,6 +1023,9 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         foreach (var volumeResource in volumeResources)
         {
             volumeResource.GeneratedClaim = await BuildPersistentVolumeClaim(volumeResource, cancellationToken).ConfigureAwait(false);
+            volumeResource.GeneratedVolume = volumeResource.TryGetLastAnnotation<KubernetesCsiPersistentVolumeSourceAnnotation>(out var source)
+                ? await BuildPersistentVolume(volumeResource, volumeResource.GeneratedClaim, source, cancellationToken).ConfigureAwait(false)
+                : null;
         }
     }
 
@@ -1008,13 +1045,19 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             },
         };
 
+        volumeResource.TryGetLastAnnotation<KubernetesCsiPersistentVolumeSourceAnnotation>(out var staticSource);
+
         foreach (var (key, value) in volumeResource.VolumeAnnotations)
         {
             claim.Metadata.Annotations[key] = await ResolveExpressionAsync(value, volumeResource.Name, cancellationToken).ConfigureAwait(false);
         }
 
         // Resolve access modes, falling back to the env-wide policy when none configured.
-        if (volumeResource.AccessModes.Count == 0)
+        if (volumeResource.AccessModes.Count == 0 && staticSource?.DefaultAccessMode is { } defaultAccessMode)
+        {
+            claim.Spec.AccessModes.Add(defaultAccessMode.ToKubernetesString());
+        }
+        else if (volumeResource.AccessModes.Count == 0)
         {
             claim.Spec.AccessModes.Add(DefaultStorageReadWritePolicy);
         }
@@ -1040,12 +1083,61 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
                 claim.Spec.StorageClassName = storageClass;
             }
         }
+        else if (!string.IsNullOrEmpty(staticSource?.DefaultStorageClassName))
+        {
+            claim.Spec.StorageClassName = staticSource.DefaultStorageClassName;
+        }
         else if (!string.IsNullOrEmpty(DefaultStorageClassName))
         {
             claim.Spec.StorageClassName = DefaultStorageClassName;
         }
 
+        if (staticSource is not null)
+        {
+            claim.Spec.VolumeName = volumeResource.GetVolumeName();
+            claim.Spec.StorageClassName ??= string.Empty;
+        }
+
         return claim;
+    }
+
+    private async Task<PersistentVolume> BuildPersistentVolume(
+        KubernetesPersistentVolumeResource volumeResource,
+        PersistentVolumeClaim claim,
+        KubernetesCsiPersistentVolumeSourceAnnotation source,
+        CancellationToken cancellationToken)
+    {
+        var volume = new PersistentVolume
+        {
+            Metadata =
+            {
+                Name = volumeResource.GetVolumeName(),
+            },
+            Spec =
+            {
+                StorageClassName = claim.Spec.StorageClassName ?? string.Empty,
+                PersistentVolumeReclaimPolicy = source.ReclaimPolicy.ToString(),
+                Csi = new CsiPersistentVolumeSourceV1
+                {
+                    Driver = source.Driver,
+                    VolumeHandle = await ResolveExpressionAsync(source.VolumeHandle, volumeResource.Name, cancellationToken).ConfigureAwait(false),
+                    FileSystemType = source.FileSystemType,
+                    ReadOnly = source.ReadOnly ? true : null,
+                },
+            },
+        };
+
+        volume.Spec.AccessModes.AddRange(claim.Spec.AccessModes);
+        volume.Spec.Capacity["storage"] = claim.Spec.Resources.Requests["storage"];
+        volume.Spec.MountOptions.AddRange(source.MountOptions);
+
+        foreach (var (key, value) in source.VolumeAttributes)
+        {
+            volume.Spec.Csi.VolumeAttributes[key] =
+                await ResolveExpressionAsync(value, volumeResource.Name, cancellationToken).ConfigureAwait(false);
+        }
+
+        return volume;
     }
 
     private async Task BuildGatewayObjects(

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
@@ -163,7 +163,7 @@ public enum PersistentVolumeAccessMode
 /// Specifies what Kubernetes does with a persistent volume after its claim is released.
 /// </summary>
 [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-public enum PersistentVolumeReclaimPolicy
+internal enum PersistentVolumeReclaimPolicy
 {
     /// <summary>
     /// Retains the backing storage for manual recovery or reuse.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
@@ -9,10 +9,11 @@ using Aspire.Hosting.Kubernetes.Resources;
 namespace Aspire.Hosting.Kubernetes;
 
 /// <summary>
-/// Represents a Kubernetes PersistentVolumeClaim as a first-class resource in the
-/// Aspire application model. A persistent volume resource carries the storage class,
-/// capacity, access modes, and metadata annotations needed to render a
-/// <c>v1.PersistentVolumeClaim</c> at publish time. Workloads bind to it with
+/// Represents Kubernetes persistent storage as a first-class resource in the Aspire
+/// application model. A persistent volume resource carries the storage class, capacity,
+/// access modes, and metadata annotations needed to render a
+/// <c>v1.PersistentVolumeClaim</c> at publish time. Deployment-target integrations can
+/// additionally configure a statically provisioned <c>v1.PersistentVolume</c>. Workloads bind to it with
 /// <see cref="KubernetesPersistentVolumeExtensions.WithPersistentVolume{T}(IResourceBuilder{T}, IResourceBuilder{KubernetesPersistentVolumeResource})"/>.
 /// </summary>
 /// <param name="name">The name of the persistent volume resource. Used as the
@@ -106,6 +107,12 @@ public sealed class KubernetesPersistentVolumeResource(
     internal PersistentVolumeClaim? GeneratedClaim { get; set; }
 
     /// <summary>
+    /// Gets the generated <see cref="PersistentVolume"/> when the resource uses a static
+    /// backing volume, populated during publish processing.
+    /// </summary>
+    internal PersistentVolume? GeneratedVolume { get; set; }
+
+    /// <summary>
     /// The canonical Kubernetes name of the PVC that backs this volume resource.
     /// Both the PVC emission path (<c>BuildPersistentVolumeClaim</c>) and the pod
     /// volume binding path (<c>WithPodSpecVolumes</c>) resolve the name via this
@@ -114,6 +121,11 @@ public sealed class KubernetesPersistentVolumeResource(
     /// publish. Do not derive the PVC name from the resource name directly.
     /// </summary>
     internal string GetClaimName() => Name.ToKubernetesResourceName();
+
+    /// <summary>
+    /// Gets the canonical Kubernetes name of the static persistent volume.
+    /// </summary>
+    internal string GetVolumeName() => $"{GetClaimName()}-pv";
 }
 
 /// <summary>
@@ -145,4 +157,21 @@ public enum PersistentVolumeAccessMode
     /// 1.27 or later (<c>ReadWriteOncePod</c> access mode).
     /// </summary>
     ReadWriteOncePod,
+}
+
+/// <summary>
+/// Specifies what Kubernetes does with a persistent volume after its claim is released.
+/// </summary>
+[Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public enum PersistentVolumeReclaimPolicy
+{
+    /// <summary>
+    /// Retains the backing storage for manual recovery or reuse.
+    /// </summary>
+    Retain,
+
+    /// <summary>
+    /// Deletes the backing storage through the volume provider.
+    /// </summary>
+    Delete,
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -136,12 +136,15 @@ internal sealed class KubernetesPublishingContext(
             }
         }
 
-        // Write first-class persistent volume resources as standalone PVC templates.
+        // Write first-class persistent volume resources as standalone PV/PVC templates.
         foreach (var volumeResource in resources.OfType<KubernetesPersistentVolumeResource>())
         {
             if (volumeResource.Parent == environment && volumeResource.GeneratedClaim is { } generatedClaim)
             {
-                await WriteKubernetesTemplatesForResource(volumeResource, [generatedClaim]).ConfigureAwait(false);
+                var generatedResources = volumeResource.GeneratedVolume is { } generatedVolume
+                    ? new BaseKubernetesResource[] { generatedVolume, generatedClaim }
+                    : [generatedClaim];
+                await WriteKubernetesTemplatesForResource(volumeResource, generatedResources).ConfigureAwait(false);
             }
         }
 
@@ -167,20 +170,30 @@ internal sealed class KubernetesPublishingContext(
     {
         foreach (var captured in environment.CapturedHelmValues)
         {
-            if (!_helmValues.TryGetValue(captured.Section, out var section))
-            {
-                continue;
-            }
-
-            if (!section.TryGetValue(captured.ResourceKey, out var resourceObj) ||
-                resourceObj is not Dictionary<string, object> resourceSection)
-            {
-                resourceSection = new Dictionary<string, object>();
-                section[captured.ResourceKey] = resourceSection;
-            }
-
-            resourceSection.TryAdd(captured.ValueKey, string.Empty);
+            EnsureCapturedHelmValuePlaceholder(captured.Section, captured.ResourceKey, captured.ValueKey);
         }
+
+        foreach (var captured in environment.CapturedHelmValueProviders)
+        {
+            EnsureCapturedHelmValuePlaceholder(captured.Section, captured.ResourceKey, captured.ValueKey);
+        }
+    }
+
+    private void EnsureCapturedHelmValuePlaceholder(string sectionName, string resourceKey, string valueKey)
+    {
+        if (!_helmValues.TryGetValue(sectionName, out var section))
+        {
+            return;
+        }
+
+        if (!section.TryGetValue(resourceKey, out var resourceObj) ||
+            resourceObj is not Dictionary<string, object> resourceSection)
+        {
+            resourceSection = new Dictionary<string, object>();
+            section[resourceKey] = resourceSection;
+        }
+
+        resourceSection.TryAdd(valueKey, string.Empty);
     }
 
     private async Task AppendResourceContextToHelmValuesAsync(IResource resource, KubernetesResource resourceContext)

--- a/src/Aspire.Hosting.Kubernetes/Resources/CsiPersistentVolumeSourceV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/CsiPersistentVolumeSourceV1.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Kubernetes.Resources;
+
+/// <summary>
+/// Represents a Container Storage Interface (CSI) persistent volume source.
+/// </summary>
+/// <remarks>
+/// This type maps to the Kubernetes <c>CSIPersistentVolumeSource</c> schema.
+/// See <see href="https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#CSIPersistentVolumeSource"/>.
+/// </remarks>
+[YamlSerializable]
+public sealed class CsiPersistentVolumeSourceV1
+{
+    /// <summary>
+    /// Gets or sets the name of the CSI driver that handles the volume.
+    /// </summary>
+    [YamlMember(Alias = "driver")]
+    public string Driver { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the unique volume identifier understood by the CSI driver.
+    /// </summary>
+    [YamlMember(Alias = "volumeHandle")]
+    public string VolumeHandle { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the filesystem type to mount.
+    /// </summary>
+    [YamlMember(Alias = "fsType")]
+    public string? FileSystemType { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the volume is mounted read-only.
+    /// </summary>
+    [YamlMember(Alias = "readOnly")]
+    public bool? ReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets the driver-specific volume attributes.
+    /// </summary>
+    [YamlMember(Alias = "volumeAttributes")]
+    public Dictionary<string, string> VolumeAttributes { get; } = [];
+}

--- a/src/Aspire.Hosting.Kubernetes/Resources/PersistentVolumeSpecV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/PersistentVolumeSpecV1.cs
@@ -83,6 +83,15 @@ public sealed class PersistentVolumeSpecV1
     public LocalVolumeSourceV1? Local { get; set; }
 
     /// <summary>
+    /// Gets or sets the Container Storage Interface (CSI) volume source.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/#CSIPersistentVolumeSource"/>.
+    /// </remarks>
+    [YamlMember(Alias = "csi")]
+    public CsiPersistentVolumeSourceV1? Csi { get; set; }
+
+    /// <summary>
     /// Represents the access modes for a Persistent Volume in a Kubernetes cluster.
     /// AccessModes define the ways in which the volume can be mounted and utilized:
     /// - ReadWriteOnce: The volume can be mounted as read-write by a single node.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
@@ -14,16 +14,16 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(60);
 
     [Fact]
-    public async Task DeployAksPersistentVolumeSurvivesRedeploy()
+    public async Task DeployAksPersistentVolumesSurviveRedeploy()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cts.Token, TestContext.Current.CancellationToken);
 
-        await DeployAksPersistentVolumeSurvivesRedeployCore(linkedCts.Token);
+        await DeployAksPersistentVolumesSurviveRedeployCore(linkedCts.Token);
     }
 
-    private async Task DeployAksPersistentVolumeSurvivesRedeployCore(CancellationToken cancellationToken)
+    private async Task DeployAksPersistentVolumesSurviveRedeployCore(CancellationToken cancellationToken)
     {
         var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
         if (string.IsNullOrEmpty(subscriptionId))
@@ -96,6 +96,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             // before setting the value consumed by the deployment pipeline.
             await auto.TypeAsync(
                 $"unset ASPIRE_PLAYGROUND && unset Azure__Location && " +
+                $"export AZURE__SUBSCRIPTIONID={subscriptionId} && " +
                 $"export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
@@ -118,15 +119,17 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 counter,
                 TimeSpan.FromMinutes(2));
 
-            await WaitForStatefulSetAndManagedDiskAsync(auto, counter);
+            await WaitForStatefulSetAndVolumesAsync(auto, counter);
+            await VerifyAzureFilesManagedIdentityAsync(auto, counter, resourceGroupName);
 
             await VerifyFileSystemGroupAsync(auto, counter, expectedFsGroup: 2000);
 
             await auto.RunCommandAsync(
                 "PVC_UID_BEFORE=$(kubectl get persistentvolumeclaim data --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
+                "SHARED_PVC_UID_BEFORE=$(kubectl get persistentvolumeclaim shared-volume --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
                 "POD_UID_BEFORE=$(kubectl get pod apiservice-statefulset-0 --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
-                "test -n \"$PVC_UID_BEFORE\" && test -n \"$POD_UID_BEFORE\" && " +
-                "echo \"First PVC UID: $PVC_UID_BEFORE\" && echo \"First pod UID: $POD_UID_BEFORE\"",
+                "test -n \"$PVC_UID_BEFORE\" && test -n \"$SHARED_PVC_UID_BEFORE\" && test -n \"$POD_UID_BEFORE\" && " +
+                "echo \"First PVC UIDs: disk=$PVC_UID_BEFORE files=$SHARED_PVC_UID_BEFORE\" && echo \"First pod UID: $POD_UID_BEFORE\"",
                 counter);
 
             var apiPort = GetAvailablePort();
@@ -137,6 +140,12 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 apiPort,
                 "?action=write",
                 "PASSED: wrote aks-pv-marker-42 revision first");
+            await VerifyApiResponseAsync(
+                auto,
+                counter,
+                apiPort,
+                "?action=write-shared",
+                "PASSED: wrote aks-files-marker-42 revision first");
             await StopPortForwardAsync(auto, counter);
 
             UpdateDeploymentRevision(appHostPath);
@@ -154,10 +163,12 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             await VerifyFileSystemGroupAsync(auto, counter, expectedFsGroup: 3000);
             await auto.RunCommandAsync(
                 "PVC_UID_AFTER=$(kubectl get persistentvolumeclaim data --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
+                "SHARED_PVC_UID_AFTER=$(kubectl get persistentvolumeclaim shared-volume --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
                 "POD_UID_AFTER=$(kubectl get pod apiservice-statefulset-0 --namespace \"$NS\" -o jsonpath='{.metadata.uid}') && " +
                 "test \"$PVC_UID_AFTER\" = \"$PVC_UID_BEFORE\" && " +
+                "test \"$SHARED_PVC_UID_AFTER\" = \"$SHARED_PVC_UID_BEFORE\" && " +
                 "test \"$POD_UID_AFTER\" != \"$POD_UID_BEFORE\" && " +
-                "echo \"Redeploy reused PVC $PVC_UID_AFTER and replaced pod $POD_UID_BEFORE with $POD_UID_AFTER\"",
+                "echo \"Redeploy reused PVCs $PVC_UID_AFTER and $SHARED_PVC_UID_AFTER, and replaced pod $POD_UID_BEFORE with $POD_UID_AFTER\"",
                 counter);
 
             apiPort = GetAvailablePort();
@@ -168,6 +179,12 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 apiPort,
                 "?action=read",
                 "PASSED: read aks-pv-marker-42 revision second");
+            await VerifyApiResponseAsync(
+                auto,
+                counter,
+                apiPort,
+                "?action=read-shared",
+                "PASSED: read aks-files-marker-42 revision second");
             await VerifyApiResponseAsync(
                 auto,
                 counter,
@@ -184,7 +201,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
 
             var duration = DateTime.UtcNow - startTime;
             DeploymentReporter.ReportDeploymentSuccess(
-                nameof(DeployAksPersistentVolumeSurvivesRedeploy),
+                nameof(DeployAksPersistentVolumesSurviveRedeploy),
                 resourceGroupName,
                 deploymentUrls,
                 duration);
@@ -194,7 +211,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             var duration = DateTime.UtcNow - startTime;
             output.WriteLine($"Test failed after {duration}: {ex.Message}");
             DeploymentReporter.ReportDeploymentFailure(
-                nameof(DeployAksPersistentVolumeSurvivesRedeploy),
+                nameof(DeployAksPersistentVolumesSurviveRedeploy),
                 resourceGroupName,
                 ex.Message,
                 ex.StackTrace);
@@ -229,6 +246,12 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             // which dynamically provisions an Azure Managed Disk.
             var data = aks.AddPersistentVolume("data")
                 .WithCapacity("1Gi");
+
+            var files = builder.AddAzureStorage("storage").AddFiles("files");
+            var share = files.AddFileShare("shared-files-share", "shared-files");
+            var sharedData = aks.AddPersistentVolume("shared-volume")
+                .WithAzureFileShare(share)
+                .WithCapacity("5Gi");
             """,
             appHostPath);
 
@@ -238,6 +261,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             """
             builder.AddProject<Projects.AksPersistentVolume_ApiService>("apiservice")
                 .WithPersistentVolume(data, "/srv/data")
+                .WithPersistentVolume(sharedData, "/srv/shared")
                 .WithEnvironment("DEPLOYMENT_REVISION", "first")
             """,
             appHostPath);
@@ -279,6 +303,8 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             const string markerPath = "/srv/data/marker.txt";
             const string newMarkerPath = "/srv/data/new-marker.txt";
             const string markerToken = "aks-pv-marker-42";
+            const string sharedMarkerPath = "/srv/shared/marker.txt";
+            const string sharedMarkerToken = "aks-files-marker-42";
             var deploymentRevision = app.Configuration["DEPLOYMENT_REVISION"]
                 ?? throw new InvalidOperationException("DEPLOYMENT_REVISION is not configured.");
 
@@ -313,7 +339,30 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                     return Results.Ok($"PASSED: wrote new {markerToken} revision {deploymentRevision}");
                 }
 
-                return Results.BadRequest("FAILED: action must be write, read, or write-new");
+                if (action == "write-shared")
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(sharedMarkerPath)!);
+                    await File.WriteAllTextAsync(sharedMarkerPath, sharedMarkerToken);
+                    return Results.Ok($"PASSED: wrote {sharedMarkerToken} revision {deploymentRevision}");
+                }
+
+                if (action == "read-shared")
+                {
+                    if (!File.Exists(sharedMarkerPath))
+                    {
+                        return Results.NotFound("FAILED: shared marker file was not found");
+                    }
+
+                    var persistedValue = await File.ReadAllTextAsync(sharedMarkerPath);
+                    if (persistedValue != sharedMarkerToken)
+                    {
+                        return Results.Problem($"FAILED: expected {sharedMarkerToken}, got {persistedValue}");
+                    }
+
+                    return Results.Ok($"PASSED: read {persistedValue} revision {deploymentRevision}");
+                }
+
+                return Results.BadRequest("FAILED: action must be write, read, write-new, write-shared, or read-shared");
             });
 
             app.MapDefaultEndpoints();
@@ -321,7 +370,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             """);
     }
 
-    private static async Task WaitForStatefulSetAndManagedDiskAsync(
+    private static async Task WaitForStatefulSetAndVolumesAsync(
         Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
@@ -341,9 +390,50 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             counter,
             TimeSpan.FromMinutes(6));
         await auto.RunCommandAsync(
+            "phase=''; for i in $(seq 1 60); do " +
+            "phase=$(kubectl get persistentvolumeclaim shared-volume --namespace \"$NS\" -o jsonpath='{.status.phase}' 2>/dev/null || true); " +
+            "if [ \"$phase\" = \"Bound\" ]; then break; fi; sleep 5; done; " +
+            "test \"$phase\" = \"Bound\" && " +
+            "PV_NAME=$(kubectl get persistentvolumeclaim shared-volume --namespace \"$NS\" -o jsonpath='{.spec.volumeName}') && " +
+            "test \"$PV_NAME\" = \"shared-volume-pv\" && " +
+            "test \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.driver}')\" = \"file.csi.azure.com\" && " +
+            "test \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.volumeAttributes.mountWithManagedIdentity}')\" = \"true\" && " +
+            "test -z \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.nodeStageSecretRef.name}')\" && " +
+            "echo \"PVC shared-volume is Bound to managed-identity Azure Files PV $PV_NAME\"",
+            counter,
+            TimeSpan.FromMinutes(6));
+        await auto.RunCommandAsync(
             "kubectl wait --for=condition=Ready pod/apiservice-statefulset-0 --namespace \"$NS\" --timeout=5m",
             counter,
             TimeSpan.FromMinutes(6));
+    }
+
+    private static async Task VerifyAzureFilesManagedIdentityAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string resourceGroupName)
+    {
+        await auto.RunCommandAsync(
+            $"STORAGE_ACCOUNT=$(az storage account list --resource-group {resourceGroupName} " +
+            "--query '[0].name' --output tsv) && " +
+            "test -n \"$STORAGE_ACCOUNT\" && " +
+            $"SMB_OAUTH=$(az storage account show --resource-group {resourceGroupName} --name \"$STORAGE_ACCOUNT\" " +
+            "--query 'azureFilesIdentityBasedAuthentication.smbOAuthSettings.isSmbOAuthEnabled' --output tsv) && " +
+            $"SHARED_KEY=$(az storage account show --resource-group {resourceGroupName} --name \"$STORAGE_ACCOUNT\" " +
+            "--query 'allowSharedKeyAccess' --output tsv) && " +
+            "test \"$SMB_OAUTH\" = \"true\" && test \"$SHARED_KEY\" = \"false\" && " +
+            "KUBELET_OBJECT_ID=$(az aks show --resource-group " + resourceGroupName + " --name \"$AKS_NAME\" " +
+            "--query 'identityProfile.kubeletidentity.objectId' --output tsv) && " +
+            $"STORAGE_ID=$(az storage account show --resource-group {resourceGroupName} --name \"$STORAGE_ACCOUNT\" --query id --output tsv) && " +
+            "ROLE_COUNT=$(az role assignment list --assignee-object-id \"$KUBELET_OBJECT_ID\" --scope \"$STORAGE_ID\" " +
+            "--query \"[?roleDefinitionName=='Storage File Data SMB MI Admin'] | length(@)\" --output tsv) && " +
+            "test \"$ROLE_COUNT\" = \"1\" && " +
+            "MOUNT_LINE=$(kubectl exec pod/apiservice-statefulset-0 --namespace \"$NS\" -- " +
+            "sh -c \"grep ' /srv/shared cifs ' /proc/mounts\") && " +
+            "printf '%s' \"$MOUNT_LINE\" | grep --fixed-strings --quiet 'sec=krb5' && " +
+            "echo \"Azure Files uses SMB OAuth with shared keys disabled; kubelet role and Kerberos mount verified\"",
+            counter,
+            TimeSpan.FromMinutes(5));
     }
 
     private static async Task VerifyFileSystemGroupAsync(
@@ -397,7 +487,8 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
         int port)
     {
         await auto.RunCommandAsync(
-            $"kubectl port-forward service/apiservice-service {port}:8080 --namespace \"$NS\" >/tmp/aks-pv-port-forward.log 2>&1 & PORT_FORWARD_PID=$!; " +
+            $"kubectl port-forward service/apiservice-service {port}:8080 --namespace \"$NS\" >/tmp/aks-pv-port-forward.log 2>&1 & " +
+            "PORT_FORWARD_PID=$(jobs -pr | tail -n 1); " +
             "test -n \"$PORT_FORWARD_PID\"",
             counter);
     }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksPersistentVolumeDeploymentTests.cs
@@ -120,7 +120,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
                 TimeSpan.FromMinutes(2));
 
             await WaitForStatefulSetAndVolumesAsync(auto, counter);
-            await VerifyAzureFilesManagedIdentityAsync(auto, counter, resourceGroupName);
+            await VerifyAzureFilesWorkloadIdentityAsync(auto, counter, resourceGroupName);
 
             await VerifyFileSystemGroupAsync(auto, counter, expectedFsGroup: 2000);
 
@@ -397,9 +397,11 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             "PV_NAME=$(kubectl get persistentvolumeclaim shared-volume --namespace \"$NS\" -o jsonpath='{.spec.volumeName}') && " +
             "test \"$PV_NAME\" = \"shared-volume-pv\" && " +
             "test \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.driver}')\" = \"file.csi.azure.com\" && " +
-            "test \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.volumeAttributes.mountWithManagedIdentity}')\" = \"true\" && " +
+            "test \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.volumeAttributes.mountWithWorkloadIdentityToken}')\" = \"true\" && " +
+            "PV_CLIENT_ID=$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.volumeAttributes.clientID}') && " +
+            "test -n \"$PV_CLIENT_ID\" && " +
             "test -z \"$(kubectl get persistentvolume \"$PV_NAME\" -o jsonpath='{.spec.csi.nodeStageSecretRef.name}')\" && " +
-            "echo \"PVC shared-volume is Bound to managed-identity Azure Files PV $PV_NAME\"",
+            "echo \"PVC shared-volume is Bound to workload-identity Azure Files PV $PV_NAME\"",
             counter,
             TimeSpan.FromMinutes(6));
         await auto.RunCommandAsync(
@@ -408,7 +410,7 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             TimeSpan.FromMinutes(6));
     }
 
-    private static async Task VerifyAzureFilesManagedIdentityAsync(
+    private static async Task VerifyAzureFilesWorkloadIdentityAsync(
         Hex1bTerminalAutomator auto,
         SequenceCounter counter,
         string resourceGroupName)
@@ -422,16 +424,34 @@ public sealed class AksPersistentVolumeDeploymentTests(ITestOutputHelper output)
             $"SHARED_KEY=$(az storage account show --resource-group {resourceGroupName} --name \"$STORAGE_ACCOUNT\" " +
             "--query 'allowSharedKeyAccess' --output tsv) && " +
             "test \"$SMB_OAUTH\" = \"true\" && test \"$SHARED_KEY\" = \"false\" && " +
-            "KUBELET_OBJECT_ID=$(az aks show --resource-group " + resourceGroupName + " --name \"$AKS_NAME\" " +
-            "--query 'identityProfile.kubeletidentity.objectId' --output tsv) && " +
+            $"PV_IDENTITY_NAME=$(az identity list --resource-group {resourceGroupName} " +
+            "--query \"[?contains(name, 'shared_volume_identity')].name | [0]\" --output tsv) && " +
+            "test -n \"$PV_IDENTITY_NAME\" && " +
+            $"PV_IDENTITY_CLIENT_ID=$(az identity show --resource-group {resourceGroupName} --name \"$PV_IDENTITY_NAME\" " +
+            "--query clientId --output tsv) && " +
+            $"PV_IDENTITY_PRINCIPAL_ID=$(az identity show --resource-group {resourceGroupName} --name \"$PV_IDENTITY_NAME\" " +
+            "--query principalId --output tsv) && " +
+            "test \"$PV_IDENTITY_CLIENT_ID\" = \"$PV_CLIENT_ID\" && " +
             $"STORAGE_ID=$(az storage account show --resource-group {resourceGroupName} --name \"$STORAGE_ACCOUNT\" --query id --output tsv) && " +
-            "ROLE_COUNT=$(az role assignment list --assignee-object-id \"$KUBELET_OBJECT_ID\" --scope \"$STORAGE_ID\" " +
+            "ROLE_COUNT=$(az role assignment list --assignee-object-id \"$PV_IDENTITY_PRINCIPAL_ID\" --scope \"$STORAGE_ID\" " +
             "--query \"[?roleDefinitionName=='Storage File Data SMB MI Admin'] | length(@)\" --output tsv) && " +
             "test \"$ROLE_COUNT\" = \"1\" && " +
+            "KUBELET_OBJECT_ID=$(az aks show --resource-group " + resourceGroupName + " --name \"$AKS_NAME\" " +
+            "--query 'identityProfile.kubeletidentity.objectId' --output tsv) && " +
+            "KUBELET_ROLE_COUNT=$(az role assignment list --assignee-object-id \"$KUBELET_OBJECT_ID\" --scope \"$STORAGE_ID\" " +
+            "--query \"[?roleDefinitionName=='Storage File Data SMB MI Admin'] | length(@)\" --output tsv) && " +
+            "test \"$KUBELET_ROLE_COUNT\" = \"0\" && " +
+            "SERVICE_ACCOUNT=$(kubectl get statefulset apiservice-statefulset --namespace \"$NS\" " +
+            "-o jsonpath='{.spec.template.spec.serviceAccountName}') && " +
+            "test \"$SERVICE_ACCOUNT\" = \"apiservice-sa\" && " +
+            $"FEDERATED_SUBJECT=$(az identity federated-credential list --resource-group {resourceGroupName} " +
+            "--identity-name \"$PV_IDENTITY_NAME\" --query \"[?name=='apiservice-fedcred'].subject | [0]\" --output tsv) && " +
+            "test \"$FEDERATED_SUBJECT\" = \"system:serviceaccount:$NS:$SERVICE_ACCOUNT\" && " +
+            "test \"$(kubectl get csidriver file.csi.azure.com -o jsonpath='{.spec.tokenRequests[0].audience}')\" = \"api://AzureADTokenExchange\" && " +
             "MOUNT_LINE=$(kubectl exec pod/apiservice-statefulset-0 --namespace \"$NS\" -- " +
             "sh -c \"grep ' /srv/shared cifs ' /proc/mounts\") && " +
             "printf '%s' \"$MOUNT_LINE\" | grep --fixed-strings --quiet 'sec=krb5' && " +
-            "echo \"Azure Files uses SMB OAuth with shared keys disabled; kubelet role and Kerberos mount verified\"",
+            "echo \"Azure Files uses SMB OAuth with shared keys disabled; per-volume workload identity, account-scoped data role, federation, and Kerberos mount verified\"",
             counter,
             TimeSpan.FromMinutes(5));
     }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesPersistentVolumeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesPersistentVolumeTests.cs
@@ -39,4 +39,111 @@ public class AzureKubernetesPersistentVolumeTests(ITestOutputHelper outputHelper
         var content = await File.ReadAllTextAsync(claimPath);
         await Verify(content, "yaml");
     }
+
+    [Fact]
+    public async Task WithAzureFileShare_GeneratesManagedIdentityStaticVolume()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+        var share = files.AddFileShare("media-share", "media");
+        var volume = aks.AddPersistentVolume("media-volume")
+            .WithAzureFileShare(share)
+            .WithCapacity("100Gi");
+
+        builder.AddContainer("app", "nginx")
+            .WithPersistentVolume(volume, "/srv/media");
+
+        var app = builder.Build();
+        app.Run();
+
+        var volumePath = Path.Combine(workspace.Path, "templates", "media-volume", "pv.yaml");
+        var claimPath = Path.Combine(workspace.Path, "templates", "media-volume", "media-volume.yaml");
+        var valuesPath = Path.Combine(workspace.Path, "values.yaml");
+
+        Assert.True(File.Exists(volumePath), $"Expected persistent volume YAML at {volumePath}.");
+        Assert.True(File.Exists(claimPath), $"Expected persistent volume claim YAML at {claimPath}.");
+        Assert.True(File.Exists(valuesPath), $"Expected Helm values YAML at {valuesPath}.");
+
+        var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+        var aksManifest = await AzureManifestUtils.GetManifestWithBicep(aks.Resource);
+
+        await Verify(await File.ReadAllTextAsync(volumePath), "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(claimPath), "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(valuesPath), "yaml")
+            .AppendContentAsFile(storageManifest.BicepText, "bicep")
+            .AppendContentAsFile(aksManifest.BicepText, "bicep");
+    }
+
+    [Fact]
+    public void WithAzureFileShare_RejectsNonAksPersistentVolume()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("k8s");
+        var storage = builder.AddAzureStorage("storage");
+        var share = storage.AddFiles("files").AddFileShare("media-share", "media");
+        var volume = k8s.AddPersistentVolume("media-volume");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => volume.WithAzureFileShare(share));
+
+        Assert.Contains("must belong to an Azure Kubernetes Service environment", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_MultipleVolumesEmitOneKubeletRoleAssignment()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+
+        aks.AddPersistentVolume("media-volume")
+            .WithAzureFileShare(files.AddFileShare("media-share", "media"));
+        aks.AddPersistentVolume("documents-volume")
+            .WithAzureFileShare(files.AddFileShare("documents-share", "documents"));
+
+        var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+
+        Assert.Equal(1, CountOccurrences(storageManifest.BicepText, "resource aksFilesRole_aks "));
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_ExistingStorageRemainsReadOnly()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var accountName = builder.AddParameter("storage-account-name");
+        var resourceGroup = builder.AddParameter("storage-resource-group");
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var storage = builder.AddAzureStorage("storage")
+            .AsExisting(accountName, resourceGroup);
+        var share = storage.AddFiles("files").AddFileShare("media-share", "media");
+
+        aks.AddPersistentVolume("media-volume")
+            .WithAzureFileShare(share);
+
+        var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+
+        Assert.Contains("resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing", storageManifest.BicepText);
+        Assert.Contains("resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' existing", storageManifest.BicepText);
+        Assert.Contains("resource media_share 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' existing", storageManifest.BicepText);
+        Assert.Contains("resource aksFilesRole_aks 'Microsoft.Authorization/roleAssignments@2022-04-01'", storageManifest.BicepText);
+        Assert.DoesNotContain("azureFilesIdentityBasedAuthentication", storageManifest.BicepText);
+        Assert.DoesNotContain("allowSharedKeyAccess", storageManifest.BicepText);
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+
+        return count;
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesPersistentVolumeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesPersistentVolumeTests.cs
@@ -3,6 +3,8 @@
 
 #pragma warning disable ASPIREAZURE003, ASPIRECOMPUTE002
 
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Kubernetes;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -57,23 +59,37 @@ public class AzureKubernetesPersistentVolumeTests(ITestOutputHelper outputHelper
         builder.AddContainer("app", "nginx")
             .WithPersistentVolume(volume, "/srv/media");
 
+        // Dependency discovery can request this template before the AKS prepare step adds FICs.
+        _ = aks.Resource.GetBicepTemplateString();
+
         var app = builder.Build();
         app.Run();
 
         var volumePath = Path.Combine(workspace.Path, "templates", "media-volume", "pv.yaml");
         var claimPath = Path.Combine(workspace.Path, "templates", "media-volume", "media-volume.yaml");
+        var statefulSetPath = Path.Combine(workspace.Path, "templates", "app", "statefulset.yaml");
+        var serviceAccountPath = Path.Combine(workspace.Path, "templates", "app", "sa.yaml");
         var valuesPath = Path.Combine(workspace.Path, "values.yaml");
 
         Assert.True(File.Exists(volumePath), $"Expected persistent volume YAML at {volumePath}.");
         Assert.True(File.Exists(claimPath), $"Expected persistent volume claim YAML at {claimPath}.");
+        Assert.True(File.Exists(statefulSetPath), $"Expected workload YAML at {statefulSetPath}.");
+        Assert.True(File.Exists(serviceAccountPath), $"Expected service account YAML at {serviceAccountPath}.");
         Assert.True(File.Exists(valuesPath), $"Expected Helm values YAML at {valuesPath}.");
+        Assert.True(volume.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles));
+        Assert.Equal(TimeSpan.FromMinutes(15), aks.Resource.KubernetesEnvironment.HelmDeploymentTimeout);
+        Assert.Contains(azureFiles.Identity, aks.Resource.References);
 
+        var identityManifest = await AzureManifestUtils.GetManifestWithBicep(azureFiles.Identity);
         var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
         var aksManifest = await AzureManifestUtils.GetManifestWithBicep(aks.Resource);
 
         await Verify(await File.ReadAllTextAsync(volumePath), "yaml")
             .AppendContentAsFile(await File.ReadAllTextAsync(claimPath), "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(statefulSetPath), "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(serviceAccountPath), "yaml")
             .AppendContentAsFile(await File.ReadAllTextAsync(valuesPath), "yaml")
+            .AppendContentAsFile(identityManifest.BicepText, "bicep")
             .AppendContentAsFile(storageManifest.BicepText, "bicep")
             .AppendContentAsFile(aksManifest.BicepText, "bicep");
     }
@@ -93,7 +109,7 @@ public class AzureKubernetesPersistentVolumeTests(ITestOutputHelper outputHelper
     }
 
     [Fact]
-    public async Task WithAzureFileShare_MultipleVolumesEmitOneKubeletRoleAssignment()
+    public async Task WithAzureFileShare_MultipleVolumesUseSeparateIdentitiesAndShareScopedRoles()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var aks = builder.AddAzureKubernetesEnvironment("aks");
@@ -107,7 +123,242 @@ public class AzureKubernetesPersistentVolumeTests(ITestOutputHelper outputHelper
 
         var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
 
-        Assert.Equal(1, CountOccurrences(storageManifest.BicepText, "resource aksFilesRole_aks "));
+        Assert.Equal(2, builder.Resources.OfType<AzureUserAssignedIdentityResource>().Count());
+        Assert.Equal(2, CountOccurrences(storageManifest.BicepText, "resource azureFilesRole_"));
+        Assert.Equal(2, CountOccurrences(storageManifest.BicepText, "scope: storage"));
+        Assert.DoesNotContain("aksKubeletPrincipalId", storageManifest.BicepText);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_SharedVolumeFederatesEveryConsumer()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volume = aks.AddPersistentVolume("shared-volume")
+            .WithAzureFileShare(share);
+
+        builder.AddContainer("first", "nginx")
+            .WithPersistentVolume(volume, "/srv/shared");
+        builder.AddContainer("second", "nginx")
+            .WithPersistentVolume(volume, "/srv/shared");
+
+        var app = builder.Build();
+        app.Run();
+
+        var aksManifest = await AzureManifestUtils.GetManifestWithBicep(aks.Resource);
+        Assert.Contains("resource fedcred_first__shared_volume ", aksManifest.BicepText);
+        Assert.Contains("resource fedcred_second__shared_volume ", aksManifest.BicepText);
+        Assert.Contains("subject: 'system:serviceaccount:default:first-sa'", aksManifest.BicepText);
+        Assert.Contains("subject: 'system:serviceaccount:default:second-sa'", aksManifest.BicepText);
+        Assert.Equal(1, CountOccurrences(aksManifest.BicepText, "dependsOn:"));
+
+        var firstServiceAccount = await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "first", "sa.yaml"));
+        var secondServiceAccount = await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "second", "sa.yaml"));
+        Assert.Contains("name: \"first-sa\"", firstServiceAccount);
+        Assert.Contains("name: \"second-sa\"", secondServiceAccount);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_UsesApplicationServiceAccountForVolumeFederation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var appIdentity = builder.AddAzureUserAssignedIdentity("app-identity");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volume = aks.AddPersistentVolume("shared-volume")
+            .WithAzureFileShare(share);
+
+        builder.AddContainer("orders-api", "nginx")
+            .WithAzureUserAssignedIdentity(appIdentity)
+            .WithPersistentVolume(volume, "/srv/shared");
+
+        var app = builder.Build();
+        app.Run();
+
+        var aksManifest = await AzureManifestUtils.GetManifestWithBicep(aks.Resource);
+        Assert.Contains("resource fedcred_orders_api ", aksManifest.BicepText);
+        Assert.Contains("resource fedcred_orders_api__shared_volume ", aksManifest.BicepText);
+        Assert.Equal(2, CountOccurrences(aksManifest.BicepText, "subject: 'system:serviceaccount:default:orders-api-sa'"));
+
+        var serviceAccount = await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "orders-api", "sa.yaml"));
+        Assert.Contains("azure.workload.identity/client-id", serviceAccount);
+        Assert.Contains(".Values.parameters.orders_api.identityClientId", serviceAccount);
+        Assert.Equal(1, CountOccurrences(serviceAccount, "kind: \"ServiceAccount\""));
+
+        var values = await File.ReadAllTextAsync(Path.Combine(workspace.Path, "values.yaml"));
+        Assert.Contains("orders_api:", values);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_NormalizesServiceAccountName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volume = aks.AddPersistentVolume("SharedVolume")
+            .WithAzureFileShare(share);
+
+        builder.AddContainer("Api", "nginx")
+            .WithPersistentVolume(volume, "/srv/shared");
+
+        var app = builder.Build();
+        app.Run();
+
+        var aksManifest = await AzureManifestUtils.GetManifestWithBicep(aks.Resource);
+        Assert.Contains("subject: 'system:serviceaccount:default:api-sa'", aksManifest.BicepText);
+    }
+
+    [Fact]
+    public void WithAzureFileShare_DerivesValidIdentityNameFromMaximumLengthVolumeName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volumeName = $"v{new string('a', 63)}";
+
+        var volume = aks.AddPersistentVolume(volumeName)
+            .WithAzureFileShare(share);
+
+        Assert.True(volume.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles));
+        Assert.Equal(64, azureFiles.Identity.Name.Length);
+        Assert.EndsWith("-identity", azureFiles.Identity.Name);
+    }
+
+    [Fact]
+    public void WithAzureFileShare_DerivedIdentityNameDoesNotContainConsecutiveHyphens()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volumeName = $"{new string('a', 45)}-{new string('b', 18)}";
+
+        var volume = aks.AddPersistentVolume(volumeName)
+            .WithAzureFileShare(share);
+
+        Assert.True(volume.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles));
+        Assert.DoesNotContain("--", azureFiles.Identity.Name);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_RepeatedCallReusesVolumeIdentity()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var storage = builder.AddAzureStorage("storage");
+        var share = storage.AddFiles("files").AddFileShare("shared-files", "shared");
+        var volume = aks.AddPersistentVolume("shared-volume")
+            .WithAzureFileShare(share)
+            .WithAzureFileShare(share);
+
+        Assert.True(volume.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles));
+        Assert.Single(builder.Resources.OfType<AzureUserAssignedIdentityResource>());
+
+        var storageManifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+        Assert.Equal(1, CountOccurrences(storageManifest.BicepText, "resource azureFilesRole_shared_volume "));
+        Assert.Equal("shared-volume-identity", azureFiles.Identity.Name);
+    }
+
+    [Fact]
+    public async Task WithAzureFileShare_NormalizesLegacyServiceAccountAlias()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+        var volume = aks.AddPersistentVolume("shared-volume")
+            .WithAzureFileShare(share);
+
+        builder.AddContainer("app", "nginx")
+            .PublishAsKubernetesService(resource => resource.Workload!.PodTemplate.Spec.ServiceAccount = "app-sa")
+            .WithPersistentVolume(volume, "/srv/shared");
+
+        var app = builder.Build();
+        app.Run();
+
+        var statefulSet = await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "app", "statefulset.yaml"));
+        Assert.Contains("serviceAccountName: \"app-sa\"", statefulSet);
+        Assert.DoesNotContain("serviceAccount: \"", statefulSet);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithAzureFileShare_CoScopesGeneratedIdentityWithExistingAks(bool configureExistingFirst)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        var aksName = builder.AddParameter("aks-name");
+        var aksResourceGroup = builder.AddParameter("aks-resource-group");
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        if (configureExistingFirst)
+        {
+            aks.AsExisting(aksName, aksResourceGroup);
+        }
+        var share = builder.AddAzureStorage("storage")
+            .AddFiles("files")
+            .AddFileShare("shared-files", "shared");
+
+        var volume = aks.AddPersistentVolume("shared-volume")
+            .WithAzureFileShare(share);
+        if (!configureExistingFirst)
+        {
+            aks.AsExisting(aksName, aksResourceGroup);
+        }
+
+        builder.AddContainer("app", "nginx")
+            .WithPersistentVolume(volume, "/srv/shared");
+
+        var app = builder.Build();
+        app.Run();
+
+        Assert.True(volume.Resource.TryGetLastAnnotation<AzureFileSharePersistentVolumeAnnotation>(out var azureFiles));
+        Assert.NotNull(azureFiles.Identity.Scope);
+        Assert.Same(aksResourceGroup.Resource, azureFiles.Identity.Scope.ResourceGroup);
+    }
+
+    [Fact]
+    public void WithAzureFileShare_RejectsParameterizedKubernetesNamespace()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var namespaceParameter = builder.AddParameter("kubernetes-namespace");
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        builder.CreateResourceBuilder(aks.Resource.KubernetesEnvironment)
+            .WithHelm(options => options.WithNamespace(namespaceParameter));
+        var identity = builder.AddAzureUserAssignedIdentity("volume-identity");
+        aks.Resource.WorkloadIdentities[new AksWorkloadIdentityBindingKey("app", "volume")] =
+            new AksWorkloadIdentityBinding("app-sa", "app-fedcred", identity.Resource);
+
+        var exception = Assert.Throws<InvalidOperationException>(aks.Resource.GetBicepTemplateString);
+        Assert.Contains("requires a literal Kubernetes namespace", exception.Message);
+    }
+
+    [Fact]
+    public void AksWithoutWorkloadIdentity_AllowsParameterizedKubernetesNamespace()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var namespaceParameter = builder.AddParameter("kubernetes-namespace");
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+        builder.CreateResourceBuilder(aks.Resource.KubernetesEnvironment)
+            .WithHelm(options => options.WithNamespace(namespaceParameter));
+
+        var bicep = aks.Resource.GetBicepTemplateString();
+
+        Assert.DoesNotContain("federatedIdentityCredentials", bicep);
     }
 
     [Fact]
@@ -129,7 +380,9 @@ public class AzureKubernetesPersistentVolumeTests(ITestOutputHelper outputHelper
         Assert.Contains("resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing", storageManifest.BicepText);
         Assert.Contains("resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' existing", storageManifest.BicepText);
         Assert.Contains("resource media_share 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' existing", storageManifest.BicepText);
-        Assert.Contains("resource aksFilesRole_aks 'Microsoft.Authorization/roleAssignments@2022-04-01'", storageManifest.BicepText);
+        Assert.Contains("resource azureFilesRole_media_volume 'Microsoft.Authorization/roleAssignments@2022-04-01'", storageManifest.BicepText);
+        Assert.Contains("scope: storage", storageManifest.BicepText);
+        Assert.DoesNotContain("aksKubeletPrincipalId", storageManifest.BicepText);
         Assert.DoesNotContain("azureFilesIdentityBasedAuthentication", storageManifest.BicepText);
         Assert.DoesNotContain("allowSharedKeyAccess", storageManifest.BicepText);
     }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.bicep
@@ -1,67 +1,17 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param aksKubeletPrincipalId_aks string
-
-resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
-  name: take('storage${uniqueString(resourceGroup().id)}', 24)
-  kind: 'StorageV2'
+resource media_volume_identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('media_volume_identity-${uniqueString(resourceGroup().id)}', 128)
   location: location
-  sku: {
-    name: 'Standard_GRS'
-  }
-  properties: {
-    accessTier: 'Hot'
-    allowSharedKeyAccess: false
-    azureFilesIdentityBasedAuthentication: {
-      directoryServiceOptions: 'None'
-      smbOAuthSettings: {
-        isSmbOAuthEnabled: true
-      }
-    }
-    isHnsEnabled: false
-    minimumTlsVersion: 'TLS1_2'
-    networkAcls: {
-      defaultAction: 'Allow'
-    }
-  }
-  tags: {
-    'aspire-resource-name': 'storage'
-  }
 }
 
-resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
-  name: 'default'
-  parent: storage
-}
+output id string = media_volume_identity.id
 
-resource media_share 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
-  name: 'media'
-  parent: files
-}
+output clientId string = media_volume_identity.properties.clientId
 
-resource aksFilesRole_aks 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(storage.id, aksKubeletPrincipalId_aks, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e'))
-  properties: {
-    principalId: aksKubeletPrincipalId_aks
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e')
-    principalType: 'ServicePrincipal'
-  }
-  scope: storage
-}
+output principalId string = media_volume_identity.properties.principalId
 
-output blobEndpoint string = storage.properties.primaryEndpoints.blob
+output principalName string = media_volume_identity.name
 
-output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
-
-output queueEndpoint string = storage.properties.primaryEndpoints.queue
-
-output tableEndpoint string = storage.properties.primaryEndpoints.table
-
-output fileEndpoint string = storage.properties.primaryEndpoints.file
-
-output name string = storage.name
-
-output resourceGroupName string = resourceGroup().name
-
-output id string = storage.id
+output name string = media_volume_identity.name

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.bicep
@@ -1,0 +1,67 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param aksKubeletPrincipalId_aks string
+
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+  name: take('storage${uniqueString(resourceGroup().id)}', 24)
+  kind: 'StorageV2'
+  location: location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  properties: {
+    accessTier: 'Hot'
+    allowSharedKeyAccess: false
+    azureFilesIdentityBasedAuthentication: {
+      directoryServiceOptions: 'None'
+      smbOAuthSettings: {
+        isSmbOAuthEnabled: true
+      }
+    }
+    isHnsEnabled: false
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      defaultAction: 'Allow'
+    }
+  }
+  tags: {
+    'aspire-resource-name': 'storage'
+  }
+}
+
+resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
+  name: 'default'
+  parent: storage
+}
+
+resource media_share 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
+  name: 'media'
+  parent: files
+}
+
+resource aksFilesRole_aks 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, aksKubeletPrincipalId_aks, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e'))
+  properties: {
+    principalId: aksKubeletPrincipalId_aks
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e')
+    principalType: 'ServicePrincipal'
+  }
+  scope: storage
+}
+
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
+
+output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
+
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
+
+output tableEndpoint string = storage.properties.primaryEndpoints.table
+
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
+output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
+
+output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.yaml
@@ -13,7 +13,8 @@ spec:
       storageAccount: "{{ .Values.config.media_volume.storage_outputs_name }}"
       shareName: "media"
       protocol: "smb"
-      mountWithManagedIdentity: "true"
+      clientID: "{{ .Values.config.media_volume.media_volume_identity_outputs_clientId }}"
+      mountWithWorkloadIdentityToken: "true"
   accessModes:
     - "ReadWriteMany"
   mountOptions:

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#00.verified.yaml
@@ -1,0 +1,31 @@
+﻿---
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "media-volume-pv"
+spec:
+  storageClassName: "azurefile-csi"
+  csi:
+    driver: "file.csi.azure.com"
+    volumeHandle: "{{ .Values.config.media_volume.storage_outputs_resourceGroupName }}#{{ .Values.config.media_volume.storage_outputs_name }}#media"
+    volumeAttributes:
+      resourceGroup: "{{ .Values.config.media_volume.storage_outputs_resourceGroupName }}"
+      storageAccount: "{{ .Values.config.media_volume.storage_outputs_name }}"
+      shareName: "media"
+      protocol: "smb"
+      mountWithManagedIdentity: "true"
+  accessModes:
+    - "ReadWriteMany"
+  mountOptions:
+    - "dir_mode=0777"
+    - "file_mode=0777"
+    - "uid=0"
+    - "gid=0"
+    - "mfsymlinks"
+    - "cache=strict"
+    - "nosharesock"
+    - "actimeo=30"
+    - "nobrl"
+  capacity:
+    storage: "100Gi"
+  persistentVolumeReclaimPolicy: "Retain"

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.bicep
@@ -1,83 +1,67 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param acrName string
+param azureFilesIdentityPrincipalId_media_volume string
 
-resource aks 'Microsoft.ContainerService/managedClusters@2026-01-01' = {
-  name: take('aks-${uniqueString(resourceGroup().id)}', 63)
-  tags: {
-    'aspire-resource-name': 'aks'
-  }
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+  name: take('storage${uniqueString(resourceGroup().id)}', 24)
+  kind: 'StorageV2'
   location: location
-  properties: {
-    dnsPrefix: 'aks-dns'
-    agentPoolProfiles: [
-      {
-        name: 'system'
-        count: 1
-        vmSize: 'Standard_D2s_v5'
-        osType: 'Linux'
-        maxCount: 3
-        minCount: 1
-        enableAutoScaling: true
-        mode: 'System'
-      }
-      {
-        name: 'workload'
-        count: 1
-        vmSize: 'Standard_D2s_v5'
-        osType: 'Linux'
-        maxCount: 3
-        minCount: 1
-        enableAutoScaling: true
-        mode: 'User'
-      }
-    ]
-    oidcIssuerProfile: {
-      enabled: true
-    }
-    securityProfile: {
-      workloadIdentity: {
-        enabled: true
-      }
-    }
-    storageProfile: {
-      fileCSIDriver: {
-        enabled: true
-      }
-    }
-  }
   sku: {
-    name: 'Base'
-    tier: 'Free'
+    name: 'Standard_GRS'
   }
-  identity: {
-    type: 'SystemAssigned'
-  }
-}
-
-resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
-  name: acrName
-}
-
-resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.id, aks.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
   properties: {
-    principalId: aks.properties.identityProfile.kubeletidentity.objectId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    accessTier: 'Hot'
+    allowSharedKeyAccess: false
+    azureFilesIdentityBasedAuthentication: {
+      directoryServiceOptions: 'None'
+      smbOAuthSettings: {
+        isSmbOAuthEnabled: true
+      }
+    }
+    isHnsEnabled: false
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      defaultAction: 'Allow'
+    }
+  }
+  tags: {
+    'aspire-resource-name': 'storage'
+  }
+}
+
+resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
+  name: 'default'
+  parent: storage
+}
+
+resource media_share 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
+  name: 'media'
+  parent: files
+}
+
+resource azureFilesRole_media_volume 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storage.id, azureFilesIdentityPrincipalId_media_volume, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e'))
+  properties: {
+    principalId: azureFilesIdentityPrincipalId_media_volume
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a235d3ee-5935-4cfb-8cc5-a3303ad5995e')
     principalType: 'ServicePrincipal'
   }
-  scope: acr
+  scope: storage
 }
 
-output id string = aks.id
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
-output name string = aks.name
+output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
 
-output clusterFqdn string = aks.properties.fqdn
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
-output oidcIssuerUrl string = aks.properties.oidcIssuerProfile.issuerURL
+output tableEndpoint string = storage.properties.primaryEndpoints.table
 
-output kubeletIdentityObjectId string = aks.properties.identityProfile.kubeletidentity.objectId
+output fileEndpoint string = storage.properties.primaryEndpoints.file
 
-output nodeResourceGroup string = aks.properties.nodeResourceGroup
+output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
+
+output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.bicep
@@ -1,0 +1,83 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param acrName string
+
+resource aks 'Microsoft.ContainerService/managedClusters@2026-01-01' = {
+  name: take('aks-${uniqueString(resourceGroup().id)}', 63)
+  tags: {
+    'aspire-resource-name': 'aks'
+  }
+  location: location
+  properties: {
+    dnsPrefix: 'aks-dns'
+    agentPoolProfiles: [
+      {
+        name: 'system'
+        count: 1
+        vmSize: 'Standard_D2s_v5'
+        osType: 'Linux'
+        maxCount: 3
+        minCount: 1
+        enableAutoScaling: true
+        mode: 'System'
+      }
+      {
+        name: 'workload'
+        count: 1
+        vmSize: 'Standard_D2s_v5'
+        osType: 'Linux'
+        maxCount: 3
+        minCount: 1
+        enableAutoScaling: true
+        mode: 'User'
+      }
+    ]
+    oidcIssuerProfile: {
+      enabled: true
+    }
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
+    storageProfile: {
+      fileCSIDriver: {
+        enabled: true
+      }
+    }
+  }
+  sku: {
+    name: 'Base'
+    tier: 'Free'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: acrName
+}
+
+resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, aks.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: aks.properties.identityProfile.kubeletidentity.objectId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: acr
+}
+
+output id string = aks.id
+
+output name string = aks.name
+
+output clusterFqdn string = aks.properties.fqdn
+
+output oidcIssuerUrl string = aks.properties.oidcIssuerProfile.issuerURL
+
+output kubeletIdentityObjectId string = aks.properties.identityProfile.kubeletidentity.objectId
+
+output nodeResourceGroup string = aks.properties.nodeResourceGroup

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#01.verified.yaml
@@ -1,0 +1,13 @@
+﻿---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "media-volume"
+spec:
+  storageClassName: "azurefile-csi"
+  volumeName: "media-volume-pv"
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "100Gi"

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.bicep
@@ -1,0 +1,101 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param acrName string
+
+param identityName_app__media_volume string
+
+resource aks 'Microsoft.ContainerService/managedClusters@2026-01-01' = {
+  name: take('aks-${uniqueString(resourceGroup().id)}', 63)
+  tags: {
+    'aspire-resource-name': 'aks'
+  }
+  location: location
+  properties: {
+    dnsPrefix: 'aks-dns'
+    agentPoolProfiles: [
+      {
+        name: 'system'
+        count: 1
+        vmSize: 'Standard_D2s_v5'
+        osType: 'Linux'
+        maxCount: 3
+        minCount: 1
+        enableAutoScaling: true
+        mode: 'System'
+      }
+      {
+        name: 'workload'
+        count: 1
+        vmSize: 'Standard_D2s_v5'
+        osType: 'Linux'
+        maxCount: 3
+        minCount: 1
+        enableAutoScaling: true
+        mode: 'User'
+      }
+    ]
+    oidcIssuerProfile: {
+      enabled: true
+    }
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
+    storageProfile: {
+      fileCSIDriver: {
+        enabled: true
+      }
+    }
+  }
+  sku: {
+    name: 'Base'
+    tier: 'Free'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: acrName
+}
+
+resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, aks.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: aks.properties.identityProfile.kubeletidentity.objectId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: acr
+}
+
+resource identity_app__media_volume 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = {
+  name: identityName_app__media_volume
+}
+
+resource fedcred_app__media_volume 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2024-11-30' = {
+  name: 'app-fedcred'
+  properties: {
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+    issuer: aks.properties.oidcIssuerProfile.issuerURL
+    subject: 'system:serviceaccount:default:app-sa'
+  }
+  parent: identity_app__media_volume
+}
+
+output id string = aks.id
+
+output name string = aks.name
+
+output clusterFqdn string = aks.properties.fqdn
+
+output oidcIssuerUrl string = aks.properties.oidcIssuerProfile.issuerURL
+
+output kubeletIdentityObjectId string = aks.properties.identityProfile.kubeletidentity.objectId
+
+output nodeResourceGroup string = aks.properties.nodeResourceGroup

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.yaml
@@ -1,6 +1,40 @@
-﻿parameters: {}
-secrets: {}
-config:
-  media_volume:
-    storage_outputs_resourceGroupName: ""
-    storage_outputs_name: ""
+﻿---
+apiVersion: "apps/v1"
+kind: "StatefulSet"
+metadata:
+  name: "app-statefulset"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "app"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/component: "app"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      serviceAccountName: "app-sa"
+      nodeSelector:
+        agentpool: "workload"
+      containers:
+        - image: "nginx:latest"
+          name: "app"
+          volumeMounts:
+            - name: "media-volume"
+              mountPath: "/srv/media"
+          imagePullPolicy: "IfNotPresent"
+      volumes:
+        - name: "media-volume"
+          persistentVolumeClaim:
+            claimName: "media-volume"
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
+      app.kubernetes.io/component: "app"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#02.verified.yaml
@@ -1,0 +1,6 @@
+﻿parameters: {}
+secrets: {}
+config:
+  media_volume:
+    storage_outputs_resourceGroupName: ""
+    storage_outputs_name: ""

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#03.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#03.verified.yaml
@@ -1,0 +1,9 @@
+﻿---
+apiVersion: "v1"
+kind: "ServiceAccount"
+metadata:
+  name: "app-sa"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "app"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#04.verified.yaml
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Snapshots/AzureKubernetesPersistentVolumeTests.WithAzureFileShare_GeneratesManagedIdentityStaticVolume#04.verified.yaml
@@ -1,0 +1,7 @@
+﻿parameters: {}
+secrets: {}
+config:
+  media_volume:
+    storage_outputs_resourceGroupName: ""
+    storage_outputs_name: ""
+    media_volume_identity_outputs_clientId: ""

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFileStorageConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFileStorageConnectionPropertiesTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureFileStorageConnectionPropertiesTests
+{
+    [Fact]
+    public void AzureFileStorageResourceGetConnectionPropertiesReturnsExpectedValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+
+        var properties = ((IResourceWithConnectionString)files.Resource).GetConnectionProperties().ToArray();
+
+        Assert.Collection(
+            properties,
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("{storage.outputs.fileEndpoint}", property.Value.ValueExpression);
+            });
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFileStorageShareConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFileStorageShareConnectionPropertiesTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureFileStorageShareConnectionPropertiesTests
+{
+    [Fact]
+    public void AzureFileStorageShareResourceGetConnectionPropertiesReturnsExpectedValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+        var share = files.AddFileShare("share", "myshare");
+
+        var properties = ((IResourceWithConnectionString)share.Resource).GetConnectionProperties().ToArray();
+
+        Assert.Collection(
+            properties,
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("{storage.outputs.fileEndpoint}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("FileShareName", property.Key);
+                Assert.Equal("myshare", property.Value.ValueExpression);
+            });
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -277,6 +277,85 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task AddFiles_ConnectionString_resolved_expected()
+    {
+        const string filesEndpoint = "https://myfiles";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        storage.Resource.Outputs["fileEndpoint"] = filesEndpoint;
+
+        var files = storage.AddFiles("files");
+
+        Assert.Equal(filesEndpoint, await ((IResourceWithConnectionString)files.Resource).GetConnectionStringAsync());
+    }
+
+    [Fact]
+    public void AddFiles_ConnectionString_unresolved_expected()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+
+        var files = storage.AddFiles("files");
+
+        Assert.Equal("{storage.outputs.fileEndpoint}", files.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AddFiles_AfterRunAsEmulatorThrows()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => storage.AddFiles("files"));
+
+        Assert.Equal("Emulator currently does not support file storage.", exception.Message);
+    }
+
+    [Fact]
+    public void RunAsEmulator_AfterAddFilesThrows()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        storage.AddFiles("files");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => storage.RunAsEmulator());
+
+        Assert.Equal("Emulator currently does not support file storage.", exception.Message);
+    }
+
+    [Fact]
+    public async Task AddFileShare_ConnectionString_resolved_expected()
+    {
+        const string fileShareName = "my-file-share";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        storage.Resource.Outputs["fileEndpoint"] = "https://myfiles";
+
+        var files = storage.AddFiles("files");
+        var share = files.AddFileShare("share", fileShareName);
+
+        var filesConnectionString = await ((IResourceWithConnectionString)files.Resource).GetConnectionStringAsync();
+        var expected = $"Endpoint={filesConnectionString};FileShareName={fileShareName}";
+
+        Assert.Equal(expected, await ((IResourceWithConnectionString)share.Resource).GetConnectionStringAsync());
+        Assert.Same(files.Resource, share.Resource.Parent);
+    }
+
+    [Fact]
+    public void AddFileShare_ConnectionString_unresolved_expected()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+
+        var files = storage.AddFiles("files");
+        var share = files.AddFileShare("share");
+
+        Assert.Equal("Endpoint={storage.outputs.fileEndpoint};FileShareName=share", share.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
     public async Task AddQueues_ConnectionString_resolved_expected_RunAsEmulator()
     {
         const string expected = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;";
@@ -392,10 +471,64 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
         var queues = storage.AddQueues("myqueues");
         var queue = storage.AddQueue(name: "myqueue", queueName: "my-queue");
         var tables = storage.AddTables("mytables");
+        var files = storage.AddFiles("myfiles");
+        var fileShare = files.AddFileShare(name: "myshare", fileShareName: "my-file-share");
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
 
         await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddAzureFiles_GeneratesSmbOAuthAndFileShare()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+        var share = files.AddFileShare("media", "media-share");
+
+        Assert.Same(storage.Resource, files.Resource.Parent);
+        Assert.Same(files.Resource, share.Resource.Parent);
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddAzureFiles_AsExistingReferencesAccountServiceAndShare()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var accountName = builder.AddParameter("storage-account-name");
+        var resourceGroup = builder.AddParameter("storage-resource-group");
+        var storage = builder.AddAzureStorage("storage")
+            .AsExisting(accountName, resourceGroup);
+        var files = storage.AddFiles("files");
+        files.AddFileShare("media", "media-share");
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddFiles_WhenReferencedAddsFileShareContributorRole()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+        builder.AddContainer("app", "image")
+            .WithReference(files);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        _ = await GetManifestWithBicep(model, storage.Resource);
+
+        var roles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), resource => resource.Name == "storage-roles");
+        var rolesManifest = await GetManifestWithBicep(roles, skipPreparer: true);
+
+        Assert.Contains("StorageFileDataSmbShareContributor", rolesManifest.BicepText);
+        Assert.Contains("0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb", rolesManifest.BicepText);
     }
 
     [Fact]
@@ -662,7 +795,7 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
 
             param principalId string
 
-            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+            resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
               name: storage_outputs_name
             }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStoragePrivateEndpointLockdownTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStoragePrivateEndpointLockdownTests.cs
@@ -92,4 +92,21 @@ public class AzureStoragePrivateEndpointLockdownTests
 
         await Verify(manifest.BicepText, extension: "bicep");
     }
+
+    [Fact]
+    public async Task AddAzureStorage_WithFilesPrivateEndpoint_GeneratesCorrectBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("pesubnet", "10.0.1.0/24");
+        var storage = builder.AddAzureStorage("storage");
+        var files = storage.AddFiles("files");
+
+        subnet.AddPrivateEndpoint(files);
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
+
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageResourceUriExpressionTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageResourceUriExpressionTests.cs
@@ -52,6 +52,29 @@ public class AzureStorageResourceUriExpressionTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    public void FileUriExpressionReturnsExpectedValueOrThrowUnderEmulator(bool isEmulator)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var storage = builder.AddAzureStorage("storage");
+        if (isEmulator)
+        {
+            storage.RunAsEmulator();
+        }
+
+        var resource = Assert.Single(builder.Resources.OfType<AzureStorageResource>());
+        if (isEmulator)
+        {
+            Assert.Throws<InvalidOperationException>(() => resource.FileUriExpression);
+        }
+        else
+        {
+            Assert.Equal("{storage.outputs.fileEndpoint}", resource.FileUriExpression.ValueExpression);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     public void QueueUriExpressionReturnsExpectedValue(bool isEmulator)
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
@@ -67,7 +67,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource env_storageVolume 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('envstoragevolume${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -81,12 +81,12 @@ resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   tags: tags
 }
 
-resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
   name: 'default'
   parent: env_storageVolume
 }
 
-resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('sharesvolumescache0-${uniqueString(resourceGroup().id)}', 63)
   properties: {
     enabledProtocols: 'SMB'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
@@ -69,7 +69,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource env_storageVolume 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: 'vol${resourceToken}'
   kind: 'StorageV2'
   location: location
@@ -83,12 +83,12 @@ resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   tags: tags
 }
 
-resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
   name: 'default'
   parent: env_storageVolume
 }
 
-resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('${toLower('cache')}-${toLower('Appdata')}', 60)
   properties: {
     enabledProtocols: 'SMB'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWithCompactNamingPreservesUniqueString.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWithCompactNamingPreservesUniqueString.verified.bicep
@@ -69,7 +69,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: my_long_env_name
 }
 
-resource my_long_env_name_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource my_long_env_name_storageVolume 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('mylongenvsv${resourceToken}', 24)
   kind: 'StorageV2'
   location: location
@@ -83,12 +83,12 @@ resource my_long_env_name_storageVolume 'Microsoft.Storage/storageAccounts@2024-
   tags: tags
 }
 
-resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
   name: 'default'
   parent: my_long_env_name_storageVolume
 }
 
-resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('${toLower('cache')}-${toLower('Appdata')}', 60)
   properties: {
     enabledProtocols: 'SMB'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CompactNamingMultipleVolumesHaveUniqueNames.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CompactNamingMultipleVolumesHaveUniqueNames.verified.bicep
@@ -69,7 +69,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: my_ace
 }
 
-resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('myacesv${resourceToken}', 24)
   kind: 'StorageV2'
   location: location
@@ -83,12 +83,12 @@ resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   tags: tags
 }
 
-resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
   name: 'default'
   parent: my_ace_storageVolume
 }
 
-resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('${toLower('druid')}-${toLower('druid_shared')}', 60)
   properties: {
     enabledProtocols: 'SMB'
@@ -110,7 +110,7 @@ resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/stora
   parent: my_ace
 }
 
-resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('${toLower('druid')}-${toLower('coordinator_var')}', 60)
   properties: {
     enabledProtocols: 'SMB'
@@ -132,7 +132,7 @@ resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/stora
   parent: my_ace
 }
 
-resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('${toLower('druid')}-${toLower('bm0')}', 60)
   properties: {
     enabledProtocols: 'SMB'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#03.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#03.verified.txt
@@ -67,7 +67,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: my_ace
 }
 
-resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('myacestoragevolume${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -81,12 +81,12 @@ resource my_ace_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   tags: tags
 }
 
-resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
   name: 'default'
   parent: my_ace_storageVolume
 }
 
-resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('sharesvolumesdruid0-${uniqueString(resourceGroup().id)}', 63)
   properties: {
     enabledProtocols: 'SMB'
@@ -108,7 +108,7 @@ resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/stora
   parent: my_ace
 }
 
-resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('sharesvolumesdruid1-${uniqueString(resourceGroup().id)}', 63)
   properties: {
     enabledProtocols: 'SMB'
@@ -130,7 +130,7 @@ resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/stora
   parent: my_ace
 }
 
-resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
   name: take('sharesbindmountsdruid0-${uniqueString(resourceGroup().id)}', 63)
   properties: {
     enabledProtocols: 'SMB'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#01.verified.bicep
@@ -5,7 +5,7 @@ param storageName string
 
 param principalId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: storageName
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#01.verified.bicep
@@ -5,7 +5,7 @@ param storage_Sku string
 
 param sku_description string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -34,7 +34,11 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#01.verified.bicep
@@ -5,7 +5,7 @@ param funcstorage634f8_outputs_name string
 
 param principalId string
 
-resource funcstorage634f8 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource funcstorage634f8 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: funcstorage634f8_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage.verified.bicep
@@ -5,7 +5,7 @@ param my_own_storage_outputs_name string
 
 param principalId string
 
-resource my_own_storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource my_own_storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: my_own_storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments.verified.bicep
@@ -5,7 +5,7 @@ param my_own_storage_outputs_name string
 
 param principalId string
 
-resource my_own_storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource my_own_storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: my_own_storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.MultipleAddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.MultipleAddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments#00.verified.bicep
@@ -5,7 +5,7 @@ param my_own_storage_outputs_name string
 
 param principalId string
 
-resource my_own_storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource my_own_storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: my_own_storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.MultipleAddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.MultipleAddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments#01.verified.bicep
@@ -5,7 +5,7 @@ param funcstorage634f8_outputs_name string
 
 param principalId string
 
-resource funcstorage634f8 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource funcstorage634f8 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: funcstorage634f8_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=False_operation=Publish.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=False_operation=Publish.verified.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param principalId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=False_operation=Run.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=False_operation=Run.verified.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param principalId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=True_operation=Run.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesDefaultRoleAssignmentsInRunModeIfReferenced_addContainerAppsInfra=True_operation=Run.verified.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param principalId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesRoleAssignmentsInRunMode_operation=Run.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourcePreparerTests.AppliesRoleAssignmentsInRunMode_operation=Run.verified.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param principalId string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: storage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_AutoCreatesBothSubnetAndStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_AutoCreatesBothSubnetAndStorage.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -538,7 +538,7 @@ param sql_store_outputs_name string
 
 param principalId string
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -602,7 +602,7 @@ output name string = sql_nsg.name
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('sqlstore${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -632,7 +632,11 @@ output queueEndpoint string = sql_store.properties.primaryEndpoints.queue
 
 output tableEndpoint string = sql_store.properties.primaryEndpoints.table
 
+output fileEndpoint string = sql_store.properties.primaryEndpoints.file
+
 output name string = sql_store.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = sql_store.id
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_BothExplicitSubnetAndStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_BothExplicitSubnetAndStorage.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 
@@ -118,7 +118,7 @@ resource script_sql_db 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('depscriptstorage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -148,7 +148,11 @@ output queueEndpoint string = depscriptstorage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = depscriptstorage.properties.primaryEndpoints.table
 
+output fileEndpoint string = depscriptstorage.properties.primaryEndpoints.file
+
 output name string = depscriptstorage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = depscriptstorage.id
 
@@ -571,7 +575,7 @@ param depscriptstorage_outputs_name string
 
 param principalId string
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitStorage_AutoCreatesSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitStorage_AutoCreatesSubnet.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 
@@ -118,7 +118,7 @@ resource script_sql_db 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('depscriptstorage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -148,7 +148,11 @@ output queueEndpoint string = depscriptstorage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = depscriptstorage.properties.primaryEndpoints.table
 
+output fileEndpoint string = depscriptstorage.properties.primaryEndpoints.file
+
 output name string = depscriptstorage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = depscriptstorage.id
 
@@ -576,7 +580,7 @@ param depscriptstorage_outputs_name string
 
 param principalId string
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitSubnet_AutoCreatesStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitSubnet_AutoCreatesStorage.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -533,7 +533,7 @@ param sql_store_outputs_name string
 
 param principalId string
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -551,7 +551,7 @@ resource sql_store_StorageFileDataPrivilegedContributor 'Microsoft.Authorization
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('sqlstore${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -581,7 +581,11 @@ output queueEndpoint string = sql_store.properties.primaryEndpoints.queue
 
 output tableEndpoint string = sql_store.properties.primaryEndpoints.table
 
+output fileEndpoint string = sql_store.properties.primaryEndpoints.file
+
 output name string = sql_store.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = sql_store.id
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_StorageBeforePrivateEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_StorageBeforePrivateEndpoint.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 
@@ -118,7 +118,7 @@ resource script_sql_db 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('depscriptstorage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -148,7 +148,11 @@ output queueEndpoint string = depscriptstorage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = depscriptstorage.properties.primaryEndpoints.table
 
+output fileEndpoint string = depscriptstorage.properties.primaryEndpoints.file
+
 output name string = depscriptstorage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = depscriptstorage.id
 
@@ -576,7 +580,7 @@ param depscriptstorage_outputs_name string
 
 param principalId string
 
-resource depscriptstorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource depscriptstorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: depscriptstorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_SubnetBeforePrivateEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_SubnetBeforePrivateEndpoint.verified.bicep
@@ -45,7 +45,7 @@ resource sqlServerAdmin 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   name: sql_outputs_sqlserveradminname
 }
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -533,7 +533,7 @@ param sql_store_outputs_name string
 
 param principalId string
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: sql_store_outputs_name
 }
 
@@ -551,7 +551,7 @@ resource sql_store_StorageFileDataPrivilegedContributor 'Microsoft.Authorization
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource sql_store 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource sql_store 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('sqlstore${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -581,7 +581,11 @@ output queueEndpoint string = sql_store.properties.primaryEndpoints.queue
 
 output tableEndpoint string = sql_store.properties.primaryEndpoints.table
 
+output fileEndpoint string = sql_store.properties.primaryEndpoints.file
+
 output name string = sql_store.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = sql_store.id
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAsExistingResource_RespectsExistingAzureResourceAnnotation_ForAzureStorageResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAsExistingResource_RespectsExistingAzureResourceAnnotation_ForAzureStorageResource.verified.bicep
@@ -5,7 +5,7 @@ param existing_storage_name string
 
 param existing_storage_rg string
 
-resource test_storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource test_storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: existing_storage_name
   scope: resourceGroup(existing_storage_rg)
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureFiles_AsExistingReferencesAccountServiceAndShare.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureFiles_AsExistingReferencesAccountServiceAndShare.verified.bicep
@@ -1,0 +1,34 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param storage_account_name string
+
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
+  name: storage_account_name
+}
+
+resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' existing = {
+  name: 'default'
+  parent: storage
+}
+
+resource media 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' existing = {
+  name: 'media-share'
+  parent: files
+}
+
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
+
+output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
+
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
+
+output tableEndpoint string = storage.properties.primaryEndpoints.table
+
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
+output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
+
+output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureFiles_GeneratesSmbOAuthAndFileShare.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureFiles_GeneratesSmbOAuthAndFileShare.verified.bicep
@@ -1,0 +1,55 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+  name: take('storage${uniqueString(resourceGroup().id)}', 24)
+  kind: 'StorageV2'
+  location: location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  properties: {
+    accessTier: 'Hot'
+    allowSharedKeyAccess: false
+    azureFilesIdentityBasedAuthentication: {
+      directoryServiceOptions: 'None'
+      smbOAuthSettings: {
+        isSmbOAuthEnabled: true
+      }
+    }
+    isHnsEnabled: false
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      defaultAction: 'Allow'
+    }
+  }
+  tags: {
+    'aspire-resource-name': 'storage'
+  }
+}
+
+resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
+  name: 'default'
+  parent: storage
+}
+
+resource media 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
+  name: 'media-share'
+  parent: files
+}
+
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
+
+output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
+
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
+
+output tableEndpoint string = storage.properties.primaryEndpoints.table
+
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
+output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
+
+output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param storagesku string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -32,6 +32,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishModeEnableAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishModeEnableAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param storagesku string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -32,6 +32,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaRunMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaRunMode.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param storagesku string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -32,6 +32,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaRunModeAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaRunModeAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param storagesku string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -32,6 +32,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -11,6 +11,12 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   properties: {
     accessTier: 'Hot'
     allowSharedKeyAccess: false
+    azureFilesIdentityBasedAuthentication: {
+      directoryServiceOptions: 'None'
+      smbOAuthSettings: {
+        isSmbOAuthEnabled: true
+      }
+    }
     isHnsEnabled: false
     minimumTlsVersion: 'TLS1_2'
     networkAcls: {
@@ -22,24 +28,34 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2025-06-01' = {
   name: 'default'
   parent: storage
 }
 
-resource myContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2024-01-01' = {
+resource myContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2025-06-01' = {
   name: 'my-blob-container'
   parent: blobs
 }
 
-resource queues 'Microsoft.Storage/storageAccounts/queueServices@2024-01-01' = {
+resource queues 'Microsoft.Storage/storageAccounts/queueServices@2025-06-01' = {
   name: 'default'
   parent: storage
 }
 
-resource myqueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01-01' = {
+resource myqueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2025-06-01' = {
   name: 'my-queue'
   parent: queues
+}
+
+resource files 'Microsoft.Storage/storageAccounts/fileServices@2025-06-01' = {
+  name: 'default'
+  parent: storage
+}
+
+resource myshare 'Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01' = {
+  name: 'my-file-share'
+  parent: files
 }
 
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
@@ -50,6 +66,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithDataLakePrivateEndpoint_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithDataLakePrivateEndpoint_GeneratesCorrectBicep.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -31,6 +31,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithFilesPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithFilesPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
@@ -1,0 +1,46 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+  name: take('storage${uniqueString(resourceGroup().id)}', 24)
+  kind: 'StorageV2'
+  location: location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  properties: {
+    accessTier: 'Hot'
+    allowSharedKeyAccess: false
+    azureFilesIdentityBasedAuthentication: {
+      directoryServiceOptions: 'None'
+      smbOAuthSettings: {
+        isSmbOAuthEnabled: true
+      }
+    }
+    isHnsEnabled: false
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
+    publicNetworkAccess: 'Disabled'
+  }
+  tags: {
+    'aspire-resource-name': 'storage'
+  }
+}
+
+output blobEndpoint string = storage.properties.primaryEndpoints.blob
+
+output dataLakeEndpoint string = storage.properties.primaryEndpoints.dfs
+
+output queueEndpoint string = storage.properties.primaryEndpoints.queue
+
+output tableEndpoint string = storage.properties.primaryEndpoints.table
+
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
+output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
+
+output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -31,6 +31,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithTablePrivateEndpoint_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStoragePrivateEndpointLockdownTests.AddAzureStorage_WithTablePrivateEndpoint_GeneratesCorrectBicep.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -31,6 +31,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#02.verified.bicep
@@ -5,7 +5,7 @@ param mystorage_outputs_name string
 
 param principalId string
 
-resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource mystorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: mystorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#03.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#03.verified.bicep
@@ -5,7 +5,7 @@ param mystorage_outputs_name string
 
 param principalId string
 
-resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource mystorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: mystorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#04.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#04.verified.bicep
@@ -5,7 +5,7 @@ param mystorage_outputs_name string
 
 param principalId string
 
-resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource mystorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: mystorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#02.verified.bicep
@@ -5,7 +5,7 @@ param mystorage_outputs_name string
 
 param principalId string
 
-resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource mystorage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: mystorage_outputs_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroup.verified.bicep
@@ -1,9 +1,9 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param existingResourceName string
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: existingResourceName
 }
 
@@ -15,6 +15,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroupAndStaticArguments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroupAndStaticArguments.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+resource storage 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
   name: 'existingResourcename'
 }
 
@@ -13,6 +13,10 @@ output queueEndpoint string = storage.properties.primaryEndpoints.queue
 
 output tableEndpoint string = storage.properties.primaryEndpoints.table
 
+output fileEndpoint string = storage.properties.primaryEndpoints.file
+
 output name string = storage.name
+
+output resourceGroupName string = resourceGroup().name
 
 output id string = storage.id

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
@@ -10,6 +10,7 @@
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes.Annotations;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests;
@@ -1708,6 +1709,60 @@ public class KubernetesDeployTests(ITestOutputHelper outputHelper)
         await Verify(await File.ReadAllTextAsync(Path.Combine(workspace.Path, "values.yaml")), "yaml")
             .AppendContentAsFile(
                 await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "myapp", "config.yaml")),
+                "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(overridePath), "yaml");
+    }
+
+    [Fact]
+    public async Task StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: WellKnownPipelineSteps.Publish);
+        var mockActivityReporter = new TestPipelineActivityReporter(outputHelper);
+
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+        builder.Services.AddSingleton<IPipelineActivityReporter>(mockActivityReporter);
+
+        var envBuilder = builder.AddKubernetesEnvironment("env");
+        var resourceGroup = new TestValueProvider("resolved-rg", "{storage.outputs.resourceGroupName}");
+        var accountName = new TestValueProvider("resolved-account", "{storage.outputs.name}");
+        var volume = envBuilder.AddPersistentVolume("data").WithCapacity("5Gi");
+        volume.WithAnnotation(new KubernetesCsiPersistentVolumeSourceAnnotation(
+            "example.csi.test",
+            ReferenceExpression.Create($"{resourceGroup}#{accountName}#share"),
+            new Dictionary<string, ReferenceExpression>
+            {
+                ["resourceGroup"] = ReferenceExpression.Create($"{resourceGroup}"),
+                ["account"] = ReferenceExpression.Create($"{accountName}"),
+            },
+            defaultStorageClassName: "example-csi",
+            defaultAccessMode: PersistentVolumeAccessMode.ReadWriteMany));
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        var env = envBuilder.Resource;
+        Assert.Contains(env.CapturedHelmValueProviders, captured =>
+            captured.Section == "config" &&
+            captured.ResourceKey == "data" &&
+            captured.ValueKey == "storage_outputs_resourceGroupName" &&
+            captured.ValueProvider == resourceGroup);
+        Assert.Contains(env.CapturedHelmValueProviders, captured =>
+            captured.Section == "config" &&
+            captured.ResourceKey == "data" &&
+            captured.ValueKey == "storage_outputs_name" &&
+            captured.ValueProvider == accountName);
+
+        await HelmDeploymentEngine.ResolveAndWriteDeployValuesAsync(
+            workspace.Path, env, CancellationToken.None);
+
+        var overridePath = Path.Combine(workspace.Path, HelmDeploymentEngine.GetDeployValuesFileName("env"));
+        await Verify(await File.ReadAllTextAsync(Path.Combine(workspace.Path, "values.yaml")), "yaml")
+            .AppendContentAsFile(
+                await File.ReadAllTextAsync(Path.Combine(workspace.Path, "templates", "data", "pv.yaml")),
                 "yaml")
             .AppendContentAsFile(await File.ReadAllTextAsync(overridePath), "yaml");
     }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesDeployTests.cs
@@ -1891,6 +1891,34 @@ public class KubernetesDeployTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task HelmDeploy_UsesConfiguredTimeout()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var fakeHelm = new FakeHelmRunner();
+        var mockActivityReporter = new TestPipelineActivityReporter(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: WellKnownPipelineSteps.Deploy);
+
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+        builder.Services.AddSingleton<IPipelineActivityReporter>(mockActivityReporter);
+        builder.Services.AddSingleton<IDeploymentStateManager, InMemoryDeploymentStateManager>();
+        builder.Services.AddSingleton<IHelmRunner>(fakeHelm);
+
+        var environment = builder.AddKubernetesEnvironment("env").Resource;
+        environment.HelmDeploymentTimeout = TimeSpan.FromMinutes(15);
+        builder.AddContainer("api", "myimage");
+
+        using var app = builder.Build();
+        await app.RunAsync();
+
+        Assert.StartsWith("upgrade --install", fakeHelm.LastArguments);
+        Assert.Contains("--timeout 900s", fakeHelm.LastArguments);
+    }
+
+    [Fact]
     public async Task DestroyHelm_WithState_RunsHelmUninstall()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREPIPELINES001
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes.Annotations;
 using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
@@ -1861,6 +1862,43 @@ public class KubernetesPublisherTests(ITestOutputHelper outputHelper)
             new System.Text.RegularExpressions.Regex(@"parameters:[\s\S]+data:[\s\S]+" +
                 System.Text.RegularExpressions.Regex.Escape(backupTierName) + @"\s*:"),
             valuesContent);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithStaticCsiPersistentVolume_EmitsPreboundVolumeAndClaim()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var data = k8s.AddPersistentVolume("data")
+            .WithCapacity("100Gi");
+        data.WithAnnotation(new KubernetesCsiPersistentVolumeSourceAnnotation(
+            driver: "example.csi.test",
+            volumeHandle: ReferenceExpression.Create($"account#share"),
+            volumeAttributes: new Dictionary<string, ReferenceExpression>
+            {
+                ["account"] = ReferenceExpression.Create($"account"),
+                ["share"] = ReferenceExpression.Create($"share"),
+            },
+            mountOptions: ["dir_mode=0770", "file_mode=0770"],
+            defaultStorageClassName: "example-csi",
+            defaultAccessMode: PersistentVolumeAccessMode.ReadWriteMany));
+
+        builder.AddContainer("service", "nginx")
+            .WithPersistentVolume(data, "/var/lib/data");
+
+        var app = builder.Build();
+        app.Run();
+
+        var volumePath = Path.Combine(workspace.Path, "templates", "data", "pv.yaml");
+        var claimPath = Path.Combine(workspace.Path, "templates", "data", "data.yaml");
+
+        Assert.True(File.Exists(volumePath), $"Expected persistent volume manifest at {volumePath}");
+        Assert.True(File.Exists(claimPath), $"Expected persistent volume claim manifest at {claimPath}");
+
+        await Verify(await File.ReadAllTextAsync(volumePath), "yaml")
+            .AppendContentAsFile(await File.ReadAllTextAsync(claimPath), "yaml");
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#00.verified.yaml
@@ -1,0 +1,6 @@
+﻿parameters: {}
+secrets: {}
+config:
+  data:
+    storage_outputs_resourceGroupName: ""
+    storage_outputs_name: ""

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#01.verified.yaml
@@ -1,0 +1,18 @@
+﻿---
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "data-pv"
+spec:
+  storageClassName: "example-csi"
+  csi:
+    driver: "example.csi.test"
+    volumeHandle: "{{ .Values.config.data.storage_outputs_resourceGroupName }}#{{ .Values.config.data.storage_outputs_name }}#share"
+    volumeAttributes:
+      resourceGroup: "{{ .Values.config.data.storage_outputs_resourceGroupName }}"
+      account: "{{ .Values.config.data.storage_outputs_name }}"
+  accessModes:
+    - "ReadWriteMany"
+  capacity:
+    storage: "5Gi"
+  persistentVolumeReclaimPolicy: "Retain"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesDeployTests.StaticCsiVolumeDeferredValues_EndToEnd_PublishAndResolve#02.verified.yaml
@@ -1,0 +1,4 @@
+﻿config:
+  data:
+    storage_outputs_resourceGroupName: "resolved-rg"
+    storage_outputs_name: "resolved-account"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithStaticCsiPersistentVolume_EmitsPreboundVolumeAndClaim#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithStaticCsiPersistentVolume_EmitsPreboundVolumeAndClaim#00.verified.yaml
@@ -1,0 +1,21 @@
+﻿---
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: "data-pv"
+spec:
+  storageClassName: "example-csi"
+  csi:
+    driver: "example.csi.test"
+    volumeHandle: "account#share"
+    volumeAttributes:
+      account: "account"
+      share: "share"
+  accessModes:
+    - "ReadWriteMany"
+  mountOptions:
+    - "dir_mode=0770"
+    - "file_mode=0770"
+  capacity:
+    storage: "100Gi"
+  persistentVolumeReclaimPolicy: "Retain"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithStaticCsiPersistentVolume_EmitsPreboundVolumeAndClaim#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_WithStaticCsiPersistentVolume_EmitsPreboundVolumeAndClaim#01.verified.yaml
@@ -1,0 +1,13 @@
+﻿---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "data"
+spec:
+  storageClassName: "example-csi"
+  volumeName: "data-pv"
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "100Gi"

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Go/apphost.go
@@ -32,6 +32,8 @@ func main() {
 	storage.AddQueues("queues")
 	storage.AddQueue("orders")
 	storage.AddBlobContainer("images")
+	files := storage.AddFiles("files")
+	files.AddFileShare("media")
 
 	if storage.Err() != nil {
 		log.Fatalf(aspire.FormatError(storage.Err()))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Java/AppHost.java
@@ -20,5 +20,7 @@ void main() throws Exception {
         storage.addQueues("queues");
         storage.addQueue("orders");
         storage.addBlobContainer("images");
+        var files = storage.addFiles("files");
+        files.addFileShare("media");
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/Python/apphost.py
@@ -14,4 +14,6 @@ with create_builder() as builder:
     storage.add_queues("resource")
     storage.add_queue("resource")
     storage.add_blob_container("resource")
+    files = storage.add_files("files")
+    files.add_file_share("media")
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Storage/TypeScript/apphost.mts
@@ -22,5 +22,7 @@ await storage.addTables("tables");
 await storage.addQueues("queues");
 await storage.addQueue("orders");
 await storage.addBlobContainer("images");
+const files = await storage.addFiles("files");
+await files.addFileShare("media");
 
 await builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -113,7 +113,7 @@ void main() throws Exception {
         aksVolume.withCapacity("20Gi");
         var aksStorage = builder.addAzureStorage("aks-storage");
         var aksFiles = aksStorage.addFiles("aks-files");
-        var aksShare = aksFiles.addFileShare("aks-share", new AddFileShareOptions().fileShareName("shared"));
+        var aksShare = aksFiles.addFileShare("aks-share", "shared");
         var aksFilesVolume = aks.addPersistentVolume("aks-files-volume");
         aksFilesVolume.withAzureFileShare(aksShare);
         var pipeline = builder.pipeline();

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/AppHost.java
@@ -111,6 +111,11 @@ void main() throws Exception {
         aks.addNodePool("system", new AddNodePoolOptions().vmSize(AksNodeVmSizes.StandardDSv5.StandardD2sV5));
         var aksVolume = aks.addPersistentVolume("aks-data");
         aksVolume.withCapacity("20Gi");
+        var aksStorage = builder.addAzureStorage("aks-storage");
+        var aksFiles = aksStorage.addFiles("aks-files");
+        var aksShare = aksFiles.addFileShare("aks-share", new AddFileShareOptions().fileShareName("shared"));
+        var aksFilesVolume = aks.addPersistentVolume("aks-files-volume");
+        aksFilesVolume.withAzureFileShare(aksShare);
         var pipeline = builder.pipeline();
         pipeline.addStep("custom-builder-step", (stepContext) -> { var builderSummary = stepContext.summary(); builderSummary.add("BuilderPipelineStep", "Validated"); }, new AddStepOptions().dependsOn(new String[] { WellKnownPipelineSteps.Build }).requiredBy(new String[] { WellKnownPipelineSteps.Publish }));
         pipeline.configure((configContext) -> { var builderPipeline = configContext.pipeline(); var _allSteps = builderPipeline.steps(); var _builderTaggedSteps = configContext.getSteps("custom-build"); });

--- a/tests/PolyglotAppHosts/Aspire.Hosting/Java/aspire.config.json
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/Java/aspire.config.json
@@ -10,6 +10,7 @@
     "Aspire.Hosting": "",
     "Aspire.Hosting.Azure.Kubernetes": "",
     "Aspire.Hosting.Azure.Network": "",
+    "Aspire.Hosting.Azure.Storage": "",
     "Aspire.Hosting.Redis": ""
   }
 }

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -221,6 +221,11 @@ const aks = await builder.addAzureKubernetesEnvironment("aks");
 await aks.addNodePool("system", { vmSize: AksNodeVmSizes.StandardDSv5.StandardD2sV5 });
 const aksVolume = await aks.addPersistentVolume("aks-data");
 await aksVolume.withCapacity("20Gi");
+const aksStorage = await builder.addAzureStorage("aks-storage");
+const aksFiles = await aksStorage.addFiles("aks-files");
+const aksShare = await aksFiles.addFileShare("aks-share", { fileShareName: "shared" });
+const aksFilesVolume = await aks.addPersistentVolume("aks-files-volume");
+await aksFilesVolume.withAzureFileShare(aksShare);
 
 // ===================================================================
 // Application pipeline on builder

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/aspire.config.json
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/aspire.config.json
@@ -7,6 +7,7 @@
     "Aspire.Hosting": "",
     "Aspire.Hosting.Azure.Kubernetes": "",
     "Aspire.Hosting.Azure.Network": "",
+    "Aspire.Hosting.Azure.Storage": "",
     "Aspire.Hosting.Redis": ""
   }
 }


### PR DESCRIPTION
## Description

AKS persistent volumes currently default to Azure managed disks, and Aspire has no first-class way to model an Azure file share and mount it securely into an AKS workload. This adds a keyless Azure Files path using the Azure Files CSI driver and a dedicated workload identity for each persistent volume.

### User-facing usage

**C# AppHost**

```csharp
var files = builder.AddAzureStorage("storage").AddFiles("files");
var share = files.AddFileShare("media-share", "media");

var media = aks.AddPersistentVolume("media-volume")
    .WithAzureFileShare(share)
    .WithCapacity("100Gi");

myService.WithPersistentVolume(media, "/srv/media");
```

**TypeScript AppHost**

```typescript
const storage = await builder.addAzureStorage("storage");
const files = await storage.addFiles("files");
const share = await files.addFileShare("media-share", { fileShareName: "media" });

const media = await aks.addPersistentVolume("media-volume");
await media.withAzureFileShare(share);
await media.withCapacity("100Gi");

await myService.withKubernetesPersistentVolumeMount(media, "/srv/media");
```

The change:

- adds Azure Files service and file-share resources under `AzureStorageResource`;
- enables SMB OAuth and keeps shared-key authentication disabled for Aspire-owned accounts;
- preserves read-only semantics for existing Azure Storage accounts and file shares;
- adds generic static CSI PersistentVolume generation with a pre-bound PVC and deferred deploy-time values;
- creates one user-assigned managed identity per Azure Files PV and federates every consuming workload's Kubernetes service account to it;
- configures `mountWithWorkloadIdentityToken: "true"` and removes Azure Files permissions from the AKS kubelet identity;
- grants the PV identity the account-scoped `Storage File Data SMB MI Admin` data-plane role, which has no ARM control-plane actions;
- extends the Helm readiness timeout only for AKS Azure Files workload-identity deployments so newly created federated credentials can propagate;
- generates no Kubernetes storage-key Secret and defaults the static PV reclaim policy to `Retain`;
- updates `Azure.Provisioning.Storage` to `1.2.0-beta.1`, mirrored internally by [dotnet-migrate-package run 3057583](https://dev.azure.com/dnceng/internal/_build/results?buildId=3057583). Because stable-package stabilization rejects prerelease dependencies, affected packages suppress `NU5104` only when `StabilizePackageVersion=true`; this suppression should be removed when `Azure.Provisioning.Storage 1.2.0` ships stable.

Workload-identity Azure Files mounts require Azure Files CSI driver v1.35.0 or later on Linux nodes.

### Security considerations

Each static PV receives a distinct UAMI and fixed CSI `clientID`. Only Kubernetes service accounts federated to that identity can mount the volume; unrelated pods no longer inherit Azure Files access through the node's kubelet identity. Aspire-owned accounts enable SMB OAuth and disable shared keys, and no Kubernetes Secret is generated.

Azure Files currently requires `Storage File Data SMB MI Admin` for managed-identity Kerberos mounts. This role has data actions only and cannot create, delete, or configure ARM resources. Live testing confirmed that share and file-service scopes return `Permission denied`; the supported account scope therefore covers every file share in that storage account. Use separate storage accounts when volumes require independent data-access boundaries.

Azure deployments are incremental. Removing or retargeting a PV does not automatically delete its previous UAMI or role assignment; remove those explicitly or use `aspire destroy` when the application owns the deployment resource group.

### Validation

- `./build.sh --build /p:SkipNativeBuild=true /m:1`
- stabilization build with `StabilizePackageVersion=true`
- `Aspire.Hosting.Kubernetes.Tests`: 306 passed
- `Aspire.Hosting.Azure.Kubernetes.Tests`: 105 passed
- `Aspire.Hosting.Azure.Tests`: 1712 passed, 5 existing skips
- TypeScript and Go generated SDK compilation; Python and Java SDK generation
- Live `DeployAksPersistentVolumesSurviveRedeploy` E2E: passed against AKS in 14m22s, including per-PV UAMI creation, service-account federation, account-scoped data-only RBAC, no kubelet Azure Files role, `mountWithWorkloadIdentityToken`, no `nodeStageSecretRef`, `sec=krb5`, and persistence across redeploy

Fixes #2203

Relates to #16999

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
