### PR TITLE
Fix duplicate coding agent telemetry labels

### DIFF
--- a/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
+++ b/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
@@ -57,7 +57,10 @@ internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodin
             if (rule.IsMatch(_configuration))
             {
                 agentNames ??= [];
-                agentNames.Add(rule.AgentName);
+                if (!agentNames.Contains(rule.AgentName, StringComparer.Ordinal))
+                {
+                    agentNames.Add(rule.AgentName);
+                }
             }
         }
 

--- a/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
@@ -526,6 +526,7 @@ public class AspireCliTelemetryTests
         { [("COPILOT_GITHUB_TOKEN", "token")], "copilot-cli" },
         { [("AI_AGENT", "github_copilot_vscode_agent")], "copilot-vscode" },
         { [("COPILOT_AGENT", "1")], "copilot-vscode" },
+        { [("AI_AGENT", "github_copilot_vscode_agent"), ("COPILOT_AGENT", "1")], "copilot-vscode" },
         { [("CODEX_CLI", "1")], "codex" },
         { [("CODEX_SANDBOX", "1")], "codex" },
         { [("CODEX_CI", "1")], "codex" },


### PR DESCRIPTION
## Description

Aspire CLI telemetry can report `copilot-vscode, copilot-vscode` when VS Code sets both `AI_AGENT` and `COPILOT_AGENT`. This splits one coding-agent identity into a duplicate label and reduces the quality of agent-usage analysis.

This change deduplicates matched coding-agent names while preserving detection order and adds coverage for the VS Code environment where both variables are present.

Validation:

```text
dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.CodingAgentDetector_DetectsKnownCodingAgents" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
