### PR TITLE
fix(ci): PR test selector could silently mis-attribute changed paths containing tabs or newlines

### DIFF
--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -282,42 +282,37 @@ carry it forward. Never silently regenerate it.
   no project in `Aspire.slnx`) forces the full matrix. A missed test is a silent
   regression; an extra run is just slower. Files that need no CI are dropped by
   the `prefilter` before this point.
-- **Renamed files and the fallback.** The old path of a git-detected rename
-  (`git diff -M`, default 50% content-similarity threshold) that matches no
-  Layer 2 rule is exempted from this fallback instead of forcing `ALL` — a
-  same-commit rename that also repoints the map's own rule at the new name (as
-  [microsoft/aspire#19486](https://github.com/microsoft/aspire/pull/19486)
-  did for `eng/scripts/aspire-skills-bundle.common.ps1` →
-  `aspire-skills-bundles.common.ps1`) would otherwise leave the stale old name
-  matching nothing and trip run-all, even though the new path already carries
-  whatever the map says about this content moving. This exemption only applies
-  when the rename's new path is itself present in the (post-`prefilter`)
-  changed-file set passed to the selector — i.e. something downstream actually
-  had a chance to account for it (matched a rule, was ignored, is
-  Layer-1-owned, or itself becomes an unmatched leftover that forces `ALL`). A
-  destination the `prefilter` already dropped entirely (e.g. renamed into a
-  doc-only path) never reaches that evaluation, so the old path is NOT
-  exempted in that case and the fallback still fires — silently trusting old-path
-  membership alone would otherwise under-select relative to what the
-  destination's content actually needs. The old path is still glob-matched
-  like any other changed path first, so a cross-directory rename still hits
-  the old directory's rule; only an old path matched by *nothing* is
-  exempted, and exemption can only skip forcing `ALL` — it never removes a
-  target that a rule matched. A rename git does not detect as such (below the
-  50% threshold — e.g. a move combined with a heavy rewrite in the same
-  commit) is unaffected by this exemption and reported as a plain delete + add,
-  which still forces the fallback if either side is otherwise unmapped.
-  - **Known residual limitation.** Rename detection is a content-similarity
-    heuristic, not a semantic guarantee, so it can occasionally pair an
-    unrelated deletion with an unrelated addition that merely look similar
-    (e.g. two near-identical or empty boilerplate files). If that mispaired
-    "old path" also lost its own rule in the same commit, its removal would be
-    exempted here even though it isn't really the deletion side of the rule's
-    file. This needs several independent, rare coincidences to line up, and
-    raising the similarity threshold to close it isn't viable — the real
-    rename above was only detected at 54% similarity, so any threshold high
-    enough to rule out coincidental pairing would also miss real renames like
-    it. Treated as an accepted, bounded tradeoff rather than a code fix.
+- **Rename handling.** Renames are not special-cased. Both the old and new path
+  of a git-detected rename (`git diff -M`, default 50% content-similarity
+  threshold) are evaluated exactly like any other changed path, including
+  against the run-all fallback above — an unmatched old path forces `ALL` just
+  like an unmatched deletion would.
+
+  An earlier version of this rule exempted a rename's old path from forcing
+  `ALL` when its new path was itself present in the (post-`prefilter`)
+  changed-file set, on the theory that the new path's own evaluation already
+  accounted for the moved content. That exemption was removed after an audit
+  found two ways it could silently under-select tests:
+  - **Shared-directory moves.** A `path_rules` glob scoped to the old
+    directory (e.g. `tests/Shared/Logging/**`) can have consumers beyond the
+    file that moved. Moving one file out of that directory into an unrelated
+    project's own directory exempted the old path once the new path matched
+    *its* rule — but any other file still left behind in the old directory,
+    and depending on the moved content, got no signal that anything changed.
+  - **Ignore/prefilter laundering.** A rename whose new path lands on an
+    `ignore`d glob, or is dropped by the `prefilter` before Layer 2 ever runs,
+    "satisfied" the exemption's presence check without the destination
+    contributing any real coverage — silently treating the old path as
+    accounted for when nothing had actually evaluated it.
+
+  Removing the exemption reopens
+  [microsoft/aspire#19486](https://github.com/microsoft/aspire/pull/19486)'s
+  own motivating case — a same-commit rename that also repoints the map's own
+  rule at the new name now correctly forces `ALL` again, because the stale old
+  name matches nothing. That is the accepted, safe tradeoff: an unnecessary
+  full run is strictly better than a silently skipped test, and it matches the
+  fallback's existing philosophy of failing safe to `ALL` for anything it
+  cannot positively account for.
 - **Layer 1 failure is fatal.** Audit mode returns run-all only after a
   successful selection. A graph-computation failure fails the selector in every
   mode.

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -290,10 +290,19 @@ carry it forward. Never silently regenerate it.
   did for `eng/scripts/aspire-skills-bundle.common.ps1` →
   `aspire-skills-bundles.common.ps1`) would otherwise leave the stale old name
   matching nothing and trip run-all, even though the new path already carries
-  whatever the map says about this content moving. The old path is still
-  glob-matched like any other changed path first, so a cross-directory rename
-  still hits the old directory's rule; only an old path matched by *nothing*
-  is exempted, and exemption can only skip forcing `ALL` — it never removes a
+  whatever the map says about this content moving. This exemption only applies
+  when the rename's new path is itself present in the (post-`prefilter`)
+  changed-file set passed to the selector — i.e. something downstream actually
+  had a chance to account for it (matched a rule, was ignored, is
+  Layer-1-owned, or itself becomes an unmatched leftover that forces `ALL`). A
+  destination the `prefilter` already dropped entirely (e.g. renamed into a
+  doc-only path) never reaches that evaluation, so the old path is NOT
+  exempted in that case and the fallback still fires — silently trusting old-path
+  membership alone would otherwise under-select relative to what the
+  destination's content actually needs. The old path is still glob-matched
+  like any other changed path first, so a cross-directory rename still hits
+  the old directory's rule; only an old path matched by *nothing* is
+  exempted, and exemption can only skip forcing `ALL` — it never removes a
   target that a rule matched. A rename git does not detect as such (below the
   50% threshold — e.g. a move combined with a heavy rewrite in the same
   commit) is unaffected by this exemption and reported as a plain delete + add,

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -298,6 +298,17 @@ carry it forward. Never silently regenerate it.
   50% threshold — e.g. a move combined with a heavy rewrite in the same
   commit) is unaffected by this exemption and reported as a plain delete + add,
   which still forces the fallback if either side is otherwise unmapped.
+  - **Known residual limitation.** Rename detection is a content-similarity
+    heuristic, not a semantic guarantee, so it can occasionally pair an
+    unrelated deletion with an unrelated addition that merely look similar
+    (e.g. two near-identical or empty boilerplate files). If that mispaired
+    "old path" also lost its own rule in the same commit, its removal would be
+    exempted here even though it isn't really the deletion side of the rule's
+    file. This needs several independent, rare coincidences to line up, and
+    raising the similarity threshold to close it isn't viable — the real
+    rename above was only detected at 54% similarity, so any threshold high
+    enough to rule out coincidental pairing would also miss real renames like
+    it. Treated as an accepted, bounded tradeoff rather than a code fix.
 - **Layer 1 failure is fatal.** Audit mode returns run-all only after a
   successful selection. A graph-computation failure fails the selector in every
   mode.

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -282,6 +282,22 @@ carry it forward. Never silently regenerate it.
   no project in `Aspire.slnx`) forces the full matrix. A missed test is a silent
   regression; an extra run is just slower. Files that need no CI are dropped by
   the `prefilter` before this point.
+- **Renamed files and the fallback.** The old path of a git-detected rename
+  (`git diff -M`, default 50% content-similarity threshold) that matches no
+  Layer 2 rule is exempted from this fallback instead of forcing `ALL` — a
+  same-commit rename that also repoints the map's own rule at the new name (as
+  [microsoft/aspire#19486](https://github.com/microsoft/aspire/pull/19486)
+  did for `eng/scripts/aspire-skills-bundle.common.ps1` →
+  `aspire-skills-bundles.common.ps1`) would otherwise leave the stale old name
+  matching nothing and trip run-all, even though the new path already carries
+  whatever the map says about this content moving. The old path is still
+  glob-matched like any other changed path first, so a cross-directory rename
+  still hits the old directory's rule; only an old path matched by *nothing*
+  is exempted, and exemption can only skip forcing `ALL` — it never removes a
+  target that a rule matched. A rename git does not detect as such (below the
+  50% threshold — e.g. a move combined with a heavy rewrite in the same
+  commit) is unaffected by this exemption and reported as a plain delete + add,
+  which still forces the fallback if either side is otherwise unmapped.
 - **Layer 1 failure is fatal.** Audit mode returns run-all only after a
   successful selection. A graph-computation failure fails the selector in every
   mode.

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -62,9 +62,18 @@ When `--from` / `--to` are supplied, the selector first resolves the
 **merge-base** (the branch point) of the two refs and diffs FROM there:
 
 ```text
-from := git merge-base <from> <to>      # the base..head branch point
-git diff --name-status -M <from> <to>   # Layer 1 and Layer 2
+from := git merge-base <from> <to>         # the base..head branch point
+git diff --name-status -M -z <from> <to>   # Layer 1 and Layer 2
 ```
+
+Both layers parse this output through the same `-z` (NUL-delimited) record
+parser (`Selection.ParseNameStatusOutput`), not git's default newline/tab text
+format. A path containing a tab, newline, double-quote, or backslash comes
+back from the default text format as an escaped, double-quoted literal (e.g.
+a real tab in a filename becomes the eight characters `\t`), which matches
+neither the evaluated-item index nor a directory-containment check — silently
+misattributing the change. NUL can never appear in a valid path, so `-z` lets
+git skip quoting/escaping entirely, for every path, with no exceptions.
 
 This makes a PR select on its **own** commits. A file changed on the base
 branch after the PR branched shares the merge-base, so it produces no diff and
@@ -82,15 +91,15 @@ Deletes are included. Renames include both the old path and the new path, so a
 cross-project move marks both the project that lost the file and the project
 that gained it. This is git's own rename detection (`-M`, default 50%
 content-similarity threshold): a delete+add pair below that threshold is
-reported as a plain delete and add, not a rename, and is handled as such —
-see [Layer 2 — curated](#layer-2--curated) for why the old path of a
-detected rename gets special treatment there and why a below-threshold pair
-does not.
+reported as a plain delete and add, not a rename. Either way, both paths are
+evaluated as ordinary changed paths with no rename-specific behavior — see
+[Layer 2 — curated](#layer-2--curated) for why a rename's old path is treated
+like any other unmatched leftover for the run-all fallback.
 
 `--changed-files` is a path-only input for local/debug runs. It does not carry
-rename/delete status, so each line is treated as a present changed path; a
-rename supplied this way has no "old path" to exempt from the Layer 2
-run-all fallback (below).
+rename/delete status, so each line is treated as a present changed path; this
+matches production behavior, since a rename's paths are not treated specially
+there either.
 
 ### File → project attribution
 
@@ -301,18 +310,19 @@ Flow:
    `ignore`d, and matched by no rule. The fallback is location-independent (not
    `src/**`-only): a missed test is a silent regression, so any unmapped change
    fails safe to the full matrix. Files that genuinely need no CI are dropped by
-   the prefilter in step 1, so they never reach this fallback. **Exception:** the
-   old path of a git-detected rename (see [Changed paths](#changed-paths)) that
-   matches nothing is not treated as an unmapped leftover — a same-commit rename
-   that also updates the map's own rule to the new name (as
-   [microsoft/aspire#19486](https://github.com/microsoft/aspire/pull/19486) did)
-   would otherwise force `ALL` over a stale old name that no longer matches
-   anything, even though the new path already carries whatever the map says
-   about this content. The old path is still fully glob-matched like any other
-   changed path first (a cross-directory rename must still hit the old
-   directory's rule), so this only suppresses the fallback when nothing else
-   matched it either. It cannot cause under-selection: exemption never removes
-   a target that matched, it only skips forcing `ALL` when nothing did.
+   the prefilter in step 1, so they never reach this fallback. Renames are not
+   special-cased: both the old and new path of a git-detected rename are
+   evaluated exactly like any other changed path (see
+   [Changed paths](#changed-paths)), including against this fallback. An earlier
+   version of this rule exempted a rename's old path from forcing `ALL` when its
+   new path was present, on the theory that the new path's own evaluation
+   already accounted for the moved content. That exemption was removed: it could
+   silently under-select tests when the old path was consumed only through a
+   glob rule scoped to its (now-vacated) directory — a sibling file elsewhere in
+   that directory could still depend on the moved content, but with the old path
+   hidden from the fallback nothing would signal that. See the "Rename handling"
+   note under [Caveats](./test-trigger-map.md#caveats) in `test-trigger-map.md`
+   for the full failure mode and the accepted over-selection tradeoff.
 7. Emit the per-job booleans (as one `selection` JSON object), and — in enforce
    mode for a non-ALL selection — the `OverrideProjectToBuild` props restricting
    the downstream build.

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -63,8 +63,7 @@ When `--from` / `--to` are supplied, the selector first resolves the
 
 ```text
 from := git merge-base <from> <to>      # the base..head branch point
-git diff --name-status -M <from> <to>   # Layer 1
-git diff --name-only   --no-renames <from> <to>   # Layer 2
+git diff --name-status -M <from> <to>   # Layer 1 and Layer 2
 ```
 
 This makes a PR select on its **own** commits. A file changed on the base
@@ -81,10 +80,17 @@ GitHub's own PR path filters make; see [Prior art and comparison](#prior-art-and
 
 Deletes are included. Renames include both the old path and the new path, so a
 cross-project move marks both the project that lost the file and the project
-that gained it.
+that gained it. This is git's own rename detection (`-M`, default 50%
+content-similarity threshold): a delete+add pair below that threshold is
+reported as a plain delete and add, not a rename, and is handled as such —
+see [Layer 2 — curated](#layer-2--curated) for why the old path of a
+detected rename gets special treatment there and why a below-threshold pair
+does not.
 
 `--changed-files` is a path-only input for local/debug runs. It does not carry
-rename/delete status, so each line is treated as a present changed path.
+rename/delete status, so each line is treated as a present changed path; a
+rename supplied this way has no "old path" to exempt from the Layer 2
+run-all fallback (below).
 
 ### File → project attribution
 
@@ -295,7 +301,18 @@ Flow:
    `ignore`d, and matched by no rule. The fallback is location-independent (not
    `src/**`-only): a missed test is a silent regression, so any unmapped change
    fails safe to the full matrix. Files that genuinely need no CI are dropped by
-   the prefilter in step 1, so they never reach this fallback.
+   the prefilter in step 1, so they never reach this fallback. **Exception:** the
+   old path of a git-detected rename (see [Changed paths](#changed-paths)) that
+   matches nothing is not treated as an unmapped leftover — a same-commit rename
+   that also updates the map's own rule to the new name (as
+   [microsoft/aspire#19486](https://github.com/microsoft/aspire/pull/19486) did)
+   would otherwise force `ALL` over a stale old name that no longer matches
+   anything, even though the new path already carries whatever the map says
+   about this content. The old path is still fully glob-matched like any other
+   changed path first (a cross-directory rename must still hit the old
+   directory's rule), so this only suppresses the fallback when nothing else
+   matched it either. It cannot cause under-selection: exemption never removes
+   a target that matched, it only skips forcing `ALL` when nothing did.
 7. Emit the per-job booleans (as one `selection` JSON object), and — in enforce
    mode for a non-ALL selection — the `OverrideProjectToBuild` props restricting
    the downstream build.

--- a/tests/Infrastructure.Tests/TestTriggerMap/GraphAffectedProjectsTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/GraphAffectedProjectsTests.cs
@@ -224,6 +224,28 @@ public sealed class GraphAffectedProjectsTests
         Assert.Contains("Other", affected);
     }
 
+    // Failure mode: git's default text-mode `--name-status -M` output escapes a path containing a
+    // literal tab into a double-quoted, backslash-escaped literal (e.g. `"Other/da\tta.txt"`, nine
+    // literal characters, not one real tab byte) even with `core.quotePath=false` (that setting only
+    // suppresses non-ASCII-byte escaping, not tab/newline/quote/backslash escaping). The garbled string
+    // then fails to match Other's real directory prefix, so the new owner (Other) is silently dropped
+    // from the affected set even though the old owner (Core) and its dependents are still found via the
+    // unmangled old path. `-z` (shared with Layer 2's Selection.ParseNameStatusOutput) never escapes
+    // any byte, so both sides of the rename resolve correctly regardless of path content.
+    [Fact]
+    public void CrossProjectRenameIntoTabContainingPathAttributesTheNewOwner()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        using var repo = new GitGraphFixture(workspace);
+
+        var affected = repo.RenameAcrossProjectsAndCompute("Core/data.txt", "Other/da\tta.txt");
+
+        Assert.Contains("Core", affected);
+        Assert.Contains("Mid", affected);
+        Assert.Contains("AppTests", affected);
+        Assert.Contains("Other", affected);
+    }
+
     /// <summary>
     /// Creates a disposable temp directory containing a minimal but real MSBuild project graph plus an
     /// <c>Aspire.slnx</c>, and runs <see cref="GraphAffectedProjects.Compute"/> against it using a

--- a/tests/Infrastructure.Tests/TestTriggerMap/GraphAffectedProjectsTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/GraphAffectedProjectsTests.cs
@@ -246,6 +246,28 @@ public sealed class GraphAffectedProjectsTests
         Assert.Contains("Other", affected);
     }
 
+    // Failure mode: a literal backslash is a legal filename byte on Unix, but git ALWAYS reports
+    // repo-relative paths with '/' separators regardless of host OS -- a '\' in a git-reported path can
+    // therefore never be a real directory separator to normalize; it can only be a literal character
+    // inside one path segment. ResolveChangedPaths previously ran an unconditional
+    // `rel.Replace('\\', '/')` over every changed path (git- or --changed-files-sourced), which turned a
+    // literal backslash into a fake directory boundary. A repo-root file literally named `Other\data.txt`
+    // (one segment, no real subdirectory) does not belong to the "Other" project -- but the corrupted
+    // "Other/data.txt" string satisfies Other's directory-containment prefix check, so the bug spuriously
+    // attributed a root-level, unrelated file to Other. Layer 2 makes no such rewrite (see
+    // Program.cs.ResolveChangedFiles), so Layer 1 must not either, or the two layers silently disagree on
+    // what a path even is.
+    [Fact]
+    public void BackslashContainingRootFileIsNotAttributedToSimilarlyNamedProject()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        using var repo = new GraphFixture(workspace);
+
+        var result = repo.ComputeResult("Other\\data.txt");
+
+        Assert.Empty(result.AffectedProjects);
+    }
+
     /// <summary>
     /// Creates a disposable temp directory containing a minimal but real MSBuild project graph plus an
     /// <c>Aspire.slnx</c>, and runs <see cref="GraphAffectedProjects.Compute"/> against it using a

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -125,8 +125,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
             (projectDirs ?? []).ToHashSet(StringComparer.Ordinal));
     }
 
-    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null, string[]? renameOldPaths = null)
-        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions(), renameOldPaths: renameOldPaths?.ToHashSet(StringComparer.Ordinal));
+    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null, IReadOnlyDictionary<string, string>? renames = null)
+        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions(), renames: renames);
 
     public void Dispose()
     {
@@ -336,14 +336,64 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RenameOldPathUnmatchedDoesNotForceRunAll()
     {
         // Same shape as LeftoverUnmatchedFileForcesRunAll, but the caller marks the file as the OLD
-        // side of a git-detected rename (see Program.ResolveChangedFiles / TestSelector.Select). This
-        // is the fix for PR #19486's aspire-skills-bundle(s).common.ps1 rename: when the map is updated
-        // in the same commit to reference only the new name, the old name is stale by construction, not
-        // a genuine unmapped leftover -- so it must not trip the run-all fallback.
-        var r = Select(["docs/architecture/notes.md"], renameOldPaths: ["docs/architecture/notes.md"]);
+        // side of a git-detected rename whose new side is present in changedFiles and itself matches a
+        // rule (see Program.ResolveChangedFiles / TestSelector.Select). This is the fix for PR #19486's
+        // aspire-skills-bundle(s).common.ps1 rename: when the map is updated in the same commit to
+        // reference only the new name, the old name is stale by construction, not a genuine unmapped
+        // leftover -- so it must not trip the run-all fallback, and the new path's own match is unioned
+        // in additively.
+        var r = Select(
+            ["docs/architecture/notes.md", "src/CuratedThing/Renamed.cs"],
+            renames: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["docs/architecture/notes.md"] = "src/CuratedThing/Renamed.cs",
+            });
 
         Assert.False(r.SelectsAll);
         Assert.DoesNotContain("docs/architecture/notes.md", r.UnmatchedFiles);
+        Assert.Contains("job:cjob", r.Jobs);
+    }
+
+    [Fact]
+    public void RenameOldPathWithDestinationDroppedByPrefilterStillForcesRunAll()
+    {
+        // Regression test for PR #19790 review feedback: the exemption above must require the rename's
+        // destination to be present in changedFiles, not just trust old-path membership in `renames`.
+        // Here the destination ("docs/architecture/prefiltered-away.md") is deliberately absent from
+        // `files` -- simulating Program.cs's prefilter dropping it (e.g. a rename INTO a path matched by
+        // eng/github-ci/ci-skip-entirely-patterns.txt) before it ever reaches Select. Nothing downstream
+        // ever evaluated whether that destination's content needs CI, so the old path must still be
+        // treated as a genuine unmapped leftover and force ALL -- exempting it here would silently
+        // under-select relative to what the new path's content actually needs.
+        var r = Select(
+            ["docs/architecture/notes.md"],
+            renames: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["docs/architecture/notes.md"] = "docs/architecture/prefiltered-away.md",
+            });
+
+        Assert.True(r.SelectsAll);
+        Assert.Contains("docs/architecture/notes.md", r.UnmatchedFiles);
+    }
+
+    [Fact]
+    public void RenameOldPathWithStillUnmatchedDestinationForcesRunAllViaDestination()
+    {
+        // The destination IS present in changedFiles (satisfying the "destination accounted for"
+        // guard) but itself matches no rule -- so it becomes its own unmatched leftover and forces ALL,
+        // exactly like any other unmapped file would. The old-path exemption only ever suppresses the
+        // OLD side, never the new side, so an unmatched destination "self-corrects" the selection
+        // without needing any extra logic beyond the changedFiles membership check.
+        var r = Select(
+            ["docs/architecture/notes.md", "docs/architecture/still-unmatched.md"],
+            renames: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["docs/architecture/notes.md"] = "docs/architecture/still-unmatched.md",
+            });
+
+        Assert.True(r.SelectsAll);
+        Assert.DoesNotContain("docs/architecture/notes.md", r.UnmatchedFiles);
+        Assert.Contains("docs/architecture/still-unmatched.md", r.UnmatchedFiles);
     }
 
     [Fact]
@@ -352,8 +402,15 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         // The rename-old-path exemption only suppresses the run-all ESCALATION for an otherwise
         // unmatched file; it must not suppress ordinary rule matching. src/CuratedThing/** still maps
         // to job:cjob regardless of whether this path is also flagged as a rename's old side, proving
-        // the exemption is additive-safe rather than a blanket "ignore rename old paths" shortcut.
-        var r = Select(["src/CuratedThing/Old.cs"], renameOldPaths: ["src/CuratedThing/Old.cs"]);
+        // the exemption is additive-safe rather than a blanket "ignore rename old paths" shortcut. The
+        // exemption logic is never even reached here (the old path matches its own rule first), so the
+        // paired new path below is a placeholder.
+        var r = Select(
+            ["src/CuratedThing/Old.cs", "src/CuratedThing/New.cs"],
+            renames: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["src/CuratedThing/Old.cs"] = "src/CuratedThing/New.cs",
+            });
 
         Assert.False(r.SelectsAll);
         Assert.Contains("job:cjob", r.Jobs);

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -125,8 +125,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
             (projectDirs ?? []).ToHashSet(StringComparer.Ordinal));
     }
 
-    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null)
-        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions());
+    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null, string[]? renameOldPaths = null)
+        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions(), renameOldPaths: renameOldPaths?.ToHashSet(StringComparer.Ordinal));
 
     public void Dispose()
     {
@@ -330,6 +330,33 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
 
         Assert.True(r.SelectsAll);
         Assert.Contains("docs/architecture/notes.md", r.UnmatchedFiles);
+    }
+
+    [Fact]
+    public void RenameOldPathUnmatchedDoesNotForceRunAll()
+    {
+        // Same shape as LeftoverUnmatchedFileForcesRunAll, but the caller marks the file as the OLD
+        // side of a git-detected rename (see Program.ResolveChangedFiles / TestSelector.Select). This
+        // is the fix for PR #19486's aspire-skills-bundle(s).common.ps1 rename: when the map is updated
+        // in the same commit to reference only the new name, the old name is stale by construction, not
+        // a genuine unmapped leftover -- so it must not trip the run-all fallback.
+        var r = Select(["docs/architecture/notes.md"], renameOldPaths: ["docs/architecture/notes.md"]);
+
+        Assert.False(r.SelectsAll);
+        Assert.DoesNotContain("docs/architecture/notes.md", r.UnmatchedFiles);
+    }
+
+    [Fact]
+    public void RenameOldPathStillMatchesOwnRuleAdditively()
+    {
+        // The rename-old-path exemption only suppresses the run-all ESCALATION for an otherwise
+        // unmatched file; it must not suppress ordinary rule matching. src/CuratedThing/** still maps
+        // to job:cjob regardless of whether this path is also flagged as a rename's old side, proving
+        // the exemption is additive-safe rather than a blanket "ignore rename old paths" shortcut.
+        var r = Select(["src/CuratedThing/Old.cs"], renameOldPaths: ["src/CuratedThing/Old.cs"]);
+
+        Assert.False(r.SelectsAll);
+        Assert.Contains("job:cjob", r.Jobs);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -125,8 +125,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
             (projectDirs ?? []).ToHashSet(StringComparer.Ordinal));
     }
 
-    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null, IReadOnlyDictionary<string, string>? renames = null)
-        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions(), renames: renames);
+    private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null)
+        => Selector(projectDirs).Select(files, layer1 ?? [], new SelectorOptions());
 
     public void Dispose()
     {
@@ -333,84 +333,45 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     }
 
     [Fact]
-    public void RenameOldPathUnmatchedDoesNotForceRunAll()
+    public void RenameOldPathUnmatchedForcesRunAllLikeAnyOtherLeftover()
     {
-        // Same shape as LeftoverUnmatchedFileForcesRunAll, but the caller marks the file as the OLD
-        // side of a git-detected rename whose new side is present in changedFiles and itself matches a
-        // rule (see Program.ResolveChangedFiles / TestSelector.Select). This is the fix for PR #19486's
-        // aspire-skills-bundle(s).common.ps1 rename: when the map is updated in the same commit to
-        // reference only the new name, the old name is stale by construction, not a genuine unmapped
-        // leftover -- so it must not trip the run-all fallback, and the new path's own match is unioned
-        // in additively.
-        var r = Select(
-            ["docs/architecture/notes.md", "src/CuratedThing/Renamed.cs"],
-            renames: new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["docs/architecture/notes.md"] = "src/CuratedThing/Renamed.cs",
-            });
+        // Renames are not special-cased: a rename's old and new paths are both plain changed files
+        // (see Program.ResolveChangedFiles / TestSelector.Select), and an old path matched by nothing
+        // forces the same run-all fallback as any other unmapped leftover -- exactly like
+        // LeftoverUnmatchedFileForcesRunAll above. This used to be exempted for an in-place rename
+        // whose map entry moved to the new name in the same commit (the PR #19486 motivating case), but
+        // that exemption was removed after an audit found it could silently under-select tests when the
+        // rename crossed directories into a shared-glob-consumed location, or landed on a destination
+        // the prefilter had already dropped before anything evaluated it (see
+        // docs/ci/test-trigger-map.md). The new path's own match, if any, is still unioned in
+        // additively; it just no longer suppresses the fallback for an unmatched old path.
+        var r = Select(["docs/architecture/notes.md", "src/CuratedThing/Renamed.cs"]);
 
-        Assert.False(r.SelectsAll);
-        Assert.DoesNotContain("docs/architecture/notes.md", r.UnmatchedFiles);
+        Assert.True(r.SelectsAll);
+        Assert.Contains("docs/architecture/notes.md", r.UnmatchedFiles);
         Assert.Contains("job:cjob", r.Jobs);
     }
 
     [Fact]
-    public void RenameOldPathWithDestinationDroppedByPrefilterStillForcesRunAll()
+    public void RenameWithBothUnmatchedPathsListsBothInUnmatchedFiles()
     {
-        // Regression test for PR #19790 review feedback: the exemption above must require the rename's
-        // destination to be present in changedFiles, not just trust old-path membership in `renames`.
-        // Here the destination ("docs/architecture/prefiltered-away.md") is deliberately absent from
-        // `files` -- simulating Program.cs's prefilter dropping it (e.g. a rename INTO a path matched by
-        // eng/github-ci/ci-skip-entirely-patterns.txt) before it ever reaches Select. Nothing downstream
-        // ever evaluated whether that destination's content needs CI, so the old path must still be
-        // treated as a genuine unmapped leftover and force ALL -- exempting it here would silently
-        // under-select relative to what the new path's content actually needs.
-        var r = Select(
-            ["docs/architecture/notes.md"],
-            renames: new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["docs/architecture/notes.md"] = "docs/architecture/prefiltered-away.md",
-            });
+        // Both the old and new sides of a rename are evaluated identically to any other changed file:
+        // if neither matches a rule, both are reported as unmatched leftovers (not just the new side),
+        // and the run-all fallback fires once for the pair.
+        var r = Select(["docs/architecture/notes.md", "docs/architecture/still-unmatched.md"]);
 
         Assert.True(r.SelectsAll);
         Assert.Contains("docs/architecture/notes.md", r.UnmatchedFiles);
-    }
-
-    [Fact]
-    public void RenameOldPathWithStillUnmatchedDestinationForcesRunAllViaDestination()
-    {
-        // The destination IS present in changedFiles (satisfying the "destination accounted for"
-        // guard) but itself matches no rule -- so it becomes its own unmatched leftover and forces ALL,
-        // exactly like any other unmapped file would. The old-path exemption only ever suppresses the
-        // OLD side, never the new side, so an unmatched destination "self-corrects" the selection
-        // without needing any extra logic beyond the changedFiles membership check.
-        var r = Select(
-            ["docs/architecture/notes.md", "docs/architecture/still-unmatched.md"],
-            renames: new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["docs/architecture/notes.md"] = "docs/architecture/still-unmatched.md",
-            });
-
-        Assert.True(r.SelectsAll);
-        Assert.DoesNotContain("docs/architecture/notes.md", r.UnmatchedFiles);
         Assert.Contains("docs/architecture/still-unmatched.md", r.UnmatchedFiles);
     }
 
     [Fact]
-    public void RenameOldPathStillMatchesOwnRuleAdditively()
+    public void RenameWhereBothPathsMatchTheirOwnRuleAddsTargetAdditively()
     {
-        // The rename-old-path exemption only suppresses the run-all ESCALATION for an otherwise
-        // unmatched file; it must not suppress ordinary rule matching. src/CuratedThing/** still maps
-        // to job:cjob regardless of whether this path is also flagged as a rename's old side, proving
-        // the exemption is additive-safe rather than a blanket "ignore rename old paths" shortcut. The
-        // exemption logic is never even reached here (the old path matches its own rule first), so the
-        // paired new path below is a placeholder.
-        var r = Select(
-            ["src/CuratedThing/Old.cs", "src/CuratedThing/New.cs"],
-            renames: new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["src/CuratedThing/Old.cs"] = "src/CuratedThing/New.cs",
-            });
+        // A rename's old and new paths are ordinary changed files -- if both independently match a
+        // rule (here, both live under src/CuratedThing/**), both contribute to the same target set;
+        // nothing about the rename relationship suppresses or duplicates that matching.
+        var r = Select(["src/CuratedThing/Old.cs", "src/CuratedThing/New.cs"]);
 
         Assert.False(r.SelectsAll);
         Assert.Contains("job:cjob", r.Jobs);

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -963,13 +963,13 @@ public sealed class SelectTestsCliTests
     }
 
     // P1-6c. A rename must attribute BOTH sides so a file moved OUT of a mapped directory still runs
-    // that directory's tests. git's default rename detection reports only the destination, hiding the
-    // old path; the selector passes --no-renames so the diff decomposes into delete(old)+add(new).
-    // other.txt (-> Aspire.Cli.Tests) is renamed to renamed.txt, which the map ignores so the new side
-    // adds nothing and does not trip the run-all fallback -- isolating the assertion to the old side:
-    // the deletion of other.txt must still select Aspire.Cli.Tests. Failure mode: dropping --no-renames
-    // makes git hide other.txt, so only the ignored renamed.txt is seen, the rule never fires, and the
-    // move silently skips its tests.
+    // that directory's tests. The selector diffs with `-M` (git rename detection on), which reports a
+    // rename as one "R###\told\tnew" record carrying both paths; the selector globs each side against
+    // every rule rather than only the new path. other.txt (-> Aspire.Cli.Tests) is renamed to
+    // renamed.txt, which the map ignores so the new side adds nothing and does not trip the run-all
+    // fallback -- isolating the assertion to the old side: the move of other.txt must still select
+    // Aspire.Cli.Tests. Failure mode: matching only the rename's new path would see just the ignored
+    // renamed.txt, the rule would never fire, and the move would silently skip its tests.
     [Fact]
     public void RenameOutOfMappedPathStillSelectsItsTests()
     {
@@ -1114,6 +1114,11 @@ public sealed class SelectTestsCliTests
     // this fix must avoid. So a content-heavy rewrite-plus-rename like this one is correctly NOT
     // exempted, and still forces ALL when the map's own rule/ignore entry for the old path moves to
     // the new name in the same commit -- this is expected, documented behavior, not a bug.
+    // Note: because old.txt never enters renameOldPathSet here, this test's assertion would hold even
+    // if the whole rename exemption were reverted -- it specifically pins that git's own threshold is
+    // respected (the exemption doesn't overreach to below-threshold changes), not that the exemption
+    // exists at all. RenameOldPathUnmatchedDoesNotForceRunAll and
+    // InPlaceRenameWithoutOwnMapEntryDoesNotForceRunAll are the tests that fail on that reversion.
     [Fact]
     public void RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll()
     {
@@ -1178,14 +1183,15 @@ public sealed class SelectTestsCliTests
     }
 
     // Regression: a changed file whose repo-relative path contains non-ASCII bytes must still be
-    // attributed. git's default core.quotePath=true octal-escapes and double-quotes such paths
+    // attributed. git's default (text, non-"-z") output octal-escapes and double-quotes such paths
     // (e.g. "eng/\343\203\206.../trigger.cs"), which does not glob-equal the real path, so the rule
-    // never fires. The selector passes -c core.quotePath=false so git emits the literal UTF-8 path and
-    // the rule matches, putting Aspire.Hosting.Tests in the enforce props (asserted below). If the flag
-    // regressed, the mangled path would match no rule and fall to the run-all fallback, which writes NO
-    // restriction props -- so the assertion below would fail (props missing/empty) and catch it. A CJK
-    // dir name is used deliberately (no NFC/NFD decomposition) so the test is stable on case/normalizing
-    // filesystems while still exercising the non-ASCII path.
+    // never fires. The selector diffs with `-z` (NUL-terminated fields) instead, which git never quotes
+    // or escapes regardless of the path's contents, so the rule matches and Aspire.Hosting.Tests ends up
+    // in the enforce props (asserted below). If that regressed back to the default text format, the
+    // mangled path would match no rule and fall to the run-all fallback, which writes NO restriction
+    // props -- so the assertion below would fail (props missing/empty) and catch it. A CJK dir name is
+    // used deliberately (no NFC/NFD decomposition) so the test is stable on case/normalizing filesystems
+    // while still exercising the non-ASCII path.
     [Fact]
     public void NonAsciiChangedPathUnderAMappedDirStillSelectsItsTests()
     {
@@ -1206,6 +1212,48 @@ public sealed class SelectTestsCliTests
 
             WriteFile(repoRoot, "eng/テスト/trigger.cs", "// changed");
             GitCommitAll(repoRoot, "add a non-ASCII path under a mapped directory");
+            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
+            Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
+
+            Assert.Contains("Aspire.Hosting.Tests", File.ReadAllText(propsPath));
+        });
+    }
+
+    // Regression: a same-commit rename whose path contains a literal tab byte must still be attributed
+    // via the rename exemption, not garbled by git's quoting. git's default (non-"-z") --name-status
+    // output C-style-escapes any path containing a tab, newline, double-quote, or backslash -- e.g. a
+    // literal tab in "old<TAB>name.txt" becomes the ASCII characters "old\tname.txt" (backslash + 't',
+    // not a real tab byte) inside surrounding double quotes. `-c core.quotePath=false` does NOT
+    // suppress this (it only stops the *non-ASCII-byte* octal-escaping, per
+    // NonAsciiChangedPathUnderAMappedDirStillSelectsItsTests above) -- only `-z` (NUL-terminated
+    // fields), which the selector now uses, makes git skip quoting entirely regardless of the path's
+    // bytes. This renames a tab-containing file whose OLD path has no map rule, moving its rule to the
+    // NEW path in the same commit -- the same shape as PR #19486 -- so a quoting regression would fail
+    // to glob-match the (mangled) new path's rule and force the run-all fallback instead of selecting
+    // Aspire.Hosting.Tests.
+    [Fact]
+    public void RenamedFileWithTabInPathIsAttributedCorrectlyNotGarbledByQuoting()
+    {
+        const string tab = "\t";
+        var map = $"""
+            version: 1
+            path_rules:
+              - paths: ["eng/new{tab}name.txt"]
+                targets: ["test:Aspire.Hosting.Tests"]
+            """;
+
+        WithGitRepo((repoRoot, output) =>
+        {
+            WriteFile(repoRoot, "Aspire.slnx", Slnx);
+            WriteFile(repoRoot, "map.yml", map);
+            WriteFile(repoRoot, $"eng/old{tab}name.txt", "v0");
+            GitCommitAll(repoRoot, "base");
+            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            RunGit(repoRoot, "mv", $"eng/old{tab}name.txt", $"eng/new{tab}name.txt");
+            GitCommitAll(repoRoot, "rename tab-containing file; map already targets the new name");
             var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
 
             var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -963,13 +963,13 @@ public sealed class SelectTestsCliTests
     }
 
     // P1-6c. A rename must attribute BOTH sides so a file moved OUT of a mapped directory still runs
-    // that directory's tests. The selector diffs with `-M` (git rename detection on), which reports a
-    // rename as one "R###\told\tnew" record carrying both paths; the selector globs each side against
-    // every rule rather than only the new path. other.txt (-> Aspire.Cli.Tests) is renamed to
-    // renamed.txt, which the map ignores so the new side adds nothing and does not trip the run-all
-    // fallback -- isolating the assertion to the old side: the move of other.txt must still select
-    // Aspire.Cli.Tests. Failure mode: matching only the rename's new path would see just the ignored
-    // renamed.txt, the rule would never fire, and the move would silently skip its tests.
+    // that directory's tests. The selector diffs with `-M -z` (git rename detection on, NUL-delimited),
+    // which reports a rename as one "R###\0old\0new\0" record carrying both paths; the selector globs
+    // each side against every rule rather than only the new path. other.txt (-> Aspire.Cli.Tests) is
+    // renamed to renamed.txt, which the map ignores so the new side adds nothing and does not trip the
+    // run-all fallback -- isolating the assertion to the old side: the move of other.txt must still
+    // select Aspire.Cli.Tests. Failure mode: matching only the rename's new path would see just the
+    // ignored renamed.txt, the rule would never fire, and the move would silently skip its tests.
     [Fact]
     public void RenameOutOfMappedPathStillSelectsItsTests()
     {
@@ -1263,6 +1263,20 @@ public sealed class SelectTestsCliTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => Selection.ParseNameStatusOutput(truncated));
         Assert.Contains("produced a truncated record", ex.Message, StringComparison.Ordinal);
+    }
+
+    // Regression: `Split('\0', ...)` doesn't require the string to end with the delimiter, so a stream
+    // truncated mid-path (the final field's terminating NUL never arrived -- e.g. a killed process or a
+    // partial pipe read) would otherwise parse as a shorter-but-plausible-looking path instead of failing
+    // loudly like the mid-record truncation cases above. "M\0src/Foo.cs" (missing the trailing NUL) looks
+    // exactly like a well-formed one-token record to a naive split and must still throw.
+    [Fact]
+    public void ParseNameStatusOutputThrowsOnMissingFinalTerminator()
+    {
+        var truncated = "M\0src/Foo.cs";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Selection.ParseNameStatusOutput(truncated));
+        Assert.Contains("truncated stream", ex.Message, StringComparison.Ordinal);
     }
 
     // P1-7. --changed-files trims surrounding whitespace and drops blank lines before glob matching.

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -1008,8 +1008,10 @@ public sealed class SelectTestsCliTests
     // -- not because nobody mapped it, but because the mapping moved with the file. Before the fix
     // this was indistinguishable from a genuine unmapped leftover and forced the run-all fallback
     // even though new.txt's own rule already selects the right tests. map.yml's own change is ignored
-    // here so the assertion isolates the rename, matching how the real map ignores changes to itself
-    // (see eng/github-ci/test-trigger-map.yml's own ignore entry for the analogous self-reference).
+    // here purely to isolate the rename under test from an unrelated map.yml-changed assertion -- this
+    // is a synthetic-map simplification, NOT a mirror of production: the real
+    // eng/github-ci/test-trigger-map.yml has no self-ignore entry and instead routes changes to itself
+    // to test:Infrastructure.Tests (see its own path_rules, "SelectTests acceptance/behavior tests...").
     // Failure mode (before the fix): selectsAll is true and BeforeBuildProps.props is not written (a
     // wide-open, non-narrowing enforce) despite new.txt's rule having everything needed.
     [Fact]
@@ -1055,6 +1057,55 @@ public sealed class SelectTestsCliTests
                 using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
                 Assert.False(doc.RootElement.GetProperty("selectsAll").GetBoolean());
                 Assert.Contains("Aspire.Cli.Tests", File.ReadAllText(propsPath));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", previous);
+            }
+        });
+    }
+
+    // Regression test for PR #19790 review feedback: the rename-old-path exemption above must not fire
+    // when the rename's destination never reaches TestSelector.Select because ChangedFileFilter's
+    // prefilter dropped it before both layers run (e.g. a rename INTO a doc-only path matched by
+    // eng/github-ci/ci-skip-entirely-patterns.txt in production; skip-patterns.txt here). Nothing ever
+    // evaluates whether new.md's content needs CI, so old.txt -- itself unmapped -- must still be
+    // treated as a genuine unmapped leftover and force ALL. Failure mode (the bug this guards against):
+    // exempting old.txt anyway and silently selecting nothing for a change whose destination was never
+    // accounted for by anything.
+    [Fact]
+    public void InPlaceRenameToPrefilteredDestinationStillForcesRunAll()
+    {
+        WithGitRepo((repoRoot, output) =>
+        {
+            WriteFile(repoRoot, "Aspire.slnx", Slnx);
+            WriteFile(repoRoot, "map.yml", """
+                version: 1
+                prefilter:
+                  patterns_file: skip-patterns.txt
+                path_rules:
+                  - paths: [other.txt]
+                    targets: ["test:Aspire.Cli.Tests"]
+                """);
+            WriteFile(repoRoot, "skip-patterns.txt", "**.md\n");
+            WriteFile(repoRoot, "old.txt", "v0");
+            GitCommitAll(repoRoot, "base");
+            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            RunGit(repoRoot, "mv", "old.txt", "new.md");
+            GitCommitAll(repoRoot, "rename old.txt to a doc-only path the prefilter drops");
+            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            var jsonPath = Path.Combine(repoRoot, "selection.json");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_JSON_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", jsonPath);
+            try
+            {
+                var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
+                Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
+
+                using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+                Assert.True(doc.RootElement.GetProperty("selectsAll").GetBoolean());
             }
             finally
             {

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -1005,17 +1005,20 @@ public sealed class SelectTestsCliTests
     // aspire-skills-bundles.common.ps1, singular -> plural): an IN-PLACE rename where map.yml is
     // updated, in the SAME commit, to reference only the new filename. Layer 2 reads map.yml from
     // the checked-out worktree at HEAD, so by the time it runs, old.txt matches no path_rule at all
-    // -- not because nobody mapped it, but because the mapping moved with the file. Before the fix
-    // this was indistinguishable from a genuine unmapped leftover and forced the run-all fallback
-    // even though new.txt's own rule already selects the right tests. map.yml's own change is ignored
-    // here purely to isolate the rename under test from an unrelated map.yml-changed assertion -- this
-    // is a synthetic-map simplification, NOT a mirror of production: the real
-    // eng/github-ci/test-trigger-map.yml has no self-ignore entry and instead routes changes to itself
-    // to test:Infrastructure.Tests (see its own path_rules, "SelectTests acceptance/behavior tests...").
-    // Failure mode (before the fix): selectsAll is true and BeforeBuildProps.props is not written (a
-    // wide-open, non-narrowing enforce) despite new.txt's rule having everything needed.
+    // -- not because nobody mapped it, but because the mapping moved with the file. This is the
+    // exact shape PR #19486 hit, and it forces the run-all fallback: an unmatched rename old path is
+    // not special-cased. An earlier version of this fix exempted it (trusting that new.txt's own
+    // rule already accounts for the moved content), but that exemption was removed after an audit
+    // found it could silently under-select tests for cross-directory moves out of a shared-glob
+    // directory, and for renames into a destination the prefilter drops before anything evaluates it
+    // (see docs/ci/test-trigger-map.md). Over-selecting ALL for this same-commit-rename case is the
+    // accepted, safe tradeoff. map.yml's own change is ignored here purely to isolate the rename
+    // under test from an unrelated map.yml-changed assertion -- this is a synthetic-map
+    // simplification, NOT a mirror of production: the real eng/github-ci/test-trigger-map.yml has no
+    // self-ignore entry and instead routes changes to itself to test:Infrastructure.Tests (see its
+    // own path_rules, "SelectTests acceptance/behavior tests...").
     [Fact]
-    public void InPlaceRenameWithoutOwnMapEntryDoesNotForceRunAll()
+    public void InPlaceRenameWithoutOwnMapEntryForcesRunAll()
     {
         WithGitRepo((repoRoot, output) =>
         {
@@ -1055,8 +1058,7 @@ public sealed class SelectTestsCliTests
                 Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
 
                 using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
-                Assert.False(doc.RootElement.GetProperty("selectsAll").GetBoolean());
-                Assert.Contains("Aspire.Cli.Tests", File.ReadAllText(propsPath));
+                Assert.True(doc.RootElement.GetProperty("selectsAll").GetBoolean());
             }
             finally
             {
@@ -1065,16 +1067,15 @@ public sealed class SelectTestsCliTests
         });
     }
 
-    // Regression test for PR #19790 review feedback: the rename-old-path exemption above must not fire
-    // when the rename's destination never reaches TestSelector.Select because ChangedFileFilter's
-    // prefilter dropped it before both layers run (e.g. a rename INTO a doc-only path matched by
-    // eng/github-ci/ci-skip-entirely-patterns.txt in production; skip-patterns.txt here). Nothing ever
-    // evaluates whether new.md's content needs CI, so old.txt -- itself unmapped -- must still be
-    // treated as a genuine unmapped leftover and force ALL. Failure mode (the bug this guards against):
-    // exempting old.txt anyway and silently selecting nothing for a change whose destination was never
-    // accounted for by anything.
+    // Regression mapped to the audit's FN-02 finding (rename into an ignored/prefiltered destination):
+    // ChangedFileFilter's prefilter drops new.md before it ever reaches TestSelector.Select (e.g. a
+    // rename INTO a doc-only path matched by eng/github-ci/ci-skip-entirely-patterns.txt in
+    // production; skip-patterns.txt here), so nothing ever evaluates whether its content needs CI.
+    // old.txt is itself unmapped, so it still forces ALL through the same run-all fallback as any
+    // other unmatched leftover -- there is no rename-aware logic that could be fooled by the dropped
+    // destination into selecting nothing.
     [Fact]
-    public void InPlaceRenameToPrefilteredDestinationStillForcesRunAll()
+    public void InPlaceRenameToPrefilteredDestinationForcesRunAll()
     {
         WithGitRepo((repoRoot, output) =>
         {
@@ -1114,13 +1115,11 @@ public sealed class SelectTestsCliTests
         });
     }
 
-    // Regression: the rename-old-path exemption from the run-all fallback must NOT suppress ordinary
-    // matching. If the fix made TestSelector skip a rename's old path entirely -- rather than only
-    // exempting it from forcing ALL when it would otherwise be unmatched -- a rule that still
-    // legitimately targets the old name would silently stop firing across a rename. Here BOTH old.txt
-    // and new.txt keep their own, unrelated path_rule targets across the rename (the map itself is
-    // untouched by the commit that does the rename), so both must still be selected -- proving the
-    // exemption is additive-safe, not a blanket "ignore rename old paths" shortcut.
+    // Regression: renaming a file does not disturb ordinary rule matching for either side. Both
+    // old.txt and new.txt keep their own, unrelated path_rule targets across the rename (the map
+    // itself is untouched by the commit that does the rename), so both must still be selected --
+    // each path is glob-matched exactly like any other changed file, independent of the rename
+    // relationship between them.
     [Fact]
     public void RenameWhoseOldPathIncidentallyMatchesAnUnrelatedRuleStillAddsBothTargets()
     {
@@ -1151,85 +1150,6 @@ public sealed class SelectTestsCliTests
             var props = File.ReadAllText(propsPath);
             Assert.Contains("Aspire.Hosting.Tests", props);
             Assert.Contains("Aspire.Cli.Tests", props);
-        });
-    }
-
-    // Regression/boundary test for a residual gap uncovered while empirically validating this fix
-    // against the real PR #19486 diff: one of that PR's three renamed scripts
-    // (verify-aspire-skills-bundle.ps1) was rewritten heavily enough in the same commit (~30% content
-    // similarity) that git's DEFAULT -M50% rename-similarity threshold reports it as a plain
-    // delete+add, not a rename (confirmed with `git diff -M10%`, which *does* detect it at R030).
-    // Program.cs's rename detection deliberately uses git's default threshold rather than lowering it:
-    // lowering it would risk pairing unrelated delete+add files as a false rename, which would exempt
-    // a genuinely unmatched deletion from the run-all fallback -- exactly the under-selection risk
-    // this fix must avoid. So a content-heavy rewrite-plus-rename like this one is correctly NOT
-    // exempted, and still forces ALL when the map's own rule/ignore entry for the old path moves to
-    // the new name in the same commit -- this is expected, documented behavior, not a bug.
-    // Note: because old.txt never enters renameOldPathSet here, this test's assertion would hold even
-    // if the whole rename exemption were reverted -- it specifically pins that git's own threshold is
-    // respected (the exemption doesn't overreach to below-threshold changes), not that the exemption
-    // exists at all. RenameOldPathUnmatchedDoesNotForceRunAll and
-    // InPlaceRenameWithoutOwnMapEntryDoesNotForceRunAll are the tests that fail on that reversion.
-    [Fact]
-    public void RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll()
-    {
-        var oldContent = string.Join('\n', Enumerable.Range(0, 20)
-            .Select(i => $"old line {i} of filler content for similarity padding")) + '\n';
-        // Keep only 2 of the 20 original lines; replace the rest with unrelated text so the line-level
-        // similarity between old and new content stays well under git's default 50% threshold.
-        var newContent = string.Join('\n',
-            new[]
-            {
-                "old line 0 of filler content for similarity padding",
-                "old line 1 of filler content for similarity padding",
-            }.Concat(Enumerable.Range(0, 18).Select(i => $"brand new unrelated line {i} with totally different text"))) + '\n';
-
-        WithGitRepo((repoRoot, output) =>
-        {
-            WriteFile(repoRoot, "Aspire.slnx", Slnx);
-            WriteFile(repoRoot, "map.yml", """
-                version: 1
-                ignore:
-                  - old.txt
-                """);
-            WriteFile(repoRoot, "old.txt", oldContent);
-            GitCommitAll(repoRoot, "base");
-            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
-
-            RunGit(repoRoot, "mv", "old.txt", "new.txt");
-            WriteFile(repoRoot, "new.txt", newContent);
-            // The map's ignore entry moves to the new name in the SAME commit -- exactly what PR
-            // #19486 did for its ignore-listed scripts alongside the rename.
-            WriteFile(repoRoot, "map.yml", """
-                version: 1
-                ignore:
-                  - new.txt
-                """);
-            GitCommitAll(repoRoot, "rewrite old.txt heavily while renaming it, and move its ignore entry with it");
-            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
-
-            // Confirm the setup actually reproduces "git does not detect this as a rename" at git's
-            // default similarity threshold, so the assertion below exercises the intended boundary
-            // rather than accidentally exempting a real rename.
-            var nameStatus = RunGit(repoRoot, "diff", "--name-status", "-M", baseSha, headSha);
-            Assert.Contains("D\told.txt", nameStatus);
-            Assert.Contains("A\tnew.txt", nameStatus);
-
-            var jsonPath = Path.Combine(repoRoot, "selection.json");
-            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_JSON_FILE");
-            Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", jsonPath);
-            try
-            {
-                var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
-                Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
-
-                using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
-                Assert.True(doc.RootElement.GetProperty("selectsAll").GetBoolean());
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", previous);
-            }
         });
     }
 
@@ -1273,17 +1193,16 @@ public sealed class SelectTestsCliTests
     }
 
     // Regression: a same-commit rename whose path contains a literal tab byte must still be attributed
-    // via the rename exemption, not garbled by git's quoting. git's default (non-"-z") --name-status
-    // output C-style-escapes any path containing a tab, newline, double-quote, or backslash -- e.g. a
-    // literal tab in "old<TAB>name.txt" becomes the ASCII characters "old\tname.txt" (backslash + 't',
-    // not a real tab byte) inside surrounding double quotes. `-c core.quotePath=false` does NOT
-    // suppress this (it only stops the *non-ASCII-byte* octal-escaping, per
+    // correctly, not garbled by git's quoting. git's default (non-"-z") --name-status output
+    // C-style-escapes any path containing a tab, newline, double-quote, or backslash -- e.g. a literal
+    // tab in "old<TAB>name.txt" becomes the ASCII characters "old\tname.txt" (backslash + 't', not a
+    // real tab byte) inside surrounding double quotes. `-c core.quotePath=false` does NOT suppress this
+    // (it only stops the *non-ASCII-byte* octal-escaping, per
     // NonAsciiChangedPathUnderAMappedDirStillSelectsItsTests above) -- only `-z` (NUL-terminated
     // fields), which the selector now uses, makes git skip quoting entirely regardless of the path's
-    // bytes. This renames a tab-containing file whose OLD path has no map rule, moving its rule to the
-    // NEW path in the same commit -- the same shape as PR #19486 -- so a quoting regression would fail
-    // to glob-match the (mangled) new path's rule and force the run-all fallback instead of selecting
-    // Aspire.Hosting.Tests.
+    // bytes. Both the OLD and NEW tab-containing paths keep their own path_rule across the rename, so a
+    // quoting regression on either side would fail to glob-match its (mangled) rule and drop that
+    // side's target.
     [Fact]
     public void RenamedFileWithTabInPathIsAttributedCorrectlyNotGarbledByQuoting()
     {
@@ -1291,6 +1210,8 @@ public sealed class SelectTestsCliTests
         var map = $"""
             version: 1
             path_rules:
+              - paths: ["eng/old{tab}name.txt"]
+                targets: ["test:Aspire.Cli.Tests"]
               - paths: ["eng/new{tab}name.txt"]
                 targets: ["test:Aspire.Hosting.Tests"]
             """;
@@ -1304,14 +1225,44 @@ public sealed class SelectTestsCliTests
             var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
 
             RunGit(repoRoot, "mv", $"eng/old{tab}name.txt", $"eng/new{tab}name.txt");
-            GitCommitAll(repoRoot, "rename tab-containing file; map already targets the new name");
+            GitCommitAll(repoRoot, "rename tab-containing file; map keeps both rules unchanged");
             var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
 
             var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
             Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
 
-            Assert.Contains("Aspire.Hosting.Tests", File.ReadAllText(propsPath));
+            var props = File.ReadAllText(propsPath);
+            Assert.Contains("Aspire.Cli.Tests", props);
+            Assert.Contains("Aspire.Hosting.Tests", props);
         });
+    }
+
+    // Regression for a fail-safe check in Selection.ParseNameStatusOutput: a `git diff --name-status
+    // -M -z` invocation that exits 0 but whose NUL-delimited stream ends mid-record (a rename/copy
+    // status token with no old/new path pair following it) must throw rather than silently return a
+    // partial, truncated changed-file set. Returning a partial set here could drop a path that would
+    // have matched a rule, under-selecting tests -- the opposite of this tool's fail-safe design. A
+    // real, successful `git diff` never produces this shape, so it can only be exercised synthetically
+    // against the parser directly.
+    [Fact]
+    public void ParseNameStatusOutputThrowsOnTruncatedRenameRecord()
+    {
+        // "R100\0old.txt\0" -- a rename status followed by only the old path, missing the new path.
+        var truncated = "R100\0old.txt\0";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Selection.ParseNameStatusOutput(truncated));
+        Assert.Contains("truncated rename/copy record", ex.Message, StringComparison.Ordinal);
+    }
+
+    // Same fail-safe check for a plain (non-rename/copy) status token with no path following it at all.
+    [Fact]
+    public void ParseNameStatusOutputThrowsOnTruncatedPlainRecord()
+    {
+        // "M\0" -- a modify status with no path token following it.
+        var truncated = "M\0";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Selection.ParseNameStatusOutput(truncated));
+        Assert.Contains("produced a truncated record", ex.Message, StringComparison.Ordinal);
     }
 
     // P1-7. --changed-files trims surrounding whitespace and drops blank lines before glob matching.

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -1001,6 +1001,182 @@ public sealed class SelectTestsCliTests
         });
     }
 
+    // Regression for the root cause behind PR #19486 (aspire-skills-bundle.common.ps1 renamed to
+    // aspire-skills-bundles.common.ps1, singular -> plural): an IN-PLACE rename where map.yml is
+    // updated, in the SAME commit, to reference only the new filename. Layer 2 reads map.yml from
+    // the checked-out worktree at HEAD, so by the time it runs, old.txt matches no path_rule at all
+    // -- not because nobody mapped it, but because the mapping moved with the file. Before the fix
+    // this was indistinguishable from a genuine unmapped leftover and forced the run-all fallback
+    // even though new.txt's own rule already selects the right tests. map.yml's own change is ignored
+    // here so the assertion isolates the rename, matching how the real map ignores changes to itself
+    // (see eng/github-ci/test-trigger-map.yml's own ignore entry for the analogous self-reference).
+    // Failure mode (before the fix): selectsAll is true and BeforeBuildProps.props is not written (a
+    // wide-open, non-narrowing enforce) despite new.txt's rule having everything needed.
+    [Fact]
+    public void InPlaceRenameWithoutOwnMapEntryDoesNotForceRunAll()
+    {
+        WithGitRepo((repoRoot, output) =>
+        {
+            WriteFile(repoRoot, "Aspire.slnx", Slnx);
+            WriteFile(repoRoot, "map.yml", """
+                version: 1
+                path_rules:
+                  - paths: [old.txt]
+                    targets: ["test:Aspire.Cli.Tests"]
+                ignore:
+                  - map.yml
+                """);
+            WriteFile(repoRoot, "old.txt", "v0");
+            GitCommitAll(repoRoot, "base");
+            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            RunGit(repoRoot, "mv", "old.txt", "new.txt");
+            // The map moves to the new name in the SAME commit as the rename -- exactly what PR
+            // #19486 did to eng/github-ci/test-trigger-map.yml alongside the script rename.
+            WriteFile(repoRoot, "map.yml", """
+                version: 1
+                path_rules:
+                  - paths: [new.txt]
+                    targets: ["test:Aspire.Cli.Tests"]
+                ignore:
+                  - map.yml
+                """);
+            GitCommitAll(repoRoot, "rename old.txt in place and move its map entry with it");
+            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            var jsonPath = Path.Combine(repoRoot, "selection.json");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_JSON_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", jsonPath);
+            try
+            {
+                var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
+                Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
+
+                using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+                Assert.False(doc.RootElement.GetProperty("selectsAll").GetBoolean());
+                Assert.Contains("Aspire.Cli.Tests", File.ReadAllText(propsPath));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", previous);
+            }
+        });
+    }
+
+    // Regression: the rename-old-path exemption from the run-all fallback must NOT suppress ordinary
+    // matching. If the fix made TestSelector skip a rename's old path entirely -- rather than only
+    // exempting it from forcing ALL when it would otherwise be unmatched -- a rule that still
+    // legitimately targets the old name would silently stop firing across a rename. Here BOTH old.txt
+    // and new.txt keep their own, unrelated path_rule targets across the rename (the map itself is
+    // untouched by the commit that does the rename), so both must still be selected -- proving the
+    // exemption is additive-safe, not a blanket "ignore rename old paths" shortcut.
+    [Fact]
+    public void RenameWhoseOldPathIncidentallyMatchesAnUnrelatedRuleStillAddsBothTargets()
+    {
+        const string map = """
+            version: 1
+            path_rules:
+              - paths: [old.txt]
+                targets: ["test:Aspire.Hosting.Tests"]
+              - paths: [new.txt]
+                targets: ["test:Aspire.Cli.Tests"]
+            """;
+
+        WithGitRepo((repoRoot, output) =>
+        {
+            WriteFile(repoRoot, "Aspire.slnx", Slnx);
+            WriteFile(repoRoot, "map.yml", map);
+            WriteFile(repoRoot, "old.txt", "v0");
+            GitCommitAll(repoRoot, "base");
+            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            RunGit(repoRoot, "mv", "old.txt", "new.txt");
+            GitCommitAll(repoRoot, "rename old.txt to new.txt; map keeps both rules unchanged");
+            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
+            Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
+
+            var props = File.ReadAllText(propsPath);
+            Assert.Contains("Aspire.Hosting.Tests", props);
+            Assert.Contains("Aspire.Cli.Tests", props);
+        });
+    }
+
+    // Regression/boundary test for a residual gap uncovered while empirically validating this fix
+    // against the real PR #19486 diff: one of that PR's three renamed scripts
+    // (verify-aspire-skills-bundle.ps1) was rewritten heavily enough in the same commit (~30% content
+    // similarity) that git's DEFAULT -M50% rename-similarity threshold reports it as a plain
+    // delete+add, not a rename (confirmed with `git diff -M10%`, which *does* detect it at R030).
+    // Program.cs's rename detection deliberately uses git's default threshold rather than lowering it:
+    // lowering it would risk pairing unrelated delete+add files as a false rename, which would exempt
+    // a genuinely unmatched deletion from the run-all fallback -- exactly the under-selection risk
+    // this fix must avoid. So a content-heavy rewrite-plus-rename like this one is correctly NOT
+    // exempted, and still forces ALL when the map's own rule/ignore entry for the old path moves to
+    // the new name in the same commit -- this is expected, documented behavior, not a bug.
+    [Fact]
+    public void RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll()
+    {
+        var oldContent = string.Join('\n', Enumerable.Range(0, 20)
+            .Select(i => $"old line {i} of filler content for similarity padding")) + '\n';
+        // Keep only 2 of the 20 original lines; replace the rest with unrelated text so the line-level
+        // similarity between old and new content stays well under git's default 50% threshold.
+        var newContent = string.Join('\n',
+            new[]
+            {
+                "old line 0 of filler content for similarity padding",
+                "old line 1 of filler content for similarity padding",
+            }.Concat(Enumerable.Range(0, 18).Select(i => $"brand new unrelated line {i} with totally different text"))) + '\n';
+
+        WithGitRepo((repoRoot, output) =>
+        {
+            WriteFile(repoRoot, "Aspire.slnx", Slnx);
+            WriteFile(repoRoot, "map.yml", """
+                version: 1
+                ignore:
+                  - old.txt
+                """);
+            WriteFile(repoRoot, "old.txt", oldContent);
+            GitCommitAll(repoRoot, "base");
+            var baseSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            RunGit(repoRoot, "mv", "old.txt", "new.txt");
+            WriteFile(repoRoot, "new.txt", newContent);
+            // The map's ignore entry moves to the new name in the SAME commit -- exactly what PR
+            // #19486 did for its ignore-listed scripts alongside the rename.
+            WriteFile(repoRoot, "map.yml", """
+                version: 1
+                ignore:
+                  - new.txt
+                """);
+            GitCommitAll(repoRoot, "rewrite old.txt heavily while renaming it, and move its ignore entry with it");
+            var headSha = RunGit(repoRoot, "rev-parse", "HEAD");
+
+            // Confirm the setup actually reproduces "git does not detect this as a rename" at git's
+            // default similarity threshold, so the assertion below exercises the intended boundary
+            // rather than accidentally exempting a real rename.
+            var nameStatus = RunGit(repoRoot, "diff", "--name-status", "-M", baseSha, headSha);
+            Assert.Contains("D\told.txt", nameStatus);
+            Assert.Contains("A\tnew.txt", nameStatus);
+
+            var jsonPath = Path.Combine(repoRoot, "selection.json");
+            var previous = Environment.GetEnvironmentVariable("SELECT_TESTS_JSON_FILE");
+            Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", jsonPath);
+            try
+            {
+                var propsPath = Path.Combine(repoRoot, "BeforeBuildProps.props");
+                Selection.Run(Options(repoRoot, propsPath, from: baseSha, to: headSha, skipLayer1: true, enforce: true));
+
+                using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+                Assert.True(doc.RootElement.GetProperty("selectsAll").GetBoolean());
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("SELECT_TESTS_JSON_FILE", previous);
+            }
+        });
+    }
+
     // Regression: a changed file whose repo-relative path contains non-ASCII bytes must still be
     // attributed. git's default core.quotePath=true octal-escapes and double-quotes such paths
     // (e.g. "eng/\343\203\206.../trigger.cs"), which does not glob-equal the real path, so the rule

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
@@ -113,6 +113,102 @@ public sealed class SelectTestsLayer1IntegrationTests
         });
     }
 
+    // Failure mode: Layer 1's git-diff parser used to be text-mode (splitting on raw tab/newline
+    // bytes) while Layer 2's (Program.cs's Selection.ParseNameStatusOutput) was already `-z`
+    // (NUL-delimited). A path containing a literal tab is returned by git's default text-mode
+    // name-status output as an escaped, double-quoted literal -- e.g. `"src/Core/da\tta.txt"`, ten
+    // literal characters, not one real tab byte -- even with `core.quotePath=false` (which only
+    // suppresses non-ASCII-byte escaping). That garbled string never matches the real "src/Core/"
+    // directory prefix.
+    //
+    // Both sides of the rename below are deliberately placed under a project directory Layer 1 already
+    // knows (Mid, then Core): a changed path outside every project directory would be "unmatched" and
+    // trip the selector's separate, intentional any-unmatched-file -> ALL safety net (from the
+    // rename-exemption removal), which forces ALL regardless of whether the -z bug is present --
+    // masking the exact bug this test targets instead of exercising it. With both sides
+    // Layer-1-attributable, the change never escalates to ALL either way; the only thing the bug can
+    // affect is WHICH projects the (still non-ALL) selection reaches. Core.Direct.Tests references Core
+    // directly (bypassing Mid), so it is reachable only when the NEW (tab-containing) path is correctly
+    // attributed to Core -- before the fix, the garbled new path silently drops Core from the directly-
+    // changed set and Core.Direct.Tests goes unselected: real under-selection, not a fail-safe ALL. Since
+    // Layer 1 now shares Layer 2's `-z` parser, the tab-containing path is attributed correctly and the
+    // selection reaches Core.Direct.Tests too.
+    [Fact]
+    public void RenameIntoTabContainingPathIsAttributedByLayer1InsteadOfUnderSelecting()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        using var fixture = new GraphRepoFixture(workspace, withIntermediateProject: true);
+
+        // A second test project referencing Core directly, so Core's and Mid's reverse-dependency
+        // closures diverge: Mid's closure is {Mid, Core.Tests} (Core.Tests -> Mid); Core's closure is
+        // {Core, Mid, Core.Tests, Core.Direct.Tests} (Mid -> Core, Core.Direct.Tests -> Core). Only a
+        // change correctly attributed to Core reaches Core.Direct.Tests.
+        fixture.WriteFile("tests/Core.Direct.Tests/Core.Direct.Tests.cs",
+            "namespace Core.Direct.Tests; public class T(ITestOutputHelper outputHelper) { }");
+        fixture.WriteFile("tests/Core.Direct.Tests/Core.Direct.Tests.csproj",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include="Core.Direct.Tests.cs" />
+                <ProjectReference Include="..\..\src\Core\Core.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        fixture.WriteFile("Aspire.slnx",
+            """
+            <Solution>
+              <Project Path="src/Core/Core.csproj" />
+              <Project Path="src/Mid/Mid.csproj" />
+              <Project Path="tests/Core.Tests/Core.Tests.csproj" />
+              <Project Path="tests/Core.Direct.Tests/Core.Direct.Tests.csproj" />
+            </Solution>
+            """);
+
+        // A loose file under Mid's directory -- attributed to Mid via directory containment regardless
+        // of the -z bug, so the OLD side of the rename below is never "unmatched."
+        fixture.WriteFile("src/Mid/random.txt", "payload");
+        fixture.InitGit();
+        fixture.CommitAll("base");
+        var baseSha = fixture.Git("rev-parse", "HEAD");
+
+        // Rename from Mid's directory into Core's directory, with a literal tab byte in the new file
+        // name. Both directories are Layer-1-owned, so neither side is ever unmatched -- isolating
+        // exactly the -z parsing bug's effect on which projects the closure reaches.
+        fixture.Git("mv", "src/Mid/random.txt", "src/Core/da\tta.txt");
+        fixture.CommitAll("rename into tab-containing path under Core");
+        var headSha = fixture.Git("rev-parse", "HEAD");
+
+        var propsPath = System.IO.Path.Combine(fixture.Path, "BeforeBuildProps.props");
+        fixture.WithGitHubEnvRedirected(output =>
+        {
+            var exit = Selection.Run(new RunOptions(
+                RepoRoot: fixture.Path,
+                MapPath: System.IO.Path.Combine(fixture.Path, "map.yml"),
+                SlnxPath: System.IO.Path.Combine(fixture.Path, "Aspire.slnx"),
+                From: baseSha,
+                To: headSha,
+                ChangedFilesPath: null,
+                SkipLayer1: false,
+                ForceAll: false,
+                Enforce: true,
+                BeforeBuildProps: propsPath));
+
+            Assert.Equal(0, exit);
+            // Mid (the rename's old side) is attributed regardless of the bug, so this never escalates
+            // to ALL -- the props file is always written. What the bug affects is its CONTENTS: before
+            // the fix, the garbled new path leaves Core unattributed, so Core.Direct.Tests (reachable
+            // only through Core) is silently missing even though the props file itself looks "healthy."
+            Assert.Equal(propsPath, output()["project_override_props"]);
+            var props = File.ReadAllText(propsPath);
+            Assert.Contains("tests/Core.Tests/Core.Tests.csproj", props);
+            Assert.Contains("tests/Core.Direct.Tests/Core.Direct.Tests.csproj", props);
+        });
+    }
+
     // Failure mode: the step summary reports THAT Core.Tests was selected but not HOW, so a reviewer
     // can't see the decision path. The Layer 1 cause must render the full chain -- seed file then the
     // reverse-dependency project chain -- so a change to src/Core/Core.cs shows as

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -462,7 +462,11 @@ public sealed class TestTriggerMapTests
             var tempMapPath = Path.Combine(tempDir.FullName, "test-trigger-map.yml");
             File.WriteAllText(tempMapPath, simulatedMapText);
 
-            var renameOldPaths = new HashSet<string>(StringComparer.Ordinal) { oldCommonPath, oldUpdatePath };
+            var renames = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [oldCommonPath] = newCommonPath,
+                [oldUpdatePath] = newUpdatePath,
+            };
             var changedFiles = new[] { oldCommonPath, newCommonPath, oldUpdatePath, newUpdatePath };
 
             // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
@@ -470,7 +474,7 @@ public sealed class TestTriggerMapTests
             var result = SelectWithRealMap(
                 changedFiles,
                 layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
-                renameOldPaths: renameOldPaths,
+                renames: renames,
                 mapPathOverride: tempMapPath);
 
             Assert.False(result.SelectsAll, $"unexpectedly selected ALL: {result.EscalationReason}");
@@ -745,7 +749,7 @@ public sealed class TestTriggerMapTests
     private static SelectionResult SelectWithRealMap(
         IReadOnlyCollection<string> paths,
         IReadOnlyCollection<string> layer1Affected,
-        IReadOnlySet<string>? renameOldPaths = null,
+        IReadOnlyDictionary<string, string>? renames = null,
         string? mapPathOverride = null)
     {
         var projectPaths = LoadSolutionProjectPaths();
@@ -760,7 +764,7 @@ public sealed class TestTriggerMapTests
         var mapPath = mapPathOverride ?? Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
         var selector = new TestSelector(mapPath, testProjects, projectDirectories);
 
-        return selector.Select(paths, layer1Affected, new SelectorOptions(), renameOldPaths: renameOldPaths);
+        return selector.Select(paths, layer1Affected, new SelectorOptions(), renames: renames);
     }
 
     private static string TextBetween(string text, string startMarker, string endMarker)

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -430,8 +430,11 @@ public sealed class TestTriggerMapTests
     // path is not git-rename-detected, so this fix's exemption does not (and, by design, should not)
     // apply to it -- see docs/ci/test-trigger-map.md for the rationale (lowering the similarity
     // threshold to catch it would risk pairing unrelated delete+add files as a false rename, hiding a
-    // genuine unmatched deletion). As a result, the full literal PR #19486 diff still selects ALL
-    // today, but for a narrower and more accurate reason than before the fix.
+    // genuine unmatched deletion). As a result, replaying the full, literal PR #19486 diff against
+    // today's fix still selects ALL -- for a narrower and more accurate reason than before the fix, but
+    // still ALL. That is expected, by-design, and covered by
+    // SameCommitRenameWithMapEntryMovedAndOneUndetectedPathStillForcesRunAll below, which replays all
+    // three renamed paths (not just the two this fix targets) against the same real map.
     //
     // This test uses a temp copy of the REAL map with just the two git-rename-detected paths'
     // entries updated to their new names (simulating "as if PR #19486's own map.yml edit, for these
@@ -494,6 +497,71 @@ public sealed class TestTriggerMapTests
                 "test:Infrastructure.Tests",
             ];
             Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
+    }
+
+    // Companion to SameCommitRenameWithMapEntryMovedToNewPathSelectsExactTargetsWithoutEscalating above:
+    // that test isolates the mechanism this fix targets using only the two paths PR #19486 renamed that
+    // git's default -M50% threshold actually detects as renames. This test instead replays PR #19486's
+    // full three-path change set -- including `verify-aspire-skills-bundle.ps1`, which git reports as a
+    // plain delete+add (see RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll in
+    // SelectTestsCliTests.cs for why) -- against the real production map, to make explicit and
+    // falsifiable that the LITERAL, complete PR #19486 diff still selects ALL today. That is expected:
+    // this PR fixes the in-place-rename-with-moved-map-entry mechanism, not git's own rename-similarity
+    // detection, and does not claim to change the fallback outcome for content-heavy rewrite+renames.
+    [Fact]
+    public void SameCommitRenameWithMapEntryMovedAndOneUndetectedPathStillForcesRunAll()
+    {
+        var realMapText = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
+        const string oldCommonPath = "eng/scripts/aspire-skills-bundle.common.ps1";
+        const string newCommonPath = "eng/scripts/aspire-skills-bundles.common.ps1";
+        const string oldUpdatePath = "eng/scripts/update-aspire-skills-bundle.ps1";
+        const string newUpdatePath = "eng/scripts/update-aspire-skills-bundles.ps1";
+        const string oldVerifyPath = "eng/scripts/verify-aspire-skills-bundle.ps1";
+        const string newVerifyPath = "eng/scripts/verify-aspire-skills-bundles.ps1";
+
+        Assert.Contains(oldCommonPath, realMapText);
+        Assert.Contains(oldUpdatePath, realMapText);
+        Assert.Contains(oldVerifyPath, realMapText);
+
+        var simulatedMapText = realMapText
+            .Replace(oldCommonPath, newCommonPath, StringComparison.Ordinal)
+            .Replace(oldUpdatePath, newUpdatePath, StringComparison.Ordinal)
+            .Replace(oldVerifyPath, newVerifyPath, StringComparison.Ordinal);
+
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var tempMapPath = Path.Combine(tempDir.FullName, "test-trigger-map.yml");
+            File.WriteAllText(tempMapPath, simulatedMapText);
+
+            // oldCommonPath/oldUpdatePath ARE git-rename-detected (see the golden test above); oldVerifyPath
+            // deliberately has NO entry here, modeling git's own real `--name-status -M` output for that
+            // specific pair: a plain "D" delete and a plain "A" add, with no "R###" record pairing them.
+            var renames = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [oldCommonPath] = newCommonPath,
+                [oldUpdatePath] = newUpdatePath,
+            };
+            var changedFiles = new[]
+            {
+                oldCommonPath, newCommonPath,
+                oldUpdatePath, newUpdatePath,
+                oldVerifyPath, newVerifyPath,
+            };
+
+            var result = SelectWithRealMap(
+                changedFiles,
+                layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
+                renames: renames,
+                mapPathOverride: tempMapPath);
+
+            Assert.True(result.SelectsAll, $"expected the undetected verify-aspire-skills-bundle(s).ps1 rename to force the run-all fallback, but selection was: {result.EscalationReason}");
+            Assert.Contains(oldVerifyPath, result.UnmatchedFiles);
         }
         finally
         {

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -436,7 +436,10 @@ public sealed class TestTriggerMapTests
     // This test uses a temp copy of the REAL map with just the two git-rename-detected paths'
     // entries updated to their new names (simulating "as if PR #19486's own map.yml edit, for these
     // two files, had already landed"), keeping every other rule, group, and affected-project mapping
-    // exactly as checked out on disk today.
+    // exactly as checked out on disk today. Because of that, `expectedTargets` below is coupled to the
+    // live map: an unrelated future change to test-trigger-map.yml's Aspire.Cli/Aspire.Cli.Tests
+    // routing (e.g. a new job gate or group added to their rules) can legitimately require updating
+    // this list, not just a regression in the selector.
     [Fact]
     public void SameCommitRenameWithMapEntryMovedToNewPathSelectsExactTargetsWithoutEscalating()
     {
@@ -453,37 +456,45 @@ public sealed class TestTriggerMapTests
             .Replace(oldCommonPath, newCommonPath, StringComparison.Ordinal)
             .Replace(oldUpdatePath, newUpdatePath, StringComparison.Ordinal);
 
-        var tempMapPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "test-trigger-map.yml");
-        File.WriteAllText(tempMapPath, simulatedMapText);
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var tempMapPath = Path.Combine(tempDir.FullName, "test-trigger-map.yml");
+            File.WriteAllText(tempMapPath, simulatedMapText);
 
-        var renameOldPaths = new HashSet<string>(StringComparer.Ordinal) { oldCommonPath, oldUpdatePath };
-        var changedFiles = new[] { oldCommonPath, newCommonPath, oldUpdatePath, newUpdatePath };
+            var renameOldPaths = new HashSet<string>(StringComparer.Ordinal) { oldCommonPath, oldUpdatePath };
+            var changedFiles = new[] { oldCommonPath, newCommonPath, oldUpdatePath, newUpdatePath };
 
-        // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
-        // production-code portion of PR #19486's actual diff (agent-init/telemetry commands).
-        var result = SelectWithRealMap(
-            changedFiles,
-            layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
-            renameOldPaths: renameOldPaths,
-            mapPathOverride: tempMapPath);
+            // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
+            // production-code portion of PR #19486's actual diff (agent-init/telemetry commands).
+            var result = SelectWithRealMap(
+                changedFiles,
+                layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
+                renameOldPaths: renameOldPaths,
+                mapPathOverride: tempMapPath);
 
-        Assert.False(result.SelectsAll, $"unexpectedly selected ALL: {result.EscalationReason}");
-        Assert.Empty(result.UnmatchedFiles);
+            Assert.False(result.SelectsAll, $"unexpectedly selected ALL: {result.EscalationReason}");
+            Assert.Empty(result.UnmatchedFiles);
 
-        var actualTargets = result.TestProjects.Select(name => $"test:{name}")
-            .Concat(result.Jobs)
-            .Order(StringComparer.Ordinal);
-        string[] expectedTargets =
-        [
-            "job:deployment-e2e",
-            "job:extension-e2e",
-            "job:polyglot",
-            "job:typescript-api-compat",
-            "test:Aspire.Cli.EndToEnd.Tests",
-            "test:Aspire.Cli.Tests",
-            "test:Infrastructure.Tests",
-        ];
-        Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+            var actualTargets = result.TestProjects.Select(name => $"test:{name}")
+                .Concat(result.Jobs)
+                .Order(StringComparer.Ordinal);
+            string[] expectedTargets =
+            [
+                "job:deployment-e2e",
+                "job:extension-e2e",
+                "job:polyglot",
+                "job:typescript-api-compat",
+                "test:Aspire.Cli.EndToEnd.Tests",
+                "test:Aspire.Cli.Tests",
+                "test:Infrastructure.Tests",
+            ];
+            Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+        }
+        finally
+        {
+            Directory.Delete(tempDir.FullName, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -419,104 +419,32 @@ public sealed class TestTriggerMapTests
     // PR #19486 (https://github.com/microsoft/aspire/pull/19486) renamed several `eng/scripts/*`
     // helpers and, in the SAME commit, updated their own `test-trigger-map.yml` entries to reference
     // the new filenames. Two of those renames are pure/near-pure (git's default -M50% rename detector
-    // recognizes them: R095 and R054 similarity) -- these are the ones this fix targets. Empirically
-    // verified against the real PR diff (base fd9bbf76b4, head 1e46e48122) with the fixed selector:
-    // both old paths are now correctly exempted from forcing the run-all fallback.
+    // recognizes them: R095 and R054 similarity); the third (`verify-aspire-skills-bundle.ps1`) was
+    // rewritten heavily enough in the same commit (115 lines removed, 154 added -> ~30% content
+    // similarity) that git's default -M50% threshold reports it as a plain delete+add, not a rename
+    // (confirmed with `git diff -M10%`, which *does* detect it at R030).
     //
-    // A third renamed file in that PR, `verify-aspire-skills-bundle.ps1`, was rewritten heavily enough
-    // in the same commit (115 lines removed, 154 added -> ~30% content similarity) that git's DEFAULT
-    // -M50% threshold reports it as a plain delete+add, not a rename (confirmed with `git diff -M10%`,
-    // which *does* detect it at R030). That file is deliberately NOT part of this scenario: its old
-    // path is not git-rename-detected, so this fix's exemption does not (and, by design, should not)
-    // apply to it -- see docs/ci/test-trigger-map.md for the rationale (lowering the similarity
-    // threshold to catch it would risk pairing unrelated delete+add files as a false rename, hiding a
-    // genuine unmatched deletion). As a result, replaying the full, literal PR #19486 diff against
-    // today's fix still selects ALL -- for a narrower and more accurate reason than before the fix, but
-    // still ALL. That is expected, by-design, and covered by
-    // SameCommitRenameWithMapEntryMovedAndOneUndetectedPathStillForcesRunAll below, which replays all
-    // three renamed paths (not just the two this fix targets) against the same real map.
+    // Because the map's own path_rule/ignore entries for these paths move to the new filenames in the
+    // same commit, every old path -- rename-detected or not -- matches nothing at HEAD, so each is
+    // treated as an ordinary unmatched leftover and forces the run-all fallback. This is empirically
+    // verified against the real PR diff (base fd9bbf76b4, head 1e46e48122): the selector correctly
+    // selects ALL for the same reasons production reported at that head SHA.
     //
-    // This test uses a temp copy of the REAL map with just the two git-rename-detected paths'
-    // entries updated to their new names (simulating "as if PR #19486's own map.yml edit, for these
-    // two files, had already landed"), keeping every other rule, group, and affected-project mapping
-    // exactly as checked out on disk today. Because of that, `expectedTargets` below is coupled to the
-    // live map: an unrelated future change to test-trigger-map.yml's Aspire.Cli/Aspire.Cli.Tests
-    // routing (e.g. a new job gate or group added to their rules) can legitimately require updating
-    // this list, not just a regression in the selector.
+    // An earlier version of this fix exempted the git-rename-detected old paths from the fallback
+    // (trusting that their new paths' own evaluation already accounted for the moved content). That
+    // exemption was removed after an audit found it could silently under-select tests for
+    // cross-directory moves out of a shared-glob directory, and for renames into a destination the
+    // prefilter drops before anything evaluates it (see docs/ci/test-trigger-map.md). Selecting ALL
+    // for this in-place-rename-with-moved-map-entry case is the accepted, safe tradeoff -- an
+    // unnecessary full run is strictly better than a silently skipped test.
+    //
+    // This test uses a temp copy of the REAL map with all three paths' entries left exactly as
+    // checked out on disk today (i.e. still referencing the OLD names), so replaying the literal old
+    // paths reproduces "the map has not yet been updated for this rename" -- the same shape as the
+    // production run at PR #19486's head SHA.
     [Fact]
-    public void SameCommitRenameWithMapEntryMovedToNewPathSelectsExactTargetsWithoutEscalating()
+    public void SameCommitRenameWithMapEntryMovedToNewPathForcesRunAll()
     {
-        var realMapText = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
-        const string oldCommonPath = "eng/scripts/aspire-skills-bundle.common.ps1";
-        const string newCommonPath = "eng/scripts/aspire-skills-bundles.common.ps1";
-        const string oldUpdatePath = "eng/scripts/update-aspire-skills-bundle.ps1";
-        const string newUpdatePath = "eng/scripts/update-aspire-skills-bundles.ps1";
-
-        Assert.Contains(oldCommonPath, realMapText);
-        Assert.Contains(oldUpdatePath, realMapText);
-
-        var simulatedMapText = realMapText
-            .Replace(oldCommonPath, newCommonPath, StringComparison.Ordinal)
-            .Replace(oldUpdatePath, newUpdatePath, StringComparison.Ordinal);
-
-        var tempDir = Directory.CreateTempSubdirectory();
-        try
-        {
-            var tempMapPath = Path.Combine(tempDir.FullName, "test-trigger-map.yml");
-            File.WriteAllText(tempMapPath, simulatedMapText);
-
-            var renames = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                [oldCommonPath] = newCommonPath,
-                [oldUpdatePath] = newUpdatePath,
-            };
-            var changedFiles = new[] { oldCommonPath, newCommonPath, oldUpdatePath, newUpdatePath };
-
-            // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
-            // production-code portion of PR #19486's actual diff (agent-init/telemetry commands).
-            var result = SelectWithRealMap(
-                changedFiles,
-                layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
-                renames: renames,
-                mapPathOverride: tempMapPath);
-
-            Assert.False(result.SelectsAll, $"unexpectedly selected ALL: {result.EscalationReason}");
-            Assert.Empty(result.UnmatchedFiles);
-
-            var actualTargets = result.TestProjects.Select(name => $"test:{name}")
-                .Concat(result.Jobs)
-                .Order(StringComparer.Ordinal);
-            string[] expectedTargets =
-            [
-                "job:deployment-e2e",
-                "job:extension-e2e",
-                "job:polyglot",
-                "job:typescript-api-compat",
-                "test:Aspire.Cli.EndToEnd.Tests",
-                "test:Aspire.Cli.Tests",
-                "test:Infrastructure.Tests",
-            ];
-            Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
-        }
-        finally
-        {
-            Directory.Delete(tempDir.FullName, recursive: true);
-        }
-    }
-
-    // Companion to SameCommitRenameWithMapEntryMovedToNewPathSelectsExactTargetsWithoutEscalating above:
-    // that test isolates the mechanism this fix targets using only the two paths PR #19486 renamed that
-    // git's default -M50% threshold actually detects as renames. This test instead replays PR #19486's
-    // full three-path change set -- including `verify-aspire-skills-bundle.ps1`, which git reports as a
-    // plain delete+add (see RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll in
-    // SelectTestsCliTests.cs for why) -- against the real production map, to make explicit and
-    // falsifiable that the LITERAL, complete PR #19486 diff still selects ALL today. That is expected:
-    // this PR fixes the in-place-rename-with-moved-map-entry mechanism, not git's own rename-similarity
-    // detection, and does not claim to change the fallback outcome for content-heavy rewrite+renames.
-    [Fact]
-    public void SameCommitRenameWithMapEntryMovedAndOneUndetectedPathStillForcesRunAll()
-    {
-        var realMapText = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
         const string oldCommonPath = "eng/scripts/aspire-skills-bundle.common.ps1";
         const string newCommonPath = "eng/scripts/aspire-skills-bundles.common.ps1";
         const string oldUpdatePath = "eng/scripts/update-aspire-skills-bundle.ps1";
@@ -524,6 +452,7 @@ public sealed class TestTriggerMapTests
         const string oldVerifyPath = "eng/scripts/verify-aspire-skills-bundle.ps1";
         const string newVerifyPath = "eng/scripts/verify-aspire-skills-bundles.ps1";
 
+        var realMapText = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
         Assert.Contains(oldCommonPath, realMapText);
         Assert.Contains(oldUpdatePath, realMapText);
         Assert.Contains(oldVerifyPath, realMapText);
@@ -539,14 +468,6 @@ public sealed class TestTriggerMapTests
             var tempMapPath = Path.Combine(tempDir.FullName, "test-trigger-map.yml");
             File.WriteAllText(tempMapPath, simulatedMapText);
 
-            // oldCommonPath/oldUpdatePath ARE git-rename-detected (see the golden test above); oldVerifyPath
-            // deliberately has NO entry here, modeling git's own real `--name-status -M` output for that
-            // specific pair: a plain "D" delete and a plain "A" add, with no "R###" record pairing them.
-            var renames = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                [oldCommonPath] = newCommonPath,
-                [oldUpdatePath] = newUpdatePath,
-            };
             var changedFiles = new[]
             {
                 oldCommonPath, newCommonPath,
@@ -554,13 +475,16 @@ public sealed class TestTriggerMapTests
                 oldVerifyPath, newVerifyPath,
             };
 
+            // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
+            // production-code portion of PR #19486's actual diff (agent-init/telemetry commands).
             var result = SelectWithRealMap(
                 changedFiles,
                 layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
-                renames: renames,
                 mapPathOverride: tempMapPath);
 
-            Assert.True(result.SelectsAll, $"expected the undetected verify-aspire-skills-bundle(s).ps1 rename to force the run-all fallback, but selection was: {result.EscalationReason}");
+            Assert.True(result.SelectsAll, $"expected all three old paths to force the run-all fallback, but selection was: {result.EscalationReason}");
+            Assert.Contains(oldCommonPath, result.UnmatchedFiles);
+            Assert.Contains(oldUpdatePath, result.UnmatchedFiles);
             Assert.Contains(oldVerifyPath, result.UnmatchedFiles);
         }
         finally
@@ -806,8 +730,8 @@ public sealed class TestTriggerMapTests
 
     /// <summary>
     /// Same as the single-path overload, but exercises the full <see cref="TestSelector.Select"/>
-    /// signature (multiple changed files, Layer 1 affected projects, and rename-old-path exemption)
-    /// against the real map and real <c>Aspire.slnx</c> project directories.
+    /// signature (multiple changed files and Layer 1 affected projects) against the real map and real
+    /// <c>Aspire.slnx</c> project directories.
     /// </summary>
     /// <param name="mapPathOverride">
     /// When set, load the map from this path instead of the checked-out
@@ -817,7 +741,6 @@ public sealed class TestTriggerMapTests
     private static SelectionResult SelectWithRealMap(
         IReadOnlyCollection<string> paths,
         IReadOnlyCollection<string> layer1Affected,
-        IReadOnlyDictionary<string, string>? renames = null,
         string? mapPathOverride = null)
     {
         var projectPaths = LoadSolutionProjectPaths();
@@ -832,7 +755,7 @@ public sealed class TestTriggerMapTests
         var mapPath = mapPathOverride ?? Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
         var selector = new TestSelector(mapPath, testProjects, projectDirectories);
 
-        return selector.Select(paths, layer1Affected, new SelectorOptions(), renames: renames);
+        return selector.Select(paths, layer1Affected, new SelectorOptions());
     }
 
     private static string TextBetween(string text, string startMarker, string endMarker)

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -438,10 +438,13 @@ public sealed class TestTriggerMapTests
     // for this in-place-rename-with-moved-map-entry case is the accepted, safe tradeoff -- an
     // unnecessary full run is strictly better than a silently skipped test.
     //
-    // This test uses a temp copy of the REAL map with all three paths' entries left exactly as
-    // checked out on disk today (i.e. still referencing the OLD names), so replaying the literal old
-    // paths reproduces "the map has not yet been updated for this rename" -- the same shape as the
-    // production run at PR #19486's head SHA.
+    // This test starts from the REAL map (its entries still reference the OLD names, same as checked
+    // out on disk today) and builds a temp copy with those three entries rewritten to the NEW names --
+    // simulating the map already updated for the rename, exactly as PR #19486's own commit left it (the
+    // rename and the matching map update landed together). Replaying the rename diff (both the old and
+    // new path of each file, as git reports for an R-record) against that up-to-date map reproduces the
+    // production run at PR #19486's head SHA: the new paths are fully covered, but the old paths --
+    // still present in the diff -- match nothing, which is what forces the run-all fallback below.
     [Fact]
     public void SameCommitRenameWithMapEntryMovedToNewPathForcesRunAll()
     {

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -414,6 +414,78 @@ public sealed class TestTriggerMapTests
         Assert.Empty(result.Jobs);
     }
 
+    // Golden-scenario regression test for the PR #19486 selector bug (renamed-file handling).
+    //
+    // PR #19486 (https://github.com/microsoft/aspire/pull/19486) renamed several `eng/scripts/*`
+    // helpers and, in the SAME commit, updated their own `test-trigger-map.yml` entries to reference
+    // the new filenames. Two of those renames are pure/near-pure (git's default -M50% rename detector
+    // recognizes them: R095 and R054 similarity) -- these are the ones this fix targets. Empirically
+    // verified against the real PR diff (base fd9bbf76b4, head 1e46e48122) with the fixed selector:
+    // both old paths are now correctly exempted from forcing the run-all fallback.
+    //
+    // A third renamed file in that PR, `verify-aspire-skills-bundle.ps1`, was rewritten heavily enough
+    // in the same commit (115 lines removed, 154 added -> ~30% content similarity) that git's DEFAULT
+    // -M50% threshold reports it as a plain delete+add, not a rename (confirmed with `git diff -M10%`,
+    // which *does* detect it at R030). That file is deliberately NOT part of this scenario: its old
+    // path is not git-rename-detected, so this fix's exemption does not (and, by design, should not)
+    // apply to it -- see docs/ci/test-trigger-map.md for the rationale (lowering the similarity
+    // threshold to catch it would risk pairing unrelated delete+add files as a false rename, hiding a
+    // genuine unmatched deletion). As a result, the full literal PR #19486 diff still selects ALL
+    // today, but for a narrower and more accurate reason than before the fix.
+    //
+    // This test uses a temp copy of the REAL map with just the two git-rename-detected paths'
+    // entries updated to their new names (simulating "as if PR #19486's own map.yml edit, for these
+    // two files, had already landed"), keeping every other rule, group, and affected-project mapping
+    // exactly as checked out on disk today.
+    [Fact]
+    public void SameCommitRenameWithMapEntryMovedToNewPathSelectsExactTargetsWithoutEscalating()
+    {
+        var realMapText = File.ReadAllText(Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml"));
+        const string oldCommonPath = "eng/scripts/aspire-skills-bundle.common.ps1";
+        const string newCommonPath = "eng/scripts/aspire-skills-bundles.common.ps1";
+        const string oldUpdatePath = "eng/scripts/update-aspire-skills-bundle.ps1";
+        const string newUpdatePath = "eng/scripts/update-aspire-skills-bundles.ps1";
+
+        Assert.Contains(oldCommonPath, realMapText);
+        Assert.Contains(oldUpdatePath, realMapText);
+
+        var simulatedMapText = realMapText
+            .Replace(oldCommonPath, newCommonPath, StringComparison.Ordinal)
+            .Replace(oldUpdatePath, newUpdatePath, StringComparison.Ordinal);
+
+        var tempMapPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "test-trigger-map.yml");
+        File.WriteAllText(tempMapPath, simulatedMapText);
+
+        var renameOldPaths = new HashSet<string>(StringComparer.Ordinal) { oldCommonPath, oldUpdatePath };
+        var changedFiles = new[] { oldCommonPath, newCommonPath, oldUpdatePath, newUpdatePath };
+
+        // Aspire.Cli (production) and Aspire.Cli.Tests (its test project) both changed, mirroring the
+        // production-code portion of PR #19486's actual diff (agent-init/telemetry commands).
+        var result = SelectWithRealMap(
+            changedFiles,
+            layer1Affected: ["Aspire.Cli", "Aspire.Cli.Tests"],
+            renameOldPaths: renameOldPaths,
+            mapPathOverride: tempMapPath);
+
+        Assert.False(result.SelectsAll, $"unexpectedly selected ALL: {result.EscalationReason}");
+        Assert.Empty(result.UnmatchedFiles);
+
+        var actualTargets = result.TestProjects.Select(name => $"test:{name}")
+            .Concat(result.Jobs)
+            .Order(StringComparer.Ordinal);
+        string[] expectedTargets =
+        [
+            "job:deployment-e2e",
+            "job:extension-e2e",
+            "job:polyglot",
+            "job:typescript-api-compat",
+            "test:Aspire.Cli.EndToEnd.Tests",
+            "test:Aspire.Cli.Tests",
+            "test:Infrastructure.Tests",
+        ];
+        Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+    }
+
     [Fact]
     public void SetupForTestsSelectionOutputsAreConsistentWithMap()
     {
@@ -647,6 +719,23 @@ public sealed class TestTriggerMapTests
     }
 
     private static SelectionResult SelectWithRealMap(string path)
+        => SelectWithRealMap([path], []);
+
+    /// <summary>
+    /// Same as the single-path overload, but exercises the full <see cref="TestSelector.Select"/>
+    /// signature (multiple changed files, Layer 1 affected projects, and rename-old-path exemption)
+    /// against the real map and real <c>Aspire.slnx</c> project directories.
+    /// </summary>
+    /// <param name="mapPathOverride">
+    /// When set, load the map from this path instead of the checked-out
+    /// <c>eng/github-ci/test-trigger-map.yml</c>. Used to simulate "the real map as it will look after
+    /// a specific in-flight PR's own map.yml edit lands", without depending on that PR having merged.
+    /// </param>
+    private static SelectionResult SelectWithRealMap(
+        IReadOnlyCollection<string> paths,
+        IReadOnlyCollection<string> layer1Affected,
+        IReadOnlySet<string>? renameOldPaths = null,
+        string? mapPathOverride = null)
     {
         var projectPaths = LoadSolutionProjectPaths();
         var testProjects = projectPaths
@@ -657,10 +746,10 @@ public sealed class TestTriggerMapTests
         var projectDirectories = projectPaths
             .Select(projectPath => Path.GetDirectoryName(projectPath)!.Replace('\\', '/'))
             .ToHashSet(StringComparer.Ordinal);
-        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var mapPath = mapPathOverride ?? Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
         var selector = new TestSelector(mapPath, testProjects, projectDirectories);
 
-        return selector.Select([path], [], new SelectorOptions());
+        return selector.Select(paths, layer1Affected, new SelectorOptions(), renameOldPaths: renameOldPaths);
     }
 
     private static string TextBetween(string text, string startMarker, string endMarker)

--- a/tools/SelectTests/GraphAffectedProjects.cs
+++ b/tools/SelectTests/GraphAffectedProjects.cs
@@ -473,13 +473,18 @@ internal static class GraphAffectedProjects
         // attribution, so an excluded file (e.g. a packed README.md <None> item) never gets mapped to a
         // project and fanned out. The same filter is applied to the Layer 2 input in Program.cs, so both
         // layers see the identical post-exclude change set.
-        var normalized = relativePaths.Select(rel => rel.Replace('\\', '/'));
-        if (filter is not null)
-        {
-            normalized = normalized.Where(rel => !filter.IsExcluded(rel));
-        }
+        //
+        // No `\` -> `/` normalization here: git always reports repo-relative paths with `/` separators on
+        // every OS (see GetChangedPathsFromGit), and Layer 2's own --changed-files handling (Program.cs's
+        // ResolveChangedFiles) makes the identical assumption without normalizing. A literal `\` in either
+        // source is a real filename byte on Unix, not a separator -- rewriting it to `/` would silently
+        // desync this path from the byte-identical string Layer 2 and the map's path rules match against,
+        // so a change could be attributed to the wrong project (or none) without either layer noticing.
+        var filtered = filter is null
+            ? relativePaths
+            : relativePaths.Where(rel => !filter.IsExcluded(rel));
 
-        return normalized
+        return filtered
             .Select(rel => new ChangedPath(
                 rel,
                 NormalizeFullPath(Path.Combine(repoRoot, rel.Replace('/', Path.DirectorySeparatorChar)))))

--- a/tools/SelectTests/GraphAffectedProjects.cs
+++ b/tools/SelectTests/GraphAffectedProjects.cs
@@ -489,18 +489,25 @@ internal static class GraphAffectedProjects
 
     private static IEnumerable<string> GetChangedPathsFromGit(string repoRoot, string from, string? to)
     {
-        // --name-status -M output, one record per change. Examples (TAB-separated):
-        //   M\tsrc/Aspire.Hosting/Foo.cs
-        //   A\tsrc/Aspire.Hosting/Bar.cs
-        //   D\tsrc/Shared/Old.cs
-        //   R097\tsrc/A/Old.cs\tsrc/B/New.cs     (rename: status, old path, new path)
+        // --name-status -M -z output, one record per change, NUL-terminated fields:
+        //   M\0src/Aspire.Hosting/Foo.cs\0
+        //   A\0src/Aspire.Hosting/Bar.cs\0
+        //   D\0src/Shared/Old.cs\0
+        //   R097\0src/A/Old.cs\0src/B/New.cs\0     (rename: status, old path, new path)
         // For renames we take BOTH paths; for everything else the single path. -M detects renames so
         // the old path is reported as R..., not as separate D + A.
-        // -c core.quotePath=false so a non-ASCII path comes back as the literal UTF-8 repo-relative
-        // path, not git's default octal-escaped, double-quoted form (e.g. "src/caf\303\251.cs"). The
-        // quoted form would neither match the file index nor split correctly on TAB below, mis-attributing
-        // the change. (Program.cs's Layer 2 diff does the same.)
-        var args = new List<string> { "-c", "core.quotePath=false", "diff", "--name-status", "-M" };
+        // -z NUL-terminates every field instead of git's default newline-per-record, tab-per-field text
+        // format, which quotes/escapes any path containing a byte >= 0x80, a tab, a newline, a
+        // double-quote, or a backslash (e.g. a literal tab in a name becomes the 8 characters
+        // "old\tname.txt", with a literal backslash-t, not a real tab byte) -- and `-c
+        // core.quotePath=false` only suppresses the non-ASCII-byte escaping, not the tab/newline/
+        // quote/backslash escaping. A quoted/escaped path never matches the evaluated-item index or
+        // directory containment check below, silently failing to attribute the change to its project.
+        // NUL can never appear in a valid path, so `-z` lets git skip quoting entirely, for every path,
+        // with no exceptions. Reuses Program.cs's Layer 2 parser (Selection.ParseNameStatusOutput) so
+        // both layers see byte-for-byte identical paths from a single, shared implementation instead of
+        // two parsers that could silently drift apart.
+        var args = new List<string> { "diff", "--name-status", "-M", "-z" };
         args.Add(from);
         if (to is not null)
         {
@@ -508,21 +515,7 @@ internal static class GraphAffectedProjects
         }
 
         var stdout = RunGit(repoRoot, args);
-        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            var fields = line.Split('\t', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (fields.Length < 2)
-            {
-                continue;
-            }
-
-            // fields[0] = status (M/A/D/Rxxx/Cxxx); fields[1..] = path(s). Renames/copies carry the old
-            // path at [1] and the new path at [2]; both should be attributed.
-            for (var i = 1; i < fields.Length; i++)
-            {
-                yield return fields[i];
-            }
-        }
+        return Selection.ParseNameStatusOutput(stdout).Files;
     }
 
     private static string RunGit(string repoRoot, IReadOnlyList<string> arguments)

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -473,6 +473,17 @@ internal static class Selection
         // the flat token stream and consume 1 or 2 fields per record accordingly. -M alone won't emit
         // "C" copy records -- see GraphAffectedProjects.GetChangedPathsFromGit for the same format with
         // more examples.
+        // Well-formed `-z` output always ends its last field with a NUL, same as every other field --
+        // there is no special "no trailing NUL" case. `Split` doesn't care whether the string ends with
+        // the delimiter, so a stream truncated mid-path (the final field's NUL never arrived, e.g. a
+        // killed process or a partial pipe read) would otherwise parse as a shorter-but-plausible-looking
+        // path instead of failing loudly like every other truncation case below.
+        if (stdout.Length > 0 && stdout[^1] != '\0')
+        {
+            throw new InvalidOperationException(
+                "git diff --name-status -M -z produced a truncated stream: output did not end with a NUL terminator, so the final path may be incomplete.");
+        }
+
         var tokens = stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries);
         var tokenIndex = 0;
         while (tokenIndex < tokens.Length)
@@ -1038,6 +1049,44 @@ internal static class Selection
         return $"`{member.Key}`";
     }
 
+    // Escapes bytes a `-z`-parsed path (see ParseNameStatusOutput) can legally contain but that would
+    // otherwise corrupt the Markdown this method renders into: `-z` intentionally preserves a path's raw
+    // bytes -- including a literal newline, carriage return, or backtick -- that git's older text-mode
+    // format would have quoted away. Left raw, such a path could inject extra lines/headings into the
+    // step summary or PR comment, or break out of its enclosing `code span`. Escaping is display-only;
+    // callers still match/attribute the unescaped path everywhere else.
+    private static string EscapeForDisplay(string value)
+    {
+        if (value.AsSpan().IndexOfAny('\r', '\n', '`') < 0)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '`':
+                    // A raw backtick would close the enclosing inline code span early; substitute a
+                    // visually similar character that can't be confused with real path content.
+                    sb.Append('\'');
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
     // The trigger a cause groups under. Direct file matches and graph fan-out from the same seed file
     // share a "file:" key so they render under one heading; affected-project and derived-test causes
     // get their own keyed groups.
@@ -1054,10 +1103,11 @@ internal static class Selection
     private static string CauseGroupHeader(string key)
     {
         var sep = key.IndexOf(':', StringComparison.Ordinal);
-        var (kind, value) = (key[..sep], key[(sep + 1)..]);
+        var (kind, rawValue) = (key[..sep], key[(sep + 1)..]);
+        var value = EscapeForDisplay(rawValue);
         return kind switch
         {
-            "file" => $"**{FileEmoji(value)} `{value}`** *({FileChangeKind(value)})*",
+            "file" => $"**{FileEmoji(rawValue)} `{value}`** *({FileChangeKind(rawValue)})*",
             "affected" => $"**📦 affected project `{value}`**",
             "derived" => $"**🧪 derived from test `{value}`**",
             _ => $"**`{value}`**",
@@ -1068,7 +1118,8 @@ internal static class Selection
     private static string CauseGroupDescriptor(string key)
     {
         var sep = key.IndexOf(':', StringComparison.Ordinal);
-        var (kind, value) = (key[..sep], key[(sep + 1)..]);
+        var (kind, rawValue) = (key[..sep], key[(sep + 1)..]);
+        var value = EscapeForDisplay(rawValue);
         return kind switch
         {
             "file" => $"`{value}`",
@@ -1181,7 +1232,7 @@ internal static class Selection
         sb.AppendLine();
         foreach (var file in changedFiles.OrderBy(f => f, StringComparer.Ordinal))
         {
-            sb.AppendLine(CultureInfo.InvariantCulture, $"- `{file}`");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"- `{EscapeForDisplay(file)}`");
         }
         sb.AppendLine();
         sb.AppendLine("</details>");
@@ -1198,7 +1249,7 @@ internal static class Selection
             sb.AppendLine();
             foreach (var file in excludedFiles.OrderBy(f => f, StringComparer.Ordinal))
             {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{file}`");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{EscapeForDisplay(file)}`");
             }
             sb.AppendLine();
         }
@@ -1221,7 +1272,7 @@ internal static class Selection
             sb.AppendLine();
             foreach (var file in unmatched)
             {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{file}`");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{EscapeForDisplay(file)}`");
             }
         }
         sb.AppendLine();
@@ -1351,9 +1402,9 @@ internal static class Selection
     // Terse, one-line cause for the PR comment (no rule reason text).
     private static string ShortCause(Cause cause) => cause.Kind switch
     {
-        CauseKind.Convention => $"`{cause.Trigger}`",
-        CauseKind.PathRule => $"`{cause.Trigger}`",
-        CauseKind.AffectedProject => $"affected project `{cause.Trigger}`",
+        CauseKind.Convention => $"`{EscapeForDisplay(cause.Trigger)}`",
+        CauseKind.PathRule => $"`{EscapeForDisplay(cause.Trigger)}`",
+        CauseKind.AffectedProject => $"affected project `{EscapeForDisplay(cause.Trigger)}`",
         // Name the seed changed file (and hop count) rather than the full chain, which the summary
         // carries -- the comment stays scannable. Falls back to a generic label when no path was tracked.
         CauseKind.Layer1Graph => Layer1ShortCause(cause),
@@ -1361,8 +1412,8 @@ internal static class Selection
         // derived_targets rule pulls this job in because that test project was selected. Phrasing it as a
         // noun -- not "derived from test X" -- avoids a dangling "from" that reads as if the line above it
         // in the job-reasons cell flows through this test.
-        CauseKind.DerivedFromTest => $"selected test `{cause.Trigger}`",
-        _ => cause.Trigger,
+        CauseKind.DerivedFromTest => $"selected test `{EscapeForDisplay(cause.Trigger)}`",
+        _ => EscapeForDisplay(cause.Trigger),
     };
 
     // "via graph from `seed.cs`" (+ "(N hops)" when the reverse-dependency chain is more than one edge).
@@ -1376,7 +1427,7 @@ internal static class Selection
         // path = [seedFile, project0, ..., affectedTest]; project edges = (count - 1 projects) - 1.
         var hops = path.Count - 2;
         var suffix = hops > 1 ? $" ({hops} hops)" : "";
-        return $"via graph from `{path[0]}`{suffix}";
+        return $"via graph from `{EscapeForDisplay(path[0])}`{suffix}";
     }
 
     // Full cause for the step summary, including the curated rule reason when present.
@@ -1384,16 +1435,16 @@ internal static class Selection
     {
         var head = cause.Kind switch
         {
-            CauseKind.Convention => $"convention match `{cause.Trigger}`",
-            CauseKind.PathRule => $"path rule `{cause.Trigger}`",
-            CauseKind.AffectedProject => $"affected project `{cause.Trigger}`",
+            CauseKind.Convention => $"convention match `{EscapeForDisplay(cause.Trigger)}`",
+            CauseKind.PathRule => $"path rule `{EscapeForDisplay(cause.Trigger)}`",
+            CauseKind.AffectedProject => $"affected project `{EscapeForDisplay(cause.Trigger)}`",
             // Render the full decision path (seed file -> ... -> affected test) when available, so the
             // summary explains HOW the change reached the test, not just THAT it did.
             CauseKind.Layer1Graph => cause.Path is { Count: > 0 } path
-                ? $"graph closure: {string.Join(" → ", path)}"
+                ? $"graph closure: {string.Join(" → ", path.Select(EscapeForDisplay))}"
                 : "affected by changed source (graph closure)",
-            CauseKind.DerivedFromTest => $"derived from selected test `{cause.Trigger}`",
-            _ => cause.Trigger,
+            CauseKind.DerivedFromTest => $"derived from selected test `{EscapeForDisplay(cause.Trigger)}`",
+            _ => EscapeForDisplay(cause.Trigger),
         };
 
         // Map reasons can be YAML folded scalars spanning lines; collapse to one line for the bullet.

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -216,7 +216,7 @@ internal static class Selection
         // --from/--changed-files input.
         trace.EnterStage("resolve changed files");
         var changedFileSet = options.ForceAll
-            ? new ChangedFileSet(Array.Empty<string>(), new Dictionary<string, string>(StringComparer.Ordinal))
+            ? new ChangedFileSet(Array.Empty<string>())
             : ResolveChangedFiles(options);
         var rawChangedFiles = changedFileSet.Files;
 
@@ -245,7 +245,7 @@ internal static class Selection
 
         trace.EnterStage("select (Layer 2 trigger map + Layer 1 union)");
         var selector = new TestSelector(options.MapPath, allTestProjects, projectDirectories);
-        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths, changedFileSet.Renames);
+        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths);
 
         trace.EnterStage("write summary and outputs");
         WriteSummary(options, result, allTestProjects, changedFiles, layer1Affected, excludedFiles);
@@ -412,13 +412,11 @@ internal static class Selection
     {
         if (options.ChangedFilesPath is not null)
         {
-            // An externally supplied file list carries no rename information, so there is no old
-            // side to exempt from the run-all escalation below.
             var suppliedFiles = File.ReadAllLines(options.ChangedFilesPath)
                 .Select(l => l.Trim())
                 .Where(l => l.Length > 0)
                 .ToList();
-            return new ChangedFileSet(suppliedFiles, new Dictionary<string, string>(StringComparer.Ordinal));
+            return new ChangedFileSet(suppliedFiles);
         }
 
         if (options.From is null)
@@ -432,26 +430,21 @@ internal static class Selection
         // diff -- the PR's own changes -- not a base-tip..head diff.
         var range = options.To is null ? new[] { options.From } : new[] { options.From, options.To };
         // --name-status -M (not --name-only --no-renames): a rename is reported as one "R###" record
-        // carrying BOTH paths, not decomposed into a separate delete(old) + add(new). We still
-        // glob-match both sides -- a file moved OUT of a mapped directory (e.g. eng/clipack/foo ->
-        // eng/elsewhere) must still hit that directory's rule via its old path (see
-        // SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests) -- but knowing the old->new
-        // pairing lets TestSelector stop treating a stale, no-longer-referenced old name as an unmapped
-        // "leftover" that forces the run-all fallback, PROVIDED the new side is actually still part of
-        // this diff's changed-file set (see TestSelector.Select and the root cause described there).
-        // Layer 1 already parses this same "-M" format (GraphAffectedProjects.GetChangedPathsFromGit);
-        // this keeps Layer 2 consistent.
+        // carrying BOTH paths, not decomposed into a separate delete(old) + add(new). We glob-match
+        // both sides identically to any other changed file -- a file moved OUT of a mapped directory
+        // (e.g. eng/clipack/foo -> eng/elsewhere) must still hit that directory's rule via its old path
+        // (see SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests), and an old path matched
+        // by nothing still forces the same run-all fallback as a plain deletion would (see
+        // TestSelector.Select). Layer 1 (GraphAffectedProjects.GetChangedPathsFromGit) parses the same
+        // "-M -z" format via ParseNameStatusOutput below -- one shared parser for both layers.
         // -z NUL-terminates every field instead of git's default newline-per-record, tab-per-field
         // text format. That default format quotes/escapes any path containing a byte >= 0x80, a tab,
         // a newline, a double-quote, or a backslash (e.g. a literal tab in a name becomes the 8
         // characters "old\tname.txt", with a literal backslash-t, not a real tab byte) -- and
         // `-c core.quotePath=false` only suppresses the non-ASCII-byte escaping, not the
         // tab/newline/quote/backslash escaping. A quoted/escaped path never glob-equals the real
-        // repo-relative path, so the map rules below would silently miss it, AND the mismatch would
-        // apply consistently to both the file list and renames -- so a rename whose path couldn't be
-        // attributed to any rule would still be wrongly exempted from the run-all fallback. NUL can
-        // never appear in a valid path, so `-z` lets git skip quoting entirely, for every path, with no
-        // exceptions.
+        // repo-relative path, so the map rules below would silently miss it. NUL can never appear in a
+        // valid path, so `-z` lets git skip quoting entirely, for every path, with no exceptions.
         var args = new List<string> { "diff", "--name-status", "-M", "-z" };
         args.AddRange(range);
 
@@ -461,8 +454,19 @@ internal static class Selection
             throw new InvalidOperationException($"git diff failed ({exitCode}): {stderr}");
         }
 
+        return ParseNameStatusOutput(stdout);
+    }
+
+    // Extracted from ResolveChangedFiles so tests can feed hand-crafted (including malformed)
+    // NUL-delimited `git diff --name-status -M -z` output directly, without needing an actual git
+    // process to produce it -- a real `git diff` that exits 0 never emits a truncated record, so the
+    // malformed-input path below can only be exercised synthetically. Also called directly by Layer 1
+    // (GraphAffectedProjects.GetChangedPathsFromGit), which runs the identical "-M -z" diff: sharing
+    // one parser guarantees both layers attribute byte-for-byte the same paths for every change,
+    // instead of two independently-maintained parsers that could silently drift apart.
+    internal static ChangedFileSet ParseNameStatusOutput(string stdout)
+    {
         var files = new List<string>();
-        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
         // With -z the whole stream is just NUL-delimited fields back to back -- "status\0path\0" for a
         // plain change, "R100\0old\0new\0" for a rename (the numeric similarity suffix varies) -- with
         // no per-line framing to split on first. How many fields follow depends on the status, so walk
@@ -478,37 +482,40 @@ internal static class Selection
             {
                 if (tokenIndex + 1 >= tokens.Length)
                 {
-                    break; // truncated/malformed output; nothing left to parse
+                    // `git diff` exited 0 but the NUL-delimited stream ended mid-record (a status token
+                    // with no path(s) following it). This should never happen for well-formed output;
+                    // silently stopping here would return a partial change-file set to the selector,
+                    // which could omit a rule-matching path and under-select tests -- the opposite of
+                    // this tool's fail-safe design. Fail loudly instead.
+                    throw new InvalidOperationException(
+                        $"git diff --name-status -M -z produced a truncated rename/copy record: status '{status}' at token {tokenIndex - 1} of {tokens.Length} was not followed by both an old and new path.");
                 }
 
                 var oldPath = tokens[tokenIndex++];
                 var newPath = tokens[tokenIndex++];
                 files.Add(oldPath);
                 files.Add(newPath);
-                if (status.StartsWith('R'))
-                {
-                    renames[oldPath] = newPath;
-                }
             }
             else
             {
                 if (tokenIndex >= tokens.Length)
                 {
-                    break; // truncated/malformed output; nothing left to parse
+                    // Same reasoning as above: a plain-change status token with no path following it is
+                    // malformed output from a successful git invocation, not an expected empty diff.
+                    throw new InvalidOperationException(
+                        $"git diff --name-status -M -z produced a truncated record: status '{status}' at token {tokenIndex - 1} of {tokens.Length} was not followed by a path.");
                 }
 
                 files.Add(tokens[tokenIndex++]);
             }
         }
 
-        return new ChangedFileSet(files, renames);
+        return new ChangedFileSet(files);
     }
 
-    // The old path of a git-detected rename is still glob-matched like any other changed path (see
-    // ResolveChangedFiles), but TestSelector needs the old->new pairing (not just the old side) so it
-    // can verify the new path is actually part of this diff before exempting the old side from forcing
-    // the run-all fallback.
-    private sealed record ChangedFileSet(IReadOnlyCollection<string> Files, IReadOnlyDictionary<string, string> Renames);
+    // Both paths of a git-detected rename are glob-matched identically to any other changed path (see
+    // ResolveChangedFiles) -- there is no separate old->new pairing for TestSelector to consume.
+    internal sealed record ChangedFileSet(IReadOnlyCollection<string> Files);
 
     // Repo-relative, '/'-separated directories of every project in Aspire.slnx -- the universe the
     // Layer 1 graph walks. The selector treats a changed file under one of these dirs as

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -431,19 +431,27 @@ internal static class Selection
         // From has already been rebound to the merge-base (see RunCore), so this is a branch-point..head
         // diff -- the PR's own changes -- not a base-tip..head diff.
         var range = options.To is null ? new[] { options.From } : new[] { options.From, options.To };
-        // -c core.quotePath=false: with the default (true), git octal-escapes and double-quotes any
-        // path with non-ASCII bytes (e.g. "src/caf\303\251.cs"). That escaped string is not the real
-        // repo-relative path, so the map globs below would silently miss it. Forcing quotePath off makes
-        // git emit the literal UTF-8 path, which is what the globs expect. (Layer 1's diff does the same.)
-        // --name-status -M (not --name-only --no-renames): a rename is reported as "R###\told\tnew",
-        // giving BOTH paths plus which one is which. We still glob-match both sides -- a file moved
-        // OUT of a mapped directory (e.g. eng/clipack/foo -> eng/elsewhere) must still hit that
-        // directory's rule via its old path (see SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests)
-        // -- but knowing which path is a rename's old side lets TestSelector stop treating a stale,
-        // no-longer-referenced old name as an unmapped "leftover" that forces the run-all fallback
-        // (see TestSelector.Select and the root cause described there). Layer 1 already parses this
-        // same "-M" format (GraphAffectedProjects.GetChangedPathsFromGit); this keeps Layer 2 consistent.
-        var args = new List<string> { "-c", "core.quotePath=false", "diff", "--name-status", "-M" };
+        // --name-status -M (not --name-only --no-renames): a rename is reported as one "R###" record
+        // carrying BOTH paths, not decomposed into a separate delete(old) + add(new). We still
+        // glob-match both sides -- a file moved OUT of a mapped directory (e.g. eng/clipack/foo ->
+        // eng/elsewhere) must still hit that directory's rule via its old path (see
+        // SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests) -- but knowing which path is a
+        // rename's old side lets TestSelector stop treating a stale, no-longer-referenced old name as an
+        // unmapped "leftover" that forces the run-all fallback (see TestSelector.Select and the root
+        // cause described there). Layer 1 already parses this same "-M" format
+        // (GraphAffectedProjects.GetChangedPathsFromGit); this keeps Layer 2 consistent.
+        // -z NUL-terminates every field instead of git's default newline-per-record, tab-per-field
+        // text format. That default format quotes/escapes any path containing a byte >= 0x80, a tab,
+        // a newline, a double-quote, or a backslash (e.g. a literal tab in a name becomes the 8
+        // characters "old\tname.txt", with a literal backslash-t, not a real tab byte) -- and
+        // `-c core.quotePath=false` only suppresses the non-ASCII-byte escaping, not the
+        // tab/newline/quote/backslash escaping. A quoted/escaped path never glob-equals the real
+        // repo-relative path, so the map rules below would silently miss it, AND the mismatch would
+        // apply consistently to both the file list and renameOldPaths -- so a rename whose path
+        // couldn't be attributed to any rule would still be wrongly exempted from the run-all
+        // fallback. NUL can never appear in a valid path, so `-z` lets git skip quoting entirely,
+        // for every path, with no exceptions.
+        var args = new List<string> { "diff", "--name-status", "-M", "-z" };
         args.AddRange(range);
 
         var stdout = RunProcess("git", args, options.RepoRoot, out var exitCode, out var stderr);
@@ -454,25 +462,41 @@ internal static class Selection
 
         var files = new List<string>();
         var renameOldPaths = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        // With -z the whole stream is just NUL-delimited fields back to back -- "status\0path\0" for a
+        // plain change, "R100\0old\0new\0" for a rename (the numeric similarity suffix varies) -- with
+        // no per-line framing to split on first. How many fields follow depends on the status, so walk
+        // the flat token stream and consume 1 or 2 fields per record accordingly. -M alone won't emit
+        // "C" copy records -- see GraphAffectedProjects.GetChangedPathsFromGit for the same format with
+        // more examples.
+        var tokens = stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+        var tokenIndex = 0;
+        while (tokenIndex < tokens.Length)
         {
-            // Plain changes are "Status\tpath"; renames/copies are "R100\told\tnew" (the numeric
-            // similarity suffix varies). -M alone won't emit "C" copy records -- see
-            // GraphAffectedProjects.GetChangedPathsFromGit for the same format with more examples.
-            var fields = line.Split('\t', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (fields.Length < 2)
+            var status = tokens[tokenIndex++];
+            if (status.StartsWith('R') || status.StartsWith('C'))
             {
-                continue;
-            }
+                if (tokenIndex + 1 >= tokens.Length)
+                {
+                    break; // truncated/malformed output; nothing left to parse
+                }
 
-            for (var i = 1; i < fields.Length; i++)
-            {
-                files.Add(fields[i]);
+                var oldPath = tokens[tokenIndex++];
+                var newPath = tokens[tokenIndex++];
+                files.Add(oldPath);
+                files.Add(newPath);
+                if (status.StartsWith('R'))
+                {
+                    renameOldPaths.Add(oldPath);
+                }
             }
-
-            if (fields[0].StartsWith('R') && fields.Length >= 3)
+            else
             {
-                renameOldPaths.Add(fields[1]);
+                if (tokenIndex >= tokens.Length)
+                {
+                    break; // truncated/malformed output; nothing left to parse
+                }
+
+                files.Add(tokens[tokenIndex++]);
             }
         }
 

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -216,7 +216,7 @@ internal static class Selection
         // --from/--changed-files input.
         trace.EnterStage("resolve changed files");
         var changedFileSet = options.ForceAll
-            ? new ChangedFileSet(Array.Empty<string>(), new HashSet<string>(StringComparer.Ordinal))
+            ? new ChangedFileSet(Array.Empty<string>(), new Dictionary<string, string>(StringComparer.Ordinal))
             : ResolveChangedFiles(options);
         var rawChangedFiles = changedFileSet.Files;
 
@@ -245,7 +245,7 @@ internal static class Selection
 
         trace.EnterStage("select (Layer 2 trigger map + Layer 1 union)");
         var selector = new TestSelector(options.MapPath, allTestProjects, projectDirectories);
-        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths, changedFileSet.RenameOldPaths);
+        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths, changedFileSet.Renames);
 
         trace.EnterStage("write summary and outputs");
         WriteSummary(options, result, allTestProjects, changedFiles, layer1Affected, excludedFiles);
@@ -418,7 +418,7 @@ internal static class Selection
                 .Select(l => l.Trim())
                 .Where(l => l.Length > 0)
                 .ToList();
-            return new ChangedFileSet(suppliedFiles, new HashSet<string>(StringComparer.Ordinal));
+            return new ChangedFileSet(suppliedFiles, new Dictionary<string, string>(StringComparer.Ordinal));
         }
 
         if (options.From is null)
@@ -435,11 +435,12 @@ internal static class Selection
         // carrying BOTH paths, not decomposed into a separate delete(old) + add(new). We still
         // glob-match both sides -- a file moved OUT of a mapped directory (e.g. eng/clipack/foo ->
         // eng/elsewhere) must still hit that directory's rule via its old path (see
-        // SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests) -- but knowing which path is a
-        // rename's old side lets TestSelector stop treating a stale, no-longer-referenced old name as an
-        // unmapped "leftover" that forces the run-all fallback (see TestSelector.Select and the root
-        // cause described there). Layer 1 already parses this same "-M" format
-        // (GraphAffectedProjects.GetChangedPathsFromGit); this keeps Layer 2 consistent.
+        // SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests) -- but knowing the old->new
+        // pairing lets TestSelector stop treating a stale, no-longer-referenced old name as an unmapped
+        // "leftover" that forces the run-all fallback, PROVIDED the new side is actually still part of
+        // this diff's changed-file set (see TestSelector.Select and the root cause described there).
+        // Layer 1 already parses this same "-M" format (GraphAffectedProjects.GetChangedPathsFromGit);
+        // this keeps Layer 2 consistent.
         // -z NUL-terminates every field instead of git's default newline-per-record, tab-per-field
         // text format. That default format quotes/escapes any path containing a byte >= 0x80, a tab,
         // a newline, a double-quote, or a backslash (e.g. a literal tab in a name becomes the 8
@@ -447,10 +448,10 @@ internal static class Selection
         // `-c core.quotePath=false` only suppresses the non-ASCII-byte escaping, not the
         // tab/newline/quote/backslash escaping. A quoted/escaped path never glob-equals the real
         // repo-relative path, so the map rules below would silently miss it, AND the mismatch would
-        // apply consistently to both the file list and renameOldPaths -- so a rename whose path
-        // couldn't be attributed to any rule would still be wrongly exempted from the run-all
-        // fallback. NUL can never appear in a valid path, so `-z` lets git skip quoting entirely,
-        // for every path, with no exceptions.
+        // apply consistently to both the file list and renames -- so a rename whose path couldn't be
+        // attributed to any rule would still be wrongly exempted from the run-all fallback. NUL can
+        // never appear in a valid path, so `-z` lets git skip quoting entirely, for every path, with no
+        // exceptions.
         var args = new List<string> { "diff", "--name-status", "-M", "-z" };
         args.AddRange(range);
 
@@ -461,7 +462,7 @@ internal static class Selection
         }
 
         var files = new List<string>();
-        var renameOldPaths = new HashSet<string>(StringComparer.Ordinal);
+        var renames = new Dictionary<string, string>(StringComparer.Ordinal);
         // With -z the whole stream is just NUL-delimited fields back to back -- "status\0path\0" for a
         // plain change, "R100\0old\0new\0" for a rename (the numeric similarity suffix varies) -- with
         // no per-line framing to split on first. How many fields follow depends on the status, so walk
@@ -486,7 +487,7 @@ internal static class Selection
                 files.Add(newPath);
                 if (status.StartsWith('R'))
                 {
-                    renameOldPaths.Add(oldPath);
+                    renames[oldPath] = newPath;
                 }
             }
             else
@@ -500,13 +501,14 @@ internal static class Selection
             }
         }
 
-        return new ChangedFileSet(files, renameOldPaths);
+        return new ChangedFileSet(files, renames);
     }
 
     // The old path of a git-detected rename is still glob-matched like any other changed path (see
-    // ResolveChangedFiles), but TestSelector needs to know WHICH paths are a rename's old side so it
-    // can exempt an otherwise-unmatched one from forcing the run-all fallback.
-    private sealed record ChangedFileSet(IReadOnlyCollection<string> Files, IReadOnlySet<string> RenameOldPaths);
+    // ResolveChangedFiles), but TestSelector needs the old->new pairing (not just the old side) so it
+    // can verify the new path is actually part of this diff before exempting the old side from forcing
+    // the run-all fallback.
+    private sealed record ChangedFileSet(IReadOnlyCollection<string> Files, IReadOnlyDictionary<string, string> Renames);
 
     // Repo-relative, '/'-separated directories of every project in Aspire.slnx -- the universe the
     // Layer 1 graph walks. The selector treats a changed file under one of these dirs as

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -215,9 +215,10 @@ internal static class Selection
         // run-full-ci label kill switch fired), so ResolveChangedFiles would otherwise throw for lack of a
         // --from/--changed-files input.
         trace.EnterStage("resolve changed files");
-        var rawChangedFiles = options.ForceAll
-            ? Array.Empty<string>()
+        var changedFileSet = options.ForceAll
+            ? new ChangedFileSet(Array.Empty<string>(), new HashSet<string>(StringComparer.Ordinal))
             : ResolveChangedFiles(options);
+        var rawChangedFiles = changedFileSet.Files;
 
         // Split the raw change set into excluded (reported for audit transparency) and the filtered
         // set that actually drives Layer 2. RunLayer1 applies the same filter to Layer 1's own git
@@ -244,7 +245,7 @@ internal static class Selection
 
         trace.EnterStage("select (Layer 2 trigger map + Layer 1 union)");
         var selector = new TestSelector(options.MapPath, allTestProjects, projectDirectories);
-        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths);
+        var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths, changedFileSet.RenameOldPaths);
 
         trace.EnterStage("write summary and outputs");
         WriteSummary(options, result, allTestProjects, changedFiles, layer1Affected, excludedFiles);
@@ -407,14 +408,17 @@ internal static class Selection
         Console.Out.WriteLine($"::warning::{message}");
     }
 
-    private static IReadOnlyCollection<string> ResolveChangedFiles(RunOptions options)
+    private static ChangedFileSet ResolveChangedFiles(RunOptions options)
     {
         if (options.ChangedFilesPath is not null)
         {
-            return File.ReadAllLines(options.ChangedFilesPath)
+            // An externally supplied file list carries no rename information, so there is no old
+            // side to exempt from the run-all escalation below.
+            var suppliedFiles = File.ReadAllLines(options.ChangedFilesPath)
                 .Select(l => l.Trim())
                 .Where(l => l.Length > 0)
                 .ToList();
+            return new ChangedFileSet(suppliedFiles, new HashSet<string>(StringComparer.Ordinal));
         }
 
         if (options.From is null)
@@ -426,17 +430,20 @@ internal static class Selection
         // globs expect. `<from> <to>` diffs the two refs; omitting <to> diffs against the work tree.
         // From has already been rebound to the merge-base (see RunCore), so this is a branch-point..head
         // diff -- the PR's own changes -- not a base-tip..head diff.
-        // --no-renames decomposes a rename into a delete (old path) + add (new path) so BOTH sides
-        // are glob-matched. Without it, git's default rename detection reports only the destination,
-        // so a file moved OUT of a mapped directory (e.g. eng/clipack/foo -> eng/elsewhere) would hide
-        // the old path and silently skip that directory's mapped tests. Layer 1 captures both sides via
-        // -M; this keeps Layer 2 consistent.
         var range = options.To is null ? new[] { options.From } : new[] { options.From, options.To };
         // -c core.quotePath=false: with the default (true), git octal-escapes and double-quotes any
         // path with non-ASCII bytes (e.g. "src/caf\303\251.cs"). That escaped string is not the real
         // repo-relative path, so the map globs below would silently miss it. Forcing quotePath off makes
         // git emit the literal UTF-8 path, which is what the globs expect. (Layer 1's diff does the same.)
-        var args = new List<string> { "-c", "core.quotePath=false", "diff", "--name-only", "--no-renames" };
+        // --name-status -M (not --name-only --no-renames): a rename is reported as "R###\told\tnew",
+        // giving BOTH paths plus which one is which. We still glob-match both sides -- a file moved
+        // OUT of a mapped directory (e.g. eng/clipack/foo -> eng/elsewhere) must still hit that
+        // directory's rule via its old path (see SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests)
+        // -- but knowing which path is a rename's old side lets TestSelector stop treating a stale,
+        // no-longer-referenced old name as an unmapped "leftover" that forces the run-all fallback
+        // (see TestSelector.Select and the root cause described there). Layer 1 already parses this
+        // same "-M" format (GraphAffectedProjects.GetChangedPathsFromGit); this keeps Layer 2 consistent.
+        var args = new List<string> { "-c", "core.quotePath=false", "diff", "--name-status", "-M" };
         args.AddRange(range);
 
         var stdout = RunProcess("git", args, options.RepoRoot, out var exitCode, out var stderr);
@@ -445,8 +452,37 @@ internal static class Selection
             throw new InvalidOperationException($"git diff failed ({exitCode}): {stderr}");
         }
 
-        return stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var files = new List<string>();
+        var renameOldPaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            // Plain changes are "Status\tpath"; renames/copies are "R100\told\tnew" (the numeric
+            // similarity suffix varies). -M alone won't emit "C" copy records -- see
+            // GraphAffectedProjects.GetChangedPathsFromGit for the same format with more examples.
+            var fields = line.Split('\t', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (fields.Length < 2)
+            {
+                continue;
+            }
+
+            for (var i = 1; i < fields.Length; i++)
+            {
+                files.Add(fields[i]);
+            }
+
+            if (fields[0].StartsWith('R') && fields.Length >= 3)
+            {
+                renameOldPaths.Add(fields[1]);
+            }
+        }
+
+        return new ChangedFileSet(files, renameOldPaths);
     }
+
+    // The old path of a git-detected rename is still glob-matched like any other changed path (see
+    // ResolveChangedFiles), but TestSelector needs to know WHICH paths are a rename's old side so it
+    // can exempt an otherwise-unmatched one from forcing the run-all fallback.
+    private sealed record ChangedFileSet(IReadOnlyCollection<string> Files, IReadOnlySet<string> RenameOldPaths);
 
     // Repo-relative, '/'-separated directories of every project in Aspire.slnx -- the universe the
     // Layer 1 graph walks. The selector treats a changed file under one of these dirs as

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -247,6 +247,20 @@ public sealed class TestSelector
             // targets this content's rename should select (additively; it can only add targets, never
             // suppress them) -- so don't force ALL over it. See docs/ci/test-trigger-map.md for the
             // full rationale and TestTriggerMapTests for the regression coverage.
+            //
+            // Known residual limitation: renameOldPathSet comes from git's own "-M" similarity
+            // detection, a content heuristic, not a semantic guarantee -- it can occasionally pair an
+            // unrelated deletion with an unrelated addition that merely happen to be textually similar
+            // (e.g. two near-identical or empty boilerplate files). If that mispaired "old path" also
+            // lost its own map rule in the same commit, its removal would be exempted here even though
+            // it is not really the deletion side of the file this rule was written for. This requires
+            // several independent, rare coincidences (a same-commit rule move landing on a file whose
+            // deletion git also happens to mispair with something else), and raising the similarity
+            // threshold to close it is not viable: PR #19486's own real rename (the motivating case
+            // above) was only detected at R054 similarity (see
+            // RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll), so any threshold high
+            // enough to rule out coincidental pairing would also stop detecting real renames like it.
+            // Accepted as a bounded, low-probability tradeoff rather than a code mitigation.
             if (renameOldPathSet.Contains(file))
             {
                 continue;

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -149,15 +149,21 @@ public sealed class TestSelector
     /// cause carries the seed file + reverse-dependency chain so the summary can show the full path. Null
     /// when Layer 1 did not run or produced no paths.
     /// </param>
-    /// <param name="renameOldPaths">
-    /// The old-side paths of git-detected renames in this diff (from a <c>git diff --name-status -M</c>
-    /// "R###\told\tnew" record). Such a path is still glob-matched like any other changed file above --
+    /// <param name="renames">
+    /// Git-detected renames in this diff, old path -> new path (from a <c>git diff --name-status -M</c>
+    /// "R###\told\tnew" record). The old side is still glob-matched like any other changed file above --
     /// a file moved OUT of a mapped directory must still hit that directory's rule via its old path
     /// (see <c>SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests</c>) -- but if it ends up
-    /// matched by nothing, that is not a genuine unmapped leftover: the rename's new path already
-    /// carries whatever the map says about this content moving. Such a path is therefore exempted from
-    /// the run-all fallback below. Empty when the caller has no rename information (e.g.
-    /// <c>--changed-files</c> with an externally supplied plain list).
+    /// matched by nothing, that is not necessarily a genuine unmapped leftover: the rename's new path may
+    /// already carry whatever the map says about this content moving. The old path is therefore exempted
+    /// from the run-all fallback below, but ONLY when its paired new path is present in
+    /// <paramref name="changedFiles"/> -- i.e. something downstream actually had a chance to account for
+    /// it (matched a rule, was ignored, is Layer-1-owned, or itself becomes an unmatched leftover that
+    /// forces ALL). A destination the caller's prefilter already dropped (e.g. classified as needing no
+    /// CI at all) never reaches that evaluation, so exempting the old side on its behalf would be an
+    /// unverified assumption, not a real accounting -- the fail-safe below still fires for it. Empty when
+    /// the caller has no rename information (e.g. <c>--changed-files</c> with an externally supplied
+    /// plain list).
     /// </param>
     public SelectionResult Select(
         IReadOnlyCollection<string> changedFiles,
@@ -165,11 +171,14 @@ public sealed class TestSelector
         SelectorOptions options,
         IReadOnlySet<string>? layer1AttributedPaths = null,
         IReadOnlyDictionary<string, AffectedPath>? layer1Paths = null,
-        IReadOnlySet<string>? renameOldPaths = null)
+        IReadOnlyDictionary<string, string>? renames = null)
     {
         var map = TriggerMap.Load(_mapPath);
         var attributedPaths = layer1AttributedPaths ?? new HashSet<string>(StringComparer.Ordinal);
-        var renameOldPathSet = renameOldPaths ?? new HashSet<string>(StringComparer.Ordinal);
+        var renamePairs = renames ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        // Built once for the O(1) "is the rename's destination actually part of this diff" check below,
+        // rather than re-scanning changedFiles per rename candidate.
+        var changedFileLookup = new HashSet<string>(changedFiles, StringComparer.Ordinal);
 
         // name -> the reasons it was selected. The key set IS the selected set; the lists carry the
         // attribution surfaced in the PR comment / step summary.
@@ -243,25 +252,36 @@ public sealed class TestSelector
             // The old side of a same-commit, in-place rename: e.g. this PR renamed
             // aspire-skills-bundle.common.ps1 -> aspire-skills-bundles.common.ps1 AND updated the map's
             // own path_rule to the new name in the same commit, so the old name now matches nothing.
-            // That is not a genuine unmapped leftover -- the new path above already carries whatever
-            // targets this content's rename should select (additively; it can only add targets, never
-            // suppress them) -- so don't force ALL over it. See docs/ci/test-trigger-map.md for the
-            // full rationale and TestTriggerMapTests for the regression coverage.
+            // That is not a genuine unmapped leftover -- the new path already carries whatever targets
+            // this content's rename should select (additively; it can only add targets, never suppress
+            // them) -- so don't force ALL over it. See docs/ci/test-trigger-map.md for the full
+            // rationale and TestTriggerMapTests for the regression coverage.
             //
-            // Known residual limitation: renameOldPathSet comes from git's own "-M" similarity
-            // detection, a content heuristic, not a semantic guarantee -- it can occasionally pair an
-            // unrelated deletion with an unrelated addition that merely happen to be textually similar
-            // (e.g. two near-identical or empty boilerplate files). If that mispaired "old path" also
-            // lost its own map rule in the same commit, its removal would be exempted here even though
-            // it is not really the deletion side of the file this rule was written for. This requires
-            // several independent, rare coincidences (a same-commit rule move landing on a file whose
-            // deletion git also happens to mispair with something else), and raising the similarity
-            // threshold to close it is not viable: PR #19486's own real rename (the motivating case
-            // above) was only detected at R054 similarity (see
+            // The exemption only fires when the new path is present in changedFiles (checked via
+            // changedFileLookup below), NOT merely because the old path is a known rename source. If the
+            // caller's prefilter already dropped the new path (e.g. a rename INTO a doc-only path that
+            // matches eng/github-ci/ci-skip-entirely-patterns.txt), nothing downstream ever evaluated
+            // whether that destination's content needs CI, so assuming it "carries whatever targets"
+            // would be an unverified guess, not a real accounting -- the fail-safe below must still fire
+            // for the old path in that case. When the new path IS present, either it matches something
+            // (the additive case this exemption exists for) or it matches nothing itself and becomes its
+            // own unmatched leftover (correctly still forcing ALL) -- so no separate check of what the
+            // new path resolved to is needed here.
+            //
+            // Known residual limitation: renamePairs comes from git's own "-M" similarity detection, a
+            // content heuristic, not a semantic guarantee -- it can occasionally pair an unrelated
+            // deletion with an unrelated addition that merely happen to be textually similar (e.g. two
+            // near-identical or empty boilerplate files). If that mispaired "old path" also lost its own
+            // map rule in the same commit, its removal would be exempted here even though it is not
+            // really the deletion side of the file this rule was written for. This requires several
+            // independent, rare coincidences (a same-commit rule move landing on a file whose deletion
+            // git also happens to mispair with something else), and raising the similarity threshold to
+            // close it is not viable: PR #19486's own real rename (the motivating case above) was only
+            // detected at R054 similarity (see
             // RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll), so any threshold high
             // enough to rule out coincidental pairing would also stop detecting real renames like it.
             // Accepted as a bounded, low-probability tradeoff rather than a code mitigation.
-            if (renameOldPathSet.Contains(file))
+            if (renamePairs.TryGetValue(file, out var renameDestination) && changedFileLookup.Contains(renameDestination))
             {
                 continue;
             }

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -149,36 +149,31 @@ public sealed class TestSelector
     /// cause carries the seed file + reverse-dependency chain so the summary can show the full path. Null
     /// when Layer 1 did not run or produced no paths.
     /// </param>
-    /// <param name="renames">
-    /// Git-detected renames in this diff, old path -> new path (from a <c>git diff --name-status -M</c>
-    /// "R###\told\tnew" record). The old side is still glob-matched like any other changed file above --
-    /// a file moved OUT of a mapped directory must still hit that directory's rule via its old path
-    /// (see <c>SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests</c>) -- but if it ends up
-    /// matched by nothing, that is not necessarily a genuine unmapped leftover: the rename's new path may
-    /// already carry whatever the map says about this content moving. The old path is therefore exempted
-    /// from the run-all fallback below, but ONLY when its paired new path is present in
-    /// <paramref name="changedFiles"/> -- i.e. something downstream actually had a chance to account for
-    /// it (matched a rule, was ignored, is Layer-1-owned, or itself becomes an unmatched leftover that
-    /// forces ALL). A destination the caller's prefilter already dropped (e.g. classified as needing no
-    /// CI at all) never reaches that evaluation, so exempting the old side on its behalf would be an
-    /// unverified assumption, not a real accounting -- the fail-safe below still fires for it. Empty when
-    /// the caller has no rename information (e.g. <c>--changed-files</c> with an externally supplied
-    /// plain list).
-    /// </param>
+    /// <remarks>
+    /// A git-detected rename's old and new paths (from a <c>git diff --name-status -M</c>
+    /// "R###\told\tnew" record) both flow into <paramref name="changedFiles"/> and are evaluated
+    /// identically to any other changed path here -- there is no rename-specific handling. In
+    /// particular, an old path that ends up matched by nothing forces the same run-all fallback below
+    /// as a plain deletion would. A rename does not guarantee its new path's evaluation "covers" the
+    /// old path's content: the old location may have been part of a directory-scoped Layer 1 glob or
+    /// Layer 2 rule shared by other consumers that the new location does not carry (e.g.
+    /// <c>tests/Shared/Logging/*.cs</c> is glob-compiled by several real test projects; moving one of
+    /// its files into a single destination project's own folder would make the new path Layer-1-owned
+    /// by only that one project), or the new path may land somewhere the caller's prefilter drops
+    /// before either layer ever evaluates it. An earlier version of this method exempted an unmatched
+    /// rename old path from the fallback when its new path was present in <paramref name="changedFiles"/>;
+    /// that exemption was removed after an audit found both failure modes above are reachable in
+    /// practice. See docs/ci/test-trigger-map.md for the rationale.
+    /// </remarks>
     public SelectionResult Select(
         IReadOnlyCollection<string> changedFiles,
         IReadOnlyCollection<string> layer1Affected,
         SelectorOptions options,
         IReadOnlySet<string>? layer1AttributedPaths = null,
-        IReadOnlyDictionary<string, AffectedPath>? layer1Paths = null,
-        IReadOnlyDictionary<string, string>? renames = null)
+        IReadOnlyDictionary<string, AffectedPath>? layer1Paths = null)
     {
         var map = TriggerMap.Load(_mapPath);
         var attributedPaths = layer1AttributedPaths ?? new HashSet<string>(StringComparer.Ordinal);
-        var renamePairs = renames ?? new Dictionary<string, string>(StringComparer.Ordinal);
-        // Built once for the O(1) "is the rename's destination actually part of this diff" check below,
-        // rather than re-scanning changedFiles per rename candidate.
-        var changedFileLookup = new HashSet<string>(changedFiles, StringComparer.Ordinal);
 
         // name -> the reasons it was selected. The key set IS the selected set; the lists carry the
         // attribution surfaced in the PR comment / step summary.
@@ -246,43 +241,6 @@ public sealed class TestSelector
             if (fileMatched || ignored || layer1Owned)
             {
                 // Accounted for by some layer; nothing more to do for this file.
-                continue;
-            }
-
-            // The old side of a same-commit, in-place rename: e.g. this PR renamed
-            // aspire-skills-bundle.common.ps1 -> aspire-skills-bundles.common.ps1 AND updated the map's
-            // own path_rule to the new name in the same commit, so the old name now matches nothing.
-            // That is not a genuine unmapped leftover -- the new path already carries whatever targets
-            // this content's rename should select (additively; it can only add targets, never suppress
-            // them) -- so don't force ALL over it. See docs/ci/test-trigger-map.md for the full
-            // rationale and TestTriggerMapTests for the regression coverage.
-            //
-            // The exemption only fires when the new path is present in changedFiles (checked via
-            // changedFileLookup below), NOT merely because the old path is a known rename source. If the
-            // caller's prefilter already dropped the new path (e.g. a rename INTO a doc-only path that
-            // matches eng/github-ci/ci-skip-entirely-patterns.txt), nothing downstream ever evaluated
-            // whether that destination's content needs CI, so assuming it "carries whatever targets"
-            // would be an unverified guess, not a real accounting -- the fail-safe below must still fire
-            // for the old path in that case. When the new path IS present, either it matches something
-            // (the additive case this exemption exists for) or it matches nothing itself and becomes its
-            // own unmatched leftover (correctly still forcing ALL) -- so no separate check of what the
-            // new path resolved to is needed here.
-            //
-            // Known residual limitation: renamePairs comes from git's own "-M" similarity detection, a
-            // content heuristic, not a semantic guarantee -- it can occasionally pair an unrelated
-            // deletion with an unrelated addition that merely happen to be textually similar (e.g. two
-            // near-identical or empty boilerplate files). If that mispaired "old path" also lost its own
-            // map rule in the same commit, its removal would be exempted here even though it is not
-            // really the deletion side of the file this rule was written for. This requires several
-            // independent, rare coincidences (a same-commit rule move landing on a file whose deletion
-            // git also happens to mispair with something else), and raising the similarity threshold to
-            // close it is not viable: PR #19486's own real rename (the motivating case above) was only
-            // detected at R054 similarity (see
-            // RenameBelowGitSimilarityThresholdIsNotExemptedAndStillForcesRunAll), so any threshold high
-            // enough to rule out coincidental pairing would also stop detecting real renames like it.
-            // Accepted as a bounded, low-probability tradeoff rather than a code mitigation.
-            if (renamePairs.TryGetValue(file, out var renameDestination) && changedFileLookup.Contains(renameDestination))
-            {
                 continue;
             }
 

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -150,8 +150,8 @@ public sealed class TestSelector
     /// when Layer 1 did not run or produced no paths.
     /// </param>
     /// <remarks>
-    /// A git-detected rename's old and new paths (from a <c>git diff --name-status -M</c>
-    /// "R###\told\tnew" record) both flow into <paramref name="changedFiles"/> and are evaluated
+    /// A git-detected rename's old and new paths (from a <c>git diff --name-status -M -z</c>
+    /// "R###\0old\0new\0" record) both flow into <paramref name="changedFiles"/> and are evaluated
     /// identically to any other changed path here -- there is no rename-specific handling. In
     /// particular, an old path that ends up matched by nothing forces the same run-all fallback below
     /// as a plain deletion would. A rename does not guarantee its new path's evaluation "covers" the

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -149,15 +149,27 @@ public sealed class TestSelector
     /// cause carries the seed file + reverse-dependency chain so the summary can show the full path. Null
     /// when Layer 1 did not run or produced no paths.
     /// </param>
+    /// <param name="renameOldPaths">
+    /// The old-side paths of git-detected renames in this diff (from a <c>git diff --name-status -M</c>
+    /// "R###\told\tnew" record). Such a path is still glob-matched like any other changed file above --
+    /// a file moved OUT of a mapped directory must still hit that directory's rule via its old path
+    /// (see <c>SelectTestsCliTests.RenameOutOfMappedPathStillSelectsItsTests</c>) -- but if it ends up
+    /// matched by nothing, that is not a genuine unmapped leftover: the rename's new path already
+    /// carries whatever the map says about this content moving. Such a path is therefore exempted from
+    /// the run-all fallback below. Empty when the caller has no rename information (e.g.
+    /// <c>--changed-files</c> with an externally supplied plain list).
+    /// </param>
     public SelectionResult Select(
         IReadOnlyCollection<string> changedFiles,
         IReadOnlyCollection<string> layer1Affected,
         SelectorOptions options,
         IReadOnlySet<string>? layer1AttributedPaths = null,
-        IReadOnlyDictionary<string, AffectedPath>? layer1Paths = null)
+        IReadOnlyDictionary<string, AffectedPath>? layer1Paths = null,
+        IReadOnlySet<string>? renameOldPaths = null)
     {
         var map = TriggerMap.Load(_mapPath);
         var attributedPaths = layer1AttributedPaths ?? new HashSet<string>(StringComparer.Ordinal);
+        var renameOldPathSet = renameOldPaths ?? new HashSet<string>(StringComparer.Ordinal);
 
         // name -> the reasons it was selected. The key set IS the selected set; the lists carry the
         // attribution surfaced in the PR comment / step summary.
@@ -225,6 +237,18 @@ public sealed class TestSelector
             if (fileMatched || ignored || layer1Owned)
             {
                 // Accounted for by some layer; nothing more to do for this file.
+                continue;
+            }
+
+            // The old side of a same-commit, in-place rename: e.g. this PR renamed
+            // aspire-skills-bundle.common.ps1 -> aspire-skills-bundles.common.ps1 AND updated the map's
+            // own path_rule to the new name in the same commit, so the old name now matches nothing.
+            // That is not a genuine unmapped leftover -- the new path above already carries whatever
+            // targets this content's rename should select (additively; it can only add targets, never
+            // suppress them) -- so don't force ALL over it. See docs/ci/test-trigger-map.md for the
+            // full rationale and TestTriggerMapTests for the regression coverage.
+            if (renameOldPathSet.Contains(file))
+            {
                 continue;
             }
 


### PR DESCRIPTION
## What broke

The selective PR CI test-selector (`tools/SelectTests`) has two layers that independently parse `git diff` output: Layer 1 (`GraphAffectedProjects.cs`, MSBuild project graph) and Layer 2 (`Program.cs`, curated map). Layer 1 used git's default text-mode `--name-status -M` output; Layer 2 used a NUL-delimited `-z` parser. Git's text mode quote-escapes tabs/newlines/quotes/backslashes in a path, so a changed file containing one of those bytes never matched Layer 1's attribution index — the change silently failed to select its own project, the opposite of the selector's fail-safe design.

While tracing this (from PR #19486, CI run [33197019835](https://github.com/microsoft/aspire/actions/runs/33197019835)), a few adjacent gaps surfaced in the same code:

- Layer 1 also unconditionally rewrote `\` → `/` in every changed path, even though git never uses `\` as a separator — a literal backslash in a filename could be corrupted into a fake directory boundary and mis-attributed to an unrelated project.
- Raw changed-file paths (which can contain literal `\r`/`\n`/backticks) were interpolated into the job summary and PR comment Markdown unescaped.
- A truncated `-z` stream (missing the final NUL) parsed as if it were valid instead of failing loudly.

## Root cause

Layer 1 had its own hand-rolled parser, independent from and less safe than Layer 2's. The two layers had quietly drifted.

## The fix

- Layer 1 now issues the same `git diff --name-status -M -z` as Layer 2, and both parse it through one shared method, `ParseNameStatusOutput` (`tools/SelectTests/Program.cs`).
- Removed Layer 1's `\`→`/` path rewrite; both layers now trust git's raw `/`-separated paths, matching Layer 2's existing behavior.
- Added an `EscapeForDisplay` helper and applied it everywhere a raw path is rendered into Markdown.
- `ParseNameStatusOutput` now throws if a `-z` stream doesn't end with a NUL terminator.

## Why this approach

A separate fix was also attempted and rejected: exempting a rename's old path from the run-all fallback when its new path was already present in the changed-file set. An audit found that unsafe — a directory-scoped glob can have consumers beyond the file that moved, and a rename landing on an `ignore`d glob or dropped by the prefilter satisfies the exemption's presence check without anything evaluating the real destination. Both could silently under-select tests. The exemption was removed; renames remain un-special-cased, and an unmatched rename old path still forces `ALL`, same as a plain deletion. `docs/ci/test-trigger-map.md` documents this under "Rename handling."

## Call-out

Replaying PR #19486's exact diff still selects `ALL` — that PR's original symptom isn't "fixed" here, and that's intentional: an unnecessary full run is safer than a silently skipped test. The actual bug fixed is the narrower NUL-safety/escaping issue above, found while tracing the rename investigation.

## Testing

New coverage under `tests/Infrastructure.Tests/TestTriggerMap/` (169 tests passing) covers: tab/newline-containing renamed paths attributed correctly by both layers, truncated `-z` streams failing loudly, Markdown escaping of raw paths, the backslash-corruption false-attribution case, and the rename-exemption-removed behavior — including a golden replay of PR #19486's real diff (base `fd9bbf76b4` / head `1e46e48122335ba5e970a5f78777a44fe3e963d2`) confirming it still forces `ALL`.

Fixes # (no tracked issue — found during investigation of microsoft/aspire#19486)