### PR TITLE
Use managed identity for sandbox image pulls

### DIFF
--- a/src/Aspire.Hosting.Azure.Sandboxes/Aspire.Hosting.Azure.Sandboxes.csproj
+++ b/src/Aspire.Hosting.Azure.Sandboxes/Aspire.Hosting.Azure.Sandboxes.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)ContainerRegistryInfrastructure.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)CrossScopeAcrPullIdentityPreparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)AzureRoleAssignmentUtils.cs" LinkBase="Utils" />
     <Compile Include="$(SharedDir)FileLock.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxContainerDeployment.cs
+++ b/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxContainerDeployment.cs
@@ -631,21 +631,14 @@ internal static class AzureSandboxContainerDeployment
         string ownerId,
         string deployId)
     {
-        AzureDevComputeRegistryCredentials? registryCredentials = null;
-        var registry = resource.Parent.ContainerRegistry;
-        if (registry is not null)
+        var managedIdentityClientId = await resource.Parent.AcrPullIdentityClientIdOutputReference
+            .GetValueAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(managedIdentityClientId))
         {
-            var registryEndpoint = await registry.RegistryEndpoint.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(registryEndpoint) &&
-                imageReference.StartsWith($"{registryEndpoint}/", StringComparison.OrdinalIgnoreCase))
-            {
-                var token = await GetAcrRefreshTokenAsync(context, registryEndpoint).ConfigureAwait(false);
-                registryCredentials = new AzureDevComputeRegistryCredentials
-                {
-                    Username = token.Username,
-                    Token = token.Token
-                };
-            }
+            throw new InvalidOperationException(
+                $"Azure sandbox group '{resource.Parent.Name}' does not have an image-pull managed identity client ID. " +
+                $"For an existing sandbox group, call 'WithAcrPullIdentity' with an identity that is already attached to the group and has AcrPull on the configured registry.");
         }
 
         return await client.CreateDiskImageAsync(
@@ -654,30 +647,13 @@ internal static class AzureSandboxContainerDeployment
             {
                 Name = diskImageName,
                 Labels = CreateLabels(resource, ownerId, deployId),
-                Image = new AzureDevComputeDiskImageSpec
+                Source = new AzureDevComputeRegistryDiskImageSource
                 {
-                    Base = imageReference
-                },
-                RegistryCredentials = registryCredentials
+                    Kind = "registry",
+                    ImageUrl = imageReference,
+                    ManagedIdentityClientId = managedIdentityClientId
+                }
             },
-            context.CancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task<AcrRefreshToken> GetAcrRefreshTokenAsync(PipelineStepContext context, string registryEndpoint)
-    {
-        var azureEnvironment = context.Model.Resources.OfType<AzureEnvironmentResource>().FirstOrDefault() ??
-            throw new InvalidOperationException("AzureEnvironmentResource must be present in the application model.");
-        var provisioningContext = await azureEnvironment.ProvisioningContextTask.Task.ConfigureAwait(false);
-        var tenantId = provisioningContext.Tenant.TenantId?.ToString()
-            ?? throw new InvalidOperationException("Tenant ID is required for ACR authentication but was not available in provisioning context.");
-
-        var acrLoginService = context.Services.GetRequiredService<IAcrLoginService>();
-        var tokenCredentialProvider = context.Services.GetRequiredService<ITokenCredentialProvider>();
-
-        return await acrLoginService.GetRefreshTokenAsync(
-            registryEndpoint,
-            tenantId,
-            tokenCredentialProvider.TokenCredential,
             context.CancellationToken).ConfigureAwait(false);
     }
 
@@ -1439,8 +1415,8 @@ internal static class AzureSandboxContainerDeployment
         var options = GetAzureSandboxContainerOptions(resource.TargetResource);
         var endpointOptions = options?.Endpoints?.ToDictionary(
             static endpoint => endpoint.Name!,
-            StringComparers.EndpointAnnotationName);
-        var unmatchedEndpointOptions = endpointOptions is null ? null : new HashSet<string>(endpointOptions.Keys, StringComparers.EndpointAnnotationName);
+            StringComparer.OrdinalIgnoreCase);
+        var unmatchedEndpointOptions = endpointOptions is null ? null : new HashSet<string>(endpointOptions.Keys, StringComparer.OrdinalIgnoreCase);
         var endpoints = new Dictionary<int, SandboxEndpoint>();
         foreach (var resolvedEndpoint in resource.TargetResource.ResolveEndpoints())
         {

--- a/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxGroupAcrPullIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxGroupAcrPullIdentityAnnotation.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Identifies the user-assigned identity used to import sandbox images from the configured Azure Container Registry.
+/// </summary>
+/// <param name="identity">The user-assigned identity used for image pulls.</param>
+internal sealed class AzureSandboxGroupAcrPullIdentityAnnotation(AzureUserAssignedIdentityResource identity) : IAcrPullIdentityAnnotation
+{
+    /// <summary>
+    /// Gets the user-assigned identity used for image pulls.
+    /// </summary>
+    public AzureUserAssignedIdentityResource Identity { get; } = identity;
+}

--- a/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxGroupResource.cs
@@ -110,6 +110,8 @@ public sealed class AzureSandboxGroupResource : AzureProvisioningResource, IAzur
     /// </summary>
     public BicepOutputReference LocationOutputReference => new("location", this);
 
+    internal BicepOutputReference AcrPullIdentityClientIdOutputReference => new("acrPullIdentityClientId", this);
+
     internal ManagedServiceIdentityType ManagedIdentityType { get; set; } = ManagedServiceIdentityType.None;
 
     internal List<AzureUserAssignedIdentityResource> UserAssignedIdentities { get; } = [];
@@ -158,6 +160,9 @@ public sealed class AzureSandboxGroupResource : AzureProvisioningResource, IAzur
 
         var containerRegistry = ContainerRegistry ??
             throw new InvalidOperationException($"No container registry associated with Azure sandbox group '{Name}'. This should have been added automatically.");
+        var acrPullIdentity = this.TryGetLastAnnotation<AzureSandboxGroupAcrPullIdentityAnnotation>(out var acrPullIdentityAnnotation)
+            ? acrPullIdentityAnnotation.Identity
+            : null;
         var computeEnvironments = context.Model.Resources.OfType<IComputeEnvironmentResource>().ToList();
         var canClaimUnassignedComputeResources = computeEnvironments.Count == 1 && ReferenceEquals(computeEnvironments[0], this);
 
@@ -179,6 +184,30 @@ public sealed class AzureSandboxGroupResource : AzureProvisioningResource, IAzur
                 continue;
             }
 
+            if (this.IsExisting())
+            {
+                if (acrPullIdentity is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Azure sandbox group '{Name}' is existing and cannot be mutated to attach an image-pull identity. " +
+                        $"Call 'WithAcrPullIdentity' with a user-assigned identity that is already attached to the sandbox group and has AcrPull on the configured registry.");
+                }
+
+                if (!acrPullIdentity.IsExisting())
+                {
+                    throw new InvalidOperationException(
+                        $"Azure sandbox group '{Name}' is existing, but its image-pull identity '{acrPullIdentity.Name}' is not. " +
+                        $"Call 'PublishAsExisting' on the identity because it must already be attached to the sandbox group and have AcrPull on the configured registry.");
+                }
+            }
+
+            if (acrPullIdentity is not null && UserAssignedIdentities.Contains(acrPullIdentity))
+            {
+                throw new InvalidOperationException(
+                    $"Azure sandbox group '{Name}' uses identity '{acrPullIdentity.Name}' for both image pulls and workloads. " +
+                    "Use a dedicated image-pull identity so its AcrPull permission is not exposed to sandbox workloads.");
+            }
+
             if (resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentity))
             {
                 if (appIdentity.IdentityResource is not AzureUserAssignedIdentityResource userAssignedIdentity)
@@ -191,6 +220,13 @@ public sealed class AzureSandboxGroupResource : AzureProvisioningResource, IAzur
                 {
                     throw new InvalidOperationException(
                         $"Compute resource '{resource.Name}' uses managed identity '{userAssignedIdentity.Name}', but workload identities are not supported when publishing to existing Azure sandbox group '{Name}'.");
+                }
+
+                if (ReferenceEquals(acrPullIdentity, userAssignedIdentity))
+                {
+                    throw new InvalidOperationException(
+                        $"Azure sandbox group '{Name}' uses identity '{userAssignedIdentity.Name}' for both image pulls and workload '{resource.Name}'. " +
+                        "Use a dedicated image-pull identity so its AcrPull permission is not exposed to sandbox workloads.");
                 }
 
                 AddUserAssignedIdentity(userAssignedIdentity);

--- a/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxesExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sandboxes/AzureSandboxesExtensions.cs
@@ -10,8 +10,10 @@ using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Sandboxes.Provisioning;
 using Azure.Provisioning;
 using Azure.Provisioning.Authorization;
+using Azure.Provisioning.ContainerRegistry;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Resources;
+using Azure.Provisioning.Roles;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
@@ -42,6 +44,36 @@ public static class AzureSandboxesExtensions
         static void ConfigureInfrastructure(AzureResourceInfrastructure infrastructure)
         {
             var sandboxResource = (AzureSandboxGroupResource)infrastructure.AspireResource;
+            UserAssignedIdentity? newAcrPullIdentity = null;
+            string? acrPullIdentityResourceId = null;
+            BicepValue<string> acrPullIdentityClientId = new(string.Empty);
+
+            if (sandboxResource.TryGetLastAnnotation<AzureSandboxGroupAcrPullIdentityAnnotation>(out var identityAnnotation))
+            {
+                acrPullIdentityClientId = identityAnnotation.Identity.ClientId.AsProvisioningParameter(infrastructure);
+                if (!sandboxResource.IsExisting())
+                {
+                    var identityIdParameter = identityAnnotation.Identity.Id.AsProvisioningParameter(infrastructure);
+                    acrPullIdentityResourceId = BicepFunction.Interpolate($"{identityIdParameter}").Compile().ToString();
+                }
+            }
+            else if (!sandboxResource.IsExisting())
+            {
+                var tags = new ProvisioningParameter("tags", typeof(object))
+                {
+                    Value = new BicepDictionary<string>()
+                };
+                infrastructure.Add(tags);
+                newAcrPullIdentity = new UserAssignedIdentity(
+                    Infrastructure.NormalizeBicepIdentifier($"{sandboxResource.Name}_acr_pull_mi"))
+                {
+                    Tags = tags
+                };
+                infrastructure.Add(newAcrPullIdentity);
+                acrPullIdentityResourceId = BicepFunction.Interpolate($"{newAcrPullIdentity.Id}").Compile().ToString();
+                acrPullIdentityClientId = newAcrPullIdentity.ClientId.ToBicepExpression();
+            }
+
             var sandboxGroup = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
@@ -56,16 +88,41 @@ public static class AzureSandboxesExtensions
                         Properties = [],
                         Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
                     };
-                    ApplyManagedServiceIdentity(resource.Identity, sandboxResource, infrastructure);
+                    ApplyManagedServiceIdentity(
+                        resource.Identity,
+                        sandboxResource,
+                        infrastructure,
+                        acrPullIdentityResourceId);
                     return resource;
                 });
 
             infrastructure.Add(new ProvisioningOutput("id", typeof(string)) { Value = sandboxGroup.Id.ToBicepExpression() });
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = sandboxGroup.Name.ToBicepExpression() });
             infrastructure.Add(new ProvisioningOutput("location", typeof(string)) { Value = sandboxGroup.Location.ToBicepExpression() });
+            infrastructure.Add(new ProvisioningOutput("acrPullIdentityClientId", typeof(string)) { Value = acrPullIdentityClientId });
 
             if (!sandboxResource.IsExisting())
             {
+                if (newAcrPullIdentity is not null)
+                {
+                    var registry = sandboxResource.ContainerRegistry ??
+                        throw new InvalidOperationException($"No container registry associated with Azure sandbox group '{sandboxResource.Name}'. This should have been added automatically.");
+                    var containerRegistry = (ContainerRegistryService)registry.AddAsExistingResource(infrastructure);
+                    infrastructure.Add(containerRegistry);
+                    var pullRoleAssignment = containerRegistry.CreateRoleAssignment(
+                        ContainerRegistryBuiltInRole.AcrPull,
+                        newAcrPullIdentity);
+
+                    // Azure.Provisioning currently omits the identity from the generated role-assignment name.
+                    // Include it so multiple sandbox groups can safely use the same registry.
+                    // https://github.com/Azure/azure-sdk-for-net/issues/47265
+                    pullRoleAssignment.Name = BicepFunction.CreateGuid(
+                        containerRegistry.Id,
+                        newAcrPullIdentity.Id,
+                        pullRoleAssignment.RoleDefinitionId);
+                    infrastructure.Add(pullRoleAssignment);
+                }
+
                 AddSandboxGroupDeploymentPrincipalRoleAssignment(infrastructure, sandboxGroup);
             }
         }
@@ -80,7 +137,11 @@ public static class AzureSandboxesExtensions
         AzureSandboxCleanupResource.EnsureAdded(builder);
         builder.Services.Configure<AzureProvisioningOptions>(options => options.SupportsTargetedRoleAssignments = true);
         resource.DefaultContainerRegistry = CreateDefaultAzureContainerRegistry(builder, $"{name}-acr");
-        return builder.AddResource(resource);
+        var resourceBuilder = builder.AddResource(resource);
+        resourceBuilder.WithCrossScopeAcrPullIdentity(
+            identity => new AzureSandboxGroupAcrPullIdentityAnnotation(identity),
+            canPrepareIdentity: static sandboxGroup => !sandboxGroup.IsExisting());
+        return resourceBuilder;
     }
 
     /// <summary>
@@ -158,11 +219,12 @@ public static class AzureSandboxesExtensions
     }
 
     /// <summary>
-    /// Configures the Azure sandbox group to use no managed identity.
+    /// Configures the Azure sandbox group workloads to use no managed identity.
     /// </summary>
     /// <param name="builder">The sandbox group resource builder.</param>
     /// <returns>The resource builder.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>This does not remove the dedicated user-assigned identity used to import images from Azure Container Registry.</remarks>
     [AspireExport]
     [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureSandboxGroupResource> WithNoManagedIdentity(this IResourceBuilder<AzureSandboxGroupResource> builder)
@@ -175,11 +237,12 @@ public static class AzureSandboxesExtensions
     }
 
     /// <summary>
-    /// Configures the Azure sandbox group to use a system-assigned managed identity.
+    /// Configures the Azure sandbox group workloads to use a system-assigned managed identity.
     /// </summary>
     /// <param name="builder">The sandbox group resource builder.</param>
     /// <returns>The resource builder.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>This does not replace the dedicated user-assigned identity used to import images from Azure Container Registry.</remarks>
     [AspireExport]
     [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureSandboxGroupResource> WithSystemAssignedIdentity(this IResourceBuilder<AzureSandboxGroupResource> builder)
@@ -192,7 +255,7 @@ public static class AzureSandboxesExtensions
     }
 
     /// <summary>
-    /// Configures the Azure sandbox group to use a user-assigned managed identity.
+    /// Configures the Azure sandbox group workloads to use a user-assigned managed identity.
     /// </summary>
     /// <param name="builder">The sandbox group resource builder.</param>
     /// <param name="identity">The user-assigned managed identity resource.</param>
@@ -213,6 +276,44 @@ public static class AzureSandboxesExtensions
             builder.Resource.UserAssignedIdentities.Add(identity.Resource);
         }
         return builder;
+    }
+
+    /// <summary>
+    /// Configures the sandbox group to use the supplied user-assigned identity when importing images from
+    /// the configured Azure Container Registry.
+    /// </summary>
+    /// <param name="builder">The sandbox group resource builder.</param>
+    /// <param name="identityBuilder">The user-assigned identity used for image pulls.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// <para>
+    /// Aspire does not create an <c>AcrPull</c> role assignment for a caller-supplied identity. The caller is
+    /// responsible for granting the identity <c>AcrPull</c> on the selected registry.
+    /// </para>
+    /// <para>
+    /// For a newly managed sandbox group, Aspire attaches the supplied identity to the group. For an existing
+    /// sandbox group, Aspire treats the group as read-only; the identity must already be attached to the group
+    /// and authorized for the selected registry.
+    /// </para>
+    /// <para>
+    /// This identity is used only for importing images. It is separate from identities configured for sandbox
+    /// workloads with <see cref="WithUserAssignedIdentity"/> or <c>WithAzureUserAssignedIdentity</c>.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="identityBuilder"/> is null.</exception>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static IResourceBuilder<AzureSandboxGroupResource> WithAcrPullIdentity(
+        this IResourceBuilder<AzureSandboxGroupResource> builder,
+        IResourceBuilder<AzureUserAssignedIdentityResource> identityBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(identityBuilder);
+
+        return builder.WithAnnotation(
+            new AzureSandboxGroupAcrPullIdentityAnnotation(identityBuilder.Resource),
+            ResourceAnnotationMutationBehavior.Replace);
     }
 
     private static AzureSandboxOptions CopyAzureSandboxOptions(AzureSandboxOptions options)
@@ -238,9 +339,7 @@ public static class AzureSandboxesExtensions
     private static void AddSandboxGroupDeploymentPrincipalRoleAssignment(AzureResourceInfrastructure infrastructure, SandboxGroup sandboxGroup)
     {
         var principalId = new ProvisioningParameter(AzureBicepResource.KnownParameters.UserPrincipalId, typeof(Guid));
-        var principalType = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
         infrastructure.Add(principalId);
-        infrastructure.Add(principalType);
 
         // Sandbox deployment creates disk images, sandboxes, lifecycle settings, and public
         // ports through the Azure Dev Compute data-plane API after the sandbox group ARM
@@ -257,7 +356,6 @@ public static class AzureSandboxesExtensions
                 principalId,
                 BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", SandboxGroupDataOwnerRoleId)),
             Scope = new IdentifierExpression(sandboxGroup.BicepIdentifier),
-            PrincipalType = principalType,
             PrincipalId = principalId,
             RoleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", SandboxGroupDataOwnerRoleId)
         });
@@ -303,7 +401,7 @@ public static class AzureSandboxesExtensions
             return;
         }
 
-        var names = new HashSet<string>(StringComparers.EndpointAnnotationName);
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var endpoint in options.Endpoints)
         {
             if (endpoint is null)
@@ -368,14 +466,29 @@ public static class AzureSandboxesExtensions
         }
     }
 
-    private static void ApplyManagedServiceIdentity(ManagedServiceIdentity identity, AzureSandboxGroupResource resource, AzureResourceInfrastructure infrastructure)
+    private static void ApplyManagedServiceIdentity(
+        ManagedServiceIdentity identity,
+        AzureSandboxGroupResource resource,
+        AzureResourceInfrastructure infrastructure,
+        string? acrPullIdentityResourceId)
     {
-        if (resource.ManagedIdentityType == ManagedServiceIdentityType.None && resource.UserAssignedIdentities.Count == 0)
+        var hasUserAssignedIdentity = acrPullIdentityResourceId is not null || resource.UserAssignedIdentities.Count > 0;
+        if (resource.ManagedIdentityType == ManagedServiceIdentityType.None && !hasUserAssignedIdentity)
         {
             return;
         }
 
-        identity.ManagedServiceIdentityType = resource.ManagedIdentityType;
+        identity.ManagedServiceIdentityType = (resource.ManagedIdentityType, hasUserAssignedIdentity) switch
+        {
+            (ManagedServiceIdentityType.None, true) => ManagedServiceIdentityType.UserAssigned,
+            (ManagedServiceIdentityType.SystemAssigned, true) => ManagedServiceIdentityType.SystemAssignedUserAssigned,
+            _ => resource.ManagedIdentityType
+        };
+
+        if (acrPullIdentityResourceId is not null)
+        {
+            identity.UserAssignedIdentities[acrPullIdentityResourceId] = new UserAssignedIdentityDetails();
+        }
 
         foreach (var userAssignedIdentity in resource.UserAssignedIdentities)
         {

--- a/src/Aspire.Hosting.Azure.Sandboxes/Internal/Adc/AzureDevComputeClient.cs
+++ b/src/Aspire.Hosting.Azure.Sandboxes/Internal/Adc/AzureDevComputeClient.cs
@@ -62,7 +62,7 @@ internal sealed class AzureDevComputeClient(HttpClient httpClient, TokenCredenti
         return SendCreateAsync<AzureDevComputeDiskImage>(
             scope,
             HttpMethod.Put,
-            $"{GetSandboxGroupPath(scope)}/diskimages",
+            $"{GetSandboxGroupPath(scope)}/diskimages/v2",
             request,
             cancellationToken);
     }
@@ -493,7 +493,7 @@ internal sealed class AzureDevComputeClient(HttpClient httpClient, TokenCredenti
 
         // The published OpenAPI lists the global management host, but the `aca` CLI sends
         // sandbox group data-plane requests to the regional host with this preview API version:
-        //   https://management.westus3.azuredevcompute.io/.../diskimages?api-version=2026-02-01-preview
+        //   https://management.westus3.azuredevcompute.io/.../diskimages/v2?api-version=2026-02-01-preview
         return new UriBuilder(Uri.UriSchemeHttps, host)
         {
             Path = pathOnly,
@@ -520,21 +520,16 @@ internal sealed class AzureDevComputeCreateDiskImageRequest
 
     public Dictionary<string, string> Labels { get; init; } = [];
 
-    public required AzureDevComputeDiskImageSpec Image { get; init; }
-
-    public AzureDevComputeRegistryCredentials? RegistryCredentials { get; init; }
+    public required AzureDevComputeRegistryDiskImageSource Source { get; init; }
 }
 
-internal sealed class AzureDevComputeDiskImageSpec
+internal sealed class AzureDevComputeRegistryDiskImageSource
 {
-    public required string Base { get; init; }
-}
+    public required string Kind { get; init; }
 
-internal sealed class AzureDevComputeRegistryCredentials
-{
-    public required string Username { get; init; }
+    public required string ImageUrl { get; init; }
 
-    public required string Token { get; init; }
+    public required string ManagedIdentityClientId { get; init; }
 }
 
 internal sealed class AzureDevComputeDiskImage

--- a/src/Aspire.Hosting.Azure.Sandboxes/README.md
+++ b/src/Aspire.Hosting.Azure.Sandboxes/README.md
@@ -10,7 +10,7 @@ Use this integration to deploy container-backed Aspire compute resources to Azur
 * Permission to create sandbox groups, Azure Container Registry resources, and scoped role assignments.
 * Docker or Podman for building and inspecting Linux/amd64 OCI images.
 
-The integration grants the deployment identity the **Container Apps SandboxGroup Data Owner** role on a sandbox group that it provisions. When using an existing sandbox group, grant that role to the deployment identity before deploying.
+The integration grants the deployment identity the **Container Apps SandboxGroup Data Owner** role on a sandbox group that it provisions. It also creates a dedicated user-assigned managed identity, attaches it to the sandbox group, and grants it only **AcrPull** on the selected Azure Container Registry. When using an existing sandbox group, grant the data-owner role to the deployment identity before deploying and configure an image-pull identity as described below.
 
 ### Add the integration
 
@@ -79,13 +79,13 @@ await builder.build().run();
 
 Endpoints are not exposed unless they are marked external. External endpoints require an explicit `Anonymous = true` opt-in for anonymous access. Sandbox egress is configured with full inspection and deny-by-default behavior.
 
-Images are resolved to immutable Linux/amd64 digests before import. Deployment state stores sandbox, disk-image, endpoint, and endpoint-security metadata, but does not persist registry credentials. Stable ownership labels are derived from the AppHost and Azure deployment scope so a later deploy or destroy can find resources after `--clear-cache`; the scope and application identity remain part of the label to prevent resource-name-only sweeping across apps.
+Images are resolved to immutable Linux/amd64 digests before import. The ADC V2 import request identifies the dedicated image-pull managed identity by client ID; Aspire does not materialize, persist, or send registry refresh credentials. Deployment state stores sandbox, disk-image, endpoint, and endpoint-security metadata. Stable ownership labels are derived from the AppHost and Azure deployment scope so a later deploy or destroy can find resources after `--clear-cache`; the scope and application identity remain part of the label to prevent resource-name-only sweeping across apps.
 
 Duration options use `TimeSpan` in C#. Generated TypeScript SDKs represent `TimeSpan` values as milliseconds, where one second is `1_000`.
 
 ## Deployment architecture
 
-Sandbox groups are ARM resources, but sandbox instances, disk images, ports, and lifecycle settings are currently exposed only through the regional Azure Dev Compute preview data plane. Aspire therefore performs sandbox deployment in-process rather than through an ARM deployment script. This lets the deployment pipeline inspect local container images, resolve and validate immutable Linux/amd64 digests, report polling progress, persist deployment state, retain a previous endpoint generation during updates, and clean up stale or failed data-plane resources.
+Sandbox groups and their image-pull identities are ARM resources, but sandbox instances, disk images, ports, and lifecycle settings are currently exposed only through the regional Azure Dev Compute preview data plane. Aspire therefore performs sandbox deployment in-process rather than through an ARM deployment script. This lets the deployment pipeline inspect local container images, resolve and validate immutable Linux/amd64 digests, import them through the ADC V2 managed-identity API, report polling progress, persist deployment state, retain a previous endpoint generation during updates, and clean up stale or failed data-plane resources.
 
 This design means Aspire owns retry, polling, state recovery, and cleanup behavior while the preview data-plane contract evolves. The implementation is intentionally isolated in the Sandboxes integration and should be reevaluated when Azure provides a stable ARM resource or deployment primitive for these operations.
 
@@ -93,10 +93,29 @@ To keep endpoint references usable during an ordinary redeploy of the same immut
 
 ## Publish, deploy, and destroy behavior
 
-* `aspire publish` emits reviewable Bicep for the sandbox group, registry, managed identities, and role assignments. Sandbox instances, disk images, ports, and data-plane URLs are deploy-time resources and are not created by publish.
-* `aspire deploy` provisions the ARM resources, builds or resolves the workload image to an immutable Linux/amd64 digest, creates the ADC disk image and sandbox, configures lifecycle and ports, and records IDs, URLs, ownership, scope, and security metadata in deployment state. Public URLs are shown in the deployment summary.
+* `aspire publish` emits reviewable Bicep for the sandbox group, registry, dedicated image-pull identity, and least-privilege role assignments. Sandbox instances, disk images, ports, and data-plane URLs are deploy-time resources and are not created by publish.
+* `aspire deploy` provisions the ARM resources, builds or resolves the workload image to an immutable Linux/amd64 digest, imports it with the image-pull identity client ID, creates the sandbox, configures lifecycle and ports, and records IDs, URLs, ownership, scope, and security metadata in deployment state. Public URLs are shown in the deployment summary.
 * `aspire destroy` removes the current and labeled retained sandbox generations and disk images before Azure resource-group cleanup. Stable ownership labels allow cleanup after deployment state is cleared when the same AppHost and Azure sandbox group scope are still configured.
 * Existing sandbox groups use the subscription, resource group, location, and name from the group's actual Azure outputs rather than the ambient deployment resource group.
+
+## Existing sandbox groups and registries
+
+For a newly managed sandbox group, Aspire creates and attaches a dedicated image-pull identity and grants it **AcrPull** on the registry selected with `WithAzureContainerRegistry`. This identity must remain separate from workload identities configured with `WithAzureUserAssignedIdentity`; Aspire rejects attempts to reuse it for a workload.
+
+Aspire treats an existing sandbox group as read-only. Supply an existing identity with `WithAcrPullIdentity`; that identity must already be attached to the group and must already have **AcrPull** on the selected registry:
+
+```csharp
+var registry = builder.AddAzureContainerRegistry("registry")
+    .PublishAsExisting("existing-acr", "shared-rg");
+
+var pullIdentity = builder.AddAzureUserAssignedIdentity("sandbox-pull")
+    .PublishAsExisting("existing-sandbox-pull", "shared-rg");
+
+var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+    .PublishAsExisting("existing-sandboxes", "shared-rg")
+    .WithAzureContainerRegistry(registry)
+    .WithAcrPullIdentity(pullIdentity);
+```
 
 ## Preview limitations
 

--- a/src/Aspire.Hosting.Azure/AcrLoginService.cs
+++ b/src/Aspire.Hosting.Azure/AcrLoginService.cs
@@ -75,67 +75,29 @@ internal sealed class AcrLoginService : IAcrLoginService
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
         ArgumentNullException.ThrowIfNull(credential);
 
-        var containerRuntime = await _containerRuntimeResolver.ResolveAsync(cancellationToken).ConfigureAwait(false);
-        await ExecuteWithAcrRetryAsync(
-            registryEndpoint,
-            async () =>
-            {
-                var refreshToken = await GetRefreshTokenCoreAsync(registryEndpoint, tenantId, credential, cancellationToken).ConfigureAwait(false);
-                await containerRuntime.LoginToRegistryAsync(registryEndpoint, refreshToken.Username, refreshToken.Token, cancellationToken).ConfigureAwait(false);
-                return true;
-            },
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task<AcrRefreshToken> GetRefreshTokenAsync(
-        string registryEndpoint,
-        string tenantId,
-        TokenCredential credential,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(registryEndpoint);
-        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
-        ArgumentNullException.ThrowIfNull(credential);
-
-        return await ExecuteWithAcrRetryAsync(
-            registryEndpoint,
-            () => GetRefreshTokenCoreAsync(registryEndpoint, tenantId, credential, cancellationToken),
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<AcrRefreshToken> GetRefreshTokenCoreAsync(
-        string registryEndpoint,
-        string tenantId,
-        TokenCredential credential,
-        CancellationToken cancellationToken)
-    {
+        // Step 1: Acquire AAD access token for ACR audience
         var tokenRequestContext = new TokenRequestContext([AcrScope]);
         var aadToken = await credential.GetTokenAsync(tokenRequestContext, cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug("AAD access token acquired for ACR audience, registry: {RegistryEndpoint}, token length: {TokenLength}",
             registryEndpoint, aadToken.Token.Length);
 
-        var refreshToken = await ExchangeAadTokenForAcrRefreshTokenAsync(
-            registryEndpoint, tenantId, aadToken.Token, cancellationToken).ConfigureAwait(false);
-
-        _logger.LogDebug("ACR refresh token acquired, length: {TokenLength}", refreshToken.Length);
-
-        return new AcrRefreshToken(AcrUsername, refreshToken);
-    }
-
-    private async Task<T> ExecuteWithAcrRetryAsync<T>(
-        string registryEndpoint,
-        Func<Task<T>> action,
-        CancellationToken cancellationToken)
-    {
+        var containerRuntime = await _containerRuntimeResolver.ResolveAsync(cancellationToken).ConfigureAwait(false);
         var retryStartTimestamp = _timeProvider.GetTimestamp();
 
         for (var attempt = 1; ; attempt++)
         {
             try
             {
-                return await action().ConfigureAwait(false);
+                // Step 2: Exchange AAD token for ACR refresh token
+                var refreshToken = await ExchangeAadTokenForAcrRefreshTokenAsync(
+                    registryEndpoint, tenantId, aadToken.Token, cancellationToken).ConfigureAwait(false);
+
+                _logger.LogDebug("ACR refresh token acquired, length: {TokenLength}", refreshToken.Length);
+
+                // Step 3: Login to the registry using container runtime
+                await containerRuntime.LoginToRegistryAsync(registryEndpoint, AcrUsername, refreshToken, cancellationToken).ConfigureAwait(false);
+                return;
             }
             catch (HttpRequestException ex) when (ShouldRetryAcrLoginFailure(ex, attempt, retryStartTimestamp))
             {
@@ -143,7 +105,7 @@ internal sealed class AcrLoginService : IAcrLoginService
                 // data-plane endpoint and RBAC propagation catch up with ARM deployment success.
                 _logger.LogWarning(
                     ex,
-                    "ACR operation for {RegistryEndpoint} failed on attempt {Attempt} of {MaxAttempts}. Retrying in {RetryDelay}.",
+                    "ACR login to {RegistryEndpoint} failed on attempt {Attempt} of {MaxAttempts}. Retrying in {RetryDelay}.",
                     registryEndpoint,
                     attempt,
                     MaxLoginAttempts,

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -46,7 +46,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.ContainerRegistry" />
-    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Sandboxes" />
     <InternalsVisibleTo Include="Aspire.Hosting.Foundry" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -141,15 +141,6 @@ public sealed class AzurePublishingContext(
         var principalId = ParameterLookup[environment.PrincipalId];
         MainInfrastructure.Add(principalId);
 
-        ProvisioningParameter? principalType = null;
-        if (bicepResourcesToPublish.Any(resource =>
-            resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.PrincipalType, out var value) &&
-            value is null))
-        {
-            principalType = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
-            MainInfrastructure.Add(principalType);
-        }
-
         var rg = new ResourceGroup("rg")
         {
             Name = resourceGroupParam,
@@ -337,11 +328,6 @@ public sealed class AzurePublishingContext(
                 if (parameter.Key == AzureBicepResource.KnownParameters.PrincipalId && parameter.Value is null)
                 {
                     module.Parameters.Add(parameter.Key, principalId);
-                    continue;
-                }
-                if (parameter.Key == AzureBicepResource.KnownParameters.PrincipalType && parameter.Value is null)
-                {
-                    module.Parameters.Add(parameter.Key, principalType!);
                     continue;
                 }
 

--- a/src/Aspire.Hosting.Azure/IAcrLoginService.cs
+++ b/src/Aspire.Hosting.Azure/IAcrLoginService.cs
@@ -25,20 +25,4 @@ internal interface IAcrLoginService
         string tenantId,
         TokenCredential credential,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets an ACR refresh token using Azure credentials.
-    /// </summary>
-    /// <param name="registryEndpoint">The ACR endpoint (e.g., "myregistry.azurecr.io").</param>
-    /// <param name="tenantId">The Azure tenant ID.</param>
-    /// <param name="credential">The Azure credential to use for authentication.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The refresh token and username to use for ACR token authentication.</returns>
-    Task<AcrRefreshToken> GetRefreshTokenAsync(
-        string registryEndpoint,
-        string tenantId,
-        TokenCredential credential,
-        CancellationToken cancellationToken = default);
 }
-
-internal sealed record AcrRefreshToken(string Username, string Token);

--- a/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
@@ -37,7 +37,7 @@ internal static class BicepUtilities
     /// <summary>
     /// Converts the parameters to a JSON object compatible with the ARM template.
     /// </summary>
-    public static async Task SetParametersAsync(JsonObject parameters, AzureBicepResource resource, bool skipKnownValues = false, CancellationToken cancellationToken = default, ValueProviderContext? valueProviderContext = null)
+    public static async Task SetParametersAsync(JsonObject parameters, AzureBicepResource resource, bool skipKnownValues = false, CancellationToken cancellationToken = default)
     {
         // Convert the parameters to a JSON object
         foreach (var parameter in resource.Parameters)
@@ -62,9 +62,7 @@ internal static class BicepUtilities
                     bool b => b,
                     Guid g => g.ToString(),
                     JsonNode node => node,
-                    IValueProvider v => valueProviderContext is null
-                        ? await v.GetValueAsync(cancellationToken).ConfigureAwait(false)
-                        : await v.GetValueAsync(valueProviderContext, cancellationToken).ConfigureAwait(false),
+                    IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
                     null => null,
                     _ => throw new NotSupportedException($"The parameter value type {parameterValue.GetType()} is not supported.")
                 }
@@ -75,7 +73,7 @@ internal static class BicepUtilities
     /// <summary>
     /// Sets the scope information for a Bicep resource.
     /// </summary>
-    public static async Task SetScopeAsync(JsonObject scope, AzureBicepResource resource, CancellationToken cancellationToken = default, ValueProviderContext? valueProviderContext = null)
+    public static async Task SetScopeAsync(JsonObject scope, AzureBicepResource resource, CancellationToken cancellationToken = default)
     {
         scope.Clear();
 
@@ -90,9 +88,9 @@ internal static class BicepUtilities
 
         if (targetScope.HasResourceGroup)
         {
-            await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken, valueProviderContext).ConfigureAwait(false);
+            await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
         }
-        await SetScopeValueAsync(scope, "subscription", targetScope.Subscription, cancellationToken, valueProviderContext).ConfigureAwait(false);
+        await SetScopeValueAsync(scope, "subscription", targetScope.Subscription, cancellationToken).ConfigureAwait(false);
         if (targetScope.IsTenantScope)
         {
             scope["tenant"] = "current";
@@ -123,7 +121,7 @@ internal static class BicepUtilities
     /// <summary>
     /// Gets the current checksum for a Bicep resource from configuration.
     /// </summary>
-    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, IConfiguration section, CancellationToken cancellationToken = default, ValueProviderContext? valueProviderContext = null)
+    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, IConfiguration section, CancellationToken cancellationToken = default)
     {
         // Fill in parameters from configuration
         if (section[DeploymentStateParametersKey] is not string jsonString)
@@ -149,10 +147,10 @@ internal static class BicepUtilities
             _ = resource.GetBicepTemplateString();
 
             // Now overwrite with live object values skipping known values.
-            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken, valueProviderContext: valueProviderContext).ConfigureAwait(false);
+            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (scope is not null)
             {
-                await SetScopeAsync(scope, resource, cancellationToken: cancellationToken, valueProviderContext: valueProviderContext).ConfigureAwait(false);
+                await SetScopeAsync(scope, resource, cancellationToken).ConfigureAwait(false);
             }
 
             // Get the checksum of the new values
@@ -168,7 +166,7 @@ internal static class BicepUtilities
     /// <summary>
     /// Gets the current checksum for a Bicep resource from deployment state.
     /// </summary>
-    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, DeploymentStateSection section, ILogger logger, CancellationToken cancellationToken = default, ValueProviderContext? valueProviderContext = null)
+    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, DeploymentStateSection section, ILogger logger, CancellationToken cancellationToken = default)
     {
         if (section.Data[DeploymentStateParametersKey]?.GetValue<string>() is not { Length: > 0 } jsonString)
         {
@@ -191,10 +189,10 @@ internal static class BicepUtilities
 
             _ = resource.GetBicepTemplateString();
 
-            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken, valueProviderContext: valueProviderContext).ConfigureAwait(false);
+            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (scope is not null)
             {
-                await SetScopeAsync(scope, resource, cancellationToken, valueProviderContext).ConfigureAwait(false);
+                await SetScopeAsync(scope, resource, cancellationToken).ConfigureAwait(false);
             }
 
             return GetChecksum(resource, parameters, scope);
@@ -218,7 +216,7 @@ internal static class BicepUtilities
             : null;
     }
 
-    private static async Task SetScopeValueAsync(JsonObject scope, string propertyName, object? value, CancellationToken cancellationToken, ValueProviderContext? valueProviderContext)
+    private static async Task SetScopeValueAsync(JsonObject scope, string propertyName, object? value, CancellationToken cancellationToken)
     {
         if (value is null)
         {
@@ -228,9 +226,7 @@ internal static class BicepUtilities
         scope[propertyName] = value switch
         {
             string s => s,
-            IValueProvider v => valueProviderContext is null
-                ? await v.GetValueAsync(cancellationToken).ConfigureAwait(false)
-                : await v.GetValueAsync(valueProviderContext, cancellationToken).ConfigureAwait(false),
+            IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
             _ => throw new NotSupportedException($"The scope {propertyName} value type {value.GetType()} is not supported.")
         };
     }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultAzurePrincipalProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultAzurePrincipalProvider.cs
@@ -13,9 +13,8 @@ internal sealed class DefaultAzurePrincipalProvider(ITokenCredentialProvider tok
 {
     // Microsoft Entra reports the token's identity type in the `idtyp` claim: "app" for app-only
     // (service principal / managed identity / federated workload identity) tokens and "user" for
-    // user-delegated ones. Because `idtyp` is optional, the parser also uses the token shape:
-    // delegated tokens carry `scp` or user name claims, while app-only tokens can omit `roles`
-    // when the resource authorizes clients through an ACL.
+    // user-delegated ones. Only "app" needs matching here because every other value — including
+    // "user" and the claim being absent entirely — falls through to the User default below.
     // See: https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#payload-claims
     private const string IdTypApp = "app";
 
@@ -82,20 +81,14 @@ internal sealed class DefaultAzurePrincipalProvider(ITokenCredentialProvider tok
                     "the credential does not contain a valid 'oid' (object id) claim.");
             }
 
-            // `idtyp` is authoritative when present. When it is absent, `scp` or a user name
-            // claim identifies a delegated token. App-only tokens can omit `roles` when the
-            // resource performs ACL-based authorization, so the absence of application roles
-            // cannot be used to fall back to User.
-            var identityType = GetRootString(root, "idtyp");
-            var hasDelegatedScopes = GetRootString(root, "scp") is { Length: > 0 };
-            var hasUserName =
-                GetRootString(root, "upn") is { Length: > 0 } ||
-                GetRootString(root, "email") is { Length: > 0 } ||
-                GetRootString(root, "preferred_username") is { Length: > 0 } ||
-                GetRootString(root, "unique_name") is { Length: > 0 };
-            var isAppOnly =
-                string.Equals(identityType, IdTypApp, StringComparison.OrdinalIgnoreCase) ||
-                (identityType is null && !hasDelegatedScopes && !hasUserName);
+            // Default to "User" so older tokens — and any flow that omits `idtyp` — keep the
+            // historical behavior of a hardcoded "User" principalType instead of regressing to an
+            // empty value. `idtyp` is an optional claim that Entra only emits for app-only tokens
+            // unless the resource opts in via `include_user_token`, so absence is not evidence of
+            // a user identity; it just means we can't tell and fall back to the previous default.
+            // The comparison is case-insensitive for resilience against future producers that emit
+            // different casing than the lower-case values Entra documents.
+            var isAppOnly = string.Equals(GetRootString(root, "idtyp"), IdTypApp, StringComparison.OrdinalIgnoreCase);
 
             var principalType = isAppOnly
                 ? PrincipalTypeServicePrincipal
@@ -142,16 +135,6 @@ internal sealed class DefaultAzurePrincipalProvider(ITokenCredentialProvider tok
             return email;
         }
 
-        if (GetRootString(root, "preferred_username") is { Length: > 0 } preferredUserName)
-        {
-            return preferredUserName;
-        }
-
-        if (GetRootString(root, "unique_name") is { Length: > 0 } uniqueName)
-        {
-            return uniqueName;
-        }
-
         if (isAppOnly && GetRootString(root, "app_displayname") is { Length: > 0 } appDisplayName)
         {
             return appDisplayName;
@@ -167,5 +150,4 @@ internal sealed class DefaultAzurePrincipalProvider(ITokenCredentialProvider tok
         root.TryGetProperty(claimName, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
-
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -64,8 +64,7 @@ internal sealed class BicepProvisioner(
             return false;
         }
 
-        var valueProviderContext = new ValueProviderContext { ExecutionContext = executionContext, Caller = resource };
-        var currentCheckSum = await BicepUtilities.GetCurrentChecksumAsync(resource, stateSection, logger, cancellationToken, valueProviderContext).ConfigureAwait(false);
+        var currentCheckSum = await BicepUtilities.GetCurrentChecksumAsync(resource, stateSection, logger, cancellationToken).ConfigureAwait(false);
         var configCheckSum = stateSection.Data[BicepUtilities.DeploymentStateChecksumKey]?.GetValue<string>();
 
         if (string.IsNullOrEmpty(configCheckSum))
@@ -567,11 +566,10 @@ internal sealed class BicepProvisioner(
         logger.LogDebug("Setting parameters and scope for resource {ResourceName}", resource.Name);
         // Convert the parameters to a JSON object
         var parameters = new JsonObject();
-        var valueProviderContext = new ValueProviderContext { ExecutionContext = executionContext, Caller = resource };
-        await BicepUtilities.SetParametersAsync(parameters, resource, cancellationToken: cancellationToken, valueProviderContext: valueProviderContext).ConfigureAwait(false);
+        await BicepUtilities.SetParametersAsync(parameters, resource, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var scope = new JsonObject();
-        await BicepUtilities.SetScopeAsync(scope, resource, cancellationToken: cancellationToken, valueProviderContext: valueProviderContext).ConfigureAwait(false);
+        await BicepUtilities.SetScopeAsync(scope, resource, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var deployments = isTenantScoped
             ? context.Tenant.GetArmDeployments()
@@ -1397,10 +1395,9 @@ internal sealed class BicepProvisioner(
 
         if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.UserPrincipalId, out var userPrincipalId) && userPrincipalId is null)
         {
-            // userPrincipalId is the Azure environment's deployment-principal parameter.
-            // Published artifacts bind it from the outer main.bicep principalId parameter;
-            // direct `aspire deploy` has no outer template, so bind it from the current
-            // authenticated principal even though deploy runs with a publish execution context.
+            // Published artifacts bind this environment deployment-principal parameter from the outer
+            // main.bicep template. Direct `aspire deploy` has no outer template, so supply the current
+            // authenticated principal even though deploy uses a publish execution context.
             resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId] = context.Principal.Id;
         }
 
@@ -1413,10 +1410,7 @@ internal sealed class BicepProvisioner(
 
         if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.PrincipalType, out var principalType) && principalType is null)
         {
-            if (!resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.UserPrincipalId))
-            {
-                ValidateUnknownPrincipalParameter(context);
-            }
+            ValidateUnknownPrincipalParameter(context);
 
             // Use the principal type detected from the credential's access token (the `idtyp`
             // claim) instead of hardcoding "User". A hardcoded "User" caused the role-assignment

--- a/src/Shared/CrossScopeAcrPullIdentityPreparer.cs
+++ b/src/Shared/CrossScopeAcrPullIdentityPreparer.cs
@@ -18,7 +18,7 @@ using Azure.Provisioning.Roles;
 // This linked helper runs after the application model and final registry selection are complete. For
 // only that cross-scope case, it creates a standalone identity and lets AzureResourcePreparer emit the
 // role assignment as a separately scoped module. Package-specific annotations remain in their owning
-// assemblies, so this source is linked into only the ACA and App Service projects.
+// assemblies, so this source is linked into only the ACA, App Service, and Sandboxes projects.
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
@@ -41,12 +41,13 @@ internal static class CrossScopeAcrPullIdentityPreparer
     public static IResourceBuilder<TEnvironment> WithCrossScopeAcrPullIdentity<TEnvironment>(
         this IResourceBuilder<TEnvironment> builder,
         Func<AzureUserAssignedIdentityResource, IAcrPullIdentityAnnotation> createIdentityAnnotation,
-        Action<IResourceBuilder<AzureUserAssignedIdentityResource>>? configureIdentity = null)
+        Action<IResourceBuilder<AzureUserAssignedIdentityResource>>? configureIdentity = null,
+        Func<TEnvironment, bool>? canPrepareIdentity = null)
         where TEnvironment : IResource, IAzureComputeEnvironmentResource
     {
         builder.WithAnnotation(new PipelineStepAnnotation(context =>
         {
-            if (!ShouldPrepareIdentity(context.PipelineContext.ExecutionContext, builder.Resource))
+            if (!ShouldPrepareIdentity(context.PipelineContext.ExecutionContext, builder.Resource, canPrepareIdentity))
             {
                 return [];
             }
@@ -59,7 +60,7 @@ internal static class CrossScopeAcrPullIdentityPreparer
                     Description = $"Prepares the ACR pull identity for {builder.Resource.Name}.",
                     Action = stepContext =>
                     {
-                        PrepareIdentity(stepContext, builder, createIdentityAnnotation, configureIdentity);
+                        PrepareIdentity(stepContext, builder, createIdentityAnnotation, configureIdentity, canPrepareIdentity);
                         return Task.CompletedTask;
                     },
                     RequiredBySteps = [AzureEnvironmentResource.PrepareResourcesStepName]
@@ -72,12 +73,18 @@ internal static class CrossScopeAcrPullIdentityPreparer
 
     private static bool ShouldPrepareIdentity<TEnvironment>(
         DistributedApplicationExecutionContext executionContext,
-        TEnvironment environment)
+        TEnvironment environment,
+        Func<TEnvironment, bool>? canPrepareIdentity)
         where TEnvironment : IResource, IAzureComputeEnvironmentResource
     {
         // Run mode does not emit the environment Bicep that contains the problematic role assignment.
         // Adding a standalone Azure identity there would unnecessarily change the local application model.
         if (!executionContext.IsPublishMode)
+        {
+            return false;
+        }
+
+        if (canPrepareIdentity is not null && !canPrepareIdentity(environment))
         {
             return false;
         }
@@ -104,10 +111,11 @@ internal static class CrossScopeAcrPullIdentityPreparer
         PipelineStepContext context,
         IResourceBuilder<TEnvironment> builder,
         Func<AzureUserAssignedIdentityResource, IAcrPullIdentityAnnotation> createIdentityAnnotation,
-        Action<IResourceBuilder<AzureUserAssignedIdentityResource>>? configureIdentity)
+        Action<IResourceBuilder<AzureUserAssignedIdentityResource>>? configureIdentity,
+        Func<TEnvironment, bool>? canPrepareIdentity)
         where TEnvironment : IResource, IAzureComputeEnvironmentResource
     {
-        if (!ShouldPrepareIdentity(context.ExecutionContext, builder.Resource) ||
+        if (!ShouldPrepareIdentity(context.ExecutionContext, builder.Resource, canPrepareIdentity) ||
             builder.Resource.ContainerRegistry is not AzureContainerRegistryResource registry)
         {
             return;

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureSandboxesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureSandboxesDeploymentTests.cs
@@ -122,16 +122,21 @@ public sealed class AzureSandboxesDeploymentTests(ITestOutputHelper output)
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
+            output.WriteLine("Step 7: Verifying the default managed-identity image-pull wiring...");
+            await auto.TypeAsync(VerifyManagedIdentityPullWiringCommand(resourceGroupName));
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
             await auto.TypeAsync(CaptureSandboxUrlFromStateCommand(stateMarkerFile, firstUrlFile));
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            output.WriteLine("Step 7: Verifying the first sandbox URL...");
+            output.WriteLine("Step 8: Verifying the first sandbox URL...");
             await auto.TypeAsync(VerifySandboxUrlCommand(firstUrlFile));
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
 
-            output.WriteLine("Step 8: Redeploying the sandbox app...");
+            output.WriteLine("Step 9: Redeploying the sandbox app...");
             await auto.TypeAsync($"aspire deploy 2>&1 | tee {BashQuote(secondDeployOutputFile)}");
             await auto.EnterAsync();
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
@@ -141,7 +146,7 @@ public sealed class AzureSandboxesDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            output.WriteLine("Step 9: Verifying the redeploy summary and both sandbox URLs...");
+            output.WriteLine("Step 10: Verifying the redeploy summary and both sandbox URLs...");
             await auto.TypeAsync(VerifyRetainedUrlSummaryCommand(firstUrlFile, secondUrlFile, secondDeployOutputFile));
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
@@ -157,7 +162,7 @@ public sealed class AzureSandboxesDeploymentTests(ITestOutputHelper output)
             deploymentUrls["first-retained"] = File.ReadAllText(firstUrlFile).Trim();
             deploymentUrls["second-current"] = File.ReadAllText(secondUrlFile).Trim();
 
-            output.WriteLine("Step 10: Destroying the Azure sandbox deployment...");
+            output.WriteLine("Step 11: Destroying the Azure sandbox deployment...");
             await auto.AspireDestroyAsync(counter, TimeSpan.FromMinutes(10));
             destroyCompleted = true;
 
@@ -277,6 +282,20 @@ public sealed class AzureSandboxesDeploymentTests(ITestOutputHelper output)
             "if [ -z \"$URL\" ]; then echo \"Sandbox URL not found in $STATE_FILE\"; cat \"$STATE_FILE\"; exit 1; fi && " +
             $"printf '%s\\n' \"$URL\" > {BashQuote(outputFile)} && " +
             "echo \"Sandbox URL from state: $URL\"";
+    }
+
+    private static string VerifyManagedIdentityPullWiringCommand(string resourceGroupName)
+    {
+        return
+            $"GROUP_ID=$(az resource list --resource-group {BashQuote(resourceGroupName)} --resource-type Microsoft.App/sandboxGroups --query '[0].id' -o tsv) && " +
+            "if [ -z \"$GROUP_ID\" ]; then echo \"Sandbox group was not found\"; exit 1; fi && " +
+            "PULL_ID=$(az resource show --ids \"$GROUP_ID\" --api-version 2026-02-01-preview --query 'keys(identity.userAssignedIdentities)[0]' -o tsv) && " +
+            "if [ -z \"$PULL_ID\" ]; then echo \"Sandbox image-pull identity was not attached\"; exit 1; fi && " +
+            "PULL_PRINCIPAL_ID=$(az identity show --ids \"$PULL_ID\" --query principalId -o tsv) && " +
+            $"ACR_ID=$(az acr list --resource-group {BashQuote(resourceGroupName)} --query '[0].id' -o tsv) && " +
+            "ROLE_COUNT=$(az role assignment list --assignee \"$PULL_PRINCIPAL_ID\" --scope \"$ACR_ID\" --role AcrPull --query 'length(@)' -o tsv) && " +
+            "if [ \"$ROLE_COUNT\" != \"1\" ]; then echo \"Expected one AcrPull assignment for $PULL_ID on $ACR_ID, found $ROLE_COUNT\"; exit 1; fi && " +
+            "echo \"Default sandbox image-pull identity is attached and has AcrPull\"";
     }
 
     private static string VerifySandboxUrlCommand(string urlFile)

--- a/tests/Aspire.Hosting.Azure.Tests/AcrLoginServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AcrLoginServiceTests.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
 using System.Net;
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Publishing;
 using Azure.Core;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -44,39 +43,6 @@ public class AcrLoginServiceTests
         var login = Assert.Single(runtime.LoginToRegistryCalls);
         Assert.Equal("registry.azurecr.io", login.registryServer);
         Assert.Equal("refresh-token", login.password);
-    }
-
-    [Fact]
-    public async Task GetRefreshTokenAsync_RetriesTransientExchangeFailures()
-    {
-        var handler = new CallbackHttpMessageHandler((attempt, _) =>
-        {
-            if (attempt == 1)
-            {
-                throw new HttpRequestException("Transient socket failure");
-            }
-
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("""{"refresh_token":"refresh-token","expires_in":3600}""")
-            });
-        });
-        var timeProvider = new ImmediateTimeProvider();
-        var service = new AcrLoginService(
-            new TestHttpClientFactory(handler),
-            new ThrowingContainerRuntimeResolver(),
-            NullLogger<AcrLoginService>.Instance,
-            timeProvider);
-
-        var token = await service.GetRefreshTokenAsync(
-            "registry.azurecr.io",
-            "tenant",
-            new StaticTokenCredential());
-
-        Assert.Equal("00000000-0000-0000-0000-000000000000", token.Username);
-        Assert.Equal("refresh-token", token.Token);
-        Assert.Equal(2, handler.CallCount);
-        Assert.Equal(1, timeProvider.DelayCount);
     }
 
     [Fact]
@@ -245,14 +211,6 @@ public class AcrLoginServiceTests
         {
             IsDisposed = true;
             return ValueTask.CompletedTask;
-        }
-    }
-
-    private sealed class ThrowingContainerRuntimeResolver : IContainerRuntimeResolver
-    {
-        public Task<IContainerRuntime> ResolveAsync(CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
         }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -1440,27 +1440,6 @@ public class AzureBicepProvisionerTests
         Assert.Equal(principalId, resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId]);
     }
 
-    [Theory]
-    [InlineData(false, "User")]
-    [InlineData(true, "ServicePrincipal")]
-    public void PopulateWellKnownParameters_BindsPrincipalTypeFromCurrentPrincipal(bool isServicePrincipal, string expectedPrincipalType)
-    {
-        var resource = new AzureBicepResource("sandbox-group", templateString: "output id string = 'ok'");
-        resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId] = null;
-        resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = null;
-
-        var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
-            principal: new AzurePrincipal(
-                Guid.NewGuid(),
-                isServicePrincipal ? "app" : "user@example.com",
-                expectedPrincipalType),
-            executionContext: new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish));
-
-        PopulateWellKnownParameters(resource, context);
-
-        Assert.Equal(expectedPrincipalType, resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType]);
-    }
-
     [Fact]
     public async Task BicepCliExecutor_CompilesBicepToArm()
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSandboxesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSandboxesTests.cs
@@ -96,7 +96,7 @@ public class AzureSandboxesTests
     }
 
     [Fact]
-    public async Task AzureSandboxPublishBindsPrincipalTypeInMainBicep()
+    public async Task AzureSandboxPublishBindsUserPrincipalIdInMainBicep()
     {
         using var tempDir = new TemporaryDirectory();
         using var builder = TestDistributedApplicationBuilder.Create(
@@ -155,13 +155,83 @@ public class AzureSandboxesTests
     }
 
     [Fact]
+    public async Task SandboxImagePullIdentityIsSeparateFromWorkloadIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var pullIdentity = builder.AddAzureUserAssignedIdentity("pull-identity");
+        var workloadIdentity = builder.AddAzureUserAssignedIdentity("workload-identity");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .WithAcrPullIdentity(pullIdentity);
+        builder.AddContainer("worker", "image")
+            .WithAzureUserAssignedIdentity(workloadIdentity)
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        Assert.Equal(workloadIdentity.Resource, Assert.Single(sandboxGroup.Resource.UserAssignedIdentities));
+        Assert.DoesNotContain(pullIdentity.Resource, sandboxGroup.Resource.UserAssignedIdentities);
+
+        var (_, bicep) = await AzureManifestUtils.GetManifestWithBicep(sandboxGroup.Resource, skipPreparer: true);
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task SandboxImagePullIdentityCannotBeUsedAsWorkloadIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var identity = builder.AddAzureUserAssignedIdentity("shared-identity");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .WithAcrPullIdentity(identity);
+        builder.AddContainer("worker", "image")
+            .WithAzureUserAssignedIdentity(identity)
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default));
+        Assert.Equal(
+            "Azure sandbox group 'sandboxes' uses identity 'shared-identity' for both image pulls and workload 'worker'. " +
+            "Use a dedicated image-pull identity so its AcrPull permission is not exposed to sandbox workloads.",
+            exception.InnerException?.Message);
+    }
+
+    [Fact]
+    public async Task SandboxImagePullIdentityCannotBeConfiguredAsGroupWorkloadIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var identity = builder.AddAzureUserAssignedIdentity("shared-identity");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .WithAcrPullIdentity(identity)
+            .WithUserAssignedIdentity(identity);
+        builder.AddContainer("worker", "image")
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default));
+        Assert.Equal(
+            "Azure sandbox group 'sandboxes' uses identity 'shared-identity' for both image pulls and workloads. " +
+            "Use a dedicated image-pull identity so its AcrPull permission is not exposed to sandbox workloads.",
+            exception.InnerException?.Message);
+    }
+
+    [Fact]
     public async Task ExistingSandboxGroupRejectsWorkloadIdentityAttachment()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         var identity = builder.AddAzureUserAssignedIdentity("workload-identity");
+        var pullIdentity = builder.AddAzureUserAssignedIdentity("pull-identity")
+            .PublishAsExisting("existing-pull-identity", "existing-rg");
         var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
-            .PublishAsExisting("existing-sandboxes", "existing-rg");
+            .PublishAsExisting("existing-sandboxes", "existing-rg")
+            .WithAcrPullIdentity(pullIdentity);
         builder.AddContainer("worker", "image")
             .WithAnnotation(new AppIdentityAnnotation(identity.Resource))
             .PublishAsAzureSandbox(sandboxGroup);
@@ -173,6 +243,110 @@ public class AzureSandboxesTests
         Assert.Equal(
             "Compute resource 'worker' uses managed identity 'workload-identity', but workload identities are not supported when publishing to existing Azure sandbox group 'sandboxes'.",
             exception.InnerException?.Message);
+    }
+
+    [Fact]
+    public async Task ExistingSandboxGroupRequiresAcrPullIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry")
+            .PublishAsExisting("existing-acr", "existing-rg");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .PublishAsExisting("existing-sandboxes", "existing-rg")
+            .WithAzureContainerRegistry(registry);
+        builder.AddContainer("worker", "image")
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default));
+        Assert.Equal(
+            "Azure sandbox group 'sandboxes' is existing and cannot be mutated to attach an image-pull identity. " +
+            "Call 'WithAcrPullIdentity' with a user-assigned identity that is already attached to the sandbox group and has AcrPull on the configured registry.",
+            exception.InnerException?.Message);
+        Assert.DoesNotContain(model.Resources, resource => resource.Name == "sandboxes-mi");
+    }
+
+    [Fact]
+    public async Task ExistingSandboxGroupWithAcrPullIdentityRemainsReadOnly()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry")
+            .PublishAsExisting("existing-acr", "existing-rg");
+        var pullIdentity = builder.AddAzureUserAssignedIdentity("pull-identity")
+            .PublishAsExisting("existing-pull-identity", "existing-rg");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .PublishAsExisting("existing-sandboxes", "existing-rg")
+            .WithAzureContainerRegistry(registry)
+            .WithAcrPullIdentity(pullIdentity);
+        builder.AddContainer("worker", "image")
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var (_, bicep) = await AzureManifestUtils.GetManifestWithBicep(sandboxGroup.Resource, skipPreparer: true);
+        await Verify(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task ExistingSandboxGroupRequiresExistingAcrPullIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var pullIdentity = builder.AddAzureUserAssignedIdentity("pull-identity");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .PublishAsExisting("existing-sandboxes", "existing-rg")
+            .WithAcrPullIdentity(pullIdentity);
+        builder.AddContainer("worker", "image")
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default));
+        Assert.Equal(
+            "Azure sandbox group 'sandboxes' is existing, but its image-pull identity 'pull-identity' is not. " +
+            "Call 'PublishAsExisting' on the identity because it must already be attached to the sandbox group and have AcrPull on the configured registry.",
+            exception.InnerException?.Message);
+    }
+
+    [Fact]
+    public async Task CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var registry = builder.AddAzureContainerRegistry("registry")
+            .PublishAsExisting("existing-acr", "existing-rg");
+        var sandboxGroup = builder.AddAzureSandboxGroup("sandboxes")
+            .WithAzureContainerRegistry(registry);
+        builder.AddContainer("worker", "image")
+            .PublishAsAzureSandbox(sandboxGroup);
+
+        using var app = builder.Build();
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var pullIdentity = Assert.Single(
+            model.Resources.OfType<AzureUserAssignedIdentityResource>(),
+            resource => resource.Name == "sandboxes-mi");
+        var roles = Assert.Single(
+            model.Resources.OfType<AzureRoleAssignmentResource>(),
+            resource => resource.Name == "sandboxes-mi-roles-registry");
+        Assert.Same(registry.Resource, roles.TargetAzureResource);
+
+        var (_, groupBicep) = await AzureManifestUtils.GetManifestWithBicep(sandboxGroup.Resource, skipPreparer: true);
+        var (_, identityBicep) = await AzureManifestUtils.GetManifestWithBicep(pullIdentity, skipPreparer: true);
+        var (rolesManifest, rolesBicep) = await AzureManifestUtils.GetManifestWithBicep(roles, skipPreparer: true);
+
+        await Verify(groupBicep, extension: "bicep")
+            .AppendContentAsFile(identityBicep, "bicep", "identity")
+            .AppendContentAsFile(rolesBicep, "bicep", "roles")
+            .AppendContentAsFile(rolesManifest.ToString(), "json", "roles");
     }
 
     [Fact]
@@ -219,14 +393,14 @@ public class AzureSandboxesTests
     }
 
     [Fact]
-    public async Task AzureDevComputeClientCreatesDiskImageWithRegistryCredentials()
+    public async Task AzureDevComputeClientCreatesV2DiskImageWithManagedIdentity()
     {
         var credential = new RecordingTokenCredential();
         var handler = new RecordingHandler(async request =>
         {
             Assert.Equal(HttpMethod.Put, request.Method);
             Assert.Equal("management.westus3.azuredevcompute.io", request.RequestUri?.Host);
-            Assert.Equal("/subscriptions/sub/resourceGroups/rg/sandboxGroups/sg/diskimages", request.RequestUri?.AbsolutePath);
+            Assert.Equal("/subscriptions/sub/resourceGroups/rg/sandboxGroups/sg/diskimages/v2", request.RequestUri?.AbsolutePath);
             Assert.Equal("?api-version=2026-02-01-preview", request.RequestUri?.Query);
             Assert.Equal("Bearer", request.Headers.Authorization?.Scheme);
             Assert.Equal("test-token", request.Headers.Authorization?.Parameter);
@@ -236,9 +410,12 @@ public class AzureSandboxesTests
             var root = document.RootElement;
             Assert.Equal("site-1234", root.GetProperty("name").GetString());
             Assert.Equal("site-container", root.GetProperty("labels").GetProperty("aspire-resource").GetString());
-            Assert.Equal("example.azurecr.io/site:tag", root.GetProperty("image").GetProperty("base").GetString());
-            Assert.Equal("00000000-0000-0000-0000-000000000000", root.GetProperty("registryCredentials").GetProperty("username").GetString());
-            Assert.Equal("refresh-token", root.GetProperty("registryCredentials").GetProperty("token").GetString());
+            var source = root.GetProperty("source");
+            Assert.Equal("registry", source.GetProperty("kind").GetString());
+            Assert.Equal("example.azurecr.io/site@sha256:abc123", source.GetProperty("imageUrl").GetString());
+            Assert.Equal("00000000-0000-0000-0000-000000000000", source.GetProperty("managedIdentityClientId").GetString());
+            Assert.False(root.TryGetProperty("registryCredentials", out _));
+            Assert.False(source.TryGetProperty("registryCredentials", out _));
 
             return JsonResponse(
                 """
@@ -261,14 +438,11 @@ public class AzureSandboxesTests
                 {
                     ["aspire-resource"] = "site-container"
                 },
-                Image = new AzureDevComputeDiskImageSpec
+                Source = new AzureDevComputeRegistryDiskImageSource
                 {
-                    Base = "example.azurecr.io/site:tag"
-                },
-                RegistryCredentials = new AzureDevComputeRegistryCredentials
-                {
-                    Username = "00000000-0000-0000-0000-000000000000",
-                    Token = "refresh-token"
+                    Kind = "registry",
+                    ImageUrl = "example.azurecr.io/site@sha256:abc123",
+                    ManagedIdentityClientId = "00000000-0000-0000-0000-000000000000"
                 }
             },
             CancellationToken.None);
@@ -889,7 +1063,7 @@ public class AzureSandboxesTests
     [Fact]
     public void SandboxDiskImageFailureRedactsServiceStatusDetails()
     {
-        const string secret = "short-lived-acr-refresh-token";
+        const string secret = "sensitive-service-detail";
         var exception = AzureSandboxContainerDeployment.CreateDiskImageFailureException(
             new AzureDevComputeDiskImage
             {
@@ -1107,11 +1281,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.Equal(1, attempts);
@@ -1132,11 +1302,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.Equal(1, attempts);
@@ -1156,11 +1322,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.True(exception.ResponseMayHaveBeenLost);
@@ -1179,11 +1341,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.True(exception.ResponseMayHaveBeenLost);
@@ -1205,11 +1363,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.True(exception.ResponseMayHaveBeenLost);
@@ -1231,11 +1385,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.True(exception.ResponseMayHaveBeenLost);
@@ -1254,11 +1404,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.False(exception.ResponseMayHaveBeenLost);
@@ -1277,11 +1423,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             cancellationTokenSource.Token));
 
         Assert.False(exception.ResponseMayHaveBeenLost);
@@ -1300,11 +1442,7 @@ public class AzureSandboxesTests
 
         var exception = await Assert.ThrowsAsync<AzureDevComputeCreateException>(() => client.CreateDiskImageAsync(
             new AzureDevComputeResourceScope("sub", "rg", "sg", "westus3"),
-            new AzureDevComputeCreateDiskImageRequest
-            {
-                Name = "disk-image",
-                Image = new AzureDevComputeDiskImageSpec { Base = "example.azurecr.io/site@sha256:abc123" }
-            },
+            CreateDiskImageRequest(),
             CancellationToken.None));
 
         Assert.False(exception.ResponseMayHaveBeenLost);
@@ -1332,7 +1470,7 @@ public class AzureSandboxesTests
     [Fact]
     public async Task AzureDevComputeClientDoesNotExposeErrorBodies()
     {
-        const string secret = "registry-refresh-token-secret";
+        const string secret = "sensitive-response-value";
         var handler = new RecordingHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
         {
             Content = new StringContent(secret, Encoding.UTF8, "text/plain")
@@ -2585,6 +2723,20 @@ public class AzureSandboxesTests
     private sealed class TestProject : IProjectMetadata
     {
         public string ProjectPath => "testproject";
+    }
+
+    private static AzureDevComputeCreateDiskImageRequest CreateDiskImageRequest()
+    {
+        return new AzureDevComputeCreateDiskImageRequest
+        {
+            Name = "disk-image",
+            Source = new AzureDevComputeRegistryDiskImageSource
+            {
+                Kind = "registry",
+                ImageUrl = "example.azurecr.io/site@sha256:abc123",
+                ManagedIdentityClientId = "00000000-0000-0000-0000-000000000000"
+            }
+        };
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/Aspire.Hosting.Azure.Tests/DefaultAzurePrincipalProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DefaultAzurePrincipalProviderTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Azure.Core;
 
@@ -57,8 +56,8 @@ public class DefaultAzurePrincipalProviderTests
     [Fact]
     public async Task GetPrincipalAsync_DefaultsTypeToUserWhenIdtypMissing()
     {
-        // Tokens with no identity-type or delegated/application permission shape retain the
-        // historical User fallback.
+        // Legacy tokens and some federated flows omit the `idtyp` claim. Defaulting to "User"
+        // preserves the behavior that shipped before the auto-detect change.
         var token = CreateTestToken(Guid.NewGuid(), upn: "test@example.com");
         var tokenCredentialProvider = new TestTokenCredentialProviderWithCustomToken(token);
         var provider = new DefaultAzurePrincipalProvider(tokenCredentialProvider);
@@ -95,71 +94,6 @@ public class DefaultAzurePrincipalProviderTests
         var principal = await provider.GetPrincipalAsync();
 
         Assert.Equal("ServicePrincipal", principal.Type);
-    }
-
-    [Fact]
-    public async Task GetPrincipalAsync_DetectsServicePrincipalFromRolesWhenIdtypMissing()
-    {
-        var payloadJson = """
-            {"oid":"11111111-2222-3333-4444-555555555555","appid":"22222222-3333-4444-5555-666666666666","roles":["Application.Read.All"]}
-            """;
-        var tokenCredentialProvider = new TestTokenCredentialProviderWithCustomToken(CreateTokenFromPayload(payloadJson));
-        var provider = new DefaultAzurePrincipalProvider(tokenCredentialProvider);
-
-        var principal = await provider.GetPrincipalAsync();
-
-        Assert.Equal("ServicePrincipal", principal.Type);
-    }
-
-    [Fact]
-    public async Task GetPrincipalAsync_DetectsRoleLessServicePrincipalWhenIdtypMissing()
-    {
-        // Entra can issue app-only tokens without `roles` when the target resource authorizes
-        // clients through an ACL instead of application permissions.
-        var payloadJson = """
-            {"oid":"11111111-2222-3333-4444-555555555555","appid":"22222222-3333-4444-5555-666666666666","app_displayname":"acl-authorized-app"}
-            """;
-        var tokenCredentialProvider = new TestTokenCredentialProviderWithCustomToken(CreateTokenFromPayload(payloadJson));
-        var provider = new DefaultAzurePrincipalProvider(tokenCredentialProvider);
-
-        var principal = await provider.GetPrincipalAsync();
-
-        Assert.Equal("ServicePrincipal", principal.Type);
-        Assert.Equal("acl-authorized-app", principal.Name);
-    }
-
-    [Fact]
-    public async Task GetPrincipalAsync_DetectsDelegatedTokenFromScopesWhenRolesAreAlsoPresent()
-    {
-        var payloadJson = """
-            {"oid":"11111111-2222-3333-4444-555555555555","appid":"22222222-3333-4444-5555-666666666666","scp":"User.Read","roles":["Application.Read.All"]}
-            """;
-        var tokenCredentialProvider = new TestTokenCredentialProviderWithCustomToken(CreateTokenFromPayload(payloadJson));
-        var provider = new DefaultAzurePrincipalProvider(tokenCredentialProvider);
-
-        var principal = await provider.GetPrincipalAsync();
-
-        Assert.Equal("User", principal.Type);
-    }
-
-    [Theory]
-    [InlineData("preferred_username", "preferred@example.com")]
-    [InlineData("unique_name", "unique@example.com")]
-    public async Task GetPrincipalAsync_DetectsUserFromOptionalUserNameClaims(string claimName, string claimValue)
-    {
-        var payload = new JsonObject
-        {
-            ["oid"] = "11111111-2222-3333-4444-555555555555",
-            [claimName] = claimValue
-        };
-        var tokenCredentialProvider = new TestTokenCredentialProviderWithCustomToken(
-            CreateTokenFromPayload(payload.ToJsonString()));
-        var provider = new DefaultAzurePrincipalProvider(tokenCredentialProvider);
-
-        var principal = await provider.GetPrincipalAsync();
-
-        Assert.Equal("User", principal.Type);
-        Assert.Equal(claimValue, principal.Name);
     }
 
     [Fact]
@@ -245,7 +179,7 @@ public class DefaultAzurePrincipalProviderTests
     // Entra's groups-overage payload nests an object under `_claim_sources`; this variant hides a
     // conflicting `idtyp` there while the token itself carries none, so no ordering is involved.
     [InlineData("""
-        {"oid":"11111111-2222-3333-4444-555555555555","upn":"real@example.com","_claim_sources":{"src1":{"idtyp":"app"}}}
+        {"oid":"11111111-2222-3333-4444-555555555555","_claim_sources":{"src1":{"idtyp":"app"}}}
         """, "User")]
     public async Task GetPrincipalAsync_IgnoresClaimsNestedInsideOtherClaims(string payloadJson, string expectedPrincipalType)
     {

--- a/tests/Aspire.Hosting.Azure.Tests/FakeAcrLoginService.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FakeAcrLoginService.cs
@@ -36,16 +36,4 @@ internal sealed class FakeAcrLoginService : IAcrLoginService
         var containerRuntime = await _containerRuntimeResolver.ResolveAsync(cancellationToken);
         await containerRuntime.LoginToRegistryAsync(registryEndpoint, AcrUsername, "fake-refresh-token", cancellationToken);
     }
-
-    public Task<AcrRefreshToken> GetRefreshTokenAsync(
-        string registryEndpoint,
-        string tenantId,
-        TokenCredential credential,
-        CancellationToken cancellationToken = default)
-    {
-        LastRegistryEndpoint = registryEndpoint;
-        LastTenantId = tenantId;
-
-        return Task.FromResult(new AcrRefreshToken(AcrUsername, "fake-refresh-token"));
-    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_IgnoresAzureBicepResourcesWithIgnoreAnnotation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_IgnoresAzureBicepResourcesWithIgnoreAnnotation.verified.bicep
@@ -6,8 +6,6 @@ param location string
 
 param principalId string
 
-param principalType string
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
   location: location
@@ -27,7 +25,7 @@ module included_storage_roles 'included-storage-roles/included-storage-roles.bic
   params: {
     location: location
     included_storage_outputs_name: included_storage.outputs.name
-    principalType: principalType
+    principalType: ''
     principalId: principalId
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#00.verified.bicep
@@ -1,11 +1,19 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+param tags object = { }
+
 param hostmi_outputs_id string
+
+param hostgroup_acr_outputs_name string
 
 param userPrincipalId string
 
-param principalType string
+resource hostgroup_acr_pull_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('hostgroup_acr_pull_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
 
 resource hostgroup 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
   name: take('hostgroup-${uniqueString(resourceGroup().id)}', 63)
@@ -13,6 +21,7 @@ resource hostgroup 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
+      '${hostgroup_acr_pull_mi.id}': { }
       '${hostmi_outputs_id}': { }
     }
   }
@@ -22,12 +31,25 @@ resource hostgroup 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
   }
 }
 
+resource hostgroup_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: hostgroup_acr_outputs_name
+}
+
+resource hostgroup_acr_hostgroup_acr_pull_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(hostgroup_acr.id, hostgroup_acr_pull_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: hostgroup_acr_pull_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: hostgroup_acr
+}
+
 resource hostgroup_deploymentPrincipalDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(hostgroup.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c'))
   properties: {
     principalId: userPrincipalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c')
-    principalType: principalType
   }
   scope: hostgroup
 }
@@ -37,3 +59,5 @@ output id string = hostgroup.id
 output name string = hostgroup.name
 
 output location string = hostgroup.location
+
+output acrPullIdentityClientId string = hostgroup_acr_pull_mi.properties.clientId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#00.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#00.verified.json
@@ -3,7 +3,7 @@
   "path": "hostgroup.module.bicep",
   "params": {
     "hostmi_outputs_id": "{hostmi.outputs.id}",
-    "userPrincipalId": "",
-    "principalType": ""
+    "hostgroup_acr_outputs_name": "{hostgroup-acr.outputs.name}",
+    "userPrincipalId": ""
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#01.verified.bicep
@@ -1,17 +1,45 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+param tags object = { }
+
+param workergroup_acr_outputs_name string
+
 param userPrincipalId string
 
-param principalType string
+resource workergroup_acr_pull_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('workergroup_acr_pull_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
 
 resource workergroup 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
   name: take('workergroup-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${workergroup_acr_pull_mi.id}': { }
+    }
+  }
   properties: { }
   tags: {
     'aspire-resource-name': 'workergroup'
   }
+}
+
+resource workergroup_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: workergroup_acr_outputs_name
+}
+
+resource workergroup_acr_workergroup_acr_pull_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(workergroup_acr.id, workergroup_acr_pull_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: workergroup_acr_pull_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: workergroup_acr
 }
 
 resource workergroup_deploymentPrincipalDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
@@ -19,7 +47,6 @@ resource workergroup_deploymentPrincipalDataOwner 'Microsoft.Authorization/roleA
   properties: {
     principalId: userPrincipalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c')
-    principalType: principalType
   }
   scope: workergroup
 }
@@ -29,3 +56,5 @@ output id string = workergroup.id
 output name string = workergroup.name
 
 output location string = workergroup.location
+
+output acrPullIdentityClientId string = workergroup_acr_pull_mi.properties.clientId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#01.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AddAzureSandboxResourcesGeneratesBicep#01.verified.json
@@ -2,7 +2,7 @@
   "type": "azure.bicep.v0",
   "path": "workergroup.module.bicep",
   "params": {
-    "userPrincipalId": "",
-    "principalType": ""
+    "workergroup_acr_outputs_name": "{workergroup-acr.outputs.name}",
+    "userPrincipalId": ""
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AzureSandboxPublishBindsUserPrincipalIdInMainBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.AzureSandboxPublishBindsUserPrincipalIdInMainBicep.verified.bicep
@@ -6,8 +6,6 @@ param location string
 
 param principalId string
 
-param principalType string
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
   location: location
@@ -26,7 +24,7 @@ module sandboxes 'sandboxes/sandboxes.bicep' = {
   scope: rg
   params: {
     location: location
+    sandboxes_acr_outputs_name: sandboxes_acr.outputs.name
     userPrincipalId: principalId
-    principalType: principalType
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#identity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#identity.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param tags object = { }
+
+resource sandboxes_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('sandboxes_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+output id string = sandboxes_mi.id
+
+output clientId string = sandboxes_mi.properties.clientId
+
+output principalId string = sandboxes_mi.properties.principalId
+
+output principalName string = sandboxes_mi.name
+
+output name string = sandboxes_mi.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#roles.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#roles.verified.bicep
@@ -1,0 +1,18 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param principalId string
+
+resource registry 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: 'existing-acr'
+}
+
+resource registry_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(registry.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: registry
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#roles.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity#roles.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v1",
+  "path": "sandboxes-mi-roles-registry.module.bicep",
+  "params": {
+    "principalId": "{sandboxes-mi.outputs.principalId}"
+  },
+  "scope": {
+    "resourceGroup": "existing-rg"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.CrossResourceGroupRegistryUsesStandaloneAcrPullIdentity.verified.bicep
@@ -1,0 +1,40 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param sandboxes_mi_outputs_clientid string
+
+param sandboxes_mi_outputs_id string
+
+param userPrincipalId string
+
+resource sandboxes 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
+  name: take('sandboxes-${uniqueString(resourceGroup().id)}', 63)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${sandboxes_mi_outputs_id}': { }
+    }
+  }
+  properties: { }
+  tags: {
+    'aspire-resource-name': 'sandboxes'
+  }
+}
+
+resource sandboxes_deploymentPrincipalDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sandboxes.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c'))
+  properties: {
+    principalId: userPrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c')
+  }
+  scope: sandboxes
+}
+
+output id string = sandboxes.id
+
+output name string = sandboxes.name
+
+output location string = sandboxes.location
+
+output acrPullIdentityClientId string = sandboxes_mi_outputs_clientid

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.ExistingSandboxGroupWithAcrPullIdentityRemainsReadOnly.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.ExistingSandboxGroupWithAcrPullIdentityRemainsReadOnly.verified.bicep
@@ -1,0 +1,16 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param pull_identity_outputs_clientid string
+
+resource sandboxes 'Microsoft.App/sandboxGroups@2026-02-01-preview' existing = {
+  name: 'existing-sandboxes'
+}
+
+output id string = sandboxes.id
+
+output name string = sandboxes.name
+
+output location string = sandboxes.location
+
+output acrPullIdentityClientId string = pull_identity_outputs_clientid

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.SandboxImagePullIdentityIsSeparateFromWorkloadIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSandboxesTests.SandboxImagePullIdentityIsSeparateFromWorkloadIdentity.verified.bicep
@@ -1,0 +1,43 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param pull_identity_outputs_clientid string
+
+param pull_identity_outputs_id string
+
+param workload_identity_outputs_id string
+
+param userPrincipalId string
+
+resource sandboxes 'Microsoft.App/sandboxGroups@2026-02-01-preview' = {
+  name: take('sandboxes-${uniqueString(resourceGroup().id)}', 63)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${pull_identity_outputs_id}': { }
+      '${workload_identity_outputs_id}': { }
+    }
+  }
+  properties: { }
+  tags: {
+    'aspire-resource-name': 'sandboxes'
+  }
+}
+
+resource sandboxes_deploymentPrincipalDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sandboxes.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c'))
+  properties: {
+    principalId: userPrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c24cf47c-5077-412d-a19c-45202126392c')
+  }
+  scope: sandboxes
+}
+
+output id string = sandboxes.id
+
+output name string = sandboxes.name
+
+output location string = sandboxes.location
+
+output acrPullIdentityClientId string = pull_identity_outputs_clientid

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Sandboxes/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.Sandboxes/TypeScript/apphost.mts
@@ -10,6 +10,8 @@ import {
 const builder = await createBuilder();
 
 const sandboxes = await builder.addAzureSandboxGroup("sandboxes");
+const pullIdentity = await builder.addAzureUserAssignedIdentity("sandbox-pull-identity");
+await sandboxes.withAcrPullIdentity(pullIdentity);
 await sandboxes.withUserAssignedIdentity(
     await builder.addAzureUserAssignedIdentity("sandbox-identity"));
 


### PR DESCRIPTION
## Description

This PR is stacked on and depends on microsoft/aspire#19008. Its upstream base branch, `mitchdenny/aca-sandboxes-stack-base`, is an exact mirror of the current #19008 head SHA `5e6a82bf6854efdebfd925729294d5e613fcbb9c`. Retarget this PR to `main` after #19008 merges.

Azure Container Apps Sandboxes now imports private ACR images through the ADC V2 registry-source API using a dedicated user-assigned managed identity:

- sends `kind: registry`, the immutable `imageUrl`, and `managedIdentityClientId` to `/diskimages/v2`
- creates and attaches a tagged, dedicated pull identity for newly managed sandbox groups and grants only `AcrPull` on the selected ACR
- keeps image-pull and workload identities separate and rejects identity reuse
- requires an explicitly configured, already attached/authorized existing identity for existing sandbox groups
- supports cross-resource-group registries through the shared ACR pull-identity promotion and role-assignment pattern
- removes the sandbox ACR refresh-token path and reverts the unrelated broad principal/value-provider changes from #19008

The only production change remaining in `src/Aspire.Hosting.Azure` relative to `main` is the narrow direct-`aspire deploy` population of `KnownParameters.UserPrincipalId`. Published artifacts bind that value from `main.bicep`; direct deploy has no outer template and runs with a publish execution context, so `KnownParameters.PrincipalId` is intentionally rejected there.

### Why the stacked diff changes `Aspire.Hosting.Azure`

Most of this portion of the diff reverses changes in #19008 rather than introducing new core behavior:

| Files | Reason | Net difference from `main` |
| --- | --- | --- |
| `AcrLoginService.cs`, `IAcrLoginService.cs` | Remove `GetRefreshTokenAsync`/`AcrRefreshToken` and restore the login-only implementation because ADC V2 receives a UAMI client ID, not registry credentials. | None |
| `Aspire.Hosting.Azure.csproj` | Remove the Sandboxes `InternalsVisibleTo`; the managed-identity path uses public `ITokenCredentialProvider` APIs. | None |
| `AzurePublishingContext.cs`, `DefaultAzurePrincipalProvider.cs` | Revert broad `principalType` support that is unnecessary because `Microsoft.Authorization/roleAssignments@2022-04-01` does not require `principalType`. | None |
| `BicepUtilities.cs` | Revert unrelated `ValueProviderContext` plumbing that was only supporting persisted sandbox URLs as later Bicep inputs and had no focused two-pass requirement. | None |
| `BicepProvisioner.cs` | Revert the same unrelated context/principal-type plumbing, while retaining the direct-deploy binding described above. | Eight added lines |

Validation:

- `./build.sh --pack -c Debug /p:SkipNativeBuild=true`
- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (1,788 passed; 5 skipped)
- generated TypeScript SDK restore and type-check for `tests/PolyglotAppHosts/Aspire.Hosting.Azure.Sandboxes/TypeScript`
- `dotnet build tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj --no-restore /p:SkipNativeBuild=true`
- Aspire architecture review: no findings

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
