### PR TITLE
Quarantine failing staging self-update test

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/SelfUpdateChannelPersistenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SelfUpdateChannelPersistenceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
 
@@ -12,6 +13,7 @@ public sealed class SelfUpdateChannelPersistenceTests(ITestOutputHelper output)
 {
     [Fact]
     [CaptureWorkspaceOnFailure]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/19708")]
     public async Task SelfUpdateToStaging_RelaunchedCliUsesStagingForImplicitProjectUpdate()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();


### PR DESCRIPTION
## Description

Quarantines `SelfUpdateToStaging_RelaunchedCliUsesStagingForImplicitProjectUpdate` so its current package-provenance failure no longer blocks unrelated pull requests while the underlying fix in #19731 is reviewed.

The test now carries `[QuarantinedTest]` linked to #19708. Regular CI excludes it, while the quarantine workflow retains coverage until the underlying issue is resolved.

Validation:

- Built `Aspire.Cli.EndToEnd.Tests` successfully.
- Confirmed MTP discovers the test with `quarantined=true`.
- Confirmed MTP excludes the test with the regular quarantine and outerloop filters.

Addresses #19708

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
