### PR TITLE
ci: streamline test job fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,22 +124,17 @@ jobs:
   # The release PR (aspire-repo-bot, base=main, head=extension-release/vX.Y.Z,
   # diff limited to extension/package.json + extension/CHANGELOG.md) has no
   # need for the full test graph -- no .NET changes, no CLI archives, no E2E,
-  # no stabilization build. The release-only mode runs just the VS Code
-  # extension unit tests inside the same reusable workflow as normal CI.
+  # no stabilization build. The focused workflow runs only the VS Code
+  # extension unit tests and skips VSIX packaging because there is no E2E consumer.
   extension_release_tests:
     name: Extension release tests
     needs: [prepare_for_ci]
     if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' && needs.prepare_for_ci.outputs.is_trusted_extension_release_pr == 'true' }}
-    uses: ./.github/workflows/tests.yml
-    # GitHub validates every permission requested by a reusable workflow, including jobs skipped
-    # by extensionReleaseOnly. Keep this in sync with the normal tests caller above.
+    uses: ./.github/workflows/extension-unit-tests.yml
     permissions:
-      actions: read
       contents: read
-      issues: write
-      pull-requests: write
     with:
-      extensionReleaseOnly: true
+      packageVsix: false
 
   # Stabilization gate.
   #

--- a/.github/workflows/extension-unit-tests.yml
+++ b/.github/workflows/extension-unit-tests.yml
@@ -1,0 +1,116 @@
+name: VS Code extension unit tests
+
+on:
+  workflow_call:
+    inputs:
+      packageVsix:
+        required: false
+        type: boolean
+        default: true
+      extensionVersionOverride:
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  extension_tests_win:
+    name: Run VS Code extension unit tests (Windows)
+    runs-on: windows-latest
+    env:
+      NPM_REGISTRY: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
+    defaults:
+      run:
+        working-directory: ./extension
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js environment
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22.x'
+      - name: Install Corepack
+        run: |
+          # Scope Corepack's cache to this job so prepareCorepackYarn.mjs cannot
+          # collide with any other build sharing the runner's user profile.
+          # Cannot be set at job-level env: the `runner` context is unavailable
+          # in job env evaluation, so we forward it through $GITHUB_ENV instead.
+          $CorepackHome = Join-Path $env:RUNNER_TEMP 'corepack'
+          $env:COREPACK_HOME = $CorepackHome
+          "COREPACK_HOME=$CorepackHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          $CorepackVersion = (Get-Content -Raw -Path 'scripts/corepack-version.txt').Trim()
+          # The hosted Windows image already has a yarn shim in npm's global
+          # prefix. The npm Corepack package owns that shim too, so force only
+          # in CI where the tool install is isolated to this ephemeral job.
+          npm install --global --force --registry "$env:NPM_REGISTRY" "corepack@$CorepackVersion"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $npmGlobalBin = (npm prefix --global).Trim()
+          $env:PATH = "$npmGlobalBin$([IO.Path]::PathSeparator)$env:PATH"
+          $npmGlobalBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          $installed = (corepack --version).Trim()
+          if ($installed -ne $CorepackVersion) {
+            Write-Error "corepack version mismatch: expected $CorepackVersion, got '$installed'. The bundled Corepack on PATH may be taking precedence over the npm-global install."
+            exit 1
+          }
+
+          corepack enable
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          # Seed Corepack's cache from the internal dnceng npm feed. Corepack's
+          # built-in `corepack prepare --activate` would download Yarn 1.x from
+          # its hardcoded upstream endpoint rather than the configured internal
+          # feed, bypassing the dependency source this workflow is supposed to
+          # validate. The shared prepareCorepackYarn.mjs script does the
+          # equivalent via `npm pack` against $NPM_REGISTRY, then drops the same
+          # on-disk layout Corepack would have written.
+          node ./scripts/prepareCorepackYarn.mjs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          corepack yarn --version
+      - name: Validate lockfile registries
+        # Allowlist scoped to lines starting with "resolved" (the only lines in
+        # yarn.lock that carry a tarball URL — `npm:` aliases don't).
+        # CONTRIBUTING.MD asks contributors to regenerate yarn.lock through the
+        # internal dotnet-public-npm feed; an allowlist catches drift to any
+        # other public mirror or tarball host.
+        run: |
+          node -e "const fs = require('fs'); const allow = 'pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm'; const bad = fs.readFileSync('yarn.lock', 'utf8').split(/\r?\n/).filter(l => /^\s*resolved\s+\x22/.test(l)).filter(l => !l.includes(allow)); if (bad.length) { throw new Error('extension/yarn.lock contains resolved entries outside the internal dotnet-public-npm feed. Regenerate it through the internal feed before restoring. First offender -> ' + bad[0]); }"
+      - name: Install dependencies
+        run: corepack yarn install --frozen-lockfile --non-interactive
+      - name: Run tests
+        run: corepack yarn test
+      # The VSIX steps run even when 'Run tests' failed. The E2E workflow installs
+      # this artifact but deliberately runs independently from the unit-test result,
+      # so packaging must use !cancelled() rather than the default success() check.
+      - name: Override extension version for PR builds
+        if: ${{ inputs.packageVsix && !cancelled() && inputs.extensionVersionOverride != '' }}
+        run: corepack yarn version --new-version "${{ inputs.extensionVersionOverride }}" --no-git-tag-version
+      - name: Package VSIX
+        if: ${{ inputs.packageVsix && !cancelled() }}
+        env:
+          ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: "true"
+        run: corepack yarn run vsce package --pre-release -o out/aspire-extension.vsix
+      - name: Assert E2E VSIX contains bridge
+        if: ${{ inputs.packageVsix && !cancelled() }}
+        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension.vsix -Expected Present
+      # Packaged separately because the E2E VSIX intentionally contains the bridge.
+      # No env override here reproduces the shipping build, where webpack stubs the
+      # bridge in production mode and step-scoped env values do not leak.
+      - name: Package production VSIX
+        if: ${{ inputs.packageVsix && !cancelled() }}
+        run: corepack yarn run vsce package --pre-release -o out/aspire-extension-production.vsix
+      - name: Assert production VSIX excludes bridge
+        if: ${{ inputs.packageVsix && !cancelled() }}
+        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension-production.vsix -Expected Absent
+      - name: Upload VSIX
+        if: ${{ inputs.packageVsix && !cancelled() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: aspire-extension
+          path: extension/out/aspire-extension.vsix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,6 @@ on:
       extensionVersionOverride:
         required: false
         type: string
-      extensionReleaseOnly:
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   actions: read
@@ -22,7 +18,6 @@ permissions:
 jobs:
   setup_for_tests:
     name: Setup for tests
-    if: ${{ !inputs.extensionReleaseOnly }}
     runs-on: ubuntu-latest
     # This job checks out and runs PR-authored code (SelectTests, the test build), so it is kept at
     # contents:read with no pull-requests:write. The selection comment is posted from the
@@ -37,7 +32,6 @@ jobs:
       SELECT_TESTS_COMMENT_FILE: ${{ github.workspace }}/artifacts/select-tests-comment.md
     outputs:
       tests_matrix_no_nugets: ${{ steps.split_matrix.outputs.tests_matrix_no_nugets }}
-      tests_matrix_no_nugets_overflow: ${{ steps.split_matrix.outputs.tests_matrix_no_nugets_overflow }}
       tests_matrix_requires_nugets_linux: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_linux }}
       tests_matrix_requires_nugets_windows: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_windows }}
       tests_matrix_requires_nugets_macos: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_macos }}
@@ -257,14 +251,12 @@ jobs:
 
   build_packages:
     name: Build packages
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-packages.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
   build_cli_archive_linux:
     name: Build native CLI archive (Linux)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -272,7 +264,6 @@ jobs:
 
   build_cli_archive_linux_arm64:
     name: Build native CLI archive (Linux ARM64)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -284,7 +275,6 @@ jobs:
   # without waiting for the slower Windows/macOS builds.
   build_cli_archive_windows:
     name: Build native CLI archive (Windows)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -292,7 +282,6 @@ jobs:
 
   build_cli_archive_windows_arm64:
     name: Build native CLI archive (Windows ARM64)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -300,7 +289,6 @@ jobs:
 
   build_cli_archive_macos:
     name: Build native CLI archive (macOS)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -308,7 +296,6 @@ jobs:
 
   build_cli_archive_macos_x64:
     name: Build native CLI archive (macOS x64)
-    if: ${{ !inputs.extensionReleaseOnly }}
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -385,7 +372,7 @@ jobs:
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null }}
 
   tests_no_nugets:
-    name: ${{ matrix.shortname }}
+    name: No-package tests
     uses: ./.github/workflows/run-tests.yml
     needs: setup_for_tests
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets).include[0] != null }}
@@ -401,27 +388,10 @@ jobs:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
       properties: ${{ toJson(matrix.properties) }}
 
-  tests_no_nugets_overflow:
-    name: ${{ matrix.shortname }}
-    uses: ./.github/workflows/run-tests.yml
-    needs: setup_for_tests
-    if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets_overflow).include[0] != null }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets_overflow) }}
-    with:
-      testShortName: ${{ matrix.shortname }}
-      os: ${{ matrix.runs-on }}
-      testProjectPath: ${{ matrix.testProjectPath }}
-      mtpBaseArgs: ${{ matrix.mtpBaseArgs }}
-      extraTestArgs: "--filter-not-trait \"quarantined=true\" --filter-not-trait \"outerloop=true\" ${{ matrix.extraTestArgs }}"
-      versionOverrideArg: ${{ inputs.versionOverrideArg }}
-      properties: ${{ toJson(matrix.properties) }}
-
   # Split requires-nugets tests by OS so each group depends only on
   # the CLI archive build for its platform, avoiding cross-OS blocking.
   tests_requires_nugets_linux:
-    name: ${{ matrix.shortname }}
+    name: Package tests - Linux
     uses: ./.github/workflows/run-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null }}
@@ -438,7 +408,7 @@ jobs:
       properties: ${{ toJson(matrix.properties) }}
 
   tests_requires_nugets_windows:
-    name: ${{ matrix.shortname }}
+    name: Package tests - Windows
     uses: ./.github/workflows/run-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_windows]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null }}
@@ -455,7 +425,7 @@ jobs:
       properties: ${{ toJson(matrix.properties) }}
 
   tests_requires_nugets_macos:
-    name: ${{ matrix.shortname }}
+    name: Package tests - macOS
     uses: ./.github/workflows/run-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_macos]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null }}
@@ -472,7 +442,7 @@ jobs:
       properties: ${{ toJson(matrix.properties) }}
 
   tests_requires_cli_archive:
-    name: ${{ matrix.shortname }}
+    name: CLI archive tests
     uses: ./.github/workflows/run-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_e2e_image]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null }}
@@ -585,113 +555,16 @@ jobs:
 
   extension_tests_win:
     name: Run VS Code extension unit tests (Windows)
-    runs-on: windows-latest
+    uses: ./.github/workflows/extension-unit-tests.yml
     needs: [setup_for_tests]
     # Also gated on run_extension_e2e (not just run_extension_unit): this job packages and uploads
-    # the aspire-extension VSIX that extension_e2e_tests installs, so skipping it would leave the
-    # shards with nothing to install. !cancelled() lets release-only calls run after setup_for_tests
-    # is intentionally skipped.
-    if: ${{ !cancelled() && (inputs.extensionReleaseOnly || needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true') }}
-    env:
-      NPM_REGISTRY: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-      COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
-    defaults:
-      run:
-        working-directory: ./extension
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Node.js environment
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22.x'
-      - name: Install Corepack
-        run: |
-          # Scope Corepack's cache to this job so prepareCorepackYarn.mjs cannot
-          # collide with any other build sharing the runner's user profile.
-          # Cannot be set at job-level env: the `runner` context is unavailable
-          # in job env evaluation, so we forward it through $GITHUB_ENV instead.
-          $CorepackHome = Join-Path $env:RUNNER_TEMP 'corepack'
-          $env:COREPACK_HOME = $CorepackHome
-          "COREPACK_HOME=$CorepackHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-          $CorepackVersion = (Get-Content -Raw -Path 'scripts/corepack-version.txt').Trim()
-          # The hosted Windows image already has a yarn shim in npm's global
-          # prefix. The npm Corepack package owns that shim too, so force only
-          # in CI where the tool install is isolated to this ephemeral job.
-          npm install --global --force --registry "$env:NPM_REGISTRY" "corepack@$CorepackVersion"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-          $npmGlobalBin = (npm prefix --global).Trim()
-          $env:PATH = "$npmGlobalBin$([IO.Path]::PathSeparator)$env:PATH"
-          $npmGlobalBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-          $installed = (corepack --version).Trim()
-          if ($installed -ne $CorepackVersion) {
-            Write-Error "corepack version mismatch: expected $CorepackVersion, got '$installed'. The bundled Corepack on PATH may be taking precedence over the npm-global install."
-            exit 1
-          }
-
-          corepack enable
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-          # Seed Corepack's cache from the internal dnceng npm feed. Corepack's
-          # built-in `corepack prepare --activate` would download Yarn 1.x from
-          # its hardcoded upstream endpoint rather than the configured internal
-          # feed, bypassing the dependency source this workflow is supposed to
-          # validate. The shared
-          # prepareCorepackYarn.mjs script does the equivalent via `npm pack`
-          # against $NPM_REGISTRY, then drops the same on-disk layout Corepack
-          # would have written.
-          node ./scripts/prepareCorepackYarn.mjs
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-          corepack yarn --version
-      - name: Validate lockfile registries
-        # Allowlist scoped to lines starting with "resolved" (the only lines in
-        # yarn.lock that carry a tarball URL — `npm:` aliases don't).
-        # CONTRIBUTING.MD asks contributors to regenerate yarn.lock through the
-        # internal dotnet-public-npm feed; an allowlist catches drift to any
-        # other public mirror or tarball host.
-        run: |
-          node -e "const fs = require('fs'); const allow = 'pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm'; const bad = fs.readFileSync('yarn.lock', 'utf8').split(/\r?\n/).filter(l => /^\s*resolved\s+\x22/.test(l)).filter(l => !l.includes(allow)); if (bad.length) { throw new Error('extension/yarn.lock contains resolved entries outside the internal dotnet-public-npm feed. Regenerate it through the internal feed before restoring. First offender -> ' + bad[0]); }"
-      - name: Install dependencies
-        run: corepack yarn install --frozen-lockfile --non-interactive
-      - name: Run tests
-        run: corepack yarn test
-      # The VSIX steps from here down run even when 'Run tests' failed. extension_e2e_tests
-      # installs the artifact this job uploads but is deliberately not gated on the unit-test
-      # result, so the packaging has to happen regardless or that decoupling buys nothing.
-      # Release-only calls do not have an E2E consumer, so they stop after the unit tests.
-      - name: Override extension version for PR builds
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() && inputs.extensionVersionOverride != '' }}
-        run: corepack yarn version --new-version "${{ inputs.extensionVersionOverride }}" --no-git-tag-version
-      - name: Package VSIX
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() }}
-        env:
-          ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: "true"
-        run: corepack yarn run vsce package --pre-release -o out/aspire-extension.vsix
-      - name: Assert E2E VSIX contains bridge
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() }}
-        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension.vsix -Expected Present
-      # Packaged separately (not reusing out/aspire-extension.vsix) because the step above already
-      # proved that VSIX contains the bridge on purpose; asserting Absent against it would be
-      # self-contradictory. No env override here is the point: webpack.config.js only stubs the
-      # bridge in `--mode production` when ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE isn't 'true', and
-      # GitHub Actions step `env:` blocks don't leak into later steps, so this reproduces exactly
-      # what Extension.proj's shipping build packages, with no ability to inherit the opt-in above.
-      - name: Package production VSIX
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() }}
-        run: corepack yarn run vsce package --pre-release -o out/aspire-extension-production.vsix
-      - name: Assert production VSIX excludes bridge
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() }}
-        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension-production.vsix -Expected Absent
-      - name: Upload VSIX
-        if: ${{ !inputs.extensionReleaseOnly && !cancelled() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: aspire-extension
-          path: extension/out/aspire-extension.vsix
+    # the aspire-extension VSIX that extension_e2e_tests installs. The focused workflow preserves
+    # packaging after unit-test failures so E2E
+    # still receives its VSIX and provides an independent signal.
+    if: ${{ needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    with:
+      packageVsix: true
+      extensionVersionOverride: ${{ inputs.extensionVersionOverride }}
 
   extension_bootstrap_linux:
     name: Validate VS Code extension bootstrap (Linux)
@@ -809,7 +682,6 @@ jobs:
       typescript_sdk_tests,
       typescript_api_compat,
       tests_no_nugets,
-      tests_no_nugets_overflow,
       tests_requires_nugets_linux,
       tests_requires_nugets_windows,
       tests_requires_nugets_macos,
@@ -818,44 +690,39 @@ jobs:
     ]
     steps:
       - name: Checkout code
-        if: ${{ !inputs.extensionReleaseOnly }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create test results directory
-        if: ${{ !inputs.extensionReleaseOnly }}
         shell: bash
         run: mkdir -p "${{ github.workspace }}/testresults"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ !inputs.extensionReleaseOnly }}
         with:
           pattern: logs-*-ubuntu-latest
           merge-multiple: true
           path: ${{ github.workspace }}/testresults/ubuntu-latest
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ !inputs.extensionReleaseOnly }}
         with:
           pattern: logs-*-windows-latest
           merge-multiple: true
           path: ${{ github.workspace }}/testresults/windows-latest
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ !inputs.extensionReleaseOnly }}
         with:
           pattern: logs-*-macos-latest
           merge-multiple: true
           path: testresults/macos-latest
 
       - name: Upload test results
-        if: ${{ always() && !inputs.extensionReleaseOnly }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: All-TestResults
           path: ${{ github.workspace }}/testresults/**/*.trx
 
       - name: Generate test results summary
-        if: ${{ always() && !inputs.extensionReleaseOnly }}
+        if: ${{ always() }}
         shell: bash
         run: |
           ${{ github.workspace }}/dotnet.sh \
@@ -866,7 +733,7 @@ jobs:
             --combined
 
       - name: Generate CI timeline
-        if: ${{ always() && !inputs.extensionReleaseOnly }}
+        if: ${{ always() }}
         continue-on-error: true
         shell: bash
         env:
@@ -883,8 +750,6 @@ jobs:
         # For example, one of setup_* jobs failing and the dependent test jobs getting 'skipped'.
         # Some jobs are optional and can have an empty matrix. In those cases we allow a 'skipped'
         # result. Specifically:
-        # - tests_no_nugets_overflow: this overflow bucket is expected to be empty unless the
-        #   primary no-nugets matrix exceeds the overflow threshold.
         # - the test-bucket jobs (tests_no_nugets, tests_requires_nugets_{linux,windows,macos},
         #   tests_requires_cli_archive): selective CI routes a PR's changes to a subset of buckets, so
         #   any bucket can be legitimately empty -> its job is 'skipped'. Each is therefore gated on its
@@ -896,17 +761,12 @@ jobs:
         #   Aspire CLI, or the extension E2E workflow wiring.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
-        # Release-only calls intentionally skip every dependency except extension_tests_win, which
-        # must succeed. Normal calls retain the existing unexpected-skip checks below.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
         if: >-
           ${{ always() &&
               (contains(needs.*.result, 'failure') ||
                contains(needs.*.result, 'cancelled') ||
-               (inputs.extensionReleaseOnly &&
-                needs.extension_tests_win.result != 'success') ||
-               (!inputs.extensionReleaseOnly &&
-                ((github.event_name == 'pull_request' &&
+               ((github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
                  (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
                   needs.extension_e2e_tests.result == 'skipped') ||
@@ -956,7 +816,7 @@ jobs:
                  (github.ref == 'refs/heads/main' &&
                   (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true'))) ||
                  (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
-                  needs.tests_requires_nugets_macos.result == 'skipped')))))) }}
+                  needs.tests_requires_nugets_macos.result == 'skipped'))))) }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1

--- a/docs/ci/TestingOnCI.md
+++ b/docs/ci/TestingOnCI.md
@@ -134,7 +134,6 @@ Each CI platform has a thin script that transforms the canonical matrix:
 - Expands each entry for every OS in its `supportedOSes` array
 - Maps OS names to GitHub runners (`linux` → `ubuntu-latest`, etc.)
 - Preserves dependency metadata within the `properties` sub-object (including `requiresNugets`, `requiresCliArchive`, `requiresGitHubToken`), and custom runner overrides on each expanded entry
-- Applies overflow splitting for the `no_nugets` category (threshold: 250 entries) to stay under the GitHub Actions 256-job-per-matrix limit
 - Outputs a single `all_tests` matrix, which `.github/workflows/tests.yml` further splits by dependency type and OS using `eng/scripts/split-test-matrix-by-deps.ps1`
 
 **Azure DevOps** (future):
@@ -148,16 +147,14 @@ This separation keeps 90% of the logic platform-agnostic while allowing each CI 
 In `.github/workflows/tests.yml`, the workflow:
 
 1. Receives the OS-expanded `all_tests` matrix from the `enumerate-tests` action
-2. Splits that matrix with `eng/scripts/split-test-matrix-by-deps.ps1` into 6 buckets:
+2. Splits that matrix with `eng/scripts/split-test-matrix-by-deps.ps1` into 5 buckets:
    - `tests_matrix_no_nugets`
-   - `tests_matrix_no_nugets_overflow`
    - `tests_matrix_requires_nugets_linux`
    - `tests_matrix_requires_nugets_windows`
    - `tests_matrix_requires_nugets_macos`
    - `tests_matrix_requires_cli_archive`
 3. Runs the CI jobs so the critical path stays as short as possible:
     - `tests_no_nugets`: Runs immediately after enumeration
-    - `tests_no_nugets_overflow`: Runs immediately (handles entries beyond the 250-entry threshold)
     - `build_packages`: Produces the shared package feed used by all package-dependent jobs
     - `build_cli_archive_linux`, `build_cli_archive_windows`, `build_cli_archive_macos`: Build native CLI archives and the matching RID-specific DCP/Dashboard packages in parallel with `build_packages`
     - `tests_requires_nugets_linux`, `tests_requires_nugets_windows`, `tests_requires_nugets_macos`: Wait for `build_packages` plus only the CLI archive job for their OS
@@ -180,7 +177,7 @@ The workflow intentionally favors shorter dependency chains over a smaller numbe
 
 #### GitHub Actions 256-Job Limit
 
-GitHub Actions enforces a maximum of 256 jobs per `strategy.matrix`. To stay within this limit, the `no_nugets` category (typically the largest) is split into primary and overflow buckets at a threshold of 250 entries. If the total entry count is below 250, the overflow matrix is empty and the overflow job is skipped.
+GitHub Actions enforces a maximum of 256 jobs per `strategy.matrix`. The matrix splitter fails explicitly if any dependency bucket exceeds that limit, so the workflow cannot silently omit test entries.
 
 ## Enabling Test Splitting for a Project
 

--- a/docs/ci/ci-pipeline-optimizations.md
+++ b/docs/ci/ci-pipeline-optimizations.md
@@ -32,7 +32,6 @@ The main test workflow in `.github/workflows/tests.yml` is organized into these 
 
 4. Test execution lanes
    - `tests_no_nugets`
-   - `tests_no_nugets_overflow`
    - `tests_requires_nugets_linux`
    - `tests_requires_nugets_windows`
    - `tests_requires_nugets_macos`

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -17,7 +17,8 @@
 #   job:polyglot               tests.yml -> polyglot-validation.yml (py/go/java/rust/ts)
 #   job:typescript-sdk         tests.yml -> typescript-sdk-tests.yml
 #   job:typescript-api-compat  tests.yml -> typescript-api-compat.yml
-#   job:extension-unit         tests.yml extension_tests_win + extension_bootstrap_linux
+#   job:extension-unit         tests.yml extension_tests_win + extension_bootstrap_linux,
+#                              with unit/package steps in extension-unit-tests.yml
 #   job:extension-e2e          tests.yml -> extension-e2e-tests.yml
 #   job:winget-installer       tests.yml prepare_winget_installer_artifacts
 #   job:homebrew-installer     tests.yml prepare_homebrew_installer_artifacts
@@ -195,7 +196,9 @@ path_rules:
       - src/Aspire.Hosting*/api/*.ats.txt
     targets: [job:typescript-api-compat, job:polyglot]
     reason: an integration's *.ats.txt baseline tracks its exported ATS surface; the polyglot playground regenerates+compiles that surface per language, so a baseline change must run polyglot too
-  - paths: [extension/**]
+  - paths:
+      - extension/**
+      - .github/workflows/extension-unit-tests.yml
     targets: [job:extension-unit]
     reason: extension_tests_win + extension_bootstrap_linux run yarn build/test in extension/
   - paths:
@@ -208,6 +211,7 @@ path_rules:
       - tests/Aspire.Hosting.Tests/Cli/**
       - eng/scripts/get-aspire-cli*
       - .github/workflows/tests.yml
+      - .github/workflows/extension-unit-tests.yml
       - .github/workflows/extension-e2e-tests.yml
       - .github/workflows/build-packages.yml
       - .github/workflows/build-cli-native-archives.yml

--- a/eng/scripts/expand-test-matrix-github.ps1
+++ b/eng/scripts/expand-test-matrix-github.ps1
@@ -13,7 +13,7 @@
   have a similar script with different runner mappings and output format.
 
   Downstream consumers (e.g., tests.yml) are responsible for splitting the
-  matrix by dependency type and handling overflow.
+  matrix by dependency type.
 
 .PARAMETER CanonicalMatrixFile
   Path to the canonical test matrix JSON file (output of build-test-matrix.ps1).

--- a/eng/scripts/split-test-matrix-by-deps.ps1
+++ b/eng/scripts/split-test-matrix-by-deps.ps1
@@ -5,14 +5,11 @@
 .DESCRIPTION
   Takes a flat all_tests matrix JSON (already OS-expanded) and splits it into
   dependency-based matrices for GitHub Actions consumption:
-  1. tests_matrix_no_nugets (primary) — tests with no package dependencies
-  2. tests_matrix_no_nugets_overflow — overflow when primary exceeds threshold
-  3. tests_matrix_requires_nugets_{linux,windows,macos} — tests needing built
+  1. tests_matrix_no_nugets — tests with no package dependencies
+  2. tests_matrix_requires_nugets_{linux,windows,macos} — tests needing built
      NuGet packages, split by OS so each group can depend on the per-OS CLI
      archive build that produces its RID-specific DCP/Dashboard NuGets
-  4. tests_matrix_requires_cli_archive — tests needing CLI native archives
-
-  The overflow mechanism keeps each matrix under GitHub Actions' 256-job limit.
+  3. tests_matrix_requires_cli_archive — tests needing CLI native archives
 
 .PARAMETER AllTestsMatrix
   JSON string of the all_tests matrix ({"include": [...]}).
@@ -23,10 +20,6 @@
 
 .PARAMETER OutputToGitHubEnv
   If set, outputs to GITHUB_OUTPUT environment file.
-
-.PARAMETER OverflowThreshold
-  Maximum entries in the no_nugets primary bucket before overflow kicks in.
-  Defaults to 250 (GitHub Actions hard limit is 256).
 
 .NOTES
   PowerShell 7+
@@ -41,10 +34,7 @@ param(
   [string]$AllTestsMatrixFile = "",
 
   [Parameter(Mandatory=$false)]
-  [switch]$OutputToGitHubEnv,
-
-  [Parameter(Mandatory=$false)]
-  [int]$OverflowThreshold = 250
+  [switch]$OutputToGitHubEnv
 )
 
 $ErrorActionPreference = 'Stop'
@@ -115,22 +105,9 @@ $nugetEntriesMacos   = @($nugetEntries | Where-Object { (Get-OsCategory $_.'runs
 
 Write-Host "    ↳ nugets linux: $($nugetEntriesLinux.Count), windows: $($nugetEntriesWindows.Count), macos: $($nugetEntriesMacos.Count)"
 
-# Split no_nugets into primary + overflow
-$noNugetPrimary = @()
-$noNugetOverflow = @()
-
-if ($noNugetEntries.Count -le $OverflowThreshold) {
-  $noNugetPrimary = $noNugetEntries
-} else {
-  $noNugetPrimary = @($noNugetEntries[0..($OverflowThreshold - 1)])
-  $noNugetOverflow = @($noNugetEntries[$OverflowThreshold..($noNugetEntries.Count - 1)])
-  Write-Host "  ↳ no_nugets overflow: $($noNugetPrimary.Count) primary + $($noNugetOverflow.Count) overflow"
-}
-
 # Validate no bucket exceeds the hard limit
 $buckets = @{
-  'tests_matrix_no_nugets' = $noNugetPrimary
-  'tests_matrix_no_nugets_overflow' = $noNugetOverflow
+  'tests_matrix_no_nugets' = $noNugetEntries
   'tests_matrix_requires_nugets_linux' = $nugetEntriesLinux
   'tests_matrix_requires_nugets_windows' = $nugetEntriesWindows
   'tests_matrix_requires_nugets_macos' = $nugetEntriesMacos

--- a/extension/src/test/e2eBridgeProductionGate.test.ts
+++ b/extension/src/test/e2eBridgeProductionGate.test.ts
@@ -75,7 +75,7 @@ suite('E2E bridge production gate', () => {
     });
 
     test('packages the E2E VSIX with the bridge opt-in and asserts the emitted bundle', () => {
-        const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'tests.yml'), 'utf8');
+        const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'extension-unit-tests.yml'), 'utf8');
 
         assert.ok(
             workflow.includes('ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: "true"'),
@@ -101,7 +101,7 @@ suite('E2E bridge production gate', () => {
      * check in this workflow would stay green while the bridge shipped to the Marketplace.
      */
     test('packages a production VSIX without the bridge opt-in and asserts the bridge is absent', () => {
-        const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'tests.yml'), 'utf8');
+         const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'extension-unit-tests.yml'), 'utf8');
 
         assert.ok(
             workflow.includes('corepack yarn run vsce package --pre-release -o out/aspire-extension-production.vsix'),

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -15,6 +15,8 @@ namespace Infrastructure.Tests.Pipelines;
 public sealed class ExtensionE2eWorkflowTests
 {
     private const string CallerWorkflowRelativePath = ".github/workflows/tests.yml";
+    private const string ExtensionUnitWorkflowRelativePath = ".github/workflows/extension-unit-tests.yml";
+
     [Fact]
     public void AdvisoryShardRowsRemainIssueTrackedWithoutWeakeningRunnerStep()
     {
@@ -84,14 +86,15 @@ public sealed class ExtensionE2eWorkflowTests
 
         // The VSIX the shards install is published even when the unit tests fail; without this the
         // decoupling above buys nothing because the artifact would never exist.
-        var extensionUnitJob = (YamlMappingNode)jobs.Children[new YamlScalarNode("extension_tests_win")];
+        var extensionUnitJobs = LoadWorkflowJobs(ExtensionUnitWorkflowRelativePath);
+        var extensionUnitJob = (YamlMappingNode)extensionUnitJobs.Children[new YamlScalarNode("extension_tests_win")];
         var unitSteps = ((YamlSequenceNode)extensionUnitJob.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>().ToList();
         var uploadStep = Assert.Single(unitSteps, step => Scalar(step, "name") == "Upload VSIX");
         Assert.Contains("!cancelled()", Scalar(uploadStep, "if") ?? string.Empty, StringComparison.Ordinal);
-        Assert.Contains("!inputs.extensionReleaseOnly", Scalar(uploadStep, "if") ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("inputs.packageVsix", Scalar(uploadStep, "if") ?? string.Empty, StringComparison.Ordinal);
         var packageStep = Assert.Single(unitSteps, step => Scalar(step, "name") == "Package VSIX");
         Assert.Contains("!cancelled()", Scalar(packageStep, "if") ?? string.Empty, StringComparison.Ordinal);
-        Assert.Contains("!inputs.extensionReleaseOnly", Scalar(packageStep, "if") ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("inputs.packageVsix", Scalar(packageStep, "if") ?? string.Empty, StringComparison.Ordinal);
 
         var resultsJob = (YamlMappingNode)jobs.Children[new YamlScalarNode("results")];
         var steps = (YamlSequenceNode)resultsJob.Children[new YamlScalarNode("steps")];
@@ -102,6 +105,16 @@ public sealed class ExtensionE2eWorkflowTests
     }
 
     private static YamlMappingNode LoadExtensionE2eJob() => ExtensionE2eWorkflow.Job();
+
+    private static YamlMappingNode LoadWorkflowJobs(string relativePath)
+    {
+        var yaml = new YamlStream();
+        using var reader = new StringReader(File.ReadAllText(Path.Combine(RepoRoot.Path, relativePath)));
+        yaml.Load(reader);
+
+        var root = Assert.IsType<YamlMappingNode>(yaml.Documents[0].RootNode);
+        return Assert.IsType<YamlMappingNode>(root.Children[new YamlScalarNode("jobs")]);
+    }
 
     private static IEnumerable<YamlMappingNode> MatrixIncludeRows(YamlMappingNode job)
     {

--- a/tests/Infrastructure.Tests/PowerShellScripts/ExpandTestMatrixGitHubTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/ExpandTestMatrixGitHubTests.cs
@@ -575,20 +575,17 @@ public class ExpandTestMatrixGitHubTests : IDisposable
         // Read split results from GITHUB_OUTPUT file
         var splitOutputs = ParseGitHubOutputFile(githubOutputFile);
         var noNugets = splitOutputs["tests_matrix_no_nugets"];
-        var noNugetsOverflow = splitOutputs["tests_matrix_no_nugets_overflow"];
         var nugetsLinux = splitOutputs["tests_matrix_requires_nugets_linux"];
         var nugetsWindows = splitOutputs["tests_matrix_requires_nugets_windows"];
         var nugetsMacos = splitOutputs["tests_matrix_requires_nugets_macos"];
         var cliArchiveMatrix = splitOutputs["tests_matrix_requires_cli_archive"];
 
-        var allNoNugets = noNugets.Include.Concat(noNugetsOverflow.Include).ToArray();
-
         // Regular project: 1 project × 3 OSes = 3
-        var regularEntries = allNoNugets.Where(e => e.ProjectName == "RegularProject").ToArray();
+        var regularEntries = noNugets.Include.Where(e => e.ProjectName == "RegularProject").ToArray();
         Assert.Equal(3, regularEntries.Length);
 
         // Split project: 2 classes × 3 OSes = 6
-        var splitEntries = allNoNugets.Where(e => e.ProjectName == "SplitMultiOS").ToArray();
+        var splitEntries = noNugets.Include.Where(e => e.ProjectName == "SplitMultiOS").ToArray();
         Assert.Equal(6, splitEntries.Length);
         Assert.Equal(2, splitEntries.Count(e => e.RunsOn == "ubuntu-latest"));
         Assert.Equal(2, splitEntries.Count(e => e.RunsOn == "windows-latest"));
@@ -607,7 +604,7 @@ public class ExpandTestMatrixGitHubTests : IDisposable
         Assert.True(cliE2eEntries[0].Properties.GetValueOrDefault("requiresCliArchive"));
 
         // Total no-nugets: 3 + 6 = 9, Total nugets: 1 (linux only), Total cli-archive: 1
-        Assert.Equal(9, allNoNugets.Length);
+        Assert.Equal(9, noNugets.Include.Length);
         Assert.Single(nugetsLinux.Include);
         Assert.Empty(nugetsWindows.Include);
         Assert.Empty(nugetsMacos.Include);

--- a/tests/Infrastructure.Tests/PowerShellScripts/SplitTestMatrixByDepsTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/SplitTestMatrixByDepsTests.cs
@@ -123,38 +123,19 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
     [Fact]
     [RequiresTools(["pwsh"])]
-    public async Task OverflowsEntriesBeyondThreshold()
+    public async Task FailsWhenNoNugetsMatrixExceedsGitHubLimit()
     {
-        var entries = Enumerable.Range(1, 8).Select(i =>
+        var entries = Enumerable.Range(1, 257).Select(i =>
             (object)new { name = $"T{i}", shortname = $"t{i}", runs_on = "ubuntu-latest" }).ToArray();
 
         var matrixJson = BuildMatrixJson(entries);
 
-        var result = await RunScript(allTestsMatrix: matrixJson, overflowThreshold: 5);
+        var result = await RunScript(allTestsMatrix: matrixJson);
 
-        result.EnsureSuccessful();
-
-        var outputs = ParseGitHubOutputFile();
-        Assert.Equal(5, outputs["tests_matrix_no_nugets"].Include.Length);
-        Assert.Equal(3, outputs["tests_matrix_no_nugets_overflow"].Include.Length);
-    }
-
-    [Fact]
-    [RequiresTools(["pwsh"])]
-    public async Task NoOverflowWhenBelowThreshold()
-    {
-        var entries = Enumerable.Range(1, 5).Select(i =>
-            (object)new { name = $"T{i}", shortname = $"t{i}", runs_on = "ubuntu-latest" }).ToArray();
-
-        var matrixJson = BuildMatrixJson(entries);
-
-        var result = await RunScript(allTestsMatrix: matrixJson, overflowThreshold: 10);
-
-        result.EnsureSuccessful();
-
-        var outputs = ParseGitHubOutputFile();
-        Assert.Equal(5, outputs["tests_matrix_no_nugets"].Include.Length);
-        Assert.Empty(outputs["tests_matrix_no_nugets_overflow"].Include);
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("tests_matrix_no_nugets", result.Output, StringComparison.Ordinal);
+        Assert.Contains("257 entries", result.Output, StringComparison.Ordinal);
+        Assert.Contains("limit of 256", result.Output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -169,7 +150,6 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
         var outputs = ParseGitHubOutputFile();
         Assert.Empty(outputs["tests_matrix_no_nugets"].Include);
-        Assert.Empty(outputs["tests_matrix_no_nugets_overflow"].Include);
         Assert.Empty(outputs["tests_matrix_requires_nugets_linux"].Include);
         Assert.Empty(outputs["tests_matrix_requires_nugets_windows"].Include);
         Assert.Empty(outputs["tests_matrix_requires_nugets_macos"].Include);
@@ -189,7 +169,6 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
         var outputs = ParseGitHubOutputFile();
         Assert.True(outputs.ContainsKey("tests_matrix_no_nugets"));
-        Assert.True(outputs.ContainsKey("tests_matrix_no_nugets_overflow"));
         Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_linux"));
         Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_windows"));
         Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_macos"));
@@ -247,8 +226,7 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
     private async Task<CommandResult> RunScript(
         string? allTestsMatrix = null,
-        string? allTestsMatrixFile = null,
-        int? overflowThreshold = null)
+        string? allTestsMatrixFile = null)
     {
         using var cmd = new PowerShellCommand(_scriptPath, _output)
             .WithTimeout(TimeSpan.FromMinutes(2))
@@ -269,12 +247,6 @@ public class SplitTestMatrixByDepsTests : IDisposable
         {
             args.Add("-AllTestsMatrixFile");
             args.Add($"\"{allTestsMatrixFile}\"");
-        }
-
-        if (overflowThreshold.HasValue)
-        {
-            args.Add("-OverflowThreshold");
-            args.Add(overflowThreshold.Value.ToString());
         }
 
         args.Add("-OutputToGitHubEnv");

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -27,6 +27,19 @@ public sealed class TestTriggerMapTests
     }
 
     [Fact]
+    public void ExtensionUnitWorkflowChangesSelectUnitAndE2eJobs()
+    {
+        const string workflow = ".github/workflows/extension-unit-tests.yml";
+        var targets = s_map.PathRules
+            .Where(rule => rule.Paths.Any(path => TestTriggerMap.GlobMatches(path, workflow)))
+            .SelectMany(rule => rule.Targets)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains("job:extension-unit", targets);
+        Assert.Contains("job:extension-e2e", targets);
+    }
+
+    [Fact]
     public void RulesAreWellFormed()
     {
         // Structural hygiene: a path rule with no globs, or globs but no targets, is dead weight

--- a/tests/Infrastructure.Tests/WorkflowScripts/ExtensionReleaseFastPathWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ExtensionReleaseFastPathWorkflowTests.cs
@@ -10,54 +10,50 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
 {
     private static readonly YamlMappingNode s_testsWorkflow = LoadWorkflow("tests.yml");
     private static readonly YamlMappingNode s_testJobs = Mapping(s_testsWorkflow, "jobs");
+    private static readonly YamlMappingNode s_extensionUnitWorkflow = LoadWorkflow("extension-unit-tests.yml");
+    private static readonly YamlMappingNode s_extensionUnitJobs = Mapping(s_extensionUnitWorkflow, "jobs");
     private static readonly YamlMappingNode s_ciWorkflow = LoadWorkflow("ci.yml");
     private static readonly YamlMappingNode s_ciJobs = Mapping(s_ciWorkflow, "jobs");
 
     [Fact]
-    public void WorkflowCallDeclaresReleaseOnlyInputDisabledByDefault()
+    public void FocusedExtensionWorkflowSupportsOptionalPackaging()
+    {
+        var workflowCall = Mapping(Mapping(s_extensionUnitWorkflow, "on"), "workflow_call");
+        var inputs = Mapping(workflowCall, "inputs");
+        var packageVsix = Mapping(inputs, "packageVsix");
+
+        Assert.Equal("boolean", Scalar(packageVsix, "type"));
+        Assert.Equal("true", Scalar(packageVsix, "default"));
+
+        var extensionVersionOverride = Mapping(inputs, "extensionVersionOverride");
+        Assert.Equal("string", Scalar(extensionVersionOverride, "type"));
+        Assert.Equal(string.Empty, Scalar(extensionVersionOverride, "default"));
+    }
+
+    [Fact]
+    public void FullTestsWorkflowDoesNotExposeReleaseOnlyMode()
     {
         var workflowCall = Mapping(Mapping(s_testsWorkflow, "on"), "workflow_call");
-        var input = Mapping(Mapping(workflowCall, "inputs"), "extensionReleaseOnly");
+        var inputs = Mapping(workflowCall, "inputs");
 
-        Assert.Equal("boolean", Scalar(input, "type"));
-        Assert.Equal("false", Scalar(input, "default"));
+        Assert.False(inputs.Children.ContainsKey(new YamlScalarNode("extensionReleaseOnly")));
     }
 
     [Fact]
-    public void ReleaseOnlyModeSkipsSetupAndIndependentArtifactProducers()
+    public void FocusedExtensionWorkflowContainsOnlyUnitTests()
     {
-        string[] skippedJobs =
-        [
-            "setup_for_tests",
-            "build_packages",
-            "build_cli_archive_linux",
-            "build_cli_archive_linux_arm64",
-            "build_cli_archive_windows",
-            "build_cli_archive_windows_arm64",
-            "build_cli_archive_macos",
-            "build_cli_archive_macos_x64",
-        ];
-
-        Assert.All(skippedJobs, jobName =>
-        {
-            var condition = Scalar(Mapping(s_testJobs, jobName), "if") ?? string.Empty;
-            Assert.Contains("!inputs.extensionReleaseOnly", condition, StringComparison.Ordinal);
-        });
+        Assert.Equal(
+            ["extension_tests_win"],
+            s_extensionUnitJobs.Children.Keys.Cast<YamlScalarNode>().Select(key => key.Value));
     }
 
     [Fact]
-    public void ExtensionUnitTestsRunInlineWhenSetupIsSkippedForReleaseOnlyMode()
+    public void FocusedExtensionWorkflowRunsUnitTestsAndOwnsPackaging()
     {
-        var job = Mapping(s_testJobs, "extension_tests_win");
+        var job = Mapping(s_extensionUnitJobs, "extension_tests_win");
 
         Assert.False(job.Children.ContainsKey(new YamlScalarNode("uses")));
         Assert.Equal("windows-latest", Scalar(job, "runs-on"));
-
-        var condition = CollapseWhitespace(Scalar(job, "if"));
-        Assert.StartsWith("${{ !cancelled() &&", condition, StringComparison.Ordinal);
-        Assert.Contains("inputs.extensionReleaseOnly", condition, StringComparison.Ordinal);
-        Assert.Contains("needs.setup_for_tests.outputs.run_extension_unit == 'true'", condition, StringComparison.Ordinal);
-        Assert.Contains("needs.setup_for_tests.outputs.run_extension_e2e == 'true'", condition, StringComparison.Ordinal);
 
         var steps = Steps(job);
         Assert.Equal(
@@ -83,12 +79,31 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
     }
 
     [Fact]
-    public void ReleaseOnlyModeDisablesVsixPackagingWithoutChangingNormalPackaging()
+    public void NormalAndReleaseCallersShareFocusedWorkflowWithDifferentPackaging()
     {
-        var steps = Steps(Mapping(s_testJobs, "extension_tests_win"));
+        var normalExtensionTests = Mapping(s_testJobs, "extension_tests_win");
+        Assert.Equal("./.github/workflows/extension-unit-tests.yml", Scalar(normalExtensionTests, "uses"));
+        Assert.Equal(
+            "${{ needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}",
+            Scalar(normalExtensionTests, "if"));
+        Assert.Equal(["setup_for_tests"], SequenceScalars(normalExtensionTests, "needs"));
+
+        var normalInputs = Mapping(normalExtensionTests, "with");
+        Assert.Equal("true", Scalar(normalInputs, "packageVsix"));
+        Assert.Equal("${{ inputs.extensionVersionOverride }}", Scalar(normalInputs, "extensionVersionOverride"));
+
+        var releaseExtensionTests = Mapping(s_ciJobs, "extension_release_tests");
+        Assert.Equal("./.github/workflows/extension-unit-tests.yml", Scalar(releaseExtensionTests, "uses"));
+        Assert.Equal("false", Scalar(Mapping(releaseExtensionTests, "with"), "packageVsix"));
+    }
+
+    [Fact]
+    public void FocusedWorkflowPackagesAfterTestFailuresOnlyWhenRequested()
+    {
+        var steps = Steps(Mapping(s_extensionUnitJobs, "extension_tests_win"));
         var overrideVersion = Assert.Single(steps, step => Scalar(step, "name") == "Override extension version for PR builds");
         Assert.Equal(
-            "${{ !inputs.extensionReleaseOnly && !cancelled() && inputs.extensionVersionOverride != '' }}",
+            "${{ inputs.packageVsix && !cancelled() && inputs.extensionVersionOverride != '' }}",
             Scalar(overrideVersion, "if"));
 
         string[] packagingSteps =
@@ -103,12 +118,12 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
         Assert.All(packagingSteps, stepName =>
         {
             var step = Assert.Single(steps, candidate => Scalar(candidate, "name") == stepName);
-            Assert.Equal("${{ !inputs.extensionReleaseOnly && !cancelled() }}", Scalar(step, "if"));
+            Assert.Equal("${{ inputs.packageVsix && !cancelled() }}", Scalar(step, "if"));
         });
     }
 
     [Fact]
-    public void FinalResultsRequiresReleaseUnitTestSuccessAndPreservesNormalSkipChecks()
+    public void FullTestsFinalResultsPreserveNormalSkipChecks()
     {
         var results = Mapping(s_testJobs, "results");
         var failureStep = Assert.Single(Steps(results), step => Scalar(step, "name") == "Fail if any dependency failed");
@@ -116,15 +131,6 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
 
         Assert.Contains("contains(needs.*.result, 'failure')", condition, StringComparison.Ordinal);
         Assert.Contains("contains(needs.*.result, 'cancelled')", condition, StringComparison.Ordinal);
-        Assert.Contains(
-            "(inputs.extensionReleaseOnly && needs.extension_tests_win.result != 'success')",
-            condition,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "(!inputs.extensionReleaseOnly && ((github.event_name == 'pull_request'",
-            condition,
-            StringComparison.Ordinal);
-
         string[] normalModeSkipChecks =
         [
             "needs.extension_tests_win.result == 'skipped'",
@@ -154,35 +160,45 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
     }
 
     [Fact]
-    public void ReleaseOnlyModeSkipsTestResultAggregation()
+    public void FullTestsWorkflowAlwaysAggregatesTestResults()
     {
         var steps = Steps(Mapping(s_testJobs, "results"));
-        var failureStep = Assert.Single(steps, step => Scalar(step, "name") == "Fail if any dependency failed");
 
         Assert.All(
-            steps.Where(step => step != failureStep),
-            step => Assert.Contains("!inputs.extensionReleaseOnly", Scalar(step, "if") ?? string.Empty, StringComparison.Ordinal));
+            steps.Where(step => Scalar(step, "name") is "Upload test results" or "Generate test results summary" or "Generate CI timeline"),
+            step => Assert.Equal("${{ always() }}", Scalar(step, "if")));
+        Assert.All(
+            steps.Where(step => Scalar(step, "name") is "Checkout code" or "Create test results directory" || Scalar(step, "uses")?.StartsWith("actions/download-artifact@", StringComparison.Ordinal) == true),
+            step => Assert.False(step.Children.ContainsKey(new YamlScalarNode("if"))));
     }
 
     [Fact]
-    public void ReleaseCallerGrantsAllReusableWorkflowPermissions()
+    public void TestMatrixCallersUseDescriptiveLaneNames()
     {
-        var workflowPermissions = Mapping(s_testsWorkflow, "permissions");
-        Assert.Equal("read", Scalar(workflowPermissions, "actions"));
-        Assert.Equal("read", Scalar(workflowPermissions, "contents"));
+        Dictionary<string, string> expectedNames = new()
+        {
+            ["tests_no_nugets"] = "No-package tests",
+            ["tests_requires_nugets_linux"] = "Package tests - Linux",
+            ["tests_requires_nugets_windows"] = "Package tests - Windows",
+            ["tests_requires_nugets_macos"] = "Package tests - macOS",
+            ["tests_requires_cli_archive"] = "CLI archive tests",
+        };
 
-        var normalPermissions = Mapping(Mapping(s_ciJobs, "tests"), "permissions");
+        Assert.All(
+            expectedNames,
+            expected => Assert.Equal(expected.Value, Scalar(Mapping(s_testJobs, expected.Key), "name")));
+    }
+
+    [Fact]
+    public void ReleaseCallerGrantsOnlyFocusedWorkflowPermissions()
+    {
+        var workflowPermissions = Mapping(s_extensionUnitWorkflow, "permissions");
         var releasePermissions = Mapping(Mapping(s_ciJobs, "extension_release_tests"), "permissions");
-        string[] requiredPermissions =
-        [
-            "actions",
-            "contents",
-            "issues",
-            "pull-requests",
-        ];
 
-        Assert.Equal(requiredPermissions, releasePermissions.Children.Keys.Cast<YamlScalarNode>().Select(key => key.Value).Order());
-        Assert.All(requiredPermissions, permission => Assert.Equal(Scalar(normalPermissions, permission), Scalar(releasePermissions, permission)));
+        Assert.Equal(["contents"], workflowPermissions.Children.Keys.Cast<YamlScalarNode>().Select(key => key.Value));
+        Assert.Equal(["contents"], releasePermissions.Children.Keys.Cast<YamlScalarNode>().Select(key => key.Value));
+        Assert.Equal("read", Scalar(workflowPermissions, "contents"));
+        Assert.Equal("read", Scalar(releasePermissions, "contents"));
     }
 
     [Fact]
@@ -320,11 +336,11 @@ public sealed class ExtensionReleaseFastPathWorkflowTests
             Scalar(normalTests, "if"));
 
         var releaseTests = Mapping(s_ciJobs, "extension_release_tests");
-        Assert.Equal("./.github/workflows/tests.yml", Scalar(releaseTests, "uses"));
+        Assert.Equal("./.github/workflows/extension-unit-tests.yml", Scalar(releaseTests, "uses"));
         Assert.Equal(
             "${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' && needs.prepare_for_ci.outputs.is_trusted_extension_release_pr == 'true' }}",
             Scalar(releaseTests, "if"));
-        Assert.Equal("true", Scalar(Mapping(releaseTests, "with"), "extensionReleaseOnly"));
+        Assert.Equal("false", Scalar(Mapping(releaseTests, "with"), "packageVsix"));
     }
 
     [Fact]


### PR DESCRIPTION
[automated]

## Description

**PR CI now uses focused extension validation and five stable test-matrix lanes.** This makes selector-driven skips and job names easier to interpret, while trusted extension release PRs avoid starting the full test workflow.

**Root cause.** Extension unit testing and VSIX packaging were embedded in `tests.yml`, so the release fast path had to thread an `extensionReleaseOnly` mode through the full workflow. The matrix splitter also maintained a sixth overflow lane even though the measured no-package matrix has 204 entries.

**The fix.** Extension unit testing and optional packaging now live in `extension-unit-tests.yml`, called directly by normal and release CI. Packaging still runs after unit-test failures when extension E2E needs the VSIX. The splitter emits five dependency lanes and fails explicitly if any lane exceeds GitHub's 256-job limit, rather than silently dropping tests. Static OS-qualified lane names remain distinct in CI timeline rendering, and selector routing covers both extension unit and E2E consumers.

**Why the skipped extension-release job remains.** It is the pre-existing, mutually exclusive fast path for trusted bot-authored extension release PRs. Ordinary PRs show it as skipped because GitHub renders conditional jobs in the check graph, but it consumes no runner time.

**Coverage is unchanged.** Normal PR CI still covers the rolling-build test set and adds the existing PR-only CLI E2E and starter-validation checks. The selector and enumeration criteria are unchanged; the passing run executed all 313 matrix entries exactly once plus all 34 extension E2E shards.

**Validation.**
- [PR CI run 33117080669](https://github.com/microsoft/aspire/actions/runs/33117080669) passed for commit `cccd63256d`.
- The run executed all 313 matrix entries exactly once: 204 no-package, 12 Linux package, 12 Windows package, 0 macOS package, and 85 CLI-archive entries, with no overflow jobs.
- Extension unit tests, both VSIX package assertions, artifact upload, and all 34 extension E2E shards passed; every E2E shard downloaded the VSIX successfully.
- 71 focused workflow, selector, and matrix contracts, 10 focused extension production-gate tests, and 669 broader `Infrastructure.Tests` passed locally.
- `actionlint` reported no new diagnostics in the changed workflows.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No