### PR TITLE
Fix dashboard run discovery and retention

### DIFF
--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -339,6 +339,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
     private IReadOnlyList<DashboardRunDescriptor> LoadRuns()
     {
         var existingRuns = _runs.ToDictionary(run => run.RunId, StringComparer.Ordinal);
+        var discoveredRunIds = new HashSet<string>(StringComparer.Ordinal) { RunId };
         var currentRun = existingRuns.GetValueOrDefault(RunId) ?? CreateDescriptor(_metadata, RunDirectory, isCurrent: true);
         currentRun.IsPinned = _metadata.IsPinned;
         currentRun.IsSelectable = true;
@@ -360,11 +361,15 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                 try
                 {
                     var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
-                    if (metadata is { SchemaVersion: SchemaVersion })
+                    if (metadata is { SchemaVersion: SchemaVersion } &&
+                        !string.IsNullOrEmpty(metadata.RunId) &&
+                        discoveredRunIds.Add(metadata.RunId))
                     {
                         var discoveredRun = CreateDescriptor(metadata, directory, isCurrent: false);
                         var run = existingRuns.TryGetValue(metadata.RunId, out var existingRun) &&
-                            HasSameMetadata(existingRun, discoveredRun)
+                            // A lease owns the run lock through its descriptor. Preserve that descriptor if metadata
+                            // changed between discovery reading run.json and acquiring the lock.
+                            (existingRun.IsLeased || HasSameMetadata(existingRun, discoveredRun))
                                 ? existingRun
                                 : discoveredRun;
                         run.IsPinned = metadata.IsPinned;

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -316,15 +316,15 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run)
     {
-        var storedRun = GetRunById(run.RunId);
-        if (storedRun is null)
-        {
-            return null;
-        }
-
-        var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
         lock (_runStateLock)
         {
+            var storedRun = GetRunById(run.RunId);
+            if (storedRun is null)
+            {
+                return null;
+            }
+
+            var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
             var runLock = TryOpenRunLock(runDirectory);
             if (runLock is null)
             {

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -84,7 +84,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
     private readonly ILogger<DashboardRunStore> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly Action<string> _deleteRunDirectory;
-    private readonly Lazy<IReadOnlyList<DashboardRunDescriptor>> _runs;
+    private IReadOnlyList<DashboardRunDescriptor> _runs;
     private readonly object _runStateLock = new();
     private bool _metadataPublished;
 
@@ -182,7 +182,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             ApplicationName = options.Value.ApplicationName,
             DatabaseFileName = Path.GetFileName(DatabasePath)
         };
-        _runs = new(LoadRuns);
+        _runs = [CreateDescriptor(_metadata, RunDirectory, isCurrent: true)];
 
         _logger.LogDebug(
             "Dashboard run store initialized with persistence mode '{PersistenceMode}'. Run directory: '{RunDirectory}'. Database path: '{DatabasePath}'.",
@@ -230,10 +230,13 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     public IReadOnlyList<DashboardRunDescriptor> GetRuns()
     {
-        var runs = _runs.Value;
-        return runs.Any(run => run.IsPruned || !run.IsSelectable)
-            ? runs.Where(run => !run.IsPruned && run.IsSelectable).ToArray()
-            : runs;
+        lock (_runStateLock)
+        {
+            _runs = LoadRuns();
+            return _runs.Any(run => run.IsPruned || !run.IsSelectable)
+                ? _runs.Where(run => !run.IsPruned && run.IsSelectable).ToArray()
+                : _runs;
+        }
     }
 
     public DashboardRunDescriptor GetCurrentRun() => GetRuns().Single(run => run.IsCurrent);
@@ -335,9 +338,13 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     private IReadOnlyList<DashboardRunDescriptor> LoadRuns()
     {
+        var existingRuns = _runs.ToDictionary(run => run.RunId, StringComparer.Ordinal);
+        var currentRun = existingRuns.GetValueOrDefault(RunId) ?? CreateDescriptor(_metadata, RunDirectory, isCurrent: true);
+        currentRun.IsPinned = _metadata.IsPinned;
+        currentRun.IsSelectable = true;
         var runs = new List<DashboardRunDescriptor>
         {
-            CreateDescriptor(_metadata, RunDirectory, isCurrent: true)
+            currentRun
         };
 
         if (SupportsRunSelection && Directory.Exists(_runsDirectory))
@@ -355,10 +362,15 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                     var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
                     if (metadata is { SchemaVersion: SchemaVersion })
                     {
-                        var run = CreateDescriptor(metadata, directory, isCurrent: false);
+                        var discoveredRun = CreateDescriptor(metadata, directory, isCurrent: false);
+                        var run = existingRuns.TryGetValue(metadata.RunId, out var existingRun) &&
+                            HasSameMetadata(existingRun, discoveredRun)
+                                ? existingRun
+                                : discoveredRun;
+                        run.IsPinned = metadata.IsPinned;
                         // Filter out in-progress runs that are owned by other Dashboard instances.
-                        using var runLock = TryOpenRunLock(directory);
-                        run.IsSelectable = runLock is not null;
+                        using var runLock = run.IsLeased ? null : TryOpenRunLock(directory);
+                        run.IsSelectable = run.IsLeased || runLock is not null;
                         runs.Add(run);
                     }
                 }
@@ -381,6 +393,17 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             string.Join(", ", orderedRuns.Select(run => run.RunId)));
 
         return orderedRuns;
+    }
+
+    private static bool HasSameMetadata(DashboardRunDescriptor existingRun, DashboardRunDescriptor discoveredRun)
+    {
+        return existingRun.SchemaVersion == discoveredRun.SchemaVersion &&
+            existingRun.StartedAtUtc == discoveredRun.StartedAtUtc &&
+            existingRun.EndedAtUtc == discoveredRun.EndedAtUtc &&
+            existingRun.CleanShutdown == discoveredRun.CleanShutdown &&
+            string.Equals(existingRun.ApplicationName, discoveredRun.ApplicationName, StringComparison.Ordinal) &&
+            string.Equals(existingRun.DatabasePath, discoveredRun.DatabasePath, StringComparison.Ordinal) &&
+            existingRun.IsCurrent == discoveredRun.IsCurrent;
     }
 
     public void Dispose()
@@ -439,9 +462,17 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     private void PruneRuns(Action<string> deleteRunDirectory)
     {
-        foreach (var run in _runs.Value.Where(run => !run.IsPinned).Skip(MaxRuns))
+        // Run IDs are invariant UTC timestamps and therefore also provide the durable chronological sort order.
+        // Discover pruning candidates directly from disk so runs from older schemas are still subject to retention.
+        var runDirectories = Directory.EnumerateDirectories(_runsDirectory!)
+            .Where(directory => !IsPinnedRunDirectory(directory))
+            .OrderByDescending(directory => string.Equals(directory, RunDirectory, StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(Path.GetFileName, StringComparer.Ordinal)
+            .Skip(MaxRuns)
+            .ToArray();
+
+        foreach (var directory in runDirectories)
         {
-            var directory = Path.GetDirectoryName(run.DatabasePath)!;
             using var runLock = TryOpenRunLock(directory);
             // Pinning can happen after the candidate list is created. Recheck while holding the same lock used by
             // SetRunPinned so a successful pin always completes before pruning decides whether to delete the run.
@@ -453,7 +484,12 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             try
             {
                 deleteRunDirectory(directory);
-                run.IsPruned = true;
+                lock (_runStateLock)
+                {
+                    var run = _runs.SingleOrDefault(
+                        run => string.Equals(Path.GetDirectoryName(run.DatabasePath), directory, StringComparison.OrdinalIgnoreCase));
+                    run?.IsPruned = true;
+                }
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
             {

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -363,6 +363,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                     var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
                     if (metadata is { SchemaVersion: SchemaVersion } &&
                         !string.IsNullOrEmpty(metadata.RunId) &&
+                        string.Equals(Path.GetFileName(directory), metadata.RunId, StringComparison.Ordinal) &&
                         discoveredRunIds.Add(metadata.RunId))
                     {
                         var discoveredRun = CreateDescriptor(metadata, directory, isCurrent: false);

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -659,6 +659,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using (var runLease = currentRunStore.TryAcquireRunLease(historicalRun))
         {
             Assert.NotNull(runLease);
+            Assert.True(historicalRun.IsLeased);
 
             var metadata = JsonNode.Parse(File.ReadAllText(metadataPath))!.AsObject();
             metadata[nameof(DashboardRunDescriptor.EndedAtUtc)] = JsonValue.Create(updatedEndedAtUtc);
@@ -667,6 +668,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 
             var leasedRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
             Assert.Same(historicalRun, leasedRun);
+            Assert.True(leasedRun.IsLeased);
         }
 
         var refreshedRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -637,6 +637,91 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task GetRuns_PreservesLeasedDescriptorUntilLeaseEnds()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
+        string historicalRunId;
+        string metadataPath;
+
+        using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-1))))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            metadataPath = Path.Combine(historicalRunStore.RunDirectory, "run.json");
+            await InitializeAndPublishRunAsync(historicalRunStore);
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+        var historicalRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+        var updatedEndedAtUtc = startedAt.AddMinutes(-2);
+
+        using (var runLease = currentRunStore.TryAcquireRunLease(historicalRun))
+        {
+            Assert.NotNull(runLease);
+
+            var metadata = JsonNode.Parse(File.ReadAllText(metadataPath))!.AsObject();
+            metadata[nameof(DashboardRunDescriptor.EndedAtUtc)] = JsonValue.Create(updatedEndedAtUtc);
+            metadata[nameof(DashboardRunDescriptor.CleanShutdown)] = false;
+            File.WriteAllText(metadataPath, metadata.ToJsonString());
+
+            var leasedRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+            Assert.Same(historicalRun, leasedRun);
+        }
+
+        var refreshedRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+        Assert.NotSame(historicalRun, refreshedRun);
+        Assert.Equal(updatedEndedAtUtc, refreshedRun.EndedAtUtc);
+        Assert.False(refreshedRun.CleanShutdown);
+    }
+
+    [Fact]
+    public async Task GetRuns_IgnoresNullAndDuplicateRunIds()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
+        string validRunId;
+        string duplicateMetadataPath;
+        string nullMetadataPath;
+
+        using (var validRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-3))))
+        {
+            validRunId = validRunStore.RunId;
+            await InitializeAndPublishRunAsync(validRunStore);
+        }
+
+        using (var duplicateRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-2))))
+        {
+            duplicateMetadataPath = Path.Combine(duplicateRunStore.RunDirectory, "run.json");
+            await InitializeAndPublishRunAsync(duplicateRunStore);
+        }
+
+        using (var nullRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-1))))
+        {
+            nullMetadataPath = Path.Combine(nullRunStore.RunDirectory, "run.json");
+            await InitializeAndPublishRunAsync(nullRunStore);
+        }
+
+        var duplicateMetadata = JsonNode.Parse(File.ReadAllText(duplicateMetadataPath))!.AsObject();
+        duplicateMetadata[nameof(DashboardRunDescriptor.RunId)] = validRunId;
+        File.WriteAllText(duplicateMetadataPath, duplicateMetadata.ToJsonString());
+
+        var nullMetadata = JsonNode.Parse(File.ReadAllText(nullMetadataPath))!.AsObject();
+        nullMetadata[nameof(DashboardRunDescriptor.RunId)] = null;
+        File.WriteAllText(nullMetadataPath, nullMetadata.ToJsonString());
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+        foreach (var runs in new[] { currentRunStore.GetRuns(), currentRunStore.GetRuns() })
+        {
+            Assert.Collection(
+                runs,
+                currentRun => Assert.True(currentRun.IsCurrent),
+                historicalRun => Assert.Equal(validRunId, historicalRun.RunId));
+        }
+    }
+
+    [Fact]
     public async Task RunMode_DeletesOldestRunWhenLimitIsExceeded()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
@@ -535,15 +536,26 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void GetRuns_ReusesLazySnapshot()
+    public async Task GetRuns_DiscoversRunCreatedAfterFirstCall()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
-        using var runStore = CreateRunStore(CreateOptions(workspace));
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
 
-        var first = runStore.GetRuns();
-        var second = runStore.GetRuns();
+        Assert.Collection(currentRunStore.GetRuns(), run => Assert.True(run.IsCurrent));
 
-        Assert.Same(first, second);
+        string historicalRunId;
+        using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-1))))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            await InitializeAndPublishRunAsync(historicalRunStore);
+        }
+
+        Assert.Collection(
+            currentRunStore.GetRuns(),
+            currentRun => Assert.True(currentRun.IsCurrent),
+            historicalRun => Assert.Equal(historicalRunId, historicalRun.RunId));
     }
 
     [Fact]
@@ -595,6 +607,36 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task GetRuns_IncludesPreviouslyActiveRunAfterDashboardExits()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
+        DashboardRunStore? activeRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(-1)));
+        string activeRunId;
+        try
+        {
+            activeRunId = activeRunStore.RunId;
+            await InitializeAndPublishRunAsync(activeRunStore);
+            using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+
+            Assert.Collection(currentRunStore.GetRuns(), run => Assert.True(run.IsCurrent));
+
+            activeRunStore.Dispose();
+            activeRunStore = null;
+
+            Assert.Collection(
+                currentRunStore.GetRuns(),
+                currentRun => Assert.True(currentRun.IsCurrent),
+                historicalRun => Assert.Equal(activeRunId, historicalRun.RunId));
+        }
+        finally
+        {
+            activeRunStore?.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task RunMode_DeletesOldestRunWhenLimitIsExceeded()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
@@ -617,6 +659,46 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         Assert.False(Directory.Exists(historicalRunDirectories[^1]));
         Assert.All(historicalRunDirectories[..^1], directory => Assert.True(Directory.Exists(directory)));
         Assert.True(Directory.Exists(currentRunStore.RunDirectory));
+    }
+
+    [Fact]
+    public async Task RunMode_DeletesOldestIncompatibleRunWhenLimitIsExceeded()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 5, 12, 34, 56, TimeSpan.Zero);
+        string incompatibleRunDirectory;
+
+        using (var incompatibleRunStore = CreateRunStore(
+            options,
+            new FixedTimeProvider(startedAt.AddDays(-DashboardRunStore.MaxRuns))))
+        {
+            incompatibleRunDirectory = incompatibleRunStore.RunDirectory;
+            await InitializeAndPublishRunWithoutPruningAsync(incompatibleRunStore);
+        }
+
+        var metadataPath = Path.Combine(incompatibleRunDirectory, "run.json");
+        var metadata = JsonNode.Parse(File.ReadAllText(metadataPath))!.AsObject();
+        metadata[nameof(DashboardRunDescriptor.SchemaVersion)] = DashboardRunStore.SchemaVersion - 1;
+        File.WriteAllText(metadataPath, metadata.ToJsonString());
+
+        foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns - 1))
+        {
+            using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
+            await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+        await InitializeAndPublishRunWithoutPruningAsync(currentRunStore);
+
+        Assert.Equal(DashboardRunStore.MaxRuns, currentRunStore.GetRuns().Count);
+        Assert.True(Directory.Exists(incompatibleRunDirectory));
+
+        currentRunStore.PruneExpiredRuns();
+
+        var runsDirectory = Path.GetDirectoryName(currentRunStore.RunDirectory)!;
+        Assert.Equal(DashboardRunStore.MaxRuns, Directory.GetDirectories(runsDirectory).Length);
+        Assert.False(Directory.Exists(incompatibleRunDirectory));
     }
 
     [Fact]
@@ -659,7 +741,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         Assert.False(File.Exists(prunedRun.DatabasePath));
 
         var selectableRuns = currentRunStore.GetRuns();
-        Assert.Equal(DashboardRunStore.MaxRuns - activeRunCount, selectableRuns.Count);
+        Assert.Equal(DashboardRunStore.MaxRuns, selectableRuns.Count);
         Assert.All(selectableRuns, run => Assert.True(File.Exists(run.DatabasePath)));
     }
 


### PR DESCRIPTION
## Description

Addresses two suppressed review findings from #18924 around persisted Dashboard run discovery and retention.

### Refreshing run discovery

`DashboardRunStore.GetRuns()` previously used a one-time snapshot. A run excluded because another Dashboard process still held its lock remained hidden after that process exited, and runs created after the first lookup were never discovered.

Reproduction:

1. Configure two Dashboard processes with `PersistenceMode=Run`, the same application name, and the same data directory.
2. Start Dashboard A and publish its run.
3. Start Dashboard B and open its run selector while Dashboard A is still running. Dashboard A's run is correctly excluded because it is locked.
4. Stop Dashboard A, then reopen Dashboard B's run selector.
5. Previously, Dashboard A's completed run remained hidden until Dashboard B restarted.

This scenario requires two Dashboard processes sharing storage for the same AppHost. A normal single-Dashboard stop and restart creates a new run store and does not reproduce the issue. Although overlapping Dashboards can technically occur, we may decide that this scenario is not important enough to support; this PR is intentionally a draft so that scope can be discussed.

The implementation refreshes discovery and lock availability while preserving descriptor identity for selected and leased runs.

### Pruning incompatible runs

Runs written with an older schema were excluded from discovery. Because pruning used the same discovered list, those directories were also excluded from retention and could accumulate beyond the ten-run limit.

Reproduction:

1. Create ten persisted Dashboard runs.
2. Change one run's `run.json` to contain an older `SchemaVersion`.
3. Start and publish another run so pruning executes.
4. Previously, the incompatible directory remained on disk alongside the ten retained runs.

Pruning now enumerates run directories directly. Incompatible runs remain unavailable for selection but participate in retention.

Validation:

- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (1,730 passed)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
