### PR TITLE
Fix dashboard telemetry filter races and replica searches

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -39,6 +39,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private List<SelectViewModel<ResourceTypeDetails>> _resourceViewModels = default!;
     private List<SelectViewModel<LogLevel?>> _logLevels = default!;
     private readonly CancellationTokenSource _cts = new();
+    private long _selectedLogFilterUpdateVersion;
     private Subscription? _resourcesSubscription;
     private Subscription? _logsSubscription;
     private int? _displayedItemCount;
@@ -384,20 +385,23 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     internal async Task ClearSelectedLogEntryIfExcludedAsync(string textFilter, IReadOnlyList<FieldTelemetryFilter> fieldFilters)
     {
-        if (PageViewModel.SelectedLogEntry is null)
+        var updateVersion = Interlocked.Increment(ref _selectedLogFilterUpdateVersion);
+        var selectedLogId = PageViewModel.SelectedLogEntry?.LogEntry.InternalId;
+        if (selectedLogId is null)
         {
             return;
         }
 
-        // An older filter query could finish after a newer query and clear the selection using stale filters.
-        // The query is constrained to one log and filter changes are user-driven, so this is unlikely and not
-        // worth the additional state and coordination required to guard against it.
+        // SQLite reads run off the Blazor synchronization context, so an older filter query can finish after a
+        // newer query or selection change. Only the latest query may clear the entry it originally evaluated.
         var isExcluded = await PageViewModel.IsSelectedLogEntryExcludedByFiltersAsync(
             TelemetryRepository,
             textFilter,
             fieldFilters,
             _cts.Token);
-        if (isExcluded)
+        if (isExcluded &&
+            updateVersion == Volatile.Read(ref _selectedLogFilterUpdateVersion) &&
+            selectedLogId == PageViewModel.SelectedLogEntry?.LogEntry.InternalId)
         {
             await ClearSelectedLogEntryAsync();
         }
@@ -476,6 +480,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     public void Dispose()
     {
+        Interlocked.Increment(ref _selectedLogFilterUpdateVersion);
         _cts.Cancel();
         _resourcesSubscription?.Dispose();
         _logsSubscription?.Dispose();

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -33,6 +33,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private readonly CancellationTokenSource _cts = new();
     private OtlpTrace? _trace;
     private long _detailViewUpdateVersion;
+    private long _filterMatchUpdateVersion;
     private Subscription? _tracesSubscription;
     private int _maxDepth;
     private int _resourceCount;
@@ -596,22 +597,28 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         await RefreshAfterFilterChangeAsync();
     }
 
-    private async Task RefreshAfterFilterChangeAsync()
+    internal async Task<bool> RefreshAfterFilterChangeAsync()
     {
-        await UpdateFilterMatchesAsync();
+        if (!await UpdateFilterMatchesAsync())
+        {
+            return false;
+        }
+
         ClearSelectedDataIfNotVisible();
         await InvokeAsync(StateHasChanged);
         await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
+        return true;
     }
 
-    private async Task UpdateFilterMatchesAsync()
+    internal async Task<bool> UpdateFilterMatchesAsync()
     {
+        var updateVersion = Interlocked.Increment(ref _filterMatchUpdateVersion);
         var traceId = _trace?.TraceId;
         if (traceId is null)
         {
             PageViewModel.ContextFilterMatches = null;
             PageViewModel.DurationFilterMatches = null;
-            return;
+            return true;
         }
 
         var contextFilters = PageViewModel.Filters
@@ -627,19 +634,25 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             contextFilters.Add(typeFilter);
         }
 
-        // An older filter query could finish after a newer query and apply stale matches. Each query is
-        // constrained to the current trace and filter changes are user-driven, so this is unlikely and not
-        // worth the additional state and coordination required to guard against it.
-        var hasTextFilter = !string.IsNullOrWhiteSpace(PageViewModel.Filter);
+        var filterText = PageViewModel.Filter;
+        var hasTextFilter = !string.IsNullOrWhiteSpace(filterText);
         var contextMatches = contextFilters.Count > 0 || hasTextFilter
-            ? await GetMatchingSpanIdsAsync(contextFilters, hasTextFilter ? [PageViewModel.Filter] : null)
+            ? await GetMatchingSpanIdsAsync(contextFilters, hasTextFilter ? [filterText] : null)
             : null;
         var durationMatches = durationFilters.Count > 0
             ? await GetMatchingSpanIdsAsync(durationFilters, textFragments: null)
             : null;
 
+        // A superseded filter or trace query must not publish stale matches or clear the selection from the
+        // newer view. The caller also skips its refresh when this result is no longer current.
+        if (updateVersion != Volatile.Read(ref _filterMatchUpdateVersion) || traceId != _trace?.TraceId)
+        {
+            return false;
+        }
+
         PageViewModel.ContextFilterMatches = contextMatches;
         PageViewModel.DurationFilterMatches = durationMatches;
+        return true;
 
         async Task<HashSet<string>> GetMatchingSpanIdsAsync(List<TelemetryFilter> filters, string[]? textFragments)
         {
@@ -730,6 +743,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     public void Dispose()
     {
         Interlocked.Increment(ref _detailViewUpdateVersion);
+        Interlocked.Increment(ref _filterMatchUpdateVersion);
         _cts.Cancel();
         _tracesSubscription?.Dispose();
         TelemetryContext.Dispose();

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
@@ -117,6 +117,37 @@ public sealed partial class SqliteTelemetryRepository
         }
     }
 
+    private long[] GetResourceIdsMatchingDisplayNameAlias(string text)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            // Trace Detail formats source names against instrumented resources only. Use the same resource set
+            // and helper here so replica suffixes and shortened GUID instance IDs cannot drift from the UI.
+            var resources = _cachedResourcesByKey.Values
+                .Select(resource => resource.Resource)
+                .Where(resource => !resource.UninstrumentedPeer)
+                .ToList();
+            var resourceNameCounts = resources
+                .GroupBy(resource => resource.ResourceName, StringComparers.ResourceName)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparers.ResourceName);
+
+            return _cachedResourcesByKey.Values
+                .Where(resource => !resource.Resource.UninstrumentedPeer)
+                .Where(resource =>
+                {
+                    // The SQL query already matches the base resource name. Return only aliases that add a
+                    // replica suffix match so common searches don't expand into large resource ID lists.
+                    return !resource.Resource.ResourceName.Contains(text, StringComparison.CurrentCultureIgnoreCase) &&
+                        OtlpHelpers.GetResourceName(
+                            resource.Resource,
+                            includeInstanceId: resourceNameCounts[resource.Resource.ResourceName] > 1).Contains(text, StringComparison.CurrentCultureIgnoreCase);
+                })
+                .Select(resource => resource.ResourceId)
+                .ToArray();
+        }
+    }
+
     private sealed class ResourceViewPropertiesComparer : IEqualityComparer<KeyValuePair<string, string>[]>
     {
         public static readonly ResourceViewPropertiesComparer Instance = new();

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
@@ -122,8 +122,9 @@ public sealed partial class SqliteTelemetryRepository
         EnsureCachePopulated();
         lock (_cacheLock)
         {
-            // Trace Detail formats source names against instrumented resources only. Use the same resource set
-            // and helper here so replica suffixes and shortened GUID instance IDs cannot drift from the UI.
+            // Trace Detail determines replica suffixes from instrumented resources, but it also formats
+            // uninstrumented peers against that set. Keep all resources as alias candidates so peer labels use
+            // the same suffix and shortened GUID behavior as the UI.
             var resources = _cachedResourcesByKey.Values
                 .Select(resource => resource.Resource)
                 .Where(resource => !resource.UninstrumentedPeer)
@@ -132,16 +133,16 @@ public sealed partial class SqliteTelemetryRepository
                 .GroupBy(resource => resource.ResourceName, StringComparers.ResourceName)
                 .ToDictionary(group => group.Key, group => group.Count(), StringComparers.ResourceName);
 
-            return _cachedResourcesByKey.Values
-                .Where(resource => !resource.Resource.UninstrumentedPeer)
-                .Where(resource =>
+            return _cachedResourcesByKey.Values.Where(resource =>
                 {
                     // The SQL query already matches the base resource name. Return only aliases that add a
                     // replica suffix match so common searches don't expand into large resource ID lists.
+                    var includeInstanceId = resourceNameCounts.TryGetValue(resource.Resource.ResourceName, out var resourceNameCount) &&
+                        resourceNameCount > 1;
                     return !resource.Resource.ResourceName.Contains(text, StringComparison.CurrentCultureIgnoreCase) &&
                         OtlpHelpers.GetResourceName(
                             resource.Resource,
-                            includeInstanceId: resourceNameCounts[resource.Resource.ResourceName] > 1).Contains(text, StringComparison.CurrentCultureIgnoreCase);
+                            includeInstanceId).Contains(text, StringComparison.CurrentCultureIgnoreCase);
                 })
                 .Select(resource => resource.ResourceId)
                 .ToArray();

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Reads.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Reads.cs
@@ -413,7 +413,7 @@ public sealed partial class SqliteTelemetryRepository
         };
     }
 
-    private static TraceQuery BuildSpanQuery(GetSpansRequest context)
+    private TraceQuery BuildSpanQuery(GetSpansRequest context)
     {
         var sql = new StringBuilder("""
             FROM telemetry_spans s
@@ -525,7 +525,16 @@ public sealed partial class SqliteTelemetryRepository
             {
                 var parameterName = $"SpanTextFragment{index}";
                 parameters.Add(parameterName, CreateContainsLikePattern(context.TextFragments[index]));
-                 sql.Append(CultureInfo.InvariantCulture, $"""
+                var displayNameAliasResourceIds = GetResourceIdsMatchingDisplayNameAlias(context.TextFragments[index]);
+                var displayNamePredicate = string.Empty;
+                if (displayNameAliasResourceIds.Length > 0)
+                {
+                    var resourceIdsParameterName = $"SpanTextFragmentResourceIds{index}";
+                    parameters.Add(resourceIdsParameterName, displayNameAliasResourceIds);
+                    displayNamePredicate = $" OR r.resource_id IN @{resourceIdsParameterName} OR pr.resource_id IN @{resourceIdsParameterName}";
+                }
+
+                sql.Append(CultureInfo.InvariantCulture, $"""
                      AND (
                         s.name LIKE @{parameterName} ESCAPE '!' OR
                         s.span_id LIKE @{parameterName} ESCAPE '!' OR
@@ -538,7 +547,7 @@ public sealed partial class SqliteTelemetryRepository
                         sk.kind_name LIKE @{parameterName} ESCAPE '!' OR
                         COALESCE(s.status_message, '') LIKE @{parameterName} ESCAPE '!' OR
                         EXISTS (SELECT 1 FROM telemetry_span_attributes a WHERE a.trace_id = s.trace_id AND a.span_id = s.span_id AND (a.attribute_key LIKE @{parameterName} ESCAPE '!' OR a.attribute_value LIKE @{parameterName} ESCAPE '!')) OR
-                        EXISTS (SELECT 1 FROM telemetry_span_events e WHERE e.trace_id = s.trace_id AND e.span_id = s.span_id AND e.event_name LIKE @{parameterName} ESCAPE '!')
+                        EXISTS (SELECT 1 FROM telemetry_span_events e WHERE e.trace_id = s.trace_id AND e.span_id = s.span_id AND e.event_name LIKE @{parameterName} ESCAPE '!'){displayNamePredicate}
                     )
                     """);
             }

--- a/src/Shared/Otlp/OtlpHelpers.cs
+++ b/src/Shared/Otlp/OtlpHelpers.cs
@@ -118,7 +118,7 @@ public static partial class OtlpHelpers
         // in time share the same leading characters, e.g. Guid.CreateVersion7().
         // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
         // After:  eeeeeeee
-        if (instanceId != null && Guid.TryParse(instanceId, out var guid))
+        if (instanceId is not null && Guid.TryParse(instanceId, out var guid))
         {
             Span<char> chars = stackalloc char[32];
             var result = guid.TryFormat(chars, out var charsWritten, format: "N");

--- a/src/Shared/Otlp/OtlpHelpers.cs
+++ b/src/Shared/Otlp/OtlpHelpers.cs
@@ -96,33 +96,38 @@ public static partial class OtlpHelpers
                 count++;
                 if (count >= 2)
                 {
-                    var instanceId = resource.InstanceId;
-
-                    // Convert long GUID into a shorter, more human friendly format.
-                    // The last characters are used because version 7 GUIDs created close
-                    // in time share the same leading characters, e.g. Guid.CreateVersion7().
-                    // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-                    // After:  eeeeeeee
-                    if (instanceId != null && Guid.TryParse(instanceId, out var guid))
-                    {
-                        Span<char> chars = stackalloc char[32];
-                        var result = guid.TryFormat(chars, out var charsWritten, format: "N");
-                        Debug.Assert(result, "Guid.TryFormat not successful.");
-
-                        instanceId = chars.Slice(charsWritten - 8, 8).ToString();
-                    }
-
-                    if (instanceId == null)
-                    {
-                        return item.ResourceName;
-                    }
-
-                    return $"{item.ResourceName}-{instanceId}";
+                    return GetResourceName(resource, includeInstanceId: true);
                 }
             }
         }
 
         return resource.ResourceName;
+    }
+
+    internal static string GetResourceName(IOtlpResource resource, bool includeInstanceId)
+    {
+        if (!includeInstanceId)
+        {
+            return resource.ResourceName;
+        }
+
+        var instanceId = resource.InstanceId;
+
+        // Convert long GUID into a shorter, more human friendly format.
+        // The last characters are used because version 7 GUIDs created close
+        // in time share the same leading characters, e.g. Guid.CreateVersion7().
+        // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+        // After:  eeeeeeee
+        if (instanceId != null && Guid.TryParse(instanceId, out var guid))
+        {
+            Span<char> chars = stackalloc char[32];
+            var result = guid.TryFormat(chars, out var charsWritten, format: "N");
+            Debug.Assert(result, "Guid.TryFormat not successful.");
+
+            instanceId = chars.Slice(charsWritten - 8, 8).ToString();
+        }
+
+        return instanceId is null ? resource.ResourceName : $"{resource.ResourceName}-{instanceId}";
     }
 
     /// <summary>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -322,6 +322,82 @@ public partial class StructuredLogsTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.Equal(expectedMessageCount, messageCount));
     }
 
+    [Fact]
+    public async Task FilterQuery_StaleResultDoesNotClearCurrentSelection()
+    {
+        SetupStructureLogsServices();
+
+        var restrictiveQueryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueRestrictiveQuery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Services.AddSingleton<ITelemetryRepository>(services =>
+        {
+            var inner = services.GetRequiredService<SqliteTelemetryRepository>();
+            return new TestTelemetryRepository(inner)
+            {
+                GetLogsAsyncHandler = async (context, cancellationToken) =>
+                {
+                    var textFilter = context.Filters
+                        .OfType<FieldTelemetryFilter>()
+                        .Single(filter => filter.Field == nameof(OtlpLogEntry.Message))
+                        .Value;
+                    if (textFilter == "missing")
+                    {
+                        restrictiveQueryStarted.SetResult();
+                        await continueRestrictiveQuery.Task.WaitAsync(cancellationToken);
+                    }
+
+                    return await inner.GetLogsAsync(context, cancellationToken);
+                }
+            };
+        });
+
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await repository.AddLogsAsync(new AddContext(),
+        [
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "First log"),
+                            CreateLogRecord(message: "Second log")
+                        }
+                    }
+                }
+            }
+        ]);
+        var logs = (await repository.GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 2,
+            Filters = []
+        }, CancellationToken.None)).Items;
+        var firstLog = Assert.Single(logs, log => log.Message == "First log");
+        var secondLog = Assert.Single(logs, log => log.Message == "Second log");
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        Services.GetRequiredService<DimensionManager>().InvokeOnViewportInformationChanged(viewport);
+        var cut = RenderComponent<StructuredLogs>(builder => builder.Add(p => p.ViewportInformation, viewport));
+        cut.Instance.PageViewModel.SelectedLogEntry = new StructureLogsDetailsViewModel { LogEntry = firstLog };
+
+        var olderQuery = cut.InvokeAsync(() => cut.Instance.ClearSelectedLogEntryIfExcludedAsync("missing", []));
+        await restrictiveQueryStarted.Task.WaitAsync(DefaultWaitTimeout);
+
+        cut.Instance.PageViewModel.SelectedLogEntry = new StructureLogsDetailsViewModel { LogEntry = secondLog };
+        await cut.InvokeAsync(() => cut.Instance.ClearSelectedLogEntryIfExcludedAsync("Second", []));
+
+        continueRestrictiveQuery.SetResult();
+        await olderQuery;
+
+        Assert.Equal(secondLog.InternalId, cut.Instance.PageViewModel.SelectedLogEntry?.LogEntry.InternalId);
+    }
+
     private void SetupStructureLogsServices()
     {
         FluentUISetupHelpers.SetupFluentDivider(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
@@ -979,6 +980,102 @@ public partial class TraceDetailsTests : DashboardTestContext
                 Assert.True(container.ClassList.Contains("main-grid-expanded"));
             }
         });
+    }
+
+    [Fact]
+    public async Task FilterQuery_OlderResultDoesNotReplaceCurrentMatches()
+    {
+        SetupTraceDetailsServices();
+
+        var restrictiveQueryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueRestrictiveQuery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var currentQueryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueCurrentQuery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Services.AddSingleton<ITelemetryRepository>(services =>
+        {
+            var inner = services.GetRequiredService<SqliteTelemetryRepository>();
+            return new TestTelemetryRepository(inner)
+            {
+                GetSpansAsyncHandler = async (request, cancellationToken) =>
+                {
+                    if (request.TextFragments is ["missing"])
+                    {
+                        restrictiveQueryStarted.SetResult();
+                        await continueRestrictiveQuery.Task.WaitAsync(cancellationToken);
+                    }
+                    else if (request.TextFragments is not null)
+                    {
+                        currentQueryStarted.SetResult();
+                        await continueCurrentQuery.Task.WaitAsync(cancellationToken);
+                    }
+
+                    return await inner.GetSpansAsync(request, cancellationToken);
+                }
+            };
+        });
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        Services.GetRequiredService<DimensionManager>().InvokeOnViewportInformationChanged(viewport);
+
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await repository.AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var traceId = Convert.ToHexString(Encoding.UTF8.GetBytes("1"));
+        var cut = RenderComponent<TraceDetail>(builder =>
+        {
+            builder.Add(p => p.TraceId, traceId);
+            builder.AddCascadingValue(viewport);
+        });
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Instance.PageViewModel.SpanWaterfallViewModels));
+
+        var selectedSpan = Assert.Single(Assert.IsType<List<SpanWaterfallViewModel>>(cut.Instance.PageViewModel.SpanWaterfallViewModels));
+        cut.Instance.PageViewModel.ContextFilterMatches = [];
+        cut.Instance.PageViewModel.SelectedData = new TraceDetailSelectedDataViewModel
+        {
+            SpanViewModel = SpanDetailsViewModel.Create(
+                selectedSpan.Span,
+                Services.GetRequiredService<ITelemetryRepository>(),
+                repository.GetResources())
+        };
+
+        cut.Instance.PageViewModel.Filter = "missing";
+        var olderRefresh = cut.Instance.RefreshAfterFilterChangeAsync();
+        await restrictiveQueryStarted.Task.DefaultTimeout();
+
+        cut.Instance.PageViewModel.Filter = selectedSpan.Span.Name;
+        var currentQuery = cut.Instance.UpdateFilterMatchesAsync();
+        await currentQueryStarted.Task.DefaultTimeout();
+
+        continueRestrictiveQuery.SetResult();
+        Assert.False(await olderRefresh);
+        Assert.NotNull(cut.Instance.PageViewModel.SelectedData);
+
+        continueCurrentQuery.SetResult();
+        Assert.True(await currentQuery);
+        Assert.Collection(
+            cut.Instance.PageViewModel.ContextFilterMatches!,
+            match => Assert.Equal(selectedSpan.Span.SpanId, match));
     }
 
     private static async Task<HashSet<string>> GetMatchingSpanIdsAsync(

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryRepository.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryRepository.cs
@@ -9,7 +9,9 @@ namespace Aspire.Dashboard.Components.Tests.Shared;
 
 internal sealed class TestTelemetryRepository(ITelemetryRepository inner) : ITelemetryRepository
 {
+    public Func<GetLogsContext, CancellationToken, Task<PagedResult<OtlpLogEntry>>>? GetLogsAsyncHandler { get; init; }
     public Func<GetLogsContext, CancellationToken, Task<PagedResult<LogSummary>>>? GetLogSummariesAsyncHandler { get; init; }
+    public Func<GetSpansRequest, CancellationToken, Task<GetSpansResponse>>? GetSpansAsyncHandler { get; init; }
 
     public bool IsReadOnly => inner.IsReadOnly;
     public bool HasDisplayedMaxLogLimitMessage { get => inner.HasDisplayedMaxLogLimitMessage; set => inner.HasDisplayedMaxLogLimitMessage = value; }
@@ -30,7 +32,8 @@ internal sealed class TestTelemetryRepository(ITelemetryRepository inner) : ITel
     public Subscription OnNewMetrics(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) => inner.OnNewMetrics(resourceKey, subscriptionType, callback);
     public Subscription OnNewTraces(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) => inner.OnNewTraces(resourceKey, subscriptionType, callback);
 
-    public Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken) => inner.GetLogsAsync(context, cancellationToken);
+    public Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken) =>
+        GetLogsAsyncHandler?.Invoke(context, cancellationToken) ?? inner.GetLogsAsync(context, cancellationToken);
     public Task<PagedResult<LogSummary>> GetLogSummariesAsync(GetLogsContext context, CancellationToken cancellationToken) =>
         GetLogSummariesAsyncHandler?.Invoke(context, cancellationToken) ?? inner.GetLogSummariesAsync(context, cancellationToken);
     public OtlpLogEntry? GetLog(long logId) => inner.GetLog(logId);
@@ -40,7 +43,8 @@ internal sealed class TestTelemetryRepository(ITelemetryRepository inner) : ITel
     public Task<List<string>> GetTracePropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken) => inner.GetTracePropertyKeysAsync(resourceKey, cancellationToken);
     public Task<GetTracesResponse> GetTracesAsync(GetTracesRequest context, CancellationToken cancellationToken) => inner.GetTracesAsync(context, cancellationToken);
     public Task<GetTraceSummariesResponse> GetTraceSummariesAsync(GetTracesRequest context, CancellationToken cancellationToken) => inner.GetTraceSummariesAsync(context, cancellationToken);
-    public Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken) => inner.GetSpansAsync(context, cancellationToken);
+    public Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken) =>
+        GetSpansAsyncHandler?.Invoke(context, cancellationToken) ?? inner.GetSpansAsync(context, cancellationToken);
     public Task<Dictionary<string, int>> GetTraceFieldValuesAsync(string attributeName, CancellationToken cancellationToken) => inner.GetTraceFieldValuesAsync(attributeName, cancellationToken);
     public Task<Dictionary<string, int>> GetLogsFieldValuesAsync(string attributeName, CancellationToken cancellationToken) => inner.GetLogsFieldValuesAsync(attributeName, cancellationToken);
     public bool HasUpdatedTrace(OtlpTrace trace) => inner.HasUpdatedTrace(trace);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3659,7 +3659,7 @@ public abstract class TraceTests : TelemetryRepositoryTestBase
     [Fact]
     public async Task GetSpans_FilterByTextFragments_MatchesPeerResourceDisplayName()
     {
-        var peerResource = ModelTestHelpers.CreateResource(resourceName: "service-replica-2", displayName: "service");
+        var peerResource = ModelTestHelpers.CreateResource(resourceName: "service-replica-3", displayName: "service");
         using var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => (peerResource.Name, peerResource));
         using var repositoryContext = await CreateRepositoryAsync(outgoingPeerResolvers: [outgoingPeerResolver]);
 
@@ -3726,6 +3726,11 @@ public abstract class TraceTests : TelemetryRepositoryTestBase
             }
         ]);
 
+        var persistedPeer = Assert.Single(
+            repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true),
+            resource => resource.ResourceKey == new ResourceKey("service", "replica-3"));
+        Assert.True(persistedPeer.UninstrumentedPeer);
+
         var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
@@ -3733,7 +3738,7 @@ public abstract class TraceTests : TelemetryRepositoryTestBase
             Count = int.MaxValue,
             Filters = [],
             TraceId = GetHexId("1"),
-            TextFragments = ["service-replica-2"]
+            TextFragments = ["service-replica-3"]
         }, cancellationToken: CancellationToken.None);
 
         Assert.Equal(1, result.PagedResult.TotalItemCount);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3594,6 +3594,152 @@ public abstract class TraceTests : TelemetryRepositoryTestBase
         AssertId("1-1", result.PagedResult.Items[0].SpanId);
     }
 
+    [Theory]
+    [InlineData("replica-2", "service-replica-2")]
+    [InlineData("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "service-eeeeeeee")]
+    public async Task GetSpans_FilterByTextFragments_MatchesResourceDisplayName(string instanceId, string displayName)
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service", instanceId: "replica-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service", instanceId: instanceId),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = [],
+            TextFragments = [displayName]
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, result.PagedResult.TotalItemCount);
+        AssertId("1-2", Assert.Single(result.PagedResult.Items).SpanId);
+    }
+
+    [Fact]
+    public async Task GetSpans_FilterByTextFragments_MatchesPeerResourceDisplayName()
+    {
+        var peerResource = ModelTestHelpers.CreateResource(resourceName: "service-replica-2", displayName: "service");
+        using var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => (peerResource.Name, peerResource));
+        using var repositoryContext = await CreateRepositoryAsync(outgoingPeerResolvers: [outgoingPeerResolver]);
+
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service", instanceId: "replica-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "2",
+                                spanId: "2-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service", instanceId: "replica-2"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "3",
+                                spanId: "3-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "caller"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "peer")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = [],
+            TraceId = GetHexId("1"),
+            TextFragments = ["service-replica-2"]
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, result.PagedResult.TotalItemCount);
+        AssertId("1-1", Assert.Single(result.PagedResult.Items).SpanId);
+    }
+
     [Fact]
     public async Task GetSpans_FilterByTextFragments_MatchesDisplaySummaries()
     {


### PR DESCRIPTION
## Description

Dashboard telemetry filter queries run asynchronously and can complete out of order. A stale query could replace current Trace Detail matches or clear a newer structured-log selection. SQLite span searches also matched only base resource names, so searching for a displayed replica name such as `service-replica-2` returned no direct match.

This change makes filter updates latest-wins and ties structured-log clearing to the entry that was originally evaluated. Span text queries now reuse the dashboard's resource display-name formatting and add exact source or peer resource IDs for alias-only matches, including shortened GUID instance IDs.

### User-facing usage

Rapid filter changes no longer leave Trace Detail showing stale results or unexpectedly close a newer selection. Trace Detail searches also match the replica names displayed in source and peer labels.

### Screenshots / Recordings

Filtering Trace Detail by the full `catalogservice-eshtjezb` replica alias retains the matching spans and their surrounding trace context.

![Trace Detail filtered by a replica display name](https://github.com/user-attachments/assets/ddcf547b-c746-45af-96dd-f70cb8f4c3c6)

[Trace Detail replica alias filter recording](https://github.com/user-attachments/assets/6a98e743-9466-48dd-b430-183d1e5fac05)

### Validation

- Added component tests with delayed repository reads to verify stale queries cannot publish matches or clear current selections.
- Added repository coverage for source and peer replica aliases, including shortened GUID instance IDs.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No