### PR TITLE
[automated] test(ci): canary no-.NET job selection

### DIFF
--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/selective-ci-canary.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/selective-ci-canary.txt
@@ -1,0 +1,2 @@
+Temporary marker used to validate an enforced job-only selection with no .NET tests.
+This pull request is a disposable canary and must not be merged.


### PR DESCRIPTION
## Description

[automated] Temporary canary for #19688. This PR adds an inert marker under `tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/` so enforced selection should report no .NET tests, skip test enumeration and every .NET matrix job, run only the TypeScript SDK selector target, and keep `Final Test Results` green.

Do not merge. Close this PR after capturing the workflow evidence.

Validates #19688

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
