### PR TITLE
Stabilize AppHost lifecycle and workspace terminal E2E tests

### DIFF
--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -76,6 +76,8 @@
   "aspire-vscode.strings.aspireCliVersion": "Aspire CLI Version: {0}.",
   "aspire-vscode.strings.requiredCapability": "Required capability: {0}.",
   "aspire-vscode.strings.aspireTerminalName": "Aspire terminal",
+  "aspire-vscode.strings.aspireTerminalClosedBeforeProcessStarted": "Aspire terminal closed before its process started.",
+  "aspire-vscode.strings.aspireTerminalProcessFailedToStart": "Aspire terminal process failed to start.",
   "aspire-vscode.strings.createWithAspirePlaceholder": "Choose how to set up Aspire",
   "aspire-vscode.strings.createNewAspireAppLabel": "Create a new Aspire app",
   "aspire-vscode.strings.createNewAspireAppDescription": "Start a greenfield application in a new directory using an Aspire template.",

--- a/extension/src/activation/registerCodeLensCommands.ts
+++ b/extension/src/activation/registerCodeLensCommands.ts
@@ -79,7 +79,7 @@ export function registerCodeLensCommands(
     const target = appHostPath
       ? getCliPathTargetForUri(vscode.Uri.file(appHostPath))
       : windowCliPathTarget;
-    terminalProvider.sendAspireCommandToAspireTerminal(command, true, undefined, { target });
+    return terminalProvider.sendAspireCommandToAspireTerminal(command, true, undefined, { target });
   });
   const codeLensRevealResourceRegistration = registerInstrumentedCommand('aspire-vscode.codeLensRevealResource', 'codelens', (resourceName: string, appHostPath?: string) => {
     const element = appHostTreeProvider.findResourceElement(resourceName, appHostPath);
@@ -106,7 +106,7 @@ export function registerCodeLensCommands(
     const target = appHostPath
       ? getCliPathTargetForUri(vscode.Uri.file(appHostPath))
       : windowCliPathTarget;
-    terminalProvider.sendAspireCommandToAspireTerminal('logs', true, additionalArgs, { target });
+    return terminalProvider.sendAspireCommandToAspireTerminal('logs', true, additionalArgs, { target });
   });
 
   return [

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -21,6 +21,8 @@ export const aspireHostingSdkVersion = (version: string) => vscode.l10n.t('Aspir
 export const aspireCliVersion = (version: string) => vscode.l10n.t('Aspire CLI Version: {0}.', version);
 export const requiredCapability = (capability: string) => vscode.l10n.t('Required capability: {0}.', capability);
 export const aspireTerminalName = vscode.l10n.t('Aspire terminal');
+export const aspireTerminalClosedBeforeProcessStarted = vscode.l10n.t('Aspire terminal closed before its process started.');
+export const aspireTerminalProcessFailedToStart = vscode.l10n.t('Aspire terminal process failed to start.');
 export const createWithAspirePlaceholder = vscode.l10n.t('Choose how to set up Aspire');
 export const createNewAspireAppLabel = vscode.l10n.t('Create a new Aspire app');
 export const createNewAspireAppDescription = vscode.l10n.t('Start a greenfield application in a new directory using an Aspire template.');

--- a/extension/src/test-e2e/appHostLifecycleTools.e2e.test.ts
+++ b/extension/src/test-e2e/appHostLifecycleTools.e2e.test.ts
@@ -300,6 +300,7 @@ suite('Aspire AppHost lifecycle E2E', function () {
             const linkedFixture = fixture;
             assert.ok(linkedFixture);
             const wrapper = writeTimeoutCliWrapper();
+            const timeoutMs = 10000;
             let descendantPid: number | undefined;
 
             try {
@@ -309,12 +310,12 @@ suite('Aspire AppHost lifecycle E2E', function () {
                     name: 'runAspireCli',
                     args: ['timeout-tree'],
                     workingDirectory: path.relative(getWorkspaceRoot(), linkedFixture.linkedWorktreePath),
-                    timeoutMs: 1000,
+                    timeoutMs,
                 }, 30000);
                 invocation.catch(() => undefined);
 
-                descendantPid = await waitForProcessIdFile(wrapper.pidPath, 10000);
-                await assert.rejects(invocation, /timed out after 1000ms/);
+                descendantPid = await waitForProcessIdFile(wrapper.pidPath, 30000);
+                await assert.rejects(invocation, new RegExp(`timed out after ${timeoutMs}ms`));
                 assert.strictEqual(isProcessRunning(descendantPid), false, `Expected descendant process ${descendantPid} to be gone before runAspireCli rejected.`);
             }
             finally {

--- a/extension/src/test-e2e/workspaceTargetProof.e2e.test.ts
+++ b/extension/src/test-e2e/workspaceTargetProof.e2e.test.ts
@@ -89,6 +89,7 @@ suite('Workspace target proof E2E', function () {
         assert.ok(!updateCommand.commandLine.includes(workspaceRoot), updateCommand.commandLine);
         assert.ok(!updateCommand.commandLine.includes(folderA.wrapperPath), updateCommand.commandLine);
         assert.ok(!updateCommand.commandLine.includes(folderB.wrapperPath), updateCommand.commandLine);
+        assert.ok(!updateCommand.commandLine.includes(folderC.wrapperPath), updateCommand.commandLine);
 
         await VSBrowser.instance.takeScreenshot('workspace-target-proof.png');
     });

--- a/extension/src/test-e2e/workspaceTargetProof.e2e.test.ts
+++ b/extension/src/test-e2e/workspaceTargetProof.e2e.test.ts
@@ -35,10 +35,13 @@ suite('Workspace target proof E2E', function () {
         assert.ok(runRoot, 'The E2E run root is required for sibling workspace folder fixtures.');
         const folderA = createFolderFixture(runRoot, 'folder-a', true);
         const folderB = createFolderFixture(runRoot, 'folder-b');
+        const folderC = createFolderFixture(runRoot, 'folder-c');
+        const workspaceFolderLabels = ['folder-a', 'folder-b', 'folder-c'] as const;
 
         await openAspireView();
         await addWorkspaceFolder(folderA.folderPath);
         await addWorkspaceFolder(folderB.folderPath);
+        await addWorkspaceFolder(folderC.folderPath);
         await setE2eCliPathForE2E(undefined);
 
         const folderAAppHostPath = path.join(folderA.folderPath, 'apphost.cs');
@@ -46,10 +49,10 @@ suite('Workspace target proof E2E', function () {
             ({ state }) => state.workspaceAppHostCandidatePaths.some(candidatePath => isSamePath(candidatePath, folderAAppHostPath)),
             `folder-a AppHost candidate '${folderAAppHostPath}'`);
 
-        await invokeCreateWithAspireInitForFolder('folder-b', folderB, ['folder-a', 'folder-b']);
-        await invokeCreateWithAspireInitCancellation(['folder-a', 'folder-b']);
+        await invokeCreateWithAspireInitForFolder('folder-b', folderB, workspaceFolderLabels);
+        await invokeCreateWithAspireInitCancellation(workspaceFolderLabels);
         await invokeCreateWithAspireNewForFolder('folder-a', folderA);
-        await invokeNewForFolder('folder-b', folderB);
+        await invokeNewForFolder('folder-c', folderC);
 
         const beforeCanceledCreateInvocation = getCommandInvocationCount('aspire-vscode.createWithAspire');
         const beforeCanceledCreateTerminal = getTerminalCommandCount();

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -618,6 +618,7 @@ suite('AspireTerminalProvider tests', () => {
             const terminalEvents: unknown[] = [];
             const eventSubscription = terminalProvider.onDidSendAspireCommand(event => terminalEvents.push(event));
             const terminal = {
+                processId: Promise.resolve(123),
                 sendText: (text: string, shouldExecute?: boolean) => {
                     sentTexts.push({ text, shouldExecute });
                 },
@@ -643,6 +644,71 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
+        test('rejects when the terminal process does not start', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: string[] = [];
+            const terminal = {
+                processId: Promise.resolve(undefined),
+                sendText: (text: string) => {
+                    sentTexts.push(text);
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await assert.rejects(terminalProvider.sendAspireCommandToAspireTerminal('logs'));
+
+                assert.deepStrictEqual(sentTexts, []);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
+        test('rejects when the terminal closes before its process starts', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: string[] = [];
+            const processId = new Promise<number | undefined>(() => { });
+            const terminal = {
+                processId,
+                sendText: (text: string) => {
+                    sentTexts.push(text);
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+            let closeTerminal: ((terminal: vscode.Terminal) => void) | undefined;
+            const closeListenerDispose = sinon.stub();
+            const onDidCloseTerminalStub = sinon.stub(vscode.window, 'onDidCloseTerminal').callsFake(listener => {
+                closeTerminal = listener;
+                return new vscode.Disposable(closeListenerDispose);
+            });
+
+            try {
+                const sendCommand = terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                await new Promise(resolve => setImmediate(resolve));
+                assert.ok(closeTerminal);
+
+                const rejection = assert.rejects(sendCommand);
+                closeTerminal(terminal);
+                await rejection;
+
+                assert.deepStrictEqual(sentTexts, []);
+                assert.strictEqual(closeListenerDispose.calledOnce, true);
+            }
+            finally {
+                onDidCloseTerminalStub.restore();
+                getAspireTerminalStub.restore();
+            }
+        });
+
         test('waits for the terminal process before sending a fallback command', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const sentTexts: string[] = [];
@@ -650,9 +716,12 @@ suite('AspireTerminalProvider tests', () => {
             const processId = new Promise<number | undefined>(resolve => {
                 resolveProcessId = resolve;
             });
+            const closeListenerDispose = sinon.stub();
+            const onDidCloseTerminalStub = sinon.stub(vscode.window, 'onDidCloseTerminal').returns(new vscode.Disposable(closeListenerDispose));
             const terminal = {
                 processId,
                 sendText: (text: string) => {
+                    assert.strictEqual(closeListenerDispose.calledOnce, true);
                     sentTexts.push(text);
                 },
                 show: () => { }
@@ -667,13 +736,16 @@ suite('AspireTerminalProvider tests', () => {
                 await new Promise(resolve => setImmediate(resolve));
 
                 assert.deepStrictEqual(sentTexts, []);
+                assert.strictEqual(closeListenerDispose.called, false);
 
                 resolveProcessId(123);
                 await sendCommand;
 
                 assert.deepStrictEqual(sentTexts, ['\x03', expectedCommand]);
+                assert.strictEqual(closeListenerDispose.calledOnce, true);
             }
             finally {
+                onDidCloseTerminalStub.restore();
                 getAspireTerminalStub.restore();
             }
         });

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -793,6 +793,48 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
+        test('serializes fallback interruption decisions for concurrent commands waiting on the terminal process', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: string[] = [];
+            let resolveProcessId!: (value: number | undefined) => void;
+            const processId = new Promise<number | undefined>(resolve => {
+                resolveProcessId = resolve;
+            });
+            const closeListenerDispose = sinon.stub();
+            const onDidCloseTerminalStub = sinon.stub(vscode.window, 'onDidCloseTerminal').callsFake(
+                () => new vscode.Disposable(closeListenerDispose));
+            const terminal = {
+                processId,
+                sendText: (text: string) => {
+                    sentTexts.push(text);
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                const firstCommand = terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                const secondCommand = terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                await new Promise(resolve => setImmediate(resolve));
+
+                assert.deepStrictEqual(sentTexts, []);
+                assert.strictEqual(closeListenerDispose.called, false);
+
+                resolveProcessId(123);
+                await Promise.all([firstCommand, secondCommand]);
+
+                assert.deepStrictEqual(sentTexts, [expectedCommand, '\x03', expectedCommand]);
+                assert.strictEqual(closeListenerDispose.callCount, 2);
+            }
+            finally {
+                onDidCloseTerminalStub.restore();
+                getAspireTerminalStub.restore();
+            }
+        });
+
         test('records suppressed execution mode without creating a terminal when E2E suppression is enabled', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const originalEnableBridge = process.env.ASPIRE_EXTENSION_E2E_ENABLE_BRIDGE;

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -448,6 +448,47 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
+        test('sends Ctrl+C before fallback command after shell integration executed a command', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: { text: string; shouldExecute?: boolean }[] = [];
+            let executedCommand: string | undefined;
+            let shellIntegration = {
+                executeCommand: (commandLine: string) => {
+                    executedCommand = commandLine;
+                    return {} as vscode.TerminalShellExecution;
+                }
+            } as vscode.TerminalShellIntegration | undefined;
+            const terminal = {
+                processId: Promise.resolve(123),
+                get shellIntegration() {
+                    return shellIntegration;
+                },
+                sendText: (text: string, shouldExecute?: boolean) => {
+                    sentTexts.push({ text, shouldExecute });
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                await terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                shellIntegration = undefined;
+                await terminalProvider.sendAspireCommandToAspireTerminal('logs');
+
+                assert.strictEqual(executedCommand, expectedCommand);
+                assert.deepStrictEqual(sentTexts, [
+                    { text: '\x03', shouldExecute: false },
+                    { text: expectedCommand, shouldExecute: undefined }
+                ]);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
         test('creates a new editor terminal when terminalTarget is editor', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const createdTerminal = {
@@ -612,7 +653,7 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
-        test('sends Ctrl+C before command when shell integration is unavailable', async () => {
+        test('sends Ctrl+C before a later fallback command', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const sentTexts: { text: string; shouldExecute?: boolean }[] = [];
             const terminalEvents: unknown[] = [];
@@ -631,12 +672,14 @@ suite('AspireTerminalProvider tests', () => {
 
             try {
                 await terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                await terminalProvider.sendAspireCommandToAspireTerminal('logs');
 
                 assert.deepStrictEqual(sentTexts, [
+                    { text: expectedCommand, shouldExecute: undefined },
                     { text: '\x03', shouldExecute: false },
                     { text: expectedCommand, shouldExecute: undefined }
                 ]);
-                assert.deepStrictEqual(terminalEvents.map(event => (event as { executionMode: string }).executionMode), ['sendText']);
+                assert.deepStrictEqual(terminalEvents.map(event => (event as { executionMode: string }).executionMode), ['sendText', 'sendText']);
             }
             finally {
                 eventSubscription.dispose();
@@ -709,7 +752,7 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
-        test('waits for the terminal process before sending a fallback command', async () => {
+        test('waits for the terminal process before the first fallback command without sending Ctrl+C', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const sentTexts: string[] = [];
             let resolveProcessId!: (value: number | undefined) => void;
@@ -741,7 +784,7 @@ suite('AspireTerminalProvider tests', () => {
                 resolveProcessId(123);
                 await sendCommand;
 
-                assert.deepStrictEqual(sentTexts, ['\x03', expectedCommand]);
+                assert.deepStrictEqual(sentTexts, [expectedCommand]);
                 assert.strictEqual(closeListenerDispose.calledOnce, true);
             }
             finally {

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -643,6 +643,41 @@ suite('AspireTerminalProvider tests', () => {
             }
         });
 
+        test('waits for the terminal process before sending a fallback command', async () => {
+            resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
+            const sentTexts: string[] = [];
+            let resolveProcessId!: (value: number | undefined) => void;
+            const processId = new Promise<number | undefined>(resolve => {
+                resolveProcessId = resolve;
+            });
+            const terminal = {
+                processId,
+                sendText: (text: string) => {
+                    sentTexts.push(text);
+                },
+                show: () => { }
+            } as unknown as vscode.Terminal;
+            const getAspireTerminalStub = sinon.stub(terminalProvider, 'getAspireTerminal').returns({
+                terminal,
+                dispose: () => { }
+            });
+
+            try {
+                const sendCommand = terminalProvider.sendAspireCommandToAspireTerminal('logs');
+                await new Promise(resolve => setImmediate(resolve));
+
+                assert.deepStrictEqual(sentTexts, []);
+
+                resolveProcessId(123);
+                await sendCommand;
+
+                assert.deepStrictEqual(sentTexts, ['\x03', expectedCommand]);
+            }
+            finally {
+                getAspireTerminalStub.restore();
+            }
+        });
+
         test('records suppressed execution mode without creating a terminal when E2E suppression is enabled', async () => {
             resolveCliPathStub.resolves({ cliPath: 'aspire', available: true, source: 'path' });
             const originalEnableBridge = process.env.ASPIRE_EXTENSION_E2E_ENABLE_BRIDGE;

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -1076,6 +1076,11 @@ suite('E2E launch profile', () => {
         assert.ok(workspaceTargetProofSource.includes("const wrapperDirectory = path.join(fixtureRoot, '.workspace-target-cli-wrappers');"));
         assert.ok(workspaceTargetProofSource.includes('const wrapperPath = path.join(wrapperDirectory, `aspire-${folderName}`);'));
         assert.ok(!workspaceTargetProofSource.includes('const wrapperPath = path.join(folderPath, `aspire-${folderName}`);'));
+        const workspaceRouting = getTestBlock(workspaceTargetProofSource, 'isolates folder terminals and keeps global commands window scoped');
+        assert.ok(workspaceRouting.includes("const folderC = createFolderFixture(runRoot, 'folder-c');"));
+        assert.ok(workspaceRouting.includes("const workspaceFolderLabels = ['folder-a', 'folder-b', 'folder-c'] as const;"));
+        assert.ok(workspaceRouting.includes("await invokeNewForFolder('folder-c', folderC);"));
+        assert.ok(!workspaceRouting.includes("await invokeNewForFolder('folder-b', folderB);"));
 
         const edgeCases = getTestBlock(edgeCasesSource, 'shows debugger install guidance while the Aspire panel and AppHost source are closed');
         assert.ok(edgeCases.includes("waitForNotificationMessage("));

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -1081,6 +1081,7 @@ suite('E2E launch profile', () => {
         assert.ok(workspaceRouting.includes("const workspaceFolderLabels = ['folder-a', 'folder-b', 'folder-c'] as const;"));
         assert.ok(workspaceRouting.includes("await invokeNewForFolder('folder-c', folderC);"));
         assert.ok(!workspaceRouting.includes("await invokeNewForFolder('folder-b', folderB);"));
+        assert.ok(workspaceRouting.includes('assert.ok(!updateCommand.commandLine.includes(folderC.wrapperPath), updateCommand.commandLine);'));
 
         const edgeCases = getTestBlock(edgeCasesSource, 'shows debugger install guidance while the Aspire panel and AppHost source are closed');
         assert.ok(edgeCases.includes("waitForNotificationMessage("));

--- a/extension/src/test/registerCodeLensCommands.test.ts
+++ b/extension/src/test/registerCodeLensCommands.test.ts
@@ -57,6 +57,24 @@ suite('registerCodeLensCommands', () => {
 
             assert.deepStrictEqual(sendCommandStub.firstCall.args[3], { target });
             assert.deepStrictEqual(sendCommandStub.secondCall.args[3], { target });
+
+            const terminalError = new Error('terminal startup failed');
+            const rejectedCommand = Promise.reject(terminalError);
+            void rejectedCommand.catch(() => { });
+            sendCommandStub.returns(rejectedCommand);
+
+            await assert.rejects(
+                callbacks.get('aspire-vscode.codeLensViewLogs')!('api', appHostPath),
+                error => error === terminalError);
+
+            const appHostTerminalError = new Error('AppHost terminal startup failed');
+            const rejectedAppHostCommand = Promise.reject(appHostTerminalError);
+            void rejectedAppHostCommand.catch(() => { });
+            sendCommandStub.returns(rejectedAppHostCommand);
+
+            await assert.rejects(
+                callbacks.get('aspire-vscode.codeLensViewAppHostLogs')!(appHostPath),
+                error => error === appHostTerminalError);
         }
         finally {
             registrations.forEach(registration => registration.dispose());

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -248,6 +248,11 @@ export class AspireTerminalProvider implements vscode.Disposable {
             aspireTerminal.terminal.shellIntegration.executeCommand(command);
         }
         else {
+            // createTerminal can return before the shell process accepts input. Waiting for processId
+            // prevents the first fallback command from being dropped; shell integration is already a
+            // readiness signal for the executeCommand path above.
+            await aspireTerminal.terminal.processId;
+
             // Without shell integration, VS Code can't tell whether the terminal is idle or
             // a foreground process is running, so keep the previous safe interruption behavior.
             aspireTerminal.terminal.sendText('\x03', false);

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
-import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized, terminalCommandUnsafeLiteral } from '../loc/strings';
+import { aspireTerminalClosedBeforeProcessStarted, aspireTerminalName, aspireTerminalProcessFailedToStart, dcpServerNotInitialized, rpcServerNotInitialized, terminalCommandUnsafeLiteral } from '../loc/strings';
 import { extensionLogOutputChannel } from './logging';
 import { RpcServerConnectionInfo } from '../server/AspireRpcServer';
 import { DcpServerConnectionInfo } from '../dcp/types';
@@ -312,14 +312,14 @@ export class AspireTerminalProvider implements vscode.Disposable {
                 new Promise<never>((_, reject) => {
                     closeListener = vscode.window.onDidCloseTerminal(closedTerminal => {
                         if (closedTerminal === terminal) {
-                            reject(new Error('Aspire terminal closed before its process started.'));
+                            reject(new Error(aspireTerminalClosedBeforeProcessStarted));
                         }
                     });
                 }),
             ]);
 
             if (processId === undefined) {
-                throw new Error('Aspire terminal process failed to start.');
+                throw new Error(aspireTerminalProcessFailedToStart);
             }
         }
         finally {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -250,13 +250,12 @@ export class AspireTerminalProvider implements vscode.Disposable {
             this._terminalsWithAspireCommands.add(aspireTerminal.terminal);
         }
         else {
-            const hasReceivedAspireCommand = this._terminalsWithAspireCommands.has(aspireTerminal.terminal);
-
             // createTerminal can return before the shell process accepts input. Waiting for processId
             // prevents the first fallback command from being dropped. Observe terminal closure too,
             // because processId can remain pending when the shell process fails to start.
             await this.waitForTerminalProcess(aspireTerminal.terminal);
 
+            const hasReceivedAspireCommand = this._terminalsWithAspireCommands.has(aspireTerminal.terminal);
             if (hasReceivedAspireCommand) {
                 // Without shell integration, VS Code can't tell whether the terminal is idle or
                 // a foreground process is running, so interrupt commands previously sent by Aspire.

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -118,6 +118,7 @@ export function shellArg(value: string): ShellArg {
 export class AspireTerminalProvider implements vscode.Disposable {
     private _terminalByDebugSessionId = new Map<string, AspireTerminal>();
     private _invalidatedSharedTerminals = new Set<vscode.Terminal>();
+    private readonly _terminalsWithAspireCommands = new WeakSet<vscode.Terminal>();
     private _rpcServerConnectionInfo?: RpcServerConnectionInfo;
     private _dcpServerConnectionInfo?: DcpServerConnectionInfo;
     private _windowsPowerShellPath?: string;
@@ -246,17 +247,23 @@ export class AspireTerminalProvider implements vscode.Disposable {
 
         if (executionMode === 'shellIntegration' && aspireTerminal.terminal.shellIntegration) {
             aspireTerminal.terminal.shellIntegration.executeCommand(command);
+            this._terminalsWithAspireCommands.add(aspireTerminal.terminal);
         }
         else {
+            const hasReceivedAspireCommand = this._terminalsWithAspireCommands.has(aspireTerminal.terminal);
+
             // createTerminal can return before the shell process accepts input. Waiting for processId
             // prevents the first fallback command from being dropped. Observe terminal closure too,
             // because processId can remain pending when the shell process fails to start.
             await this.waitForTerminalProcess(aspireTerminal.terminal);
 
-            // Without shell integration, VS Code can't tell whether the terminal is idle or
-            // a foreground process is running, so keep the previous safe interruption behavior.
-            aspireTerminal.terminal.sendText('\x03', false);
+            if (hasReceivedAspireCommand) {
+                // Without shell integration, VS Code can't tell whether the terminal is idle or
+                // a foreground process is running, so interrupt commands previously sent by Aspire.
+                aspireTerminal.terminal.sendText('\x03', false);
+            }
             aspireTerminal.terminal.sendText(command);
+            this._terminalsWithAspireCommands.add(aspireTerminal.terminal);
         }
 
     }

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -249,9 +249,9 @@ export class AspireTerminalProvider implements vscode.Disposable {
         }
         else {
             // createTerminal can return before the shell process accepts input. Waiting for processId
-            // prevents the first fallback command from being dropped; shell integration is already a
-            // readiness signal for the executeCommand path above.
-            await aspireTerminal.terminal.processId;
+            // prevents the first fallback command from being dropped. Observe terminal closure too,
+            // because processId can remain pending when the shell process fails to start.
+            await this.waitForTerminalProcess(aspireTerminal.terminal);
 
             // Without shell integration, VS Code can't tell whether the terminal is idle or
             // a foreground process is running, so keep the previous safe interruption behavior.
@@ -296,6 +296,29 @@ export class AspireTerminalProvider implements vscode.Disposable {
         this._terminalByDebugSessionId.set(terminalKey, aspireTerminal);
 
         return aspireTerminal;
+    }
+
+    private async waitForTerminalProcess(terminal: vscode.Terminal): Promise<void> {
+        let closeListener: vscode.Disposable | undefined;
+        try {
+            const processId = await Promise.race([
+                terminal.processId,
+                new Promise<never>((_, reject) => {
+                    closeListener = vscode.window.onDidCloseTerminal(closedTerminal => {
+                        if (closedTerminal === terminal) {
+                            reject(new Error('Aspire terminal closed before its process started.'));
+                        }
+                    });
+                }),
+            ]);
+
+            if (processId === undefined) {
+                throw new Error('Aspire terminal process failed to start.');
+            }
+        }
+        finally {
+            closeListener?.dispose();
+        }
     }
 
     invalidateSharedAspireTerminal(target?: CliPathResolutionTarget): void {


### PR DESCRIPTION
## Description

The original PR only addressed the Windows `apphost-lifecycle-tools` failure. A broader review of the August 24-26 CI runs found four distinct VS Code extension E2E failures:

| Failure | Resolution |
| --- | --- |
| Windows `edge-cases` debugger guidance | Fixed by #19702 |
| Linux `workspace-target-proof` package hive | Fixed by #19631 |
| Windows `apphost-lifecycle-tools` PID/timeout race | Fixed here |
| Linux `workspace-target-proof` dropped terminal command | Fixed here |

For `apphost-lifecycle-tools`, the synthetic CLI invocation now has ten seconds to start and the PID evidence wait has thirty seconds. The test still verifies that the descendant process is gone before `runAspireCli` rejects; product timeout and process-tree cleanup behavior are unchanged.

For `workspace-target-proof`, fallback terminal execution now waits for the terminal process to exist and rejects if the terminal closes or starts without a PID. The first command no longer sends Ctrl+C into a shell that may still be initializing, while reused terminals keep the existing Ctrl+C behavior. The reuse decision happens after startup so concurrent sends cannot both classify the terminal as fresh. The E2E also uses a separate folder C fixture for the direct `Aspire: New Project` path.

CodeLens log commands now return the terminal command promise, so startup failures flow through the existing command instrumentation instead of becoming unhandled rejections. Both startup errors are also registered in the extension localization catalog.

Local verification:

- `registerCodeLensCommands.test.ts`: 1 passing
- `aspireTerminalProvider.test.ts`: 89 passing
- `strings.test.ts`: 13 passing
- `e2eLaunchProfile.test.ts`: 72 passing
- E2E TypeScript compilation and ESLint passed
- The real VS Code 1.130.0 `workspace-target-proof` scenario passed

CI verification for head `08d7fad58`:

- [Linux `workspace-target-proof`](https://github.com/microsoft/aspire/actions/runs/33041838485/job/98422075137)
- [Windows `apphost-lifecycle-tools`](https://github.com/microsoft/aspire/actions/runs/33041838485/job/98422074206)
- [Windows `edge-cases`](https://github.com/microsoft/aspire/actions/runs/33041838485/job/98422075847)
- [Linux `apphost-lifecycle-tools`](https://github.com/microsoft/aspire/actions/runs/33041838485/job/98422073822)
- [Linux `edge-cases`](https://github.com/microsoft/aspire/actions/runs/33041838485/job/98422075621)
- The complete required check set passed: 385 passed and 3 skipped.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

---

*This fix was created using the [fix-flaky-test skill](https://github.com/microsoft/aspire/blob/main/.agents/skills/fix-flaky-test/SKILL.md).*