### PR TITLE
[automated] test(ci): canary selective .NET test matrix

### DIFF
--- a/tests/Infrastructure.Tests/selective-ci-canary.txt
+++ b/tests/Infrastructure.Tests/selective-ci-canary.txt
@@ -1,0 +1,2 @@
+Temporary marker used to validate the enforced selective .NET test matrix.
+This pull request is a disposable canary and must not be merged.


### PR DESCRIPTION
## Description

[automated] Temporary canary for #19688. This PR adds an inert marker under `tests/Infrastructure.Tests/` so enforced selection should emit only the `Infrastructure.Tests` matrix entries, skip unrelated selector-gated jobs, and keep `Final Test Results` green.

Do not merge. Close this PR after capturing the workflow evidence.

Validates #19688

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
