### PR TITLE
Prevent Aspire view from stealing sidebar focus

### DIFF
--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import { findRunningAppHost, getCommandInvocationCount, getResources, getTreeAppHostLabel, isSamePath, waitForCommandOutcome, waitForDashboardUrl, waitForExtensionState, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForResource, waitForRunningAppHost, waitForWorkspaceAppHost } from './helpers/assertions';
-import { assertClipboardMatchesLastExpectationForE2E, captureWorkspaceAppHostPathClipboardExpectationForE2E, executeE2eControlCommand, getCliWrapperInvocationCount, getCliWrapperInvocations, restoreClipboardSnapshotForE2E, restoreE2eCliPathForE2E, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, snapshotClipboardForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, touchPrimaryAppHostProject, writeDelayedPsCliWrapper, writeGatedStreamingDiscoveryCliWrapper, writeStreamingDiscoveryCliWrapper, writeTrackedDelayedPsCliWrapper, writeTrackedStreamingDiscoveryCliWrapper } from './helpers/fixtures';
+import { assertClipboardMatchesLastExpectationForE2E, captureWorkspaceAppHostPathClipboardExpectationForE2E, executeE2eControlCommand, getCliWrapperInvocationCount, getCliWrapperInvocations, reloadWorkspaceForE2E, restoreClipboardSnapshotForE2E, restoreE2eCliPathForE2E, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, snapshotClipboardForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, touchPrimaryAppHostProject, writeDelayedPsCliWrapper, writeGatedStreamingDiscoveryCliWrapper, writeStreamingDiscoveryCliWrapper, writeTrackedDelayedPsCliWrapper, writeTrackedStreamingDiscoveryCliWrapper } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
-import { cancelActiveInput, cancelAppHostsSectionTextTransition, clickTreeItem, executeCommandFromPalette, getNotificationMessages, openAspireView, startAppHostsSectionTextTransition, waitForAppHostsSectionTextAfterTransition, waitForChildTreeItem, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchText } from './helpers/vscode';
+import { cancelActiveInput, cancelAppHostsSectionTextTransition, clickTreeItem, executeCommandFromPalette, getNotificationMessages, observeVisibleSideBarSectionTitles, openAspireView, startAppHostsSectionTextTransition, waitForAppHostsSectionTextAfterTransition, waitForChildTreeItem, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchText } from './helpers/vscode';
 
 const cliStartupTimeoutMs = getCliStartupTimeoutMs();
 
@@ -37,6 +37,27 @@ suite('Aspire AppHost tree E2E', function () {
         assert.strictEqual(await item.getLabel(), label);
         assert.ok(await waitForChildTreeItem(item, 'Run AppHost'));
         assert.ok(stateFile.state.workspaceAppHostCandidatePaths.length >= 1);
+    });
+
+    test('does not activate the Aspire view when the window reloads with Explorer selected', async () => {
+        await openAspireView();
+        await waitForRepositoryIdle();
+        await waitForWorkspaceAppHost();
+        await executeE2eControlCommand({ name: 'openFile', filePath: getPrimaryAppHostProjectPath() });
+
+        try {
+            await executeCommandFromPalette('workbench.view.explorer');
+            await reloadWorkspaceForE2E();
+            await waitForRepositoryIdle();
+            await waitForWorkspaceAppHost();
+
+            const visibleSectionTitles = await observeVisibleSideBarSectionTitles();
+            assert.ok(
+                !visibleSectionTitles.includes('AppHosts'),
+                `Aspire stole sidebar focus after reload. Visible sections: ${visibleSectionTitles.join(', ')}`);
+        } finally {
+            await executeE2eControlCommand({ name: 'closeAllEditors' });
+        }
     });
 
     test('shows streamed candidates while AppHost discovery is still running', async () => {

--- a/extension/src/test-e2e/helpers/vscode.ts
+++ b/extension/src/test-e2e/helpers/vscode.ts
@@ -57,6 +57,23 @@ export async function openAspireView(): Promise<TreeSection> {
     }, 30000, `Timed out waiting for '${aspireAppHostsSectionTitle}' section. Visible sections: ${lastSectionTitles.join(', ') || '<none>'}.`);
 }
 
+export async function observeVisibleSideBarSectionTitles(durationMs = 2000): Promise<string[]> {
+    const observedTitles = new Set<string>();
+    const deadline = Date.now() + durationMs;
+
+    do {
+        const sections = await new SideBarView().getContent().getSections();
+        const titles = await Promise.all(sections.map(section => section.getTitle()));
+        for (const title of titles) {
+            observedTitles.add(title);
+        }
+
+        await delay(100);
+    } while (Date.now() < deadline);
+
+    return [...observedTitles];
+}
+
 export async function waitForTreeItem(section: TreeSection, label: string, timeoutMs = 30000): Promise<TreeItem> {
     return await VSBrowser.instance.driver.wait(async () => {
         try {

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -453,6 +453,58 @@ suite('AspireAppHostTreeProvider', () => {
         sandbox.restore();
     });
 
+    test('auto-expands a single workspace AppHost only while the Aspire view is visible', async () => {
+        const appHostPath = '/workspace/apps/Store/AppHost.csproj';
+        const dataEmitter = new vscode.EventEmitter<void>();
+        const visibilityEmitter = new vscode.EventEmitter<vscode.TreeViewVisibilityChangeEvent>();
+        let visible = false;
+        const reveal = sandbox.stub().resolves();
+        const repository = {
+            viewMode: 'workspace' as ViewMode,
+            appHosts: [],
+            workspaceResources: [],
+            workspaceAppHostPath: appHostPath,
+            workspaceAppHostCandidatePaths: [appHostPath],
+            workspaceAppHostName: 'AppHost.csproj',
+            workspaceAppHostDescription: undefined,
+            isLoading: false,
+            onDidChangeData: dataEmitter.event,
+        } as unknown as AppHostDataRepository;
+        const treeView = {
+            get visible() {
+                return visible;
+            },
+            onDidChangeVisibility: visibilityEmitter.event,
+            reveal,
+        } as unknown as Parameters<AspireAppHostTreeProvider['setTreeView']>[0];
+        const provider = new AspireAppHostTreeProvider(repository, makeTerminalProvider(), makeLaunchService());
+
+        provider.setTreeView(treeView);
+        dataEmitter.fire();
+        await flushPromises();
+
+        assert.strictEqual(reveal.called, false);
+
+        visible = true;
+        visibilityEmitter.fire({ visible });
+        await flushPromises();
+
+        assert.strictEqual(reveal.callCount, 1);
+        assert.deepStrictEqual(reveal.firstCall.args[1], { expand: true });
+
+        dataEmitter.fire();
+        await flushPromises();
+        assert.strictEqual(reveal.callCount, 1);
+
+        provider.dispose();
+        visibilityEmitter.fire({ visible: true });
+        await flushPromises();
+        assert.strictEqual(reveal.callCount, 1);
+
+        dataEmitter.dispose();
+        visibilityEmitter.dispose();
+    });
+
     test('global apphost labels add enough parent folders to disambiguate duplicate filenames', () => {
         const appHosts = [
             makeAppHost({

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -161,6 +161,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     private _contentProviderRegistration: vscode.Disposable | undefined;
     private readonly _appHostSourceContents = new Map<string, string>();
     private _treeView: vscode.TreeView<TreeElement> | undefined;
+    private _treeViewVisibilitySubscription: vscode.Disposable | undefined;
 
     private _documentCloseSubscription: vscode.Disposable | undefined;
 
@@ -272,6 +273,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         this._stoppingAppHostTimeouts.clear();
         this._contentProviderRegistration?.dispose();
         this._documentCloseSubscription?.dispose();
+        this._treeViewVisibilitySubscription?.dispose();
         this._cliRunner.dispose();
         this._onDidChangeTreeData.dispose();
         this._onDidChangeStoppingState.dispose();
@@ -279,12 +281,21 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     }
 
     setTreeView(treeView: vscode.TreeView<TreeElement>): void {
+        this._treeViewVisibilitySubscription?.dispose();
         this._treeView = treeView;
+        this._treeViewVisibilitySubscription = treeView.onDidChangeVisibility(event => {
+            if (event.visible) {
+                this._autoExpandSingleWorkspaceAppHost();
+            }
+        });
         this._autoExpandSingleWorkspaceAppHost();
     }
 
     private _autoExpandSingleWorkspaceAppHost(): void {
-        if (!this._treeView || this._repository.viewMode !== 'workspace') {
+        // TreeView.reveal() activates a hidden view container. Only reveal after the user opens
+        // Aspire so discovery during activation cannot steal sidebar focus.
+        // https://github.com/microsoft/aspire/issues/19746
+        if (!this._treeView?.visible || this._repository.viewMode !== 'workspace') {
             return;
         }
 


### PR DESCRIPTION
## Description

Reloading VS Code while another sidebar view was selected could activate the Aspire view and restore its hidden Activity Bar entry. AppHost discovery was calling `TreeView.reveal()` to auto-expand a single AppHost even while the Aspire view was hidden; VS Code activates the view container as part of that reveal.

This change preserves single-AppHost auto-expansion but defers `reveal()` until the Aspire view is already visible. A visibility listener performs the pending expansion when the user explicitly opens Aspire.

### User-facing behavior

Selecting Explorer and running **Developer: Reload Window** now leaves Explorer active. Opening Aspire explicitly still shows the single workspace AppHost expanded.

### Reproduction

1. Stop all running AppHosts.
2. Open a workspace containing exactly one AppHost.
3. Open the AppHost project or source file and leave that editor tab open.
4. Open the Aspire view and ensure it is in **Workspace** view.
5. Switch to **Explorer**.
6. Right-click the Activity Bar and uncheck **Aspire** so its icon is hidden.
7. Run **Developer: Reload Window** and wait for AppHost discovery to finish.

Before this change, Aspire reappears in the Activity Bar and becomes the active sidebar view. After this change, Aspire remains hidden and Explorer retains focus. Re-enabling and explicitly opening Aspire still auto-expands the single AppHost.

### Validation

- `extension/build.ps1`
- `corepack yarn compile-tests`
- `corepack yarn compile-e2e`
- `corepack yarn lint`
- Focused `AspireAppHostTreeProvider` unit test
- VS Code 1.135 reload-focus E2E test, red before the implementation and green afterward
- Manual reproduction using the steps above on the original and fixed extension builds

Fixes #19746

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No