### PR TITLE
Fix Azure CLI auth in Aspire Team App

### DIFF
--- a/.github/extensions/aspire-team-app/azure-devops.mjs
+++ b/.github/extensions/aspire-team-app/azure-devops.mjs
@@ -663,6 +663,7 @@ async function executeAzureCli(args, suffixArgs) {
       command.path,
       commandArgs,
       {
+        env: azureCliEnvironment(),
         timeout: COMMAND_TIMEOUT_MS,
         maxBuffer: COMMAND_MAX_BUFFER,
         windowsHide: true,
@@ -673,6 +674,15 @@ async function executeAzureCli(args, suffixArgs) {
   } catch (error) {
     throw classifyCommandError(error);
   }
+}
+
+export function azureCliEnvironment(environment = process.env) {
+  const env = { ...environment };
+  // Copilot sets this for agent correlation, but MSAL Runtime forwards it as AAD's
+  // client_session parameter and rejects otherwise valid Azure CLI token requests.
+  // https://github.com/ianphil/chamber/issues/419
+  delete env.COPILOT_AGENT_SESSION_ID;
+  return env;
 }
 
 export async function resolveAzureCliCommand({

--- a/.github/extensions/aspire-team-app/azure-devops.test.mjs
+++ b/.github/extensions/aspire-team-app/azure-devops.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   AzureDevOpsError,
+  azureCliEnvironment,
   azurePipelineIdFromRemovalKey,
   azurePipelineRemovalKey,
   discoverAzureDevOpsPipelines,
@@ -553,6 +554,20 @@ test("resolveAzureCliCommand finds the standard Windows az.cmd shim", async () =
   });
 
   assert.deepEqual(command, { path: python, prefixArgs: ["-IBm", "azure.cli"] });
+});
+
+test("Azure CLI environment excludes the Copilot agent session id", () => {
+  const environment = {
+    COPILOT_AGENT_SESSION_ID: "session-id",
+    AZURE_CONFIG_DIR: "C:\\Users\\test\\.azure",
+    PATH: "C:\\AzureCLI",
+  };
+
+  assert.deepEqual(azureCliEnvironment(environment), {
+    AZURE_CONFIG_DIR: "C:\\Users\\test\\.azure",
+    PATH: "C:\\AzureCLI",
+  });
+  assert.equal(environment.COPILOT_AGENT_SESSION_ID, "session-id");
 });
 
 test("unavailableAzureDevOpsHealth preserves an actionable provider error", () => {


### PR DESCRIPTION
## Description

The Aspire Team App could report that Azure DevOps authentication was required even when the user had an active Azure CLI login. Copilot injects `COPILOT_AGENT_SESSION_ID` into extension processes, and MSAL Runtime forwards that value as Azure AD's `client_session` parameter, causing Azure DevOps token acquisition to fail with `AADSTS901001`.

This change removes only `COPILOT_AGENT_SESSION_ID` from the environment passed to Azure CLI child processes. The extension continues to reuse the user's existing Azure CLI or `AZURE_DEVOPS_EXT_PAT` authentication, while all other environment variables remain available.

### User-facing usage

After signing in with `az login`, users can open the Aspire Team App Health tab and load Azure DevOps pipeline health without a false authentication warning.

Validation:

- `node --test .github\extensions\aspire-team-app\azure-devops.test.mjs`
- Confirmed the Health tab discovers the three official Aspire Azure DevOps pipelines without an authentication warning.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
