### PR TITLE
ci(vscode): Keep CI green when Azure Functions E2E flakes

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -362,6 +362,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: azure-functions
+            advisoryIssue: https://github.com/microsoft/aspire/issues/19639
             spec: out/test-e2e/test-e2e/azureFunctions.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64

--- a/extension/src/test/e2eShardMatrix.test.ts
+++ b/extension/src/test/e2eShardMatrix.test.ts
@@ -19,6 +19,7 @@ suite('E2E shard matrix', () => {
     // would make the assertion vacuous. Keys are `name|shardName|spec` and values are tracking issues.
     const expectedAdvisoryRows = new Map<string, string>([
         ['Linux|apphost-tree|out/test-e2e/test-e2e/appHostTree.e2e.test.js', 'https://github.com/microsoft/aspire/issues/19282'],
+        ['Linux|azure-functions|out/test-e2e/test-e2e/azureFunctions.e2e.test.js', 'https://github.com/microsoft/aspire/issues/19639'],
         ['Windows|discovery-configuration|out/test-e2e/test-e2e/discoveryConfiguration.e2e.test.js', 'https://github.com/microsoft/aspire/issues/19282'],
         ['Windows|debug-dashboard|out/test-e2e/test-e2e/debugDashboard.e2e.test.js', 'https://github.com/microsoft/aspire/issues/19282'],
     ]);


### PR DESCRIPTION
## Description

Rolling `main` CI stays red when the Linux Azure Functions extension E2E shard intermittently fails with:

```text
AssertionError [ERR_ASSERTION]: Expected the Azure Functions resource to expose an HTTPS URL.
```

Only 3 of 11 rolling `main` runs passed during the latest 36-hour investigation window. This shard appeared in five of the seven failed runs, making it the dominant recurring cause of red rolling CI.

This change keeps the shard running and uploading diagnostics, but reports completed Mocha test failures as advisory warnings so this known flake no longer fails the overall CI run. Setup failures, process crashes, signals, timeouts, unexpected exit codes, and cleanup failures remain blocking.

This preserves coverage and failure evidence instead of disabling the shard entirely. The explicit advisory-shard allowlist keeps the mitigation deliberate and reviewable.

Addresses #19639

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No