### PR TITLE
fix(ci): Reconcile duplicate automated failure issues

### DIFF
--- a/.agents/skills/automated-failure-issues/SKILL.md
+++ b/.agents/skills/automated-failure-issues/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: automated-failure-issues
+description: Use when creating or reviewing automation that files recurring CI, scheduled workflow, infrastructure, or failing-test GitHub issues.
+---
+
+# Automated Failure Issues
+
+## Overview
+
+Give each recurring failure a stable, versioned identity and delegate lifecycle mechanics to `.github/workflows/tracking-issue.js`. Treat identity as persistent data: changing normalization, field order, delimiters, or hashing re-keys every historical issue.
+
+**REQUIRED SUB-SKILL:** Use test-driven-development for behavior changes.
+
+## Core Contract
+
+| Concern | Owner | Rule |
+|---|---|---|
+| Identity | Producer/resolver | Build an exact hidden marker from stable fields, never a title or raw error message |
+| Reconciliation | `tracking-issue.js` | List by label, choose the oldest exact match, deduplicate occurrences, and close newer exact duplicates |
+| Resolution | Producer | Auto-close only from a trusted success signal and an `autoclose:true` stamp |
+
+Each producer must have exactly one lookup path. Both find and create must use the same marker and lookup label. Do not add a Search fallback, title fallback, or a second implementation with different canonical selection.
+
+For failing tests, reuse `result.issue.metadataMarker` from `tools/CreateFailingTestIssue`. The pipeline is `canonical test + workflow path -> normalize -> XxHash3 -> v1 marker -> issue body -> exact lookup`. Do not reproduce it in shell or JavaScript.
+
+For other producers, prefer a readable versioned marker whose fields are already short and stable:
+
+```javascript
+const tracking = require('./tracking-issue.js');
+const marker = `<!-- ci-failure:v1:${workflowFile}:${failureKind} -->`;
+
+await tracking.ensureLabel(github, context.repo.owner, context.repo.repo, labelDefinition);
+await tracking.recordRun(github, context, core, {
+    label: 'automation-broken',
+    marker,
+    title,
+    runId: context.runId,
+    buildBody: () => tracking.buildBody({ marker, lead, note, autoClose }),
+    comment,
+    closeDuplicates: true,
+});
+```
+
+Use XxHash3 only when stable identity fields are too long for a readable marker.
+
+## Duplicate and Migration Rules
+
+1. Query `issues.listForRepo` through `listIssuesByLabel`; GitHub Search is eventually consistent.
+2. Match complete hidden markers only. Never use titles, stack traces, fuzzy text, or model similarity.
+3. The lowest issue number is canonical, even when closed. A recurrence reopens it.
+4. An alias is proven only when a deterministic resolver parses both marker versions to the same canonical stable fields. Document the mapping and cover positive and negative fixtures; never use a prefix or fuzzy alias.
+5. Pass `closeDuplicates: true` only for machine-owned markers. The reconciler comments on and closes newer matches as `not_planned`; it never deletes or copies discussion.
+6. Serialize producers when practical. Re-listing after create heals a race but does not replace workflow concurrency.
+7. `--force-new` is an audited exception. Stamp its issue with `duplicateExemptStamp()` so reconciliation neither selects nor closes it.
+
+When identity semantics must change, bump the marker version. Keep the old exact marker as an alias until every all-state historical issue has the new marker or can never recur. Before retiring an alias, inventory open and closed labeled issues and add a migration test. Never silently reinterpret an existing version.
+
+## Auto-Close Policy
+
+The engine does not decide when a failure is fixed. The producer must verify a later success from the same trusted workflow, subject, and ref, require `readAutoClose(issue.body) === true`, then close with `state_reason: completed`. Missing or malformed stamps fail closed. Grant only the `issues: write` permission needed for mutation.
+
+## Required Tests
+
+Cover:
+
+- a frozen golden marker plus case, whitespace, and path-separator normalization;
+- changed titles and similar errors not matching;
+- oldest closed issue beating a newer open duplicate;
+- explicit legacy aliases;
+- concurrent create convergence;
+- repeated run IDs;
+- a closed canonical staying closed when that run was already recorded there;
+- duplicate-exempt issues remaining independent;
+- exact duplicates closing as `not_planned`;
+- missing `autoclose:true` preventing resolution.
+
+Extend `TrackingIssueTests.cs` through `tracking-issue.harness.js`, then add a real producer integration test. Verify label creation, all-state pagination, consumer syntax, and workflow compilation; helper-only tests are insufficient.
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---|---|
+| `search.issuesAndPullRequests` for dedup | Use the strongly consistent label list |
+| Hashing raw logs | Identify the durable subject, not one occurrence |
+| Closing fuzzy matches | Require exact markers or resolver-proven aliases |
+| Omitting `ensureLabel` | Create the lookup label before reconciliation |
+| Supplying pre-fetched open issues | Supply the complete all-state labeled inventory |
+| Putting stale-day policy in the engine | Keep resolution policy in the producer |
+| Rewriting or deleting duplicate history | Link, close, and preserve it |

--- a/.agents/skills/automated-failure-issues/SKILL.md
+++ b/.agents/skills/automated-failure-issues/SKILL.md
@@ -7,61 +7,100 @@ description: Use when creating or reviewing automation that files recurring CI, 
 
 ## Overview
 
-Give each recurring failure a stable, versioned identity and delegate lifecycle mechanics to `.github/workflows/tracking-issue.js`. Treat identity as persistent data: changing normalization, field order, delimiters, or hashing re-keys every historical issue.
+Give each recurring failure a stable, versioned identity and route every lifecycle
+operation through the checked-in tracking-issue modules. Treat identity as persistent
+data: changing normalization, field order, delimiters, or hashing re-keys every
+historical issue.
 
 **REQUIRED SUB-SKILL:** Use test-driven-development for behavior changes.
 
-## Core Contract
+## Ownership Boundary
 
 | Concern | Owner | Rule |
 |---|---|---|
-| Identity | Producer/resolver | Build an exact hidden marker from stable fields, never a title or raw error message |
-| Reconciliation | `tracking-issue.js` | List by label, choose the oldest exact match, deduplicate occurrences, and close newer exact duplicates |
-| Resolution | Producer | Auto-close only from a trusted success signal and an `autoclose:true` stamp |
+| Deterministic mechanics | `tracking-issue.js` and its transports | Find, create, relist, select, update, reopen, comment, close, and reconcile duplicates |
+| Identity | Producer or resolver | Define stable fields, normalization, marker version, and deterministic aliases |
+| Content and policy | Producer | Supply titles, bodies, comments, labels, force-new intent, and trusted close decisions |
+| Integration guidance | This skill | Preserve the ownership boundary, migration rules, and verification requirements |
 
-Each producer must have exactly one lookup path. Both find and create must use the same marker and lookup label. Do not add a Search fallback, title fallback, or a second implementation with different canonical selection.
+Use [`.github/workflows/tracking-issue.js`](../../../.github/workflows/tracking-issue.js)
+directly from JavaScript producers. Non-JavaScript callers must use the existing
+[`create-failing-test-issue-tracking.js`](../../../.github/workflows/create-failing-test-issue-tracking.js)
+adapter and
+[`tracking-issue-gh-api.js`](../../../.github/workflows/tracking-issue-gh-api.js)
+transport so they delegate to the same planner and executor. Do not invent another
+gh-backed transport or reproduce selection and mutation rules in workflow YAML,
+shell, C#, or another helper.
 
-For failing tests, reuse `result.issue.metadataMarker` from `tools/CreateFailingTestIssue`. The pipeline is `canonical test + workflow path -> normalize -> XxHash3 -> v1 marker -> issue body -> exact lookup`. Do not reproduce it in shell or JavaScript.
+Each producer has exactly one supported lookup path. Find, create, update, reopen,
+close, duplicate reconciliation, live execution, and dry-run planning must consume
+the same marker, lookup label, planner, and transport contract. Never add a Search
+fallback, title fallback, direct-create exception, or a second planner.
 
-For other producers, prefer a readable versioned marker whose fields are already short and stable:
+## Identity Design
 
-```javascript
-const tracking = require('./tracking-issue.js');
-const marker = `<!-- ci-failure:v1:${workflowFile}:${failureKind} -->`;
+Write down the identity fields and normalization before implementation. Prefer a
+readable exact marker when stable fields are already short. Use XxHash3 only when
+those fields are too long, and freeze a golden result.
 
-await tracking.ensureLabel(github, context.repo.owner, context.repo.repo, labelDefinition);
-await tracking.recordRun(github, context, core, {
-    label: 'automation-broken',
-    marker,
-    title,
-    runId: context.runId,
-    buildBody: () => tracking.buildBody({ marker, lead, note, autoClose }),
-    comment,
-    closeDuplicates: true,
-});
-```
+For failing tests, `tools/CreateFailingTestIssue` owns the pipeline
+`canonical test + workflow path -> normalize -> XxHash3 -> versioned marker`.
+Consumers reuse `result.issue.metadataMarker`; they do not recalculate or parse it.
 
-Use XxHash3 only when stable identity fields are too long for a readable marker.
+Identity must not depend on titles, raw error text, stack traces, run IDs, timestamps,
+or model similarity. Marker matching is exact. Treat changes to case folding,
+whitespace, path separators, field ordering, delimiters, or hash encoding as
+identity changes.
 
-## Duplicate and Migration Rules
+## Integration Workflow
 
-1. Query `issues.listForRepo` through `listIssuesByLabel`; GitHub Search is eventually consistent.
-2. Match complete hidden markers only. Never use titles, stack traces, fuzzy text, or model similarity.
-3. The lowest issue number is canonical, even when closed. A recurrence reopens it.
-4. An alias is proven only when a deterministic resolver parses both marker versions to the same canonical stable fields. Document the mapping and cover positive and negative fixtures; never use a prefix or fuzzy alias.
-5. Pass `closeDuplicates: true` only for machine-owned markers. The reconciler comments on and closes newer matches as `not_planned`; it never deletes or copies discussion.
-6. Serialize producers when practical. Re-listing after create heals a race but does not replace workflow concurrency.
-7. `--force-new` is an audited exception. Stamp its issue with `duplicateExemptStamp()` so reconciliation neither selects nor closes it.
+1. Add the lookup label with `ensureLabel` before reconciliation. A missing label is
+   an integration failure, not permission to use a broader lookup.
+2. Supply the exact marker, complete all-state labeled inventory, content builders,
+   and producer policy to the shared engine.
+3. Use the shared executor for live calls and its dry-run transport/planner seam for
+   previews. Dry run must differ only in transport side effects.
+4. Keep workflow markdown thin: parse trusted inputs, call the producer module, and
+   report its result.
+5. Serialize producers when practical. Create/relist convergence heals creator races
+   but does not replace workflow concurrency.
 
-When identity semantics must change, bump the marker version. Keep the old exact marker as an alias until every all-state historical issue has the new marker or can never recur. Before retiring an alias, inventory open and closed labeled issues and add a migration test. Never silently reinterpret an existing version.
+With duplicate reconciliation enabled, the shared engine lists all issue states by
+label, chooses the lowest-numbered exact match even when closed, deduplicates run
+comments across canonical and duplicate matches, and can link and close newer exact
+duplicates as `not_planned`. Without duplicate reconciliation, `reconcileRun`
+preserves its open-match preference. Producers must not pre-filter the inventory to
+open issues.
 
-## Auto-Close Policy
+`--force-new` is an audited producer intent, not a lifecycle bypass. Send it through
+the planner and stamp the resulting issue as duplicate-exempt. Reconciliation must
+neither select nor close exempt issues.
 
-The engine does not decide when a failure is fixed. The producer must verify a later success from the same trusted workflow, subject, and ref, require `readAutoClose(issue.body) === true`, then close with `state_reason: completed`. Missing or malformed stamps fail closed. Grant only the `issues: write` permission needed for mutation.
+## Version Migration and Retirement
+
+Changing identity semantics requires a new marker version. Never silently reinterpret
+an existing version.
+
+An alias is valid only when a deterministic resolver proves that both marker versions
+map to the same canonical stable fields. Document that proof and cover positive and
+negative fixtures. Prefix, title, substring, and fuzzy matching are not proof.
+
+Keep the old exact marker as an alias until every open and closed labeled issue has
+been migrated or the old identity can no longer recur. Before retiring an alias,
+inventory all states, add a migration/retirement test, and confirm every producer
+emits only the new version.
+
+## Trusted Auto-Close
+
+The engine does not decide whether a failure is fixed. The producer must verify a
+later success from the same trusted workflow, subject, and ref, require an exact
+`autoclose:true` stamp, and then ask the shared executor to close with
+`state_reason: completed`. Missing or malformed stamps fail closed. Dry-run and live
+close use the same plan. Grant only the `issues: write` permission needed to mutate.
 
 ## Required Tests
 
-Cover:
+Start with failing engine and producer tests. Cover:
 
 - a frozen golden marker plus case, whitespace, and path-separator normalization;
 - changed titles and similar errors not matching;
@@ -74,16 +113,24 @@ Cover:
 - exact duplicates closing as `not_planned`;
 - missing `autoclose:true` preventing resolution.
 
-Extend `TrackingIssueTests.cs` through `tracking-issue.harness.js`, then add a real producer integration test. Verify label creation, all-state pagination, consumer syntax, and workflow compilation; helper-only tests are insufficient.
+Exercise planner/executor behavior through `TrackingIssueTests.cs` and
+`tracking-issue.harness.js`, then add a real producer integration test through its
+checked-in harness. Cross-language adapters need conformance coverage proving they
+delegate to the same engine. Verify label creation, all-state pagination, creator
+relisting, every transport mutation, dry-run parity, consumer syntax, and workflow
+compilation; helper-only tests are insufficient.
 
 ## Common Mistakes
 
 | Mistake | Correction |
 |---|---|
-| `search.issuesAndPullRequests` for dedup | Use the strongly consistent label list |
+| Search or an alternate CLI lookup | Use the shared all-state label-list transport |
+| Lifecycle logic embedded in YAML or C# | Delegate through a checked-in adapter to the shared planner/executor |
 | Hashing raw logs | Identify the durable subject, not one occurrence |
 | Closing fuzzy matches | Require exact markers or resolver-proven aliases |
 | Omitting `ensureLabel` | Create the lookup label before reconciliation |
 | Supplying pre-fetched open issues | Supply the complete all-state labeled inventory |
+| A separate dry-run decision tree | Execute the same plan against the dry-run transport |
+| Direct create for force-new | Use the planner and duplicate-exempt stamp |
 | Putting stale-day policy in the engine | Keep resolution policy in the producer |
 | Rewriting or deleting duplicate history | Link, close, and preserve it |

--- a/.agents/skills/automated-failure-issues/SKILL.md
+++ b/.agents/skills/automated-failure-issues/SKILL.md
@@ -12,7 +12,7 @@ operation through the checked-in tracking-issue modules. Treat identity as persi
 data: changing normalization, field order, delimiters, or hashing re-keys every
 historical issue.
 
-**REQUIRED SUB-SKILL:** Use test-driven-development for behavior changes.
+**Test first:** Behavior changes start with a failing test — see [Required Tests](#required-tests).
 
 ## Ownership Boundary
 

--- a/.agents/skills/ci-test-failures/SKILL.md
+++ b/.agents/skills/ci-test-failures/SKILL.md
@@ -549,6 +549,7 @@ Remove-Item tools/scripts/artifact_* -Recurse -Force -ErrorAction SilentlyContin
 
 - .NET 10 SDK or later
 - GitHub CLI (`gh`) installed and authenticated
+- Node.js (`node` on `PATH`) for shared reconciliation by standalone `CreateFailingTestIssue --create`
 - Access to the microsoft/aspire repository
 
 ## See Also

--- a/.github/workflows/create-failing-test-issue-tracking.js
+++ b/.github/workflows/create-failing-test-issue-tracking.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const tracking = require('./tracking-issue.js');
+const { createGhApiIssueTransport } = require('./tracking-issue-gh-api.js');
+
+async function reconcile({ transport, core, issue, runId, forceNew = false }) {
+    await transport.ensureLabel({
+        name: 'failing-test',
+        color: 'b60205',
+        description: 'A test is failing in CI',
+    });
+
+    let result;
+    if (forceNew) {
+        result = await tracking.executeIssueReconciliation(transport, core, {
+            label: 'failing-test',
+            labels: issue.labels,
+            marker: issue.metadataMarker,
+            title: issue.title,
+            buildBody: () => `${issue.body}\n\n${tracking.duplicateExemptStamp()}`,
+            forceCreate: true,
+            issues: [],
+        });
+    } else {
+        result = await tracking.reconcileRun(transport, core, {
+            label: 'failing-test',
+            labels: issue.labels,
+            marker: issue.metadataMarker,
+            title: issue.title,
+            runId,
+            buildBody: () => issue.body,
+            comment: issue.commentBody,
+            closeDuplicates: true,
+        });
+    }
+
+    const previousState = result.plan?.matches?.[0]?.state ?? null;
+    const action = result.created
+        ? 'created'
+        : result.reopened
+            ? 'reopened'
+            : result.skipped
+                ? 'found'
+                : 'updated';
+    return {
+        number: result.number,
+        action,
+        created: result.created,
+        reopened: result.reopened ?? false,
+        skipped: result.skipped ?? false,
+        duplicatesClosed: result.duplicatesClosed ?? [],
+        previousState,
+    };
+}
+
+async function runCli() {
+    let input = '';
+    for await (const chunk of process.stdin) {
+        input += chunk;
+    }
+
+    const request = JSON.parse(input);
+    const logs = [];
+    const result = await reconcile({
+        transport: createGhApiIssueTransport(request.repository),
+        core: { info: message => logs.push(String(message)) },
+        issue: request.issue,
+        runId: request.runId,
+        forceNew: request.forceNew === true,
+    });
+    process.stdout.write(JSON.stringify({
+        ...result,
+        url: `https://github.com/${request.repository}/issues/${result.number}`,
+        logs,
+    }));
+}
+
+module.exports = {
+    reconcile,
+};
+
+if (require.main === module) {
+    runCli().catch(error => {
+        process.stderr.write(`${error.stack ?? error}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/.github/workflows/create-failing-test-issue.js
+++ b/.github/workflows/create-failing-test-issue.js
@@ -142,11 +142,6 @@ function formatListResponse(resolverOutcome, resultJson) {
     return { error: false, message: 'No test failures were found. Use `--url` to point to a specific workflow run.\n\n' };
 }
 
-function buildIssueSearchQuery(owner, repo, metadataMarker) {
-    const escapedMarker = String(metadataMarker ?? '').replaceAll('"', '\\"');
-    return `repo:${owner}/${repo} is:issue label:failing-test in:body "${escapedMarker}"`;
-}
-
 function isSupportedSourceUrl(value) {
     if (typeof value !== 'string') {
         return false;
@@ -158,7 +153,6 @@ function isSupportedSourceUrl(value) {
 }
 
 module.exports = {
-    buildIssueSearchQuery,
     formatListResponse,
     isSupportedSourceUrl,
     parseCommand,

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -193,6 +193,7 @@ jobs:
           const fs = require('fs');
           const helper = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/create-failing-test-issue.js`);
           const tracking = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/tracking-issue.js`);
+          const failingTestTracking = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/create-failing-test-issue-tracking.js`);
           const prNumber = process.env.PR_NUMBER ? parseInt(process.env.PR_NUMBER, 10) : null;
           const resolverFailed = process.env.RESOLVE_OUTCOME === 'failure';
           const hasResultFile = fs.existsSync(process.env.RESULT_PATH) && fs.statSync(process.env.RESULT_PATH).size > 0;
@@ -270,44 +271,16 @@ jobs:
             return;
           }
 
-          let action;
-          let issueNumber;
-          let issueUrl;
-
-          if (process.env.FORCE_NEW === 'true') {
-            const { data: issue } = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: result.issue.title,
-              body: `${result.issue.body}\n\n${tracking.duplicateExemptStamp()}`,
-              labels: result.issue.labels
-            });
-
-            action = 'created';
-            issueNumber = issue.number;
-            issueUrl = issue.html_url;
-          } else {
-            const reconciliation = await tracking.recordRun(github, context, core, {
-              label: 'failing-test',
-              labels: result.issue.labels,
-              marker: result.issue.metadataMarker,
-              title: result.issue.title,
-              runId: result.resolution.runId,
-              buildBody: () => result.issue.body,
-              comment: result.issue.commentBody,
-              closeDuplicates: true,
-            });
-
-            action = reconciliation.created
-              ? 'created'
-              : reconciliation.reopened
-                ? 'reopened'
-                : reconciliation.skipped
-                  ? 'found'
-                  : 'updated';
-            issueNumber = reconciliation.number;
-            issueUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/${issueNumber}`;
-          }
+          const reconciliation = await failingTestTracking.reconcile({
+            transport: tracking.createOctokitIssueTransport(github, context),
+            core,
+            issue: result.issue,
+            runId: result.resolution.runId,
+            forceNew: process.env.FORCE_NEW === 'true',
+          });
+          const action = reconciliation.action;
+          const issueNumber = reconciliation.number;
+          const issueUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/${issueNumber}`;
 
           const testName = result.match?.canonicalTestName ?? result.match?.displayTestName ?? '';
           let disableHint = '';

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -192,6 +192,7 @@ jobs:
         script: |
           const fs = require('fs');
           const helper = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/create-failing-test-issue.js`);
+          const tracking = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/tracking-issue.js`);
           const prNumber = process.env.PR_NUMBER ? parseInt(process.env.PR_NUMBER, 10) : null;
           const resolverFailed = process.env.RESOLVE_OUTCOME === 'failure';
           const hasResultFile = fs.existsSync(process.env.RESULT_PATH) && fs.statSync(process.env.RESULT_PATH).size > 0;
@@ -269,63 +270,43 @@ jobs:
             return;
           }
 
-          let targetIssue = null;
-          if (process.env.FORCE_NEW !== 'true') {
-            const query = helper.buildIssueSearchQuery(context.repo.owner, context.repo.repo, result.issue.metadataMarker);
-            const { data: search } = await github.rest.search.issuesAndPullRequests({
-              q: query,
-              per_page: 20
-            });
-
-            const issues = search.items.filter(item => !item.pull_request);
-            targetIssue = issues.find(item => item.state === 'open') ?? issues.find(item => item.state === 'closed') ?? null;
-          }
-
           let action;
           let issueNumber;
           let issueUrl;
 
-          if (targetIssue && targetIssue.state === 'open') {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: targetIssue.number,
-              body: result.issue.commentBody
-            });
-
-            action = 'updated';
-            issueNumber = targetIssue.number;
-            issueUrl = targetIssue.html_url;
-          } else if (targetIssue && targetIssue.state === 'closed') {
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: targetIssue.number,
-              state: 'open'
-            });
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: targetIssue.number,
-              body: result.issue.commentBody
-            });
-
-            action = 'reopened';
-            issueNumber = targetIssue.number;
-            issueUrl = targetIssue.html_url;
-          } else {
+          if (process.env.FORCE_NEW === 'true') {
             const { data: issue } = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: result.issue.title,
-              body: result.issue.body,
+              body: `${result.issue.body}\n\n${tracking.duplicateExemptStamp()}`,
               labels: result.issue.labels
             });
 
             action = 'created';
             issueNumber = issue.number;
             issueUrl = issue.html_url;
+          } else {
+            const reconciliation = await tracking.recordRun(github, context, core, {
+              label: 'failing-test',
+              labels: result.issue.labels,
+              marker: result.issue.metadataMarker,
+              title: result.issue.title,
+              runId: result.resolution.runId,
+              buildBody: () => result.issue.body,
+              comment: result.issue.commentBody,
+              closeDuplicates: true,
+            });
+
+            action = reconciliation.created
+              ? 'created'
+              : reconciliation.reopened
+                ? 'reopened'
+                : reconciliation.skipped
+                  ? 'found'
+                  : 'updated';
+            issueNumber = reconciliation.number;
+            issueUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/${issueNumber}`;
           }
 
           const testName = result.match?.canonicalTestName ?? result.match?.displayTestName ?? '';

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -31,15 +31,10 @@ on:
 permissions: {}
 
 concurrency:
-  group: >-
-    create-failing-test-issue-${{
-      github.event_name == 'workflow_dispatch'
-      && format('dispatch-{0}', github.run_id)
-      || format('{0}-{1}',
-          github.event.issue.pull_request && 'pr' || 'issue',
-          github.event.issue.number)
-    }}
+  # Issue comments cannot atomically reserve occurrence markers, so serialize writers.
+  group: create-failing-test-issue
   cancel-in-progress: false
+  queue: max
 
 jobs:
   create_failing_test_issue:

--- a/.github/workflows/create-failing-test-issue.yml
+++ b/.github/workflows/create-failing-test-issue.yml
@@ -30,26 +30,18 @@ on:
 
 permissions: {}
 
-concurrency:
-  # Issue comments cannot atomically reserve occurrence markers, so serialize writers.
-  group: create-failing-test-issue
-  cancel-in-progress: false
-  queue: max
-
 jobs:
-  create_failing_test_issue:
-    name: Create failing-test issue
+  authorize_failing_test_issue:
+    name: Authorize failing-test issue
     if: >-
       github.repository == 'microsoft/aspire' &&
       (github.event_name == 'workflow_dispatch' ||
        startsWith(github.event.comment.body, '/create-issue'))
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     permissions:
-      contents: read # checkout repository
-      issues: write # create/reopen/comment on issues
-      pull-requests: write # comment on PRs
-      actions: read # list workflow runs and download artifacts
+      contents: read
+      issues: write
     steps:
     - name: Verify user has write access
       if: github.event_name == 'issue_comment'
@@ -78,6 +70,22 @@ jobs:
             return;
           }
 
+  create_failing_test_issue:
+    name: Create failing-test issue
+    needs: authorize_failing_test_issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read # checkout repository
+      issues: write # create/reopen/comment on issues
+      pull-requests: write # comment on PRs
+      actions: read # list workflow runs and download artifacts
+    concurrency:
+      # Issue comments cannot atomically reserve occurrence markers, so serialize writers.
+      group: create-failing-test-issue
+      cancel-in-progress: false
+      queue: max
+    steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: success()
       with:
@@ -295,7 +303,7 @@ jobs:
           }
 
     - name: Post failure comment on unexpected error
-      if: failure() && steps.extract-command.outcome == 'success' && (steps.verify-permission.outcome == 'success' || steps.verify-permission.outcome == 'skipped')
+      if: failure() && steps.extract-command.outcome == 'success'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         PR_NUMBER: ${{ steps.extract-command.outputs.pr_number }}

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -183,7 +183,14 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
     // distinct, so a fresh issue filed for one cannot affect another's lookup.
     // Failure recording must include closed issues so a recurring failure reopens
     // the canonical tracker instead of filing a duplicate.
-    const issues = await tracking.listIssuesByLabel(github, owner, repo, label);
+    const liveTransport = tracking.createOctokitIssueTransport(github, context);
+    let issues = await liveTransport.listIssues(label);
+    const transport = dryRun
+        ? tracking.createDryRunIssueTransport(liveTransport, issues)
+        : liveTransport;
+    if (dryRun) {
+        issues = transport.issues;
+    }
     for (const wf of watched) {
         let recentRuns;
         try {
@@ -240,47 +247,26 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                 // the lookup label; dedup keeps automation-broken single if also listed.
                 const issueLabels = [...new Set([label, ...(wf.labels ?? [])])];
                 const issueBody = buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true });
-                if (dryRun) {
-                    const recordingIssue = managedIssues[0] ?? null;
-                    const duplicateIssues = managedIssues.slice(1).filter(issue => issue.state === 'open');
-                    for (const duplicateIssue of duplicateIssues) {
-                        log(`would CLOSE duplicate issue #${duplicateIssue.number} as not_planned (canonical #${recordingIssue.number})`);
-                        duplicateIssue.state = 'closed';
-                    }
-
-                    let occurrenceIssue = null;
-                    for (const matchingIssue of managedIssues) {
-                        if (!matchingIssue.dryRunPlaceholder &&
-                            await tracking.hasCommentForRun(github, owner, repo, matchingIssue.number, tracking.runMarker(latest.id))) {
-                            occurrenceIssue = matchingIssue;
-                            break;
-                        }
-                    }
-
-                    if (occurrenceIssue !== null) {
-                        if (recordingIssue.state === 'closed' && occurrenceIssue.number !== recordingIssue.number) {
-                            log(`would REOPEN canonical issue #${recordingIssue.number}; run ${latest.id} is recorded on duplicate #${occurrenceIssue.number}`);
-                            recordingIssue.state = 'open';
-                        }
-                        core.info(`Run ${latest.id} already recorded in #${occurrenceIssue.number}; skipping duplicate comment.`);
-                        continue;
-                    }
-
-                    log(`would RECORD failure for ${wf.file} on ${recordingIssue ? formatIssueReference(recordingIssue) : 'a new issue'}`);
-                    if (recordingIssue === null) {
-                        issues.push({ number: 0, body: issueBody, labels: issueLabels, state: 'open', dryRunPlaceholder: true });
-                    } else if (recordingIssue.state === 'closed') {
-                        recordingIssue.state = 'open';
-                    }
-                    continue;
-                }
-                const result = await tracking.recordRun(github, context, core, {
+                const recordingIssue = managedIssues[0] ?? null;
+                const result = await tracking.reconcileRun(transport, core, {
                     label, labels: issueLabels, marker, title: buildIssueTitle(wf.name),
                     runId: latest.id,
                     buildBody: () => issueBody,
                     comment, issues,
                     closeDuplicates: true,
                 });
+                if (dryRun) {
+                    for (const duplicateNumber of result.duplicatesClosed) {
+                        log(`would CLOSE duplicate issue #${duplicateNumber} as not_planned (canonical #${result.number})`);
+                    }
+                    if (result.reopened) {
+                        log(`would REOPEN canonical issue #${result.number}`);
+                    }
+                    if (!result.skipped) {
+                        log(`would RECORD failure for ${wf.file} on ${recordingIssue ? formatIssueReference(recordingIssue) : 'a new issue'}`);
+                    }
+                    continue;
+                }
                 for (const duplicateNumber of result.duplicatesClosed) {
                     const duplicateIssue = issues.find(issue => issue.number === duplicateNumber);
                     if (duplicateIssue !== undefined) {
@@ -316,20 +302,40 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                 continue;
             }
 
-            const autoClose = tracking.readAutoClose(issue.body);
-            if (autoClose !== true) {
+            const closeComment = `Latest run succeeded ([run #${newest.run_number}](${newest.html_url})). Closing automatically.`;
+            const closeOptions = {
+                issues,
+                label,
+                marker,
+                title: buildIssueTitle(wf.name),
+                buildBody: () => buildIssueBody({
+                    marker,
+                    displayName: wf.name,
+                    workflowFile: wf.file,
+                    selfReports: wf.selfReports === true,
+                }),
+                createIfMissing: false,
+                closeDuplicates: true,
+                reopen: 'never',
+                actionsForCanonical: candidate =>
+                    candidate.state === 'open' && tracking.readAutoClose(candidate.body) === true
+                        ? [
+                            { type: 'close', stateReason: 'completed' },
+                            { type: 'comment', body: closeComment },
+                        ]
+                        : [],
+            };
+            const closePlan = tracking.planIssueReconciliation(closeOptions);
+            if (!closePlan.actions.some(candidate => candidate.type === 'close')) {
                 core.info(`Issue #${issue.number} for ${wf.file} does not opt into auto-close; leaving it open.`);
                 continue;
             }
 
-            if (dryRun) {
+            const result = await tracking.executeIssueReconciliation(transport, core, closeOptions);
+            if (dryRun && result.appliedActions.some(candidate => candidate.type === 'close')) {
                 log(`would CLOSE ${formatIssueReference(issue)} (${wf.file})`);
-                issue.state = 'closed';
                 continue;
             }
-            await tracking.closeIssue(github, owner, repo, issue.number);
-            await tracking.addComment(github, owner, repo, issue.number,
-                `Latest run succeeded ([run #${newest.run_number}](${newest.html_url})). Closing automatically.`);
             issue.state = 'closed';
             core.info(`Closed #${issue.number} for ${wf.file}`);
         }

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -335,6 +335,9 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
             const canonicalClosed = result.appliedActions.some(candidate =>
                 candidate.type === 'close' && candidate.issueNumber === result.number);
             if (dryRun) {
+                for (const duplicateNumber of result.duplicatesClosed) {
+                    log(`would CLOSE duplicate issue #${duplicateNumber} as not_planned (canonical #${result.number})`);
+                }
                 if (canonicalClosed) {
                     const canonical = issues.find(candidate => candidate.number === result.number) ?? issue;
                     log(`would CLOSE ${formatIssueReference(canonical)} (${wf.file})`);

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -332,12 +332,28 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
             }
 
             const result = await tracking.executeIssueReconciliation(transport, core, closeOptions);
-            if (dryRun && result.appliedActions.some(candidate => candidate.type === 'close')) {
-                log(`would CLOSE ${formatIssueReference(issue)} (${wf.file})`);
+            const canonicalClosed = result.appliedActions.some(candidate =>
+                candidate.type === 'close' && candidate.issueNumber === result.number);
+            if (dryRun) {
+                if (canonicalClosed) {
+                    const canonical = issues.find(candidate => candidate.number === result.number) ?? issue;
+                    log(`would CLOSE ${formatIssueReference(canonical)} (${wf.file})`);
+                }
                 continue;
             }
-            issue.state = 'closed';
-            core.info(`Closed #${issue.number} for ${wf.file}`);
+
+            for (const action of result.appliedActions.filter(candidate => candidate.type === 'close')) {
+                const closedIssue = issues.find(candidate => candidate.number === action.issueNumber);
+                if (closedIssue !== undefined) {
+                    closedIssue.state = 'closed';
+                }
+            }
+
+            if (canonicalClosed) {
+                core.info(`Closed #${result.number} for ${wf.file}`);
+            } else if (result.duplicatesClosed.length > 0) {
+                core.info(`Reconciled ${result.duplicatesClosed.length} duplicate issue(s) for ${wf.file}.`);
+            }
         }
     }
 }

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -217,7 +217,9 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                 continue;
             }
 
-            const issue = tracking.findOpenIssueForMarker(issues, marker);
+            const managedIssues = tracking.findIssuesForMarkers(issues, [marker])
+                .filter(issue => !tracking.isDuplicateExempt(issue));
+            const issue = managedIssues[0] ?? null;
             const conclusion = latest.conclusion;
             // `selfReports` entries own their plain failures in-pipeline; the watchdog
             // only backstops the conclusions that reporter cannot catch.
@@ -239,11 +241,28 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                 const issueLabels = [...new Set([label, ...(wf.labels ?? [])])];
                 const issueBody = buildIssueBody({ marker, displayName: wf.name, workflowFile: wf.file, selfReports: wf.selfReports === true });
                 if (dryRun) {
-                    const recordingIssue = tracking.findOpenIssueForMarker(issues, marker) ?? tracking.findIssueForMarker(issues, marker);
-                    if (recordingIssue !== null &&
-                        !recordingIssue.dryRunPlaceholder &&
-                        await tracking.hasCommentForRun(github, owner, repo, recordingIssue.number, tracking.runMarker(latest.id))) {
-                        core.info(`Run ${latest.id} already recorded in #${recordingIssue.number}; skipping duplicate comment.`);
+                    const recordingIssue = managedIssues[0] ?? null;
+                    const duplicateIssues = managedIssues.slice(1).filter(issue => issue.state === 'open');
+                    for (const duplicateIssue of duplicateIssues) {
+                        log(`would CLOSE duplicate issue #${duplicateIssue.number} as not_planned (canonical #${recordingIssue.number})`);
+                        duplicateIssue.state = 'closed';
+                    }
+
+                    let occurrenceIssue = null;
+                    for (const matchingIssue of managedIssues) {
+                        if (!matchingIssue.dryRunPlaceholder &&
+                            await tracking.hasCommentForRun(github, owner, repo, matchingIssue.number, tracking.runMarker(latest.id))) {
+                            occurrenceIssue = matchingIssue;
+                            break;
+                        }
+                    }
+
+                    if (occurrenceIssue !== null) {
+                        if (recordingIssue.state === 'closed' && occurrenceIssue.number !== recordingIssue.number) {
+                            log(`would REOPEN canonical issue #${recordingIssue.number}; run ${latest.id} is recorded on duplicate #${occurrenceIssue.number}`);
+                            recordingIssue.state = 'open';
+                        }
+                        core.info(`Run ${latest.id} already recorded in #${occurrenceIssue.number}; skipping duplicate comment.`);
                         continue;
                     }
 
@@ -260,7 +279,14 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                     runId: latest.id,
                     buildBody: () => issueBody,
                     comment, issues,
+                    closeDuplicates: true,
                 });
+                for (const duplicateNumber of result.duplicatesClosed) {
+                    const duplicateIssue = issues.find(issue => issue.number === duplicateNumber);
+                    if (duplicateIssue !== undefined) {
+                        duplicateIssue.state = 'closed';
+                    }
+                }
                 if (result.created) {
                     issues.push({ number: result.number, body: issueBody, labels: issueLabels, state: 'open' });
                 } else if (result.reopened) {
@@ -279,7 +305,9 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
 
         const newestConclusion = typeof newest.conclusion === 'string' ? newest.conclusion.toLowerCase() : null;
         if (newestConclusion !== null && SUCCESS_CONCLUSIONS.has(newestConclusion)) {
-            const issue = tracking.findOpenIssueForMarker(issues, marker);
+            const issue = tracking.findIssuesForMarkers(issues, [marker])
+                .filter(candidate => !tracking.isDuplicateExempt(candidate))
+                .find(candidate => candidate.state === 'open') ?? null;
             const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
             const { action, reason } = decideAction({ conclusion: newest.conclusion, issue, failureConclusions });
             core.info(`${wf.file}: newest run=${newest.id ?? '?'} conclusion=${newest.conclusion ?? 'none'} -> ${action} (${reason})`);

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -179,11 +179,9 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
         });
     }
 
-    // Reuse the initial all-state inventory while recording failures so a recurring
-    // failure reopens its canonical tracker instead of filing a duplicate. Trusted
-    // success handling re-lists through the selected transport immediately before
-    // auto-close, and that live or simulated inventory becomes the shared snapshot
-    // for later watched workflows.
+    // Start each polling window from one all-state inventory. Reconciliation refreshes
+    // this snapshot so later runs and watched workflows observe canonicalization,
+    // comments, and closures performed by earlier entries in the same window.
     const liveTransport = tracking.createOctokitIssueTransport(github, context);
     let issues = await liveTransport.listIssues(label);
     const transport = dryRun
@@ -256,6 +254,7 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                     comment, issues,
                     closeDuplicates: true,
                 });
+                issues = await transport.listIssues(label);
                 if (dryRun) {
                     for (const duplicateNumber of result.duplicatesClosed) {
                         log(`would CLOSE duplicate issue #${duplicateNumber} as not_planned (canonical #${result.number})`);
@@ -267,20 +266,6 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                         log(`would RECORD failure for ${wf.file} on ${recordingIssue ? formatIssueReference(recordingIssue) : 'a new issue'}`);
                     }
                     continue;
-                }
-                for (const duplicateNumber of result.duplicatesClosed) {
-                    const duplicateIssue = issues.find(issue => issue.number === duplicateNumber);
-                    if (duplicateIssue !== undefined) {
-                        duplicateIssue.state = 'closed';
-                    }
-                }
-                if (result.created) {
-                    issues.push({ number: result.number, body: issueBody, labels: issueLabels, state: 'open' });
-                } else if (result.reopened) {
-                    const recordedIssue = tracking.findIssueForMarker(issues, marker);
-                    if (recordedIssue !== null) {
-                        recordedIssue.state = 'open';
-                    }
                 }
 
                 if (!result.skipped) {
@@ -335,6 +320,7 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
             }
 
             const result = await tracking.executeIssueReconciliation(transport, core, closeOptions);
+            issues = await transport.listIssues(label);
             const canonicalClosed = result.appliedActions.some(candidate =>
                 candidate.type === 'close' && candidate.issueNumber === result.number);
             if (dryRun) {
@@ -346,13 +332,6 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                     log(`would CLOSE ${formatIssueReference(canonical)} (${wf.file})`);
                 }
                 continue;
-            }
-
-            for (const action of result.appliedActions.filter(candidate => candidate.type === 'close')) {
-                const closedIssue = closeIssues.find(candidate => candidate.number === action.issueNumber);
-                if (closedIssue !== undefined) {
-                    closedIssue.state = 'closed';
-                }
             }
 
             if (canonicalClosed) {

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -179,10 +179,11 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
         });
     }
 
-    // List once and reuse across watched workflows; each workflow's marker is
-    // distinct, so a fresh issue filed for one cannot affect another's lookup.
-    // Failure recording must include closed issues so a recurring failure reopens
-    // the canonical tracker instead of filing a duplicate.
+    // Reuse the initial all-state inventory while recording failures so a recurring
+    // failure reopens its canonical tracker instead of filing a duplicate. Trusted
+    // success handling re-lists through the selected transport immediately before
+    // auto-close, and that live or simulated inventory becomes the shared snapshot
+    // for later watched workflows.
     const liveTransport = tracking.createOctokitIssueTransport(github, context);
     let issues = await liveTransport.listIssues(label);
     const transport = dryRun

--- a/.github/workflows/monitor-scheduled-workflows.js
+++ b/.github/workflows/monitor-scheduled-workflows.js
@@ -291,7 +291,9 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
 
         const newestConclusion = typeof newest.conclusion === 'string' ? newest.conclusion.toLowerCase() : null;
         if (newestConclusion !== null && SUCCESS_CONCLUSIONS.has(newestConclusion)) {
-            const issue = tracking.findIssuesForMarkers(issues, [marker])
+            const closeIssues = await transport.listIssues(label);
+            issues = closeIssues;
+            const issue = tracking.findIssuesForMarkers(closeIssues, [marker])
                 .filter(candidate => !tracking.isDuplicateExempt(candidate))
                 .find(candidate => candidate.state === 'open') ?? null;
             const failureConclusions = wf.selfReports ? BACKSTOP_CONCLUSIONS : FAILURE_CONCLUSIONS;
@@ -304,7 +306,7 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
 
             const closeComment = `Latest run succeeded ([run #${newest.run_number}](${newest.html_url})). Closing automatically.`;
             const closeOptions = {
-                issues,
+                issues: closeIssues,
                 label,
                 marker,
                 title: buildIssueTitle(wf.name),
@@ -339,14 +341,14 @@ async function run({ github, context, core, dryRun = false, now = new Date() }) 
                     log(`would CLOSE duplicate issue #${duplicateNumber} as not_planned (canonical #${result.number})`);
                 }
                 if (canonicalClosed) {
-                    const canonical = issues.find(candidate => candidate.number === result.number) ?? issue;
+                    const canonical = closeIssues.find(candidate => candidate.number === result.number) ?? issue;
                     log(`would CLOSE ${formatIssueReference(canonical)} (${wf.file})`);
                 }
                 continue;
             }
 
             for (const action of result.appliedActions.filter(candidate => candidate.type === 'close')) {
-                const closedIssue = issues.find(candidate => candidate.number === action.issueNumber);
+                const closedIssue = closeIssues.find(candidate => candidate.number === action.issueNumber);
                 if (closedIssue !== undefined) {
                     closedIssue.state = 'closed';
                 }

--- a/.github/workflows/report-ci-failure.js
+++ b/.github/workflows/report-ci-failure.js
@@ -119,25 +119,49 @@ async function resolveSuccess({ github, context, core }) {
     const { owner, repo } = context.repo;
 
     const marker = buildMarker(ref);
-    const open = await tracking.listOpenIssuesByLabel(github, owner, repo, AUTOMATION_BROKEN_LABEL);
-    const issue = tracking.findOpenIssueForMarker(open, marker);
+    const run = runContext(context);
+    const result = await tracking.executeIssueReconciliation(
+        tracking.createOctokitIssueTransport(github, context),
+        core,
+        {
+            label: AUTOMATION_BROKEN_LABEL,
+            marker,
+            title: buildIssueTitle(ref),
+            buildBody: () => buildIssueBody({ marker, ref }),
+            createIfMissing: false,
+            closeDuplicates: true,
+            reopen: 'never',
+            actionsForCanonical: issue => {
+                if (issue.state !== 'open' || tracking.readAutoClose(issue.body) !== true) {
+                    return [];
+                }
+                return [
+                    { type: 'close', stateReason: 'completed' },
+                    {
+                        type: 'comment',
+                        body: `CI is green again on \`${ref}\` ([run #${run.runNumber}](${run.runUrl})). Closing automatically.`,
+                    },
+                ];
+            },
+        });
 
-    if (issue === null) {
+    if (result.number === null) {
         core.info(`No open CI-failure issue for ${ref}; nothing to close.`);
         return;
     }
 
-    const autoClose = tracking.readAutoClose(issue.body);
-    if (autoClose !== true) {
-        core.info(`CI-failure issue #${issue.number} for ${ref} does not opt into auto-close; leaving it open.`);
+    const closed = result.appliedActions.some(action =>
+        action.type === 'close' && action.issueNumber === result.number);
+    if (!closed) {
+        if (result.duplicatesClosed.length > 0) {
+            core.info(`Reconciled ${result.duplicatesClosed.length} duplicate CI-failure issue(s) for ${ref}.`);
+            return;
+        }
+        core.info(`CI-failure issue #${result.number} for ${ref} is closed or does not opt into auto-close; leaving it unchanged.`);
         return;
     }
 
-    const run = runContext(context);
-    await tracking.closeIssue(github, owner, repo, issue.number);
-    await tracking.addComment(github, owner, repo, issue.number,
-        `CI is green again on \`${ref}\` ([run #${run.runNumber}](${run.runUrl})). Closing automatically.`);
-    core.info(`Closed #${issue.number} for ci.yml on ${ref}`);
+    core.info(`Closed #${result.number} for ci.yml on ${ref}`);
 }
 
 // Single entry point for ci.yml's tracker job, which runs on every push

--- a/.github/workflows/report-ci-failure.js
+++ b/.github/workflows/report-ci-failure.js
@@ -104,6 +104,7 @@ async function reportFailure({ github, context, core }) {
         runId: context.runId,
         buildBody: () => buildIssueBody({ marker, ref }),
         comment: formatComment({ run: runContext(context) }),
+        closeDuplicates: true,
     });
 
     if (!result.skipped) {

--- a/.github/workflows/report-pipeline-failure.js
+++ b/.github/workflows/report-pipeline-failure.js
@@ -104,6 +104,7 @@ async function report({ github, context, core, labels, cc = '', commentDetail = 
         runId: context.runId,
         buildBody: () => buildIssueBody({ marker, displayName, workflowFile, cc }),
         comment: formatComment({ run, detail: commentDetail }),
+        closeDuplicates: true,
     });
 
     if (!result.skipped) {

--- a/.github/workflows/specialized-test-failure-runner.js
+++ b/.github/workflows/specialized-test-failure-runner.js
@@ -82,6 +82,7 @@ module.exports = async function reportSpecializedTestFailure({ github, context, 
         runId: context.runId,
         buildBody: () => reporter.buildIssueBody({ marker, displayName, workflowFile, kind }),
         comment: reporter.formatComment({ kind, run, failedTests }),
+        closeDuplicates: true,
     });
 
     if (result.skipped) {

--- a/.github/workflows/tracking-issue-gh-api.js
+++ b/.github/workflows/tracking-issue-gh-api.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+function runGh(args, input) {
+    return new Promise((resolve, reject) => {
+        const child = spawn('gh', args, {
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+        child.stdout.on('data', chunk => { stdout += chunk; });
+        child.stderr.on('data', chunk => { stderr += chunk; });
+        child.on('error', reject);
+        child.on('close', code => {
+            if (code === 0) {
+                resolve(stdout);
+                return;
+            }
+            reject(new Error(`gh ${args.join(' ')} failed: ${stderr.trim() || stdout.trim()}`));
+        });
+        child.stdin.end(input);
+    });
+}
+
+function parsePaginatedJson(content) {
+    const value = JSON.parse(content);
+    if (Array.isArray(value[0])) {
+        return value.flat();
+    }
+    return value;
+}
+
+function createFixtureTransport(repository, fixtureDirectory) {
+    const readFixture = name => JSON.parse(
+        fs.readFileSync(path.join(fixtureDirectory, `${name}.json`), 'utf8'));
+    const listIssuesPath = path.join(fixtureDirectory, 'list-issues.json');
+    const issues = (fs.existsSync(listIssuesPath)
+        ? parsePaginatedJson(JSON.stringify(readFixture('list-issues')))
+        : [])
+        .filter(issue => !issue.pull_request)
+        .map(issue => ({ comments: [], ...issue }));
+
+    return {
+        ensureLabel: async () => {},
+        listIssues: async () => issues,
+        createIssue: async request => {
+            const response = readFixture('create-issue');
+            const issue = {
+                ...request,
+                number: response.number,
+                html_url: response.html_url ?? response.url ??
+                    `https://github.com/${repository}/issues/${response.number}`,
+                state: 'open',
+                comments: [],
+            };
+            issues.push(issue);
+            return issue;
+        },
+        updateIssue: async (issueNumber, patch) => Object.assign(
+            issues.find(issue => issue.number === issueNumber),
+            patch),
+        addComment: async (issueNumber, body) => {
+            readFixture('add-issue-comment');
+            issues.find(issue => issue.number === issueNumber).comments.push(body);
+        },
+        closeIssue: async (issueNumber, { stateReason = 'completed' } = {}) => {
+            readFixture('close-issue');
+            Object.assign(issues.find(issue => issue.number === issueNumber), {
+                state: 'closed',
+                state_reason: stateReason,
+            });
+        },
+        reopenIssue: async issueNumber => {
+            readFixture('reopen-issue');
+            issues.find(issue => issue.number === issueNumber).state = 'open';
+        },
+        listComments: async issueNumber => {
+            const fixtureName = `list-comments-${issueNumber}`;
+            const fixturePath = path.join(fixtureDirectory, `${fixtureName}.json`);
+            if (fs.existsSync(fixturePath)) {
+                return parsePaginatedJson(JSON.stringify(readFixture(fixtureName)));
+            }
+            return issues.find(issue => issue.number === issueNumber).comments.map(body => ({ body }));
+        },
+    };
+}
+
+function createGhApiIssueTransport(
+    repository,
+    {
+        runGh: invokeGh = runGh,
+        fixtureDirectory = process.env.ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR,
+    } = {}) {
+    if (fixtureDirectory) {
+        return createFixtureTransport(repository, fixtureDirectory);
+    }
+
+    const invokeJson = async (args, body) => {
+        const content = await invokeGh(
+            ['api', ...args, ...(body === undefined ? [] : ['--input', '-'])],
+            body === undefined ? undefined : JSON.stringify(body));
+        return content.trim() ? JSON.parse(content) : {};
+    };
+    const invokePaginated = async endpoint => parsePaginatedJson(
+        await invokeGh(['api', '--paginate', '--slurp', endpoint]));
+    const issueEndpoint = issueNumber => `repos/${repository}/issues/${issueNumber}`;
+
+    return {
+        ensureLabel: async definition => {
+            try {
+                await invokeJson(
+                    ['--method', 'POST', `repos/${repository}/labels`],
+                    definition);
+            } catch (error) {
+                if (!error.message.includes('HTTP 422')) {
+                    throw error;
+                }
+            }
+        },
+        listIssues: async label => (await invokePaginated(
+            `repos/${repository}/issues?labels=${encodeURIComponent(label)}&state=all&per_page=100`))
+            .filter(issue => !issue.pull_request),
+        createIssue: async request => await invokeJson(
+            ['--method', 'POST', `repos/${repository}/issues`],
+            request),
+        updateIssue: async (issueNumber, patch) => await invokeJson(
+            ['--method', 'PATCH', issueEndpoint(issueNumber)],
+            patch),
+        addComment: async (issueNumber, body) => {
+            await invokeJson(
+                ['--method', 'POST', `${issueEndpoint(issueNumber)}/comments`],
+                { body });
+        },
+        closeIssue: async (issueNumber, { stateReason = 'completed' } = {}) => {
+            await invokeJson(
+                ['--method', 'PATCH', issueEndpoint(issueNumber)],
+                { state: 'closed', state_reason: stateReason });
+        },
+        reopenIssue: async issueNumber => {
+            await invokeJson(
+                ['--method', 'PATCH', issueEndpoint(issueNumber)],
+                { state: 'open' });
+        },
+        listComments: async issueNumber => await invokePaginated(
+            `${issueEndpoint(issueNumber)}/comments?per_page=100`),
+    };
+}
+
+module.exports = {
+    createGhApiIssueTransport,
+};

--- a/.github/workflows/tracking-issue-gh-api.js
+++ b/.github/workflows/tracking-issue-gh-api.js
@@ -43,15 +43,23 @@ function createFixtureTransport(repository, fixtureDirectory) {
     const readFixture = name => JSON.parse(
         fs.readFileSync(path.join(fixtureDirectory, `${name}.json`), 'utf8'));
     const listIssuesPath = path.join(fixtureDirectory, 'list-issues.json');
+    const concurrentIssuePath = path.join(fixtureDirectory, 'concurrent-issue.json');
     const issues = (fs.existsSync(listIssuesPath)
         ? parsePaginatedJson(JSON.stringify(readFixture('list-issues')))
         : [])
         .filter(issue => !issue.pull_request)
         .map(issue => ({ comments: [], ...issue }));
+    let listCount = 0;
 
     return {
         ensureLabel: async () => {},
-        listIssues: async () => issues,
+        listIssues: async () => {
+            listCount++;
+            if (listCount === 2 && fs.existsSync(concurrentIssuePath)) {
+                issues.push({ comments: [], ...readFixture('concurrent-issue') });
+            }
+            return issues;
+        },
         createIssue: async request => {
             const response = readFixture('create-issue');
             const issue = {

--- a/.github/workflows/tracking-issue-gh-api.js
+++ b/.github/workflows/tracking-issue-gh-api.js
@@ -27,6 +27,10 @@ function runGh(args, input) {
     });
 }
 
+// Live `gh api --paginate --slurp` output is an array of page arrays,
+// `[[{...}], [{...}]]`, while fixtures and injected runners use the flat
+// `[{...}]` shape. Entries are issue or comment objects, so only a paginated
+// response can have an array as its first element.
 function parsePaginatedJson(content) {
     const value = JSON.parse(content);
     if (Array.isArray(value[0])) {

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -434,6 +434,7 @@ function createDryRunIssueTransport(sourceTransport, issues, onAction = () => {}
                 state: 'open',
                 comments: [],
                 ...request,
+                dryRunPlaceholder: true,
             };
             inventory.push(issue);
             onAction({ type: 'create', issueNumber: issue.number, ...request });

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -316,8 +316,12 @@ async function executeIssueReconciliation(transport, core, options) {
         }
     }
 
-    const canonicalIssueNumber = plan.canonicalIssueNumber ?? createdIssue?.number;
-    core.info(`Reconciled tracking issue #${canonicalIssueNumber}.`);
+    const canonicalIssueNumber = plan.canonicalIssueNumber ?? createdIssue?.number ?? null;
+    if (canonicalIssueNumber === null) {
+        core.info('No matching tracking issue to reconcile.');
+    } else {
+        core.info(`Reconciled tracking issue #${canonicalIssueNumber}.`);
+    }
     return {
         number: canonicalIssueNumber,
         created: createdIssue?.number === canonicalIssueNumber,
@@ -413,7 +417,7 @@ function createDryRunIssueTransport(sourceTransport, issues, onAction = () => {}
     const inventory = (issues ?? []).map(issue => ({
         ...issue,
         labels: [...(issue.labels ?? [])],
-        comments: issue.comments ? [...issue.comments] : undefined,
+        comments: Array.isArray(issue.comments) ? [...issue.comments] : undefined,
     }));
     let nextSyntheticIssueNumber = 0;
 

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -104,11 +104,24 @@ function planIssueReconciliation({
     title,
     buildBody,
     closeDuplicates = false,
+    createIfMissing = true,
+    forceCreate = false,
     isMatchingIssue = () => true,
     isCanonicalIssue = () => false,
     reopen = 'when-changing',
     actionsForCanonical = () => [],
 }) {
+    if (forceCreate) {
+        const body = buildBody();
+        return {
+            canonicalIssueNumber: null,
+            created: true,
+            requiresRelist: false,
+            matches: [],
+            actions: [{ type: 'create', title, body, labels: [...new Set([label, ...(labels ?? [])])] }],
+        };
+    }
+
     const matches = findIssuesForMarkers(
         issues,
         [marker, ...alternateMarkers],
@@ -117,6 +130,16 @@ function planIssueReconciliation({
     const issueLabels = [...new Set([label, ...(labels ?? [])])];
 
     if (matches.length === 0) {
+        if (!createIfMissing) {
+            return {
+                canonicalIssueNumber: null,
+                created: false,
+                requiresRelist: false,
+                matches: [],
+                actions: [],
+            };
+        }
+
         const body = buildBody();
         const syntheticIssue = {
             number: null,
@@ -372,6 +395,7 @@ async function hasCommentForRun(github, owner, repo, issueNumber, marker) {
 function createOctokitIssueTransport(github, context) {
     const { owner, repo } = context.repo;
     return {
+        ensureLabel: definition => ensureLabel(github, owner, repo, definition),
         listIssues: label => listIssuesByLabel(github, owner, repo, label),
         createIssue: request => createIssue(github, owner, repo, request),
         updateIssue: (issueNumber, patch) => updateIssue(
@@ -385,9 +409,63 @@ function createOctokitIssueTransport(github, context) {
     };
 }
 
-async function recordRun(
-    github,
-    context,
+function createDryRunIssueTransport(sourceTransport, issues, onAction = () => {}) {
+    const inventory = (issues ?? []).map(issue => ({
+        ...issue,
+        labels: [...(issue.labels ?? [])],
+        comments: issue.comments ? [...issue.comments] : undefined,
+    }));
+    let nextSyntheticIssueNumber = 0;
+
+    const findIssue = issueNumber => inventory.find(issue => issue.number === issueNumber);
+    return {
+        ensureLabel: async definition => {
+            onAction({ type: 'ensure-label', ...definition });
+        },
+        listIssues: async () => inventory,
+        createIssue: async request => {
+            const issue = {
+                number: nextSyntheticIssueNumber--,
+                state: 'open',
+                comments: [],
+                ...request,
+            };
+            inventory.push(issue);
+            onAction({ type: 'create', issueNumber: issue.number, ...request });
+            return issue;
+        },
+        updateIssue: async (issueNumber, patch) => {
+            Object.assign(findIssue(issueNumber), patch);
+            onAction({ type: 'update', issueNumber, ...patch });
+        },
+        addComment: async (issueNumber, body) => {
+            const issue = findIssue(issueNumber);
+            (issue.comments ??= []).push(body);
+            onAction({ type: 'comment', issueNumber, body });
+        },
+        closeIssue: async (issueNumber, { stateReason = 'completed' } = {}) => {
+            const issue = findIssue(issueNumber);
+            issue.state = 'closed';
+            issue.state_reason = stateReason;
+            onAction({ type: 'close', issueNumber, stateReason });
+        },
+        reopenIssue: async issueNumber => {
+            findIssue(issueNumber).state = 'open';
+            onAction({ type: 'reopen', issueNumber });
+        },
+        listComments: async issueNumber => {
+            const issue = findIssue(issueNumber);
+            if (issue.comments === undefined) {
+                issue.comments = await sourceTransport.listComments(issueNumber);
+            }
+            return issue.comments;
+        },
+        issues: inventory,
+    };
+}
+
+async function reconcileRun(
+    transport,
     core,
     {
         label,
@@ -402,7 +480,6 @@ async function recordRun(
         closeDuplicates = false,
         isMatchingIssue = () => true,
     }) {
-    const transport = createOctokitIssueTransport(github, context);
     const occurrenceMarker = runMarker(runId);
     const commentBody = `${comment}\n\n${occurrenceMarker}`;
     const prepareIssues = async inventory => {
@@ -465,7 +542,13 @@ async function recordRun(
         skipped: !recorded,
         reopened: result.reopened,
         duplicatesClosed: result.duplicatesClosed,
+        appliedActions: result.appliedActions,
+        plan: result.plan,
     };
+}
+
+async function recordRun(github, context, core, options) {
+    return await reconcileRun(createOctokitIssueTransport(github, context), core, options);
 }
 
 module.exports = {
@@ -481,6 +564,7 @@ module.exports = {
     planIssueReconciliation,
     executeIssueReconciliation,
     createOctokitIssueTransport,
+    createDryRunIssueTransport,
     ensureLabel,
     listIssuesByLabel,
     listOpenIssuesByLabel,
@@ -490,5 +574,6 @@ module.exports = {
     closeIssue,
     reopenIssue,
     hasCommentForRun,
+    reconcileRun,
     recordRun,
 };

--- a/.github/workflows/tracking-issue.js
+++ b/.github/workflows/tracking-issue.js
@@ -328,7 +328,8 @@ async function executeIssueReconciliation(transport, core, options) {
         reopened: appliedActions.some(action =>
             action.type === 'reopen' && action.issueNumber === canonicalIssueNumber),
         duplicatesClosed: appliedActions
-            .filter(action => action.type === 'close')
+            .filter(action =>
+                action.type === 'close' && action.issueNumber !== canonicalIssueNumber)
             .map(action => action.issueNumber),
         appliedActions,
         plan,

--- a/docs/ci/ci-failure-issues.md
+++ b/docs/ci/ci-failure-issues.md
@@ -85,6 +85,8 @@ canonicalization, duplicate closure, the per-run comment loop, and octokit
 primitives) live in the generic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), unit-tested by
 [`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
+Both failure recording and trusted green auto-close use its planner and executor;
+the reporter supplies only the branch identity, content, and close policy.
 
 The reporter logic — the pure helpers (marker, title, body, comment) and the
 `reportFailure()` / `resolveSuccess()` orchestrators (dispatched by `track()` from

--- a/docs/ci/ci-failure-issues.md
+++ b/docs/ci/ci-failure-issues.md
@@ -80,8 +80,9 @@ check avoids filing on a skip.
 
 ## Logic and tests
 
-The reusable issue mechanics (marker dedup, the comment-recording loop with
-per-run dedup, octokit primitives) live in the generic engine
+The reusable issue mechanics (exact-marker reconciliation, oldest-issue
+canonicalization, duplicate closure, the per-run comment loop, and octokit
+primitives) live in the generic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), unit-tested by
 [`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
 

--- a/docs/ci/monitor-scheduled-workflows.md
+++ b/docs/ci/monitor-scheduled-workflows.md
@@ -126,11 +126,12 @@ run succeeded" comment and is closed with `state_reason: completed`.
 
 ## Dedup
 
-Issue lookup uses `GET /issues?labels=automation-broken&state=open` (strongly
+Issue lookup uses `GET /issues?labels=automation-broken&state=all` (strongly
 consistent) plus a local body-marker filter — the Search API is avoided because
 its eventual-consistency window could let near-simultaneous runs each see
-"0 hits". If two open issues ever carry the same marker, the oldest (lowest
-number) is treated as canonical.
+"0 hits". If multiple issues carry the same exact marker, the oldest (lowest
+number) is canonical. Newer open matches are linked and closed with
+`state_reason: not_planned`; their discussion remains intact.
 
 ## Permissions and auth
 
@@ -146,8 +147,8 @@ warning and is skipped rather than failing the whole watchdog run.
 
 ## Logic and tests
 
-The reusable issue mechanics (marker dedup, the comment-recording loop with
-per-run dedup, octokit primitives) live in the generic, repo-agnostic engine
+The reusable issue mechanics (exact-marker reconciliation, duplicate closure, the
+per-run comment loop, and octokit primitives) live in the generic, repo-agnostic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), shared with the
 [specialized-test failure reporter](specialized-test-failure-issues.md), the
 [nightly-pipeline failure reporter](pipeline-failure-issues.md), the

--- a/docs/ci/monitor-scheduled-workflows.md
+++ b/docs/ci/monitor-scheduled-workflows.md
@@ -18,7 +18,9 @@ instead of per branch.
 
 Runs every 2 hours (`cron: '0 */2 * * *'`) and on `workflow_dispatch`. The
 manual dispatch accepts a `dry_run` boolean that logs the issue actions it
-*would* take without mutating anything on GitHub.
+*would* take without mutating anything on GitHub. Dry run executes the same shared
+reconciliation plan against an in-memory transport, rather than maintaining a
+second issue-selection implementation.
 
 Each run fetches recent completed scheduled runs and processes the runs updated
 in a three-hour polling window, oldest to newest. That prevents an hourly
@@ -148,7 +150,8 @@ warning and is skipped rather than failing the whole watchdog run.
 ## Logic and tests
 
 The reusable issue mechanics (exact-marker reconciliation, duplicate closure, the
-per-run comment loop, and octokit primitives) live in the generic, repo-agnostic engine
+per-run comment loop, trusted close mutations, dry-run transport, and octokit
+primitives) live in the generic, repo-agnostic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), shared with the
 [specialized-test failure reporter](specialized-test-failure-issues.md), the
 [nightly-pipeline failure reporter](pipeline-failure-issues.md), the

--- a/docs/ci/monitor-scheduled-workflows.md
+++ b/docs/ci/monitor-scheduled-workflows.md
@@ -125,6 +125,8 @@ plus any per-entry `labels`, and are stamped `autoClose:true`.
 When the newest completed scheduled run in the polling window concludes
 `success`, any open `automation-broken` issue for that workflow gets a "latest
 run succeeded" comment and is closed with `state_reason: completed`.
+Live success handling re-lists issues immediately before evaluating the trusted
+`autoclose:true` stamp so intervening user edits or closures are preserved.
 
 ## Dedup
 

--- a/docs/ci/pipeline-failure-issues.md
+++ b/docs/ci/pipeline-failure-issues.md
@@ -72,17 +72,18 @@ are **closed by a human** once the underlying problem is fixed; there is no
 auto-close-on-green (a dev mid-triage should not have the issue closed out from
 under them by a transient green run).
 
-Issue lookup uses `GET /issues?labels=automation-broken&state=open` (strongly
+Issue lookup uses `GET /issues?labels=automation-broken&state=all` (strongly
 consistent) plus a local marker filter. The query is a superset — it also returns
 the scanner's and specialized reporter's `automation-broken` issues — but the
 per-workflow marker (`ci-failure:<file>:scheduled`) selects only this pipeline's
 issue, so the three mechanisms never manage each other's issues. Pull requests
-returned by the list API are excluded.
+returned by the list API are excluded. The oldest exact marker match remains
+canonical; newer open matches are linked and closed as duplicates.
 
 ## Logic and tests
 
-The reusable issue mechanics (marker dedup, the comment-recording loop with
-per-run dedup, octokit primitives) live in the generic engine
+The reusable issue mechanics (exact-marker reconciliation, duplicate closure, the
+per-run comment loop, and octokit primitives) live in the generic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), unit-tested by
 [`TrackingIssueTests`](../../tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs).
 

--- a/docs/ci/pipeline-failure-issues.md
+++ b/docs/ci/pipeline-failure-issues.md
@@ -46,10 +46,12 @@ those two conclusions — see
 which:
 
 1. Ensures the `automation-broken` label exists.
-2. Finds the open issue carrying the per-workflow marker.
-3. **No open issue** → creates one (static body with the marker) and posts the
+2. Reconciles all issue states carrying the exact per-workflow marker, keeping the
+   oldest match canonical.
+3. **No matching issue** → creates one (static body with the marker) and posts the
    failure comment.
-4. **Open issue exists** → posts the failure comment, unless this run's comment is
+4. **Matching issue exists** → reopens it when needed and posts the failure comment,
+   unless this run's comment is
    already present (dedup), in which case it is a no-op.
 
 The **comment** is what fires notifications. The first filing notifies a team via

--- a/docs/ci/specialized-test-failure-issues.md
+++ b/docs/ci/specialized-test-failure-issues.md
@@ -67,12 +67,12 @@ An `actions/github-script` step then calls the shared orchestrator
 which:
 
 1. Classifies the failure and picks the label.
-2. Finds the open issue carrying the per-(workflow, kind) marker
+2. Reconciles all issue states carrying the exact per-(workflow, kind) marker
    `<!-- ci-failure:<workflow-file>:<kind> -->`.
-3. **No open issue** → creates one (static body with the marker) and posts the
+3. **No matching issue** → creates one (static body with the marker) and posts the
    failure comment.
-4. **Open issue exists** → posts the failure comment, unless this run's comment is
-   already present (dedup), in which case it is a no-op.
+4. **Matching issue exists** → reopens it when needed and posts the failure comment,
+   unless this run's comment is already present (dedup), in which case it is a no-op.
 
 The **comment** is what fires notifications; for `test-failures` it lists the
 failing tests (capped at 50, the rest are in the run artifacts). The issue body is
@@ -86,8 +86,10 @@ comment rather than filing a new issue. Issues are **closed by a human** once th
 underlying problem is fixed; there is no auto-close-on-green (a dev mid-triage
 should not have the issue closed out from under them by a transient green run).
 
-Issue lookup uses `GET /issues?labels=<label>&state=open` (strongly consistent)
-plus a local marker filter, mirroring the scanner. The markers use a distinct
+Issue lookup uses `GET /issues?labels=<label>&state=all` (strongly consistent)
+plus a local exact-marker filter, mirroring the scanner. The oldest match is
+canonical even when closed; newer exact duplicates are linked and closed as
+`not_planned`. The markers use a distinct
 `ci-failure:` prefix so the scanner and this reporter never manage each other's
 issues.
 

--- a/docs/ci/specialized-test-failure-issues.md
+++ b/docs/ci/specialized-test-failure-issues.md
@@ -100,8 +100,9 @@ scheduled pipeline is the same class of problem the scanner reports.
 
 ## Logic and tests
 
-The reusable issue mechanics (marker dedup, the comment-recording loop with
-per-run dedup, octokit primitives) live in the generic, repo-agnostic engine
+The reusable issue mechanics (exact-marker reconciliation, oldest-issue
+canonicalization, duplicate closure, the per-run comment loop, and octokit
+primitives) live in the generic, repo-agnostic engine
 [`tracking-issue.js`](../../.github/workflows/tracking-issue.js), shared with the
 [scheduled-workflow scanner](monitor-scheduled-workflows.md), the
 [nightly-pipeline failure reporter](pipeline-failure-issues.md), and the

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -344,6 +344,10 @@ path_rules:
     targets: [test:Aspire.Hosting.Sdk.Tests, test:Aspire.Hosting.DotnetTool.Tests, job:polyglot]
     reason: AppHost SDK targets + RuntimeIdentifier tool; SDK ships to every generated apphost
   - paths:
+      - tools/CreateFailingTestIssue/**
+    targets: [test:Infrastructure.Tests]
+    reason: Infrastructure.Tests dynamically builds and exercises the tool lifecycle without a ProjectReference
+  - paths:
       - tools/QuarantineTools/**
     targets: [test:QuarantineTools.Tests]
     reason: QuarantineTools.Tests exercises the quarantine/disable source-rewriting logic

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using Aspire.TestUtilities;
 using Xunit;
 
 namespace Infrastructure.Tests;
@@ -77,6 +78,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagCreatesIssueOnGitHub()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -118,6 +120,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagReusesOpenExistingIssue()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -163,6 +166,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagReopensClosedExistingIssue()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -209,6 +213,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagCreatesNewIssueWhenNoExistingIssueFound()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -253,6 +258,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task ForceNewFlagSkipsSearchAndCreatesNewIssue()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -290,6 +296,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagUsesOldestExactMatchAndClosesNewerDuplicate()
     {
         var fixtureDirectory = CreateFixtureDirectory();
@@ -338,6 +345,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagDoesNotReopenOrCommentWhenRunIsAlreadyRecordedOnCanonical()
     {
         var fixtureDirectory = CreateFixtureDirectory();

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
@@ -13,6 +13,8 @@ namespace Infrastructure.Tests;
 /// </summary>
 public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailingTestIssueFixture>, IDisposable
 {
+    private const string StableMetadataMarker = "<!-- failing-test-signature: v1:5462cd03581ff4ab -->";
+
     private readonly TemporaryWorkspace _workspace;
     private readonly CreateFailingTestIssueFixture _fixture;
     private readonly ITestOutputHelper _output;
@@ -64,7 +66,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.Contains("stdout line 1", response.Issue.Body, StringComparison.Ordinal);
         Assert.DoesNotContain("### Other info", response.Issue.Body, StringComparison.Ordinal);
         Assert.DoesNotContain("Pull Request:", response.Issue.Body, StringComparison.Ordinal);
-        Assert.StartsWith("<!-- failing-test-signature: v1:", response.Issue!.MetadataMarker, StringComparison.Ordinal);
+        Assert.Equal(StableMetadataMarker, response.Issue!.MetadataMarker);
         Assert.Single(response.Resolution!.JobUrls);
         Assert.NotNull(response.Diagnostics);
         Assert.Equal("diagnostics.log", response.Diagnostics!.LogFile);
@@ -79,10 +81,10 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     {
         var fixtureDirectory = CreateFixtureDirectory();
 
-        // Provide search-issue fixture that returns no match so tool creates a new issue
+        // Provide an all-state issue-list fixture with no match so the tool creates a new issue.
         File.WriteAllText(
-            Path.Combine(fixtureDirectory, "search-issue.json"),
-            "{}");
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            "[]");
 
         // Write a fixture response for the gh issue create call
         File.WriteAllText(
@@ -93,6 +95,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
               "url": "https://github.com/microsoft/aspire/issues/99999"
             }
             """);
+        File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
 
         var result = await RunToolAsync(
             fixtureDirectory,
@@ -111,6 +114,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.NotNull(response.Issue!.CreatedIssue);
         Assert.Equal(99999, response.Issue.CreatedIssue!.Number);
         Assert.Equal("https://github.com/microsoft/aspire/issues/99999", response.Issue.CreatedIssue.Url);
+        Assert.Contains("Recorded run 123 on issue #99999.", File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log")), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -118,19 +122,23 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     {
         var fixtureDirectory = CreateFixtureDirectory();
 
-        // Provide search-issue fixture that returns an open issue
+        // Provide an all-state issue-list fixture that returns an open issue.
         File.WriteAllText(
-            Path.Combine(fixtureDirectory, "search-issue.json"),
-            """
-            {
-              "number": 55555,
-              "url": "https://github.com/microsoft/aspire/issues/55555",
-              "state": "open"
-            }
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            $$"""
+            [
+              {
+                "number": 55555,
+                "html_url": "https://github.com/microsoft/aspire/issues/55555",
+                "state": "open",
+                "body": "{{StableMetadataMarker}}"
+              }
+            ]
             """);
 
         // Stub the add-issue-comment call
         File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-comments-55555.json"), "[]");
 
         var result = await RunToolAsync(
             fixtureDirectory,
@@ -159,20 +167,24 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     {
         var fixtureDirectory = CreateFixtureDirectory();
 
-        // Provide search-issue fixture that returns a closed issue
+        // Provide an all-state issue-list fixture that returns a closed issue.
         File.WriteAllText(
-            Path.Combine(fixtureDirectory, "search-issue.json"),
-            """
-            {
-              "number": 44444,
-              "url": "https://github.com/microsoft/aspire/issues/44444",
-              "state": "closed"
-            }
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            $$"""
+            [
+              {
+                "number": 44444,
+                "html_url": "https://github.com/microsoft/aspire/issues/44444",
+                "state": "closed",
+                "body": "{{StableMetadataMarker}}"
+              }
+            ]
             """);
 
         // Stub the reopen-issue and add-issue-comment calls
         File.WriteAllText(Path.Combine(fixtureDirectory, "reopen-issue.json"), "{}");
         File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-comments-44444.json"), "[]");
 
         var result = await RunToolAsync(
             fixtureDirectory,
@@ -201,10 +213,10 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     {
         var fixtureDirectory = CreateFixtureDirectory();
 
-        // Provide search-issue fixture that returns no match (empty object, no "number")
+        // Provide an all-state issue-list fixture with no match.
         File.WriteAllText(
-            Path.Combine(fixtureDirectory, "search-issue.json"),
-            "{}");
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            "[]");
 
         // Provide create-issue fixture
         File.WriteAllText(
@@ -215,6 +227,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
               "url": "https://github.com/microsoft/aspire/issues/88888"
             }
             """);
+        File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
 
         var result = await RunToolAsync(
             fixtureDirectory,
@@ -233,6 +246,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.Null(response.Issue!.ExistingIssue);
         Assert.NotNull(response.Issue.CreatedIssue);
         Assert.Equal(88888, response.Issue.CreatedIssue!.Number);
+        Assert.Contains("Recorded run 123 on issue #88888.", File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log")), StringComparison.Ordinal);
 
         var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
         Assert.Contains("No existing issue found. Creating new issue on GitHub...", diagnosticsLog, StringComparison.Ordinal);
@@ -242,17 +256,6 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     public async Task ForceNewFlagSkipsSearchAndCreatesNewIssue()
     {
         var fixtureDirectory = CreateFixtureDirectory();
-
-        // Even though search-issue fixture returns an existing issue, --force-new should skip it
-        File.WriteAllText(
-            Path.Combine(fixtureDirectory, "search-issue.json"),
-            """
-            {
-              "number": 55555,
-              "url": "https://github.com/microsoft/aspire/issues/55555",
-              "state": "open"
-            }
-            """);
 
         File.WriteAllText(
             Path.Combine(fixtureDirectory, "create-issue.json"),
@@ -284,6 +287,131 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
 
         var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
         Assert.Contains("--force-new flag set. Creating new issue on GitHub...", diagnosticsLog, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateFlagUsesOldestExactMatchAndClosesNewerDuplicate()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            $$"""
+            [
+              {
+                "number": 55555,
+                "html_url": "https://github.com/microsoft/aspire/issues/55555",
+                "state": "open",
+                "body": "{{StableMetadataMarker}}"
+              },
+              {
+                "number": 44444,
+                "html_url": "https://github.com/microsoft/aspire/issues/44444",
+                "state": "closed",
+                "body": "{{StableMetadataMarker}}"
+              }
+            ]
+            """);
+        File.WriteAllText(Path.Combine(fixtureDirectory, "reopen-issue.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "close-issue.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-comments-44444.json"), "[]");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-comments-55555.json"), "[]");
+
+        var result = await RunToolAsync(
+            fixtureDirectory,
+            "--test", "Tests.Namespace.Type.Method",
+            "--url", "https://github.com/microsoft/aspire/actions/runs/123",
+            "--workflow", "ci",
+            "--repo", "microsoft/aspire",
+            "--create");
+
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<CreateFailingTestIssueResponse>(result.Output, JsonOptions);
+        Assert.Equal(44444, response!.Issue!.ExistingIssue!.Number);
+        Assert.Null(response.Issue.CreatedIssue);
+
+        var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
+        Assert.Contains("Closing newer duplicate issue #55555", diagnosticsLog, StringComparison.Ordinal);
+        Assert.Contains("Found closed issue #44444. Reopening...", diagnosticsLog, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateFlagDoesNotReopenOrCommentWhenRunIsAlreadyRecordedOnCanonical()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            $$"""
+            [
+              {
+                "number": 44444,
+                "html_url": "https://github.com/microsoft/aspire/issues/44444",
+                "state": "closed",
+                "body": "{{StableMetadataMarker}}"
+              }
+            ]
+            """);
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "list-comments-44444.json"),
+            """
+            [
+              {
+                "body": "Earlier failure.\n\n<!-- run:123 -->"
+              }
+            ]
+            """);
+
+        var result = await RunToolAsync(
+            fixtureDirectory,
+            "--test", "Tests.Namespace.Type.Method",
+            "--url", "https://github.com/microsoft/aspire/actions/runs/123",
+            "--workflow", "ci",
+            "--repo", "microsoft/aspire",
+            "--create");
+
+        Assert.Equal(0, result.ExitCode);
+        var response = JsonSerializer.Deserialize<CreateFailingTestIssueResponse>(result.Output, JsonOptions);
+        Assert.Equal(44444, response!.Issue!.ExistingIssue!.Number);
+
+        var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
+        Assert.Contains("Run 123 is already recorded on issue #44444", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Reopening", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Adding comment", diagnosticsLog, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StableSignatureNormalizesCaseWhitespaceAndWorkflowSeparators()
+    {
+        var fixtureDirectory = CreateFixtureDirectory(
+            new TestTrxCase(
+                CanonicalTestName: "  TESTS.NAMESPACE.TYPE.METHOD  ",
+                DisplayName: "  TESTS.NAMESPACE.TYPE.METHOD  ",
+                Outcome: "Failed",
+                ErrorMessage: "Expected 1 but found 2."));
+        WriteJsonFixture(
+            fixtureDirectory,
+            "repos/microsoft/aspire/actions/workflows/ci.yml",
+            """
+            {
+              "id": 99,
+              "name": "CI",
+              "path": "  .GITHUB\\WORKFLOWS\\CI.YML  "
+            }
+            """);
+
+        var result = await RunToolAsync(
+            fixtureDirectory,
+            "--test", "tests.namespace.type.method",
+            "--url", "https://github.com/microsoft/aspire/actions/runs/123",
+            "--workflow", "ci",
+            "--repo", "microsoft/aspire");
+
+        Assert.Equal(0, result.ExitCode);
+        var response = JsonSerializer.Deserialize<CreateFailingTestIssueResponse>(result.Output, JsonOptions);
+        Assert.Equal(StableMetadataMarker, response!.Issue!.MetadataMarker);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
@@ -395,9 +395,11 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.Contains("Found closed issue #44444. Reopening...", diagnosticsLog, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData("open")]
+    [InlineData("closed")]
     [RequiresTools(["node"])]
-    public async Task CreateFlagDoesNotReopenOrCommentWhenRunIsAlreadyRecordedOnCanonical()
+    public async Task CreateFlagDoesNotReopenOrCommentWhenRunIsAlreadyRecordedOnCanonical(string issueState)
     {
         var fixtureDirectory = CreateFixtureDirectory();
 
@@ -408,7 +410,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
               {
                 "number": 44444,
                 "html_url": "https://github.com/microsoft/aspire/issues/44444",
-                "state": "closed",
+                "state": "{{issueState}}",
                 "body": "{{StableMetadataMarker}}"
               }
             ]
@@ -439,6 +441,8 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.Contains("Run 123 is already recorded on issue #44444", diagnosticsLog, StringComparison.Ordinal);
         Assert.DoesNotContain("Reopening", diagnosticsLog, StringComparison.Ordinal);
         Assert.DoesNotContain("Adding comment", diagnosticsLog, StringComparison.Ordinal);
+        Assert.Contains("Found existing issue #44444: https://github.com/microsoft/aspire/issues/44444", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Updated existing issue", diagnosticsLog, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -494,6 +498,7 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
         Assert.Contains("Run 123 is already recorded on issue #44444; skipping duplicate comment.", diagnosticsLog, StringComparison.Ordinal);
         Assert.DoesNotContain("Recorded run 123", diagnosticsLog, StringComparison.Ordinal);
         Assert.DoesNotContain("Adding comment", diagnosticsLog, StringComparison.Ordinal);
+        Assert.Contains("Updated existing issue #44444: https://github.com/microsoft/aspire/issues/44444", diagnosticsLog, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
@@ -391,6 +391,61 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
     }
 
     [Fact]
+    [RequiresTools(["node"])]
+    public async Task CreateFlagLogsReconciliationActionsWhenOccurrenceAlreadyRecordedOnDuplicate()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "list-issues.json"),
+            $$"""
+            [
+              {
+                "number": 55555,
+                "html_url": "https://github.com/microsoft/aspire/issues/55555",
+                "state": "open",
+                "body": "{{StableMetadataMarker}}"
+              },
+              {
+                "number": 44444,
+                "html_url": "https://github.com/microsoft/aspire/issues/44444",
+                "state": "closed",
+                "body": "{{StableMetadataMarker}}"
+              }
+            ]
+            """);
+        File.WriteAllText(Path.Combine(fixtureDirectory, "reopen-issue.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "close-issue.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-comments-44444.json"), "[]");
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "list-comments-55555.json"),
+            """
+            [
+              {
+                "body": "Earlier failure.\n\n<!-- run:123 -->"
+              }
+            ]
+            """);
+
+        var result = await RunToolAsync(
+            fixtureDirectory,
+            "--test", "Tests.Namespace.Type.Method",
+            "--url", "https://github.com/microsoft/aspire/actions/runs/123",
+            "--workflow", "ci",
+            "--repo", "microsoft/aspire",
+            "--create");
+
+        Assert.Equal(0, result.ExitCode);
+        var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
+        Assert.Contains("Found closed issue #44444. Reopening...", diagnosticsLog, StringComparison.Ordinal);
+        Assert.Contains("Closing newer duplicate issue #55555 in favor of #44444...", diagnosticsLog, StringComparison.Ordinal);
+        Assert.Contains("Run 123 is already recorded on issue #44444; skipping duplicate comment.", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recorded run 123", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Adding comment", diagnosticsLog, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task StableSignatureNormalizesCaseWhitespaceAndWorkflowSeparators()
     {
         var fixtureDirectory = CreateFixtureDirectory(

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/CreateFailingTestIssueToolTests.cs
@@ -121,6 +121,57 @@ public sealed class CreateFailingTestIssueToolTests : IClassFixture<CreateFailin
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task CreateFlagLogsCreatedCanonicalActionsWhenOccurrenceAlreadyRecordedOnNewerDuplicate()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+
+        File.WriteAllText(Path.Combine(fixtureDirectory, "list-issues.json"), "[]");
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "create-issue.json"),
+            """
+            {
+              "number": 44444,
+              "url": "https://github.com/microsoft/aspire/issues/44444"
+            }
+            """);
+        File.WriteAllText(
+            Path.Combine(fixtureDirectory, "concurrent-issue.json"),
+            $$"""
+            {
+              "number": 55555,
+              "html_url": "https://github.com/microsoft/aspire/issues/55555",
+              "state": "open",
+              "body": "{{StableMetadataMarker}}",
+              "comments": [
+                "Earlier failure.\n\n<!-- run:123 -->"
+              ]
+            }
+            """);
+        File.WriteAllText(Path.Combine(fixtureDirectory, "add-issue-comment.json"), "{}");
+        File.WriteAllText(Path.Combine(fixtureDirectory, "close-issue.json"), "{}");
+
+        var result = await RunToolAsync(
+            fixtureDirectory,
+            "--test", "Tests.Namespace.Type.Method",
+            "--url", "https://github.com/microsoft/aspire/actions/runs/123",
+            "--workflow", "ci",
+            "--repo", "microsoft/aspire",
+            "--create");
+
+        Assert.Equal(0, result.ExitCode);
+        var response = JsonSerializer.Deserialize<CreateFailingTestIssueResponse>(result.Output, JsonOptions);
+        Assert.Equal(44444, response!.Issue!.CreatedIssue!.Number);
+        Assert.Null(response.Issue.ExistingIssue);
+
+        var diagnosticsLog = File.ReadAllText(Path.Combine(fixtureDirectory, "diagnostics.log"));
+        const string DuplicateCloseLog = "Closing newer duplicate issue #55555 in favor of #44444...";
+        Assert.Equal(1, diagnosticsLog.Split(DuplicateCloseLog, StringSplitOptions.None).Length - 1);
+        Assert.Contains("Run 123 is already recorded on issue #44444; skipping duplicate comment.", diagnosticsLog, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recorded run 123", diagnosticsLog, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task CreateFlagReusesOpenExistingIssue()
     {
         var fixtureDirectory = CreateFixtureDirectory();

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
@@ -44,7 +44,30 @@ public class GitHubCliArgumentTests
             arguments);
     }
 
-    private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync(Func<Task<string>> call)
+    [Fact]
+    public async Task FailingTestIssueLookupUsesPaginatedIssueListing()
+    {
+        var arguments = await CaptureArgumentsAsync(
+            () => GitHubCli.FindIssuesByMarkerAsync(
+                "microsoft/aspire",
+                "failing-test",
+                "<!-- marker -->",
+                CancellationToken.None),
+            "[]");
+
+        Assert.Equal(
+            [
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "--paginate",
+                "--slurp",
+                "repos/microsoft/aspire/issues?labels=failing-test&state=all&per_page=100",
+            ],
+            arguments);
+    }
+
+    private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync<T>(Func<Task<T>> call, string response = "{}")
     {
         IReadOnlyList<string> captured = [];
 
@@ -56,7 +79,7 @@ public class GitHubCliArgumentTests
         GitHubCli.GhInvokerOverride = (arguments, _) =>
         {
             captured = arguments;
-            return Task.FromResult("{}");
+            return Task.FromResult(response);
         };
 
         try

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
@@ -44,29 +44,6 @@ public class GitHubCliArgumentTests
             arguments);
     }
 
-    [Fact]
-    public async Task FailingTestIssueLookupUsesPaginatedIssueListing()
-    {
-        var arguments = await CaptureArgumentsAsync(
-            () => GitHubCli.FindIssuesByMarkerAsync(
-                "microsoft/aspire",
-                "failing-test",
-                "<!-- marker -->",
-                CancellationToken.None),
-            "[]");
-
-        Assert.Equal(
-            [
-                "api",
-                "-H",
-                "Accept: application/vnd.github+json",
-                "--paginate",
-                "--slurp",
-                "repos/microsoft/aspire/issues?labels=failing-test&state=all&per_page=100",
-            ],
-            arguments);
-    }
-
     private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync<T>(Func<Task<T>> call, string response = "{}")
     {
         IReadOnlyList<string> captured = [];

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -368,6 +368,10 @@ public sealed class TestTriggerMapTests
             ["test:Infrastructure.Tests"]
         },
         {
+            "tools/CreateFailingTestIssue/FailingTestIssueCommand.cs",
+            ["test:Infrastructure.Tests"]
+        },
+        {
             "eng/scripts/smoke-installed-cli.ps1",
             ["job:winget-installer"]
         },

--- a/tests/Infrastructure.Tests/WorkflowScripts/AnalyzeCiFailureWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AnalyzeCiFailureWorkflowTests.cs
@@ -1913,7 +1913,7 @@ public sealed class AnalyzeCiFailureWorkflowTests(ITestOutputHelper output) : ID
             .Replace("${REPO}", "microsoft/aspire", StringComparison.Ordinal);
     }
 
-    private static string ExtractTopLevelMapping(string workflow, string key)
+    internal static string ExtractTopLevelMapping(string workflow, string key)
     {
         var lines = workflow.ReplaceLineEndings("\n").Split('\n');
         var mappingStart = Array.IndexOf(lines, $"{key}:");

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -338,7 +338,9 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
             });
 
         Assert.NotNull(result.Calls);
-        Assert.Equal(["ensureLabel"], result.Calls);
+        Assert.Equal("ensureLabel", result.Calls[0]);
+        Assert.Contains("listIssues", result.Calls);
+        Assert.Contains("createIssue", result.Calls);
     }
 
     [Fact]
@@ -371,6 +373,20 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
         Assert.Contains(result.Calls, call => call.Args.Contains("POST") && call.Args.Contains("repos/microsoft/aspire/issues"));
         Assert.Contains(result.Calls, call => call.Args.Contains("PATCH") && call.Input!.Contains("\"state\":\"closed\"", StringComparison.Ordinal));
         Assert.Contains(result.Calls, call => call.Args.Contains("PATCH") && call.Input!.Contains("\"state\":\"open\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GhApiTransportTreatsExistingLabelAsSuccess()
+    {
+        var result = await InvokeHarnessAsync<GhTransportResponse>(
+            "ghTransport",
+            new { operation = "ensure", labelAlreadyExists = true });
+
+        Assert.True(result.Available);
+        var call = Assert.Single(result.Calls!);
+        Assert.Contains("POST", call.Args);
+        Assert.Contains("repos/microsoft/aspire/labels", call.Args);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -251,18 +251,16 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task BuildIssueSearchQueryTargetsFailingTestIssuesByMetadataMarker()
+    public void WorkflowUsesSharedExactMarkerReconciliation()
     {
-        var query = await InvokeHarnessAsync<string>(
-            "buildIssueSearchQuery",
-            new
-            {
-                owner = "microsoft",
-                repo = "aspire",
-                metadataMarker = "<!-- failing-test-signature: v1:abc123 -->"
-            });
+        var workflowPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue.yml");
+        var workflow = File.ReadAllText(workflowPath);
 
-        Assert.Equal("repo:microsoft/aspire is:issue label:failing-test in:body \"<!-- failing-test-signature: v1:abc123 -->\"", query);
+        Assert.Contains("tracking-issue.js", workflow, StringComparison.Ordinal);
+        Assert.Contains("tracking.recordRun", workflow, StringComparison.Ordinal);
+        Assert.Contains("closeDuplicates: true", workflow, StringComparison.Ordinal);
+        Assert.Contains("tracking.duplicateExemptStamp()", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("search.issuesAndPullRequests", workflow, StringComparison.Ordinal);
     }
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -251,16 +251,164 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public void WorkflowUsesSharedExactMarkerReconciliation()
+    public void WorkflowDelegatesLifecycleToCheckedInAdapter()
     {
         var workflowPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue.yml");
         var workflow = File.ReadAllText(workflowPath);
 
-        Assert.Contains("tracking-issue.js", workflow, StringComparison.Ordinal);
-        Assert.Contains("tracking.recordRun", workflow, StringComparison.Ordinal);
-        Assert.Contains("closeDuplicates: true", workflow, StringComparison.Ordinal);
-        Assert.Contains("tracking.duplicateExemptStamp()", workflow, StringComparison.Ordinal);
+        Assert.Contains("create-failing-test-issue-tracking.js", workflow, StringComparison.Ordinal);
+        Assert.Contains(".reconcile(", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracking.recordRun", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracking.duplicateExemptStamp()", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("github.rest.issues.create({", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("search.issuesAndPullRequests", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CheckedInLifecycleAdapterExists()
+    {
+        var adapterPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue-tracking.js");
+
+        Assert.True(File.Exists(adapterPath), $"Missing lifecycle adapter: {adapterPath}");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LifecycleAdapterUsesSharedReconciliationForExistingIssue()
+    {
+        const string marker = "<!-- failing-test-signature: v1:abc -->";
+        var result = await InvokeHarnessAsync<ReconciliationResponse>(
+            "reconcile",
+            new
+            {
+                marker,
+                body = $"{marker}\n\nBody",
+                issues = new[]
+                {
+                    new { number = 42, body = marker, state = "closed", comments = Array.Empty<string>() },
+                }
+            });
+
+        Assert.True(result.Available);
+        Assert.False(result.Result!.Created);
+        Assert.Equal(42, result.Result.Number);
+        var issue = Assert.Single(result.Issues!);
+        Assert.Equal("open", issue.State);
+        Assert.Contains(issue.Comments, comment => comment.Contains("<!-- run:123 -->", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LifecycleAdapterForceNewUsesPlannerAndStampsExemption()
+    {
+        const string marker = "<!-- failing-test-signature: v1:abc -->";
+        var result = await InvokeHarnessAsync<ReconciliationResponse>(
+            "reconcile",
+            new
+            {
+                marker,
+                body = $"{marker}\n\nBody",
+                forceNew = true,
+                issues = new[]
+                {
+                    new { number = 42, body = marker, state = "open", comments = Array.Empty<string>() },
+                }
+            });
+
+        Assert.True(result.Available);
+        Assert.True(result.Result!.Created);
+        Assert.Equal(1000, result.Result.Number);
+        var created = Assert.Single(result.Issues!, issue => issue.Number == 1000);
+        Assert.Contains("<!-- tracking-issue-duplicate-exempt -->", created.Body, StringComparison.Ordinal);
+        Assert.Empty(created.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task LifecycleAdapterEnsuresFailingTestLabelBeforeReconciliation()
+    {
+        const string marker = "<!-- failing-test-signature: v1:abc -->";
+        var result = await InvokeHarnessAsync<ReconciliationResponse>(
+            "reconcile",
+            new
+            {
+                marker,
+                body = $"{marker}\n\nBody",
+                issues = Array.Empty<object>(),
+            });
+
+        Assert.NotNull(result.Calls);
+        Assert.Equal(["ensureLabel"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GhApiTransportListsAllIssueStatesWithPagination()
+    {
+        var result = await InvokeHarnessAsync<GhTransportResponse>(
+            "ghTransport",
+            new { operation = "list" });
+
+        Assert.True(result.Available);
+        var call = Assert.Single(result.Calls!);
+        Assert.Contains("--paginate", call.Args);
+        Assert.Contains("--slurp", call.Args);
+        Assert.Contains("repos/microsoft/aspire/issues?labels=failing-test&state=all&per_page=100", call.Args);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GhApiTransportOwnsEveryIssueMutation()
+    {
+        var result = await InvokeHarnessAsync<GhTransportResponse>(
+            "ghTransport",
+            new { operation = "mutate" });
+
+        Assert.True(result.Available);
+        Assert.Equal(7, result.Calls!.Length);
+        Assert.All(result.Calls, call => Assert.Equal("api", call.Args[0]));
+        Assert.Contains(result.Calls, call => call.Args.Contains("POST") && call.Args.Contains("repos/microsoft/aspire/labels"));
+        Assert.Contains(result.Calls, call => call.Args.Contains("POST") && call.Args.Contains("repos/microsoft/aspire/issues"));
+        Assert.Contains(result.Calls, call => call.Args.Contains("PATCH") && call.Input!.Contains("\"state\":\"closed\"", StringComparison.Ordinal));
+        Assert.Contains(result.Calls, call => call.Args.Contains("PATCH") && call.Input!.Contains("\"state\":\"open\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CSharpToolDelegatesLifecycleToCheckedInAdapter()
+    {
+        var commandPath = Path.Combine(_repoRoot, "tools", "CreateFailingTestIssue", "FailingTestIssueCommand.cs");
+        var command = File.ReadAllText(commandPath);
+
+        Assert.Contains("create-failing-test-issue-tracking.js", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("FindIssuesByMarkerAsync", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("CreateIssueAsync", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("IssueHasCommentMarkerAsync", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("CloseIssueAsNotPlannedAsync", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReopenIssueAsync", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CSharpToolTerminatesAdapterProcessTreeWhenCancelled()
+    {
+        var commandPath = Path.Combine(_repoRoot, "tools", "CreateFailingTestIssue", "FailingTestIssueCommand.cs");
+        var command = File.ReadAllText(commandPath);
+
+        Assert.Contains("process.Kill(entireProcessTree: true)", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProducersUseSharedPlannerForTrustedCloseAndDryRun()
+    {
+        var reportCi = File.ReadAllText(Path.Combine(_repoRoot, ".github", "workflows", "report-ci-failure.js"));
+        var monitor = File.ReadAllText(Path.Combine(_repoRoot, ".github", "workflows", "monitor-scheduled-workflows.js"));
+
+        Assert.Contains("tracking.executeIssueReconciliation(", reportCi, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracking.listOpenIssuesByLabel(", reportCi, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracking.closeIssue(", reportCi, StringComparison.Ordinal);
+
+        Assert.Contains("tracking.planIssueReconciliation(", monitor, StringComparison.Ordinal);
+        Assert.Contains("tracking.executeIssueReconciliation(", monitor, StringComparison.Ordinal);
+        Assert.DoesNotContain("tracking.closeIssue(", monitor, StringComparison.Ordinal);
     }
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
@@ -284,4 +432,14 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     private sealed record ParseCommandResult(bool Success, string TestQuery, string? SourceUrl, string Workflow, bool ForceNew, bool ListOnly, string? ErrorMessage);
 
     private sealed record FormatListResponseResult(bool Error, string Message, string[]? Tests);
+
+    private sealed record ReconciliationResponse(bool Available, ReconciliationResult? Result, ReconciliationIssue[]? Issues, string[]? Calls);
+
+    private sealed record ReconciliationResult(int Number, bool Created);
+
+    private sealed record ReconciliationIssue(int Number, string State, string Body, string[] Comments);
+
+    private sealed record GhTransportResponse(bool Available, GhInvocation[]? Calls);
+
+    private sealed record GhInvocation(string[] Args, string? Input);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -265,6 +265,18 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     }
 
     [Fact]
+    public void WorkflowSerializesIssueReconciliation()
+    {
+        var workflowPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue.yml");
+        var workflow = File.ReadAllText(workflowPath);
+
+        Assert.DoesNotContain("github.run_id", workflow, StringComparison.Ordinal);
+        Assert.Equal(
+            "cancel-in-progress=false;group=create-failing-test-issue;queue=max",
+            AnalyzeCiFailureWorkflowTests.ExtractTopLevelMapping(workflow, "concurrency"));
+    }
+
+    [Fact]
     public void CheckedInLifecycleAdapterExists()
     {
         var adapterPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue-tracking.js");

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -265,15 +265,31 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     }
 
     [Fact]
-    public void WorkflowSerializesIssueReconciliation()
+    public void WorkflowQueuesOnlyAuthorizedIssueReconciliation()
     {
         var workflowPath = Path.Combine(_repoRoot, ".github", "workflows", "create-failing-test-issue.yml");
-        var workflow = File.ReadAllText(workflowPath);
+        var workflow = File.ReadAllText(workflowPath).ReplaceLineEndings("\n");
+        var authorizationJob = ExtractJob(workflow, "authorize_failing_test_issue");
+        var reconciliationJob = ExtractJob(workflow, "create_failing_test_issue");
 
         Assert.DoesNotContain("github.run_id", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("\nconcurrency:\n", $"\n{workflow}", StringComparison.Ordinal);
+        Assert.Contains(
+            """
+                if: >-
+                  github.repository == 'microsoft/aspire' &&
+                  (github.event_name == 'workflow_dispatch' ||
+                   startsWith(github.event.comment.body, '/create-issue'))
+            """,
+            authorizationJob,
+            StringComparison.Ordinal);
+        Assert.Equal("contents=read;issues=write", ExtractJobMapping(authorizationJob, "permissions"));
+        Assert.DoesNotContain("\n    concurrency:\n", $"\n{authorizationJob}", StringComparison.Ordinal);
+        Assert.Equal(1, workflow.Split("getCollaboratorPermissionLevel", StringSplitOptions.None).Length - 1);
+        Assert.Contains("    needs: authorize_failing_test_issue\n", reconciliationJob, StringComparison.Ordinal);
         Assert.Equal(
             "cancel-in-progress=false;group=create-failing-test-issue;queue=max",
-            AnalyzeCiFailureWorkflowTests.ExtractTopLevelMapping(workflow, "concurrency"));
+            ExtractJobMapping(reconciliationJob, "concurrency"));
     }
 
     [Fact]
@@ -489,4 +505,22 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     private sealed record GhTransportResponse(bool Available, GhInvocation[]? Calls);
 
     private sealed record GhInvocation(string[] Args, string? Input);
+
+    private static string ExtractJob(string workflow, string jobName)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            workflow,
+            $@"(?ms)^  {System.Text.RegularExpressions.Regex.Escape(jobName)}:\n.*?(?=^  [A-Za-z0-9_-]+:\n|\z)");
+        Assert.True(match.Success, $"Could not find workflow job: {jobName}");
+
+        return match.Value;
+    }
+
+    private static string ExtractJobMapping(string job, string key)
+    {
+        var unindentedJob = string.Join(
+            '\n',
+            job.Split('\n').Select(line => line.StartsWith("    ", StringComparison.Ordinal) ? line[4..] : line));
+        return AnalyzeCiFailureWorkflowTests.ExtractTopLevelMapping(unindentedJob, key);
+    }
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/CreateFailingTestIssueWorkflowTests.cs
@@ -413,6 +413,25 @@ public sealed class CreateFailingTestIssueWorkflowTests : IDisposable
     }
 
     [Fact]
+    public void CSharpToolBoundsWholeAdapterReconciliation()
+    {
+        var commandPath = Path.Combine(_repoRoot, "tools", "CreateFailingTestIssue", "FailingTestIssueCommand.cs");
+        var command = File.ReadAllText(commandPath);
+
+        Assert.Contains("s_issueReconciliationTimeout = TimeSpan.FromMinutes(5)", command, StringComparison.Ordinal);
+        Assert.Contains("using var reconciliationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);", command, StringComparison.Ordinal);
+        Assert.Contains("reconciliationCts.CancelAfter(s_issueReconciliationTimeout);", command, StringComparison.Ordinal);
+        Assert.Contains("StandardInput.WriteAsync(request.AsMemory(), reconciliationCts.Token)", command, StringComparison.Ordinal);
+        Assert.Contains("StandardOutput.ReadToEndAsync(reconciliationCts.Token)", command, StringComparison.Ordinal);
+        Assert.Contains("StandardError.ReadToEndAsync(reconciliationCts.Token)", command, StringComparison.Ordinal);
+        Assert.Contains("WaitForExitAsync(reconciliationCts.Token)", command, StringComparison.Ordinal);
+        Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", command, StringComparison.Ordinal);
+        Assert.Contains("throw new TimeoutException(\"Failing-test issue reconciliation timed out after five minutes.\", ex);", command, StringComparison.Ordinal);
+        Assert.Contains("process.Kill(entireProcessTree: true)", command, StringComparison.Ordinal);
+        Assert.Contains("await process.WaitForExitAsync(CancellationToken.None)", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProducersUseSharedPlannerForTrustedCloseAndDryRun()
     {
         var reportCi = File.ReadAllText(Path.Combine(_repoRoot, ".github", "workflows", "report-ci-failure.js"));

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -155,6 +155,34 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DryRunUsesOldestCanonicalAndReportsDuplicateClosures()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = FailingRun() },
+            issues = new[]
+            {
+                new
+                {
+                    number = 44,
+                    body = $"{Marker}\n<!-- tracking-issue-duplicate-exempt -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+                new { number = 55, body = Marker, state = "closed", comments = Array.Empty<string>() },
+                new { number = 66, body = Marker, state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.Contains(result.Logs, log => log.Contains("would CLOSE duplicate issue #66 as not_planned", StringComparison.Ordinal));
+        Assert.Contains(result.Logs, log => log.Contains("would RECORD failure for generate-api-diffs.yml on issue #55", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Logs, log => log.Contains("issue #44", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ClosesIssueWhenLatestRunIsGreen()
     {
         // A successful latest run with an open issue closes it automatically, with a
@@ -307,6 +335,46 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
         Assert.Equal("closed", issue.State);
         Assert.Contains(issue.Comments, comment => comment.Contains("<!-- run:9 -->", StringComparison.Ordinal));
         Assert.Contains(issue.Comments, comment => comment.Contains("Latest run succeeded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DuplicateClosedDuringFailureIsNotClosedAgainByNewerSuccess()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                    SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+            issues = new[]
+            {
+                new
+                {
+                    number = 55,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "closed",
+                    comments = new[] { "earlier <!-- run:9 -->" },
+                },
+                new
+                {
+                    number = 66,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+            },
+        });
+
+        Assert.Equal(1, result.Calls.Count(call => call == "update"));
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 66);
+        Assert.Equal("closed", duplicate.State);
+        Assert.DoesNotContain(duplicate.Comments, comment => comment.Contains("Latest run succeeded", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -379,6 +379,45 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task SuccessOnlyWindowClosesNewerDuplicateWhenCanonicalIsAlreadyClosed()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+            issues = new[]
+            {
+                new
+                {
+                    number = 55,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "closed",
+                    comments = Array.Empty<string>(),
+                },
+                new
+                {
+                    number = 66,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+            },
+        });
+
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 66);
+        Assert.Equal("closed", duplicate.State);
+        Assert.Equal("not_planned", duplicate.StateReason);
+        Assert.DoesNotContain(duplicate.Comments, comment => comment.Contains("Latest run succeeded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotCloseWhenNewestRunInPollingWindowIsRecordedFailure()
     {
         var result = await InvokeAsync(new
@@ -475,7 +514,7 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     private sealed record MonitorResult(bool Threw, string[] Calls, MonitorIssue[] Issues, string[] Logs, ListRunRequest[] ListRunRequests);
 
-    private sealed record MonitorIssue(int Number, string State, string Body, string[] Labels, string[] Comments);
+    private sealed record MonitorIssue(int Number, string State, string? StateReason, string Body, string[] Labels, string[] Comments);
 
     private sealed record ListRunRequest(string WorkflowId, int? PerPage);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -147,6 +147,7 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
             },
         });
 
+        Assert.False(result.Threw);
         Assert.DoesNotContain(result.Logs, log => log.Contains("would RECORD", StringComparison.Ordinal));
         Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
         var issue = Assert.Single(result.Issues);

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -473,7 +473,44 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
         Assert.False(result.Threw);
         Assert.Contains("[dry-run] would CLOSE duplicate issue #66 as not_planned (canonical #55)", result.Logs);
-        Assert.DoesNotContain(result.Logs, log => log.Contains("would CLOSE #55", StringComparison.Ordinal));
+        Assert.DoesNotContain("[dry-run] would CLOSE issue #55 (generate-api-diffs.yml)", result.Logs);
+        Assert.DoesNotContain(result.Calls, call => call is "update" or "createComment");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DryRunSuccessReportsCanonicalAndDuplicateClosuresAccurately()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+            },
+            issues = new[]
+            {
+                new
+                {
+                    number = 55,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+                new
+                {
+                    number = 66,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Single(result.Logs, log => log == "[dry-run] would CLOSE duplicate issue #66 as not_planned (canonical #55)");
+        Assert.DoesNotContain("[dry-run] would CLOSE duplicate issue #55 as not_planned (canonical #55)", result.Logs);
+        Assert.Contains("[dry-run] would CLOSE issue #55 (generate-api-diffs.yml)", result.Logs);
         Assert.DoesNotContain(result.Calls, call => call is "update" or "createComment");
     }
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -226,6 +226,30 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DuplicateOnlyReconciliationDoesNotReportCanonicalAsClosed()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:false -->", state = "open", comments = Array.Empty<string>() },
+                new { number = 66, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        var canonical = Assert.Single(result.Issues, issue => issue.Number == 55);
+        Assert.Equal("open", canonical.State);
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 66);
+        Assert.Equal("closed", duplicate.State);
+        Assert.Equal("not_planned", duplicate.StateReason);
+        Assert.DoesNotContain(result.Logs, log => log.Contains("Closed #55", StringComparison.Ordinal));
+        Assert.Contains(result.Logs, log => log.Contains("Reconciled 1 duplicate", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DryRunDoesNotLogCloseWhenAutoCloseStampIsFalse()
     {
         var result = await InvokeAsync(new

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -443,6 +443,42 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DryRunSuccessReportsDuplicateOnlyReconciliation()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = true,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+            },
+            issues = new[]
+            {
+                new
+                {
+                    number = 55,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "closed",
+                    comments = Array.Empty<string>(),
+                },
+                new
+                {
+                    number = 66,
+                    body = $"{Marker}\n<!-- autoclose:true -->",
+                    state = "open",
+                    comments = Array.Empty<string>(),
+                },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Contains("[dry-run] would CLOSE duplicate issue #66 as not_planned (canonical #55)", result.Logs);
+        Assert.DoesNotContain(result.Logs, log => log.Contains("would CLOSE #55", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Calls, call => call is "update" or "createComment");
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotCloseWhenNewestRunInPollingWindowIsRecordedFailure()
     {
         var result = await InvokeAsync(new

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -206,6 +206,59 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task DoesNotCloseIssueWhenAutoCloseStampIsRemovedBeforeSuccessEvaluation()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = Array.Empty<string>() },
+            },
+            issuesAfterInitialList = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:false -->", state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Equal(2, result.ListIssuesCount);
+        Assert.Equal(["createLabel"], result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("open", issue.State);
+        Assert.Contains("<!-- autoclose:false -->", issue.Body);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotCloseIssueClosedByUserBeforeSuccessEvaluation()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            runsByFile = new Dictionary<string, object> { [WatchedFile] = SucceedingRun() },
+            issues = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "open", comments = Array.Empty<string>() },
+            },
+            issuesAfterInitialList = new[]
+            {
+                new { number = 55, body = $"{Marker}\n<!-- autoclose:true -->", state = "closed", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Equal(2, result.ListIssuesCount);
+        Assert.Equal(["createLabel"], result.Calls);
+        var issue = Assert.Single(result.Issues);
+        Assert.Equal("closed", issue.State);
+        Assert.Empty(issue.Comments);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task LeavesIssueOpenWhenAutoCloseStampIsFalse()
     {
         var result = await InvokeAsync(new
@@ -282,13 +335,22 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
                 [WatchedFile] = new[]
                 {
                     FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
-                    SucceedingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                    FailingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(45)),
+                    SucceedingRun(id: 11, runNumber: 11, updatedAt: MinutesAgo(15)),
                 },
             },
         });
 
-        Assert.Contains(result.Logs, log => log.Contains("would RECORD failure", StringComparison.Ordinal));
-        Assert.Contains(result.Logs, log => log.Contains("would CLOSE", StringComparison.Ordinal));
+        Assert.Equal(
+            [
+                "[dry-run] would RECORD failure for generate-api-diffs.yml on a new issue",
+                "[dry-run] would RECORD failure for generate-api-diffs.yml on the new issue",
+            ],
+            result.Logs.Where(log => log.Contains("would RECORD failure", StringComparison.Ordinal)));
+        Assert.Contains("[dry-run] would CLOSE the new issue (generate-api-diffs.yml)", result.Logs);
+        Assert.DoesNotContain(result.Logs, log =>
+            log.Contains("would RECORD", StringComparison.Ordinal) && log.Contains("issue #0", StringComparison.Ordinal) ||
+            log.Contains("would CLOSE", StringComparison.Ordinal) && log.Contains("issue #0", StringComparison.Ordinal));
         Assert.DoesNotContain(result.Calls, call => call is "create" or "update" or "createComment");
         Assert.Empty(result.Issues);
     }
@@ -610,7 +672,13 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     private sealed record HarnessResponse(MonitorResult Result);
 
-    private sealed record MonitorResult(bool Threw, string[] Calls, MonitorIssue[] Issues, string[] Logs, ListRunRequest[] ListRunRequests);
+    private sealed record MonitorResult(
+        bool Threw,
+        string[] Calls,
+        MonitorIssue[] Issues,
+        string[] Logs,
+        ListRunRequest[] ListRunRequests,
+        int ListIssuesCount);
 
     private sealed record MonitorIssue(int Number, string State, string? StateReason, string Body, string[] Labels, string[] Comments);
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/MonitorScheduledWorkflowsIntegrationTests.cs
@@ -113,6 +113,44 @@ public sealed class MonitorScheduledWorkflowsIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task RefreshesCanonicalIssueAfterCreateRaceBeforeRecordingNextFailure()
+    {
+        var result = await InvokeAsync(new
+        {
+            dryRun = false,
+            nextNumber = 1000,
+            runsByFile = new Dictionary<string, object>
+            {
+                [WatchedFile] = new[]
+                {
+                    FailingRun(id: 9, runNumber: 9, updatedAt: MinutesAgo(75)),
+                    FailingRun(id: 10, runNumber: 10, updatedAt: MinutesAgo(15)),
+                },
+            },
+            issuesAfterInitialList = new[]
+            {
+                new { number = 999, body = Marker, state = "open", comments = Array.Empty<string>() },
+                new { number = 1000, body = Marker, state = "open", comments = Array.Empty<string>() },
+            },
+        });
+
+        Assert.False(result.Threw);
+        Assert.Equal(1, result.Calls.Count(call => call == "create"));
+        Assert.Equal(2, result.Issues.Length);
+
+        var canonical = Assert.Single(result.Issues, issue => issue.Number == 999);
+        Assert.Equal("open", canonical.State);
+        Assert.Contains(canonical.Comments, comment => comment.Contains("<!-- run:9 -->", StringComparison.Ordinal));
+        Assert.Contains(canonical.Comments, comment => comment.Contains("<!-- run:10 -->", StringComparison.Ordinal));
+
+        var throwaway = Assert.Single(result.Issues, issue => issue.Number == 1000);
+        Assert.Equal("closed", throwaway.State);
+        Assert.Equal("not_planned", throwaway.StateReason);
+        Assert.DoesNotContain(result.Issues, issue => issue.Number > 1000);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DedupsWhenLatestFailedRunAlreadyRecorded()
     {
         // The scanner runs every 2h but watched workflows run less often, so the same

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
@@ -106,6 +106,31 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ReportFailureClosesNewerExactMarkerDuplicates()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "reportFailure",
+            env = new { REF = "main" },
+            issues = new[]
+            {
+                new { number = 5, body = "<!-- ci-failure:ci.yml:push:main -->", state = "open" },
+                new { number = 8, body = "<!-- ci-failure:ci.yml:push:main -->", state = "open" },
+            },
+        });
+
+        var canonicalIssue = Assert.Single(result.Issues, issue => issue.Number == 5);
+        Assert.Equal("open", canonicalIssue.State);
+        Assert.Contains(canonicalIssue.Comments, comment => comment.Contains("<!-- run:12345 -->", StringComparison.Ordinal));
+
+        var duplicateIssue = Assert.Single(result.Issues, issue => issue.Number == 8);
+        Assert.Equal("closed", duplicateIssue.State);
+        Assert.Equal("not_planned", duplicateIssue.StateReason);
+        Assert.Contains(duplicateIssue.Comments, comment => comment.Contains("Duplicate of #5", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ReportFailureCommentFailureLeavesRunUnrecorded()
     {
         var result = await InvokeAsync(new

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
@@ -257,6 +257,9 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
         Assert.Empty(result.Issues);
         Assert.DoesNotContain("update", result.Calls);
         Assert.DoesNotContain("createComment", result.Calls);
+        Assert.Contains("No matching tracking issue to reconcile.", result.Logs);
+        Assert.Contains("No open CI-failure issue for main; nothing to close.", result.Logs);
+        Assert.DoesNotContain(result.Logs, log => log.Contains("#undefined", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -353,7 +356,7 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
 
     private sealed record HarnessResponse(RunnerResult Result);
 
-    private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
+    private sealed record RunnerResult(bool Threw, string[] Calls, string[] Logs, RunnerIssue[] Issues);
 
     private sealed record RunnerIssue(int Number, string? Title, string State, string? StateReason, string Body, string[] Labels, string[] Comments);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportCiFailureIntegrationTests.cs
@@ -171,6 +171,37 @@ public sealed class ReportCiFailureIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ResolveSuccessClosesNewerDuplicateWhenCanonicalIsAlreadyClosed()
+    {
+        var result = await InvokeAsync(new
+        {
+            operation = "resolveSuccess",
+            env = new { REF = "main" },
+            issues = new[]
+            {
+                new
+                {
+                    number = 5,
+                    body = "lead <!-- ci-failure:ci.yml:push:main -->\n<!-- autoclose:true -->",
+                    state = "closed",
+                },
+                new
+                {
+                    number = 8,
+                    body = "lead <!-- ci-failure:ci.yml:push:main -->\n<!-- autoclose:true -->",
+                    state = "open",
+                },
+            },
+        });
+
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 8);
+        Assert.Equal("closed", duplicate.State);
+        Assert.Equal("not_planned", duplicate.StateReason);
+        Assert.DoesNotContain(duplicate.Comments, comment => comment.Contains("green again", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ResolveSuccessLeavesIssueOpenWhenAutoCloseStampIsMissing()
     {
         var result = await InvokeAsync(new

--- a/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ReportPipelineFailureIntegrationTests.cs
@@ -228,6 +228,33 @@ public sealed class ReportPipelineFailureIntegrationTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ReconcilesExactDuplicatesIntoOldestIssue()
+    {
+        const string marker = "<!-- ci-failure:deployment-tests.yml:scheduled -->";
+        var result = await InvokeAsync(new
+        {
+            env = DeploymentEnv(),
+            labels = s_deploymentLabels,
+            issues = new[]
+            {
+                new { number = 42, body = marker, state = "open" },
+                new { number = 84, body = marker, state = "open" },
+            },
+        });
+
+        Assert.DoesNotContain("create", result.Calls);
+        var canonical = Assert.Single(result.Issues, issue => issue.Number == 42);
+        Assert.Equal("open", canonical.State);
+        Assert.Contains(canonical.Comments, comment => comment.Contains("<!-- run:12345 -->", StringComparison.Ordinal));
+
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 84);
+        Assert.Equal("closed", duplicate.State);
+        Assert.Equal("not_planned", duplicate.StateReason);
+        Assert.Contains(duplicate.Comments, comment => comment.Contains("#42", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotManageAnotherWorkflowsAutomationBrokenIssue()
     {
         // Both pipelines and the scanner/specialized reporter carry automation-broken,
@@ -305,5 +332,5 @@ public sealed class ReportPipelineFailureIntegrationTests : IDisposable
 
     private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
 
-    private sealed record RunnerIssue(int Number, string? Title, string State, string Body, string[] Labels, string[] Comments);
+    private sealed record RunnerIssue(int Number, string? Title, string State, string? StateReason, string Body, string[] Labels, string[] Comments);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SpecializedTestFailureRunnerTests.cs
@@ -159,6 +159,33 @@ public sealed class SpecializedTestFailureRunnerTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ReconcilesExactDuplicatesIntoOldestIssue()
+    {
+        const string marker = "<!-- ci-failure:tests-outerloop.yml:test-failures -->";
+        var result = await InvokeAsync(new
+        {
+            env = OuterloopEnv(),
+            failedTests = new[] { "Tests.Type.A" },
+            issues = new[]
+            {
+                new { number = 42, body = marker, state = "open" },
+                new { number = 84, body = marker, state = "open" },
+            },
+        });
+
+        Assert.DoesNotContain("create", result.Calls);
+        var canonical = Assert.Single(result.Issues, issue => issue.Number == 42);
+        Assert.Equal("open", canonical.State);
+        Assert.Contains(canonical.Comments, comment => comment.Contains("<!-- run:12345 -->", StringComparison.Ordinal));
+
+        var duplicate = Assert.Single(result.Issues, issue => issue.Number == 84);
+        Assert.Equal("closed", duplicate.State);
+        Assert.Equal("not_planned", duplicate.StateReason);
+        Assert.Contains(duplicate.Comments, comment => comment.Contains("#42", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task MissingResultsPathIsClassifiedAsTestFailures()
     {
         // The extract step crashed before emitting its path (FAILED_TESTS_PATH
@@ -243,5 +270,5 @@ public sealed class SpecializedTestFailureRunnerTests : IDisposable
 
     private sealed record RunnerResult(bool Threw, string[] Calls, RunnerIssue[] Issues);
 
-    private sealed record RunnerIssue(int Number, string? Title, string State, string Body, string[] Comments);
+    private sealed record RunnerIssue(int Number, string? Title, string State, string? StateReason, string Body, string[] Comments);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
@@ -557,6 +557,27 @@ public sealed class TrackingIssueTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ExecutorReportsOnlyNonCanonicalIssuesAsDuplicatesClosed()
+    {
+        var result = await InvokeHarnessAsync<PlanExecutionResult>(
+            "planAndExecute",
+            new
+            {
+                marker = "<!-- m -->",
+                closeDuplicates = true,
+                closeCanonical = true,
+                issues = new object[]
+                {
+                    new { number = 5, body = "<!-- m -->", state = "open" },
+                    new { number = 8, body = "<!-- m -->", state = "open" },
+                }
+            });
+
+        Assert.Equal([8], result.DuplicatesClosed);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task BuildBodyEmbedsAutoCloseStampWhenTrue()
     {
         var body = await InvokeHarnessAsync<string>(
@@ -670,7 +691,8 @@ public sealed class TrackingIssueTests : IDisposable
         string[] Calls,
         IssueState[] Issues,
         IssueState[] IssuesAfterFailure,
-        ReconciliationAction[] ResumedAppliedActions);
+        ReconciliationAction[] ResumedAppliedActions,
+        int[] DuplicatesClosed);
 
     private sealed record ReconciliationPlan(int? CanonicalIssueNumber, ReconciliationAction[] Actions);
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/TrackingIssueTests.cs
@@ -93,6 +93,28 @@ public sealed class TrackingIssueTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task ForceCreatePlansAnIndependentIssueEvenWhenCanonicalExists()
+    {
+        var marker = "<!-- m -->";
+        var result = await InvokeHarnessAsync<PlanExecutionResult>(
+            "planAndExecute",
+            new
+            {
+                marker,
+                forceCreate = true,
+                body = $"{marker}\n{DuplicateExemptMarker}",
+                issues = new object[]
+                {
+                    new { number = 5, body = marker, state = "open" },
+                }
+            });
+
+        Assert.Equal("create", Assert.Single(result.Plan.Actions).Type);
+        Assert.Equal("create", Assert.Single(result.AppliedActions).Type);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task RecordRunCommentsOnExistingIssueForNewRun()
     {
         var result = await InvokeHarnessAsync<RecordRunResult>(
@@ -630,6 +652,8 @@ public sealed class TrackingIssueTests : IDisposable
     private sealed record HarnessResponse<T>(T Result);
 
     private sealed record FindIssueResult(int? Number);
+
+    private const string DuplicateExemptMarker = "<!-- tracking-issue-duplicate-exempt -->";
 
     private sealed record ReadAutoCloseResult(bool? Value);
 

--- a/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
@@ -1,5 +1,6 @@
 const fs = require('node:fs/promises');
 const helper = require('../../../.github/workflows/create-failing-test-issue.js');
+const tracking = require('../../../.github/workflows/create-failing-test-issue-tracking.js');
 
 async function main() {
     const inputPath = process.argv[2];
@@ -21,6 +22,114 @@ async function dispatch(operation, payload) {
 
         case 'formatListResponse':
             return helper.formatListResponse(payload.resolverOutcome, payload.resultJson ?? null);
+
+        case 'reconcile': {
+            if (typeof tracking.reconcile !== 'function') {
+                return { available: false };
+            }
+
+            const issues = (payload.issues ?? []).map(issue => ({
+                comments: [],
+                state: 'open',
+                ...issue,
+            }));
+            let nextNumber = payload.nextNumber ?? 1000;
+            const calls = [];
+            const transport = {
+                ensureLabel: async () => { calls.push('ensureLabel'); },
+                listIssues: async () => issues,
+                createIssue: async request => {
+                    const issue = {
+                        number: nextNumber++,
+                        state: 'open',
+                        comments: [],
+                        ...request,
+                    };
+                    issues.push(issue);
+                    return issue;
+                },
+                updateIssue: async (issueNumber, patch) => Object.assign(
+                    issues.find(issue => issue.number === issueNumber),
+                    patch),
+                addComment: async (issueNumber, body) => {
+                    issues.find(issue => issue.number === issueNumber).comments.push(body);
+                },
+                closeIssue: async (issueNumber, { stateReason }) => Object.assign(
+                    issues.find(issue => issue.number === issueNumber),
+                    { state: 'closed', stateReason }),
+                reopenIssue: async issueNumber => {
+                    issues.find(issue => issue.number === issueNumber).state = 'open';
+                },
+                listComments: async issueNumber => issues
+                    .find(issue => issue.number === issueNumber).comments
+                    .map(body => ({ body })),
+            };
+            const result = await tracking.reconcile({
+                transport,
+                core: { info: () => {} },
+                issue: {
+                    title: payload.title ?? 'Failing test',
+                    body: payload.body,
+                    labels: payload.labels ?? ['failing-test'],
+                    metadataMarker: payload.marker,
+                    commentBody: payload.comment ?? 'Failure occurrence',
+                },
+                runId: payload.runId ?? 123,
+                forceNew: payload.forceNew === true,
+            });
+            return {
+                available: true,
+                result,
+                issues,
+                calls,
+            };
+        }
+
+        case 'ghTransport': {
+            let transportFactory;
+            try {
+                transportFactory = require('../../../.github/workflows/tracking-issue-gh-api.js');
+            } catch (error) {
+                if (error.code === 'MODULE_NOT_FOUND') {
+                    return { available: false };
+                }
+                throw error;
+            }
+            if (typeof transportFactory.createGhApiIssueTransport !== 'function') {
+                return { available: false };
+            }
+
+            const calls = [];
+            const runGh = async (args, input) => {
+                calls.push({ args, input: input ?? null });
+                if (args.includes('--paginate')) {
+                    return '[]';
+                }
+                if (args.includes('POST') && args.includes('repos/microsoft/aspire/issues')) {
+                    return '{"number":1000,"html_url":"https://github.com/microsoft/aspire/issues/1000"}';
+                }
+                return '{}';
+            };
+            const transport = transportFactory.createGhApiIssueTransport(
+                'microsoft/aspire',
+                { runGh });
+            if (payload.operation === 'list') {
+                await transport.listIssues('failing-test');
+            } else {
+                await transport.ensureLabel({
+                    name: 'failing-test',
+                    color: 'b60205',
+                    description: 'A test is failing in CI',
+                });
+                await transport.createIssue({ title: 'title', body: 'body', labels: ['failing-test'] });
+                await transport.updateIssue(1000, { body: 'updated' });
+                await transport.addComment(1000, 'comment');
+                await transport.closeIssue(1000, { stateReason: 'not_planned' });
+                await transport.reopenIssue(1000);
+                await transport.listComments(1000);
+            }
+            return { available: true, calls };
+        }
 
         default:
             throw new Error(`Unsupported operation '${operation}'.`);

--- a/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
@@ -17,8 +17,7 @@ async function dispatch(operation, payload) {
         case 'parseCommand':
             return helper.parseCommand(payload.body, payload.defaultSourceUrl ?? null);
 
-        case 'buildIssueSearchQuery':
-            return helper.buildIssueSearchQuery(payload.owner ?? 'microsoft', payload.repo ?? 'aspire', payload.metadataMarker);
+
 
         case 'formatListResponse':
             return helper.formatListResponse(payload.resolverOutcome, payload.resultJson ?? null);

--- a/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/create-failing-test-issue.harness.js
@@ -37,8 +37,12 @@ async function dispatch(operation, payload) {
             const calls = [];
             const transport = {
                 ensureLabel: async () => { calls.push('ensureLabel'); },
-                listIssues: async () => issues,
+                listIssues: async () => {
+                    calls.push('listIssues');
+                    return issues;
+                },
                 createIssue: async request => {
+                    calls.push('createIssue');
                     const issue = {
                         number: nextNumber++,
                         state: 'open',
@@ -48,21 +52,30 @@ async function dispatch(operation, payload) {
                     issues.push(issue);
                     return issue;
                 },
-                updateIssue: async (issueNumber, patch) => Object.assign(
-                    issues.find(issue => issue.number === issueNumber),
-                    patch),
+                updateIssue: async (issueNumber, patch) => {
+                    calls.push('updateIssue');
+                    Object.assign(issues.find(issue => issue.number === issueNumber), patch);
+                },
                 addComment: async (issueNumber, body) => {
+                    calls.push('addComment');
                     issues.find(issue => issue.number === issueNumber).comments.push(body);
                 },
-                closeIssue: async (issueNumber, { stateReason }) => Object.assign(
-                    issues.find(issue => issue.number === issueNumber),
-                    { state: 'closed', stateReason }),
+                closeIssue: async (issueNumber, { stateReason }) => {
+                    calls.push('closeIssue');
+                    Object.assign(
+                        issues.find(issue => issue.number === issueNumber),
+                        { state: 'closed', stateReason });
+                },
                 reopenIssue: async issueNumber => {
+                    calls.push('reopenIssue');
                     issues.find(issue => issue.number === issueNumber).state = 'open';
                 },
-                listComments: async issueNumber => issues
-                    .find(issue => issue.number === issueNumber).comments
-                    .map(body => ({ body })),
+                listComments: async issueNumber => {
+                    calls.push('listComments');
+                    return issues
+                        .find(issue => issue.number === issueNumber).comments
+                        .map(body => ({ body }));
+                },
             };
             const result = await tracking.reconcile({
                 transport,
@@ -102,6 +115,9 @@ async function dispatch(operation, payload) {
             const calls = [];
             const runGh = async (args, input) => {
                 calls.push({ args, input: input ?? null });
+                if (payload.labelAlreadyExists && args.includes('repos/microsoft/aspire/labels')) {
+                    throw new Error('gh api failed: Validation Failed (HTTP 422)');
+                }
                 if (args.includes('--paginate')) {
                     return '[]';
                 }
@@ -115,6 +131,12 @@ async function dispatch(operation, payload) {
                 { runGh });
             if (payload.operation === 'list') {
                 await transport.listIssues('failing-test');
+            } else if (payload.operation === 'ensure') {
+                await transport.ensureLabel({
+                    name: 'failing-test',
+                    color: 'b60205',
+                    description: 'A test is failing in CI',
+                });
             } else {
                 await transport.ensureLabel({
                     name: 'failing-test',

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -46,7 +46,11 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                         // mutate the runner's cached issue list in the test.
                         data: store.issues
                             .filter(issue => requestedState === 'all' || issue.state === requestedState)
-                            .map(issue => ({ ...issue, labels: [...(issue.labels ?? [])], comments: [...(issue.comments ?? [])] })),
+                            .map(issue => ({
+                                ...issue,
+                                labels: [...(issue.labels ?? [])],
+                                comments: issue.comments?.length ?? 0,
+                            })),
                     };
                 },
                 create: async ({ title, body, labels }) => {

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -55,7 +55,7 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                     store.issues.push(issue);
                     return { data: issue };
                 },
-                update: async ({ issue_number, body, state }) => {
+                update: async ({ issue_number, body, state, state_reason: stateReason }) => {
                     calls.push('update');
                     if (failUpdate) {
                         throw new Error('transient update failure');
@@ -63,6 +63,7 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                     const issue = store.issues.find(i => i.number === issue_number);
                     if (body !== undefined) { issue.body = body; }
                     if (state) { issue.state = state; }
+                    if (stateReason) { issue.stateReason = stateReason; }
                 },
                 listComments: async ({ issue_number }) => {
                     const issue = store.issues.find(i => i.number === issue_number);
@@ -138,6 +139,7 @@ async function main() {
             issues: store.issues.map(issue => ({
                 number: issue.number,
                 state: issue.state,
+                stateReason: issue.stateReason ?? null,
                 body: issue.body,
                 labels: issue.labels ?? [],
                 comments: issue.comments ?? [],

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -41,7 +41,12 @@ function makeGithub(store, runsByFile, { failUpdate }) {
                     }
                     const requestedState = state ?? 'open';
                     return {
-                        data: store.issues.filter(issue => requestedState === 'all' || issue.state === requestedState),
+                        // Octokit responses are snapshots, not live references to
+                        // GitHub state. Clone them so an update call cannot silently
+                        // mutate the runner's cached issue list in the test.
+                        data: store.issues
+                            .filter(issue => requestedState === 'all' || issue.state === requestedState)
+                            .map(issue => ({ ...issue, labels: [...(issue.labels ?? [])], comments: [...(issue.comments ?? [])] })),
                     };
                 },
                 create: async ({ title, body, labels }) => {

--- a/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/monitor-scheduled-workflows.integration.harness.js
@@ -21,17 +21,29 @@ const path = require('node:path');
 
 const monitor = require('../../../.github/workflows/monitor-scheduled-workflows.js');
 
-function makeGithub(store, runsByFile, { failUpdate }) {
+function makeGithub(store, runsByFile, { failUpdate, issuesAfterInitialList }) {
     const calls = [];
     const listRunRequests = [];
+    let listIssuesCount = 0;
     return {
         calls,
         listRunRequests,
+        get listIssuesCount() {
+            return listIssuesCount;
+        },
         paginate: async (fn, params) => (await fn(params)).data,
         rest: {
             issues: {
                 createLabel: async () => { calls.push('createLabel'); },
                 listForRepo: async ({ labels, state }) => {
+                    listIssuesCount++;
+                    if (listIssuesCount === 2 && issuesAfterInitialList) {
+                        store.issues = issuesAfterInitialList.map(issue => ({
+                            comments: [],
+                            state: 'open',
+                            ...issue,
+                        }));
+                    }
                     // Production narrows by the lookup label before the marker filter
                     // (tracking-issue.js listOpenIssuesByLabel). Fail loudly if that
                     // narrowing is ever dropped so the regression is caught here
@@ -111,7 +123,10 @@ async function main() {
         issues: (input.issues ?? []).map(issue => ({ comments: [], state: 'open', ...issue })),
         next: input.nextNumber ?? 1000,
     };
-    const github = makeGithub(store, input.runsByFile ?? {}, { failUpdate: input.failUpdate === true });
+    const github = makeGithub(store, input.runsByFile ?? {}, {
+        failUpdate: input.failUpdate === true,
+        issuesAfterInitialList: input.issuesAfterInitialList,
+    });
     const logs = [];
     const warnings = [];
     const core = {
@@ -140,6 +155,7 @@ async function main() {
             logs,
             warnings,
             listRunRequests: github.listRunRequests,
+            listIssuesCount: github.listIssuesCount,
             issues: store.issues.map(issue => ({
                 number: issue.number,
                 state: issue.state,

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-ci-failure.integration.harness.js
@@ -14,7 +14,7 @@
 //     "failUpdate": false,             // make issues.update throw (transient failure)
 //     "runId": 12345, "runNumber": 7, "sha": "abcdef..."
 //   }
-// Output: { threw, calls, issues: [ { number, title, state, state_reason, body, labels, comments } ] }
+// Output: { threw, calls, logs, issues: [ { number, title, state, state_reason, body, labels, comments } ] }
 
 'use strict';
 
@@ -88,7 +88,8 @@ async function main() {
         next: input.nextNumber ?? 1000,
     };
     const github = makeGithub(store, { failComment: input.failComment === true, failUpdate: input.failUpdate === true });
-    const core = { info: () => {}, warning: () => {} };
+    const logs = [];
+    const core = { info: message => logs.push(String(message)), warning: () => {} };
     const context = {
         repo: { owner: 'microsoft', repo: 'aspire' },
         runId: input.runId ?? 12345,
@@ -108,6 +109,7 @@ async function main() {
         result: {
             threw,
             calls: github.calls,
+            logs,
             issues: store.issues.map(issue => ({
                 number: issue.number,
                 title: issue.title ?? null,

--- a/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/report-pipeline-failure.integration.harness.js
@@ -113,6 +113,7 @@ async function main() {
                 number: issue.number,
                 title: issue.title ?? null,
                 state: issue.state,
+                stateReason: issue.state_reason ?? null,
                 body: issue.body,
                 labels: issue.labels ?? [],
                 comments: issue.comments ?? [],

--- a/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/specialized-test-failure-runner.harness.js
@@ -111,6 +111,7 @@ async function main() {
                 number: issue.number,
                 title: issue.title ?? null,
                 state: issue.state,
+                stateReason: issue.state_reason ?? null,
                 body: issue.body,
                 comments: issue.comments ?? [],
             })),

--- a/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
@@ -150,6 +150,7 @@ async function dispatch(operation, payload) {
                 title: payload.title ?? 'Tracking issue',
                 buildBody: () => payload.body ?? `${payload.marker}\n\nbody`,
                 closeDuplicates: payload.closeDuplicates,
+                forceCreate: payload.forceCreate,
                 reopen: 'when-changing',
                 actionsForCanonical: issue => {
                     const actions = [];

--- a/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/tracking-issue.harness.js
@@ -193,6 +193,7 @@ async function dispatch(operation, payload) {
                 calls: github.calls,
                 issues: snapshotIssues(store.issues),
                 issuesAfterFailure,
+                duplicatesClosed: execution.duplicatesClosed,
             };
         }
 

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -12,7 +11,6 @@ namespace Aspire.TestTools;
 public static class GitHubCli
 {
     private const string FixtureDirectoryEnvironmentVariable = "ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR";
-    private const string DuplicateExemptMarker = "<!-- tracking-issue-duplicate-exempt -->";
 
     public static async Task<JsonDocument> GetJsonAsync(string endpoint, CancellationToken cancellationToken)
     {
@@ -72,217 +70,6 @@ public static class GitHubCli
             ["api", "-H", "Accept: application/vnd.github+json", endpoint],
             outputPath,
             cancellationToken).ConfigureAwait(false);
-    }
-
-    public static async Task<(int Number, string Url)> CreateIssueAsync(
-        string repository,
-        string title,
-        string body,
-        IReadOnlyList<string> labels,
-        CancellationToken cancellationToken)
-    {
-        if (TryGetFixtureContent("create-issue", ".json", out var fixtureContent))
-        {
-            using var document = JsonDocument.Parse(fixtureContent);
-            var root = document.RootElement;
-            return (root.GetProperty("number").GetInt32(), root.GetProperty("url").GetString()!);
-        }
-
-        List<string> arguments = ["issue", "create", "--repo", repository, "--title", title, "--body", body];
-
-        foreach (var label in labels)
-        {
-            arguments.Add("--label");
-            arguments.Add(label);
-        }
-
-        var stdout = await RunGhAsync(arguments, cancellationToken).ConfigureAwait(false);
-
-        // gh issue create outputs the issue URL on stdout
-        var issueUrl = stdout.Trim();
-        var issueNumber = 0;
-
-        // Extract issue number from URL: https://github.com/owner/repo/issues/123
-        var lastSlash = issueUrl.LastIndexOf('/');
-        if (lastSlash >= 0 && int.TryParse(issueUrl[(lastSlash + 1)..], out var parsed))
-        {
-            issueNumber = parsed;
-        }
-
-        return (issueNumber, issueUrl);
-    }
-
-    /// <summary>
-    /// Lists failing-test issues carrying an exact metadata marker, oldest first.
-    /// </summary>
-    public static async Task<IReadOnlyList<GitHubIssueInfo>> FindIssuesByMarkerAsync(
-        string repository,
-        string label,
-        string metadataMarker,
-        CancellationToken cancellationToken)
-    {
-        string content;
-        if (TryGetFixtureContent("list-issues", ".json", out var fixtureContent))
-        {
-            content = fixtureContent;
-        }
-        else
-        {
-            var endpoint = $"repos/{repository}/issues?labels={Uri.EscapeDataString(label)}&state=all&per_page=100";
-            content = await RunGhAsync(
-                ["api", "-H", "Accept: application/vnd.github+json", "--paginate", "--slurp", endpoint],
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        using var document = JsonDocument.Parse(content);
-        List<GitHubIssueInfo> matches = [];
-
-        void AddMatches(JsonElement items)
-        {
-            foreach (var item in items.EnumerateArray())
-            {
-                if (item.TryGetProperty("pull_request", out _))
-                {
-                    continue;
-                }
-
-                var body = item.GetProperty("body").GetString() ?? string.Empty;
-                if (!body.Contains(metadataMarker, StringComparison.Ordinal)
-                    || body.Contains(DuplicateExemptMarker, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                matches.Add(new GitHubIssueInfo(
-                    item.GetProperty("number").GetInt32(),
-                    item.GetProperty("html_url").GetString()!,
-                    item.GetProperty("state").GetString()!));
-            }
-        }
-
-        var root = document.RootElement;
-        if (root.GetArrayLength() > 0 && root[0].ValueKind is JsonValueKind.Array)
-        {
-            foreach (var page in root.EnumerateArray())
-            {
-                AddMatches(page);
-            }
-        }
-        else
-        {
-            AddMatches(root);
-        }
-
-        return matches.OrderBy(static issue => issue.Number).ToArray();
-    }
-
-    /// <summary>
-    /// Reopens a closed issue.
-    /// </summary>
-    public static async Task ReopenIssueAsync(string repository, int issueNumber, CancellationToken cancellationToken)
-    {
-        if (TryGetFixtureContent("reopen-issue", ".json", out _))
-        {
-            return;
-        }
-
-        var issueNumberString = issueNumber.ToString(CultureInfo.InvariantCulture);
-
-        // Use the API to set the state to open
-        await RunGhAsync(
-            ["api", "-X", "PATCH", $"repos/{repository}/issues/{issueNumberString}", "-f", "state=open"],
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Closes a duplicate issue without treating it as completed work.
-    /// </summary>
-    public static async Task CloseIssueAsNotPlannedAsync(string repository, int issueNumber, CancellationToken cancellationToken)
-    {
-        if (TryGetFixtureContent("close-issue", ".json", out _))
-        {
-            return;
-        }
-
-        await RunGhAsync(
-            [
-                "api",
-                "-X",
-                "PATCH",
-                $"repos/{repository}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}",
-                "-f",
-                "state=closed",
-                "-f",
-                "state_reason=not_planned",
-            ],
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Returns whether an issue comment carries the exact marker.
-    /// </summary>
-    public static async Task<bool> IssueHasCommentMarkerAsync(
-        string repository,
-        int issueNumber,
-        string marker,
-        CancellationToken cancellationToken)
-    {
-        string content;
-        if (TryGetFixtureContent($"list-comments-{issueNumber.ToString(CultureInfo.InvariantCulture)}", ".json", out var fixtureContent))
-        {
-            content = fixtureContent;
-        }
-        else
-        {
-            var endpoint = $"repos/{repository}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100";
-            content = await RunGhAsync(
-                ["api", "-H", "Accept: application/vnd.github+json", "--paginate", "--slurp", endpoint],
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        using var document = JsonDocument.Parse(content);
-        var root = document.RootElement;
-        if (root.GetArrayLength() > 0 && root[0].ValueKind is JsonValueKind.Array)
-        {
-            return root.EnumerateArray()
-                .SelectMany(static page => page.EnumerateArray())
-                .Any(comment => (comment.GetProperty("body").GetString() ?? string.Empty).Contains(marker, StringComparison.Ordinal));
-        }
-
-        return root.EnumerateArray()
-            .Any(comment => (comment.GetProperty("body").GetString() ?? string.Empty).Contains(marker, StringComparison.Ordinal));
-    }
-
-    /// <summary>
-    /// Adds a comment to an issue.
-    /// </summary>
-    public static async Task AddIssueCommentAsync(string repository, int issueNumber, string body, CancellationToken cancellationToken)
-    {
-        if (TryGetFixtureContent("add-issue-comment", ".json", out _))
-        {
-            return;
-        }
-
-        await RunGhAsync(
-            ["issue", "comment", issueNumber.ToString(CultureInfo.InvariantCulture), "--repo", repository, "--body", body],
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    private static bool TryGetFixtureContent(string name, string extension, out string content)
-    {
-        var fixtureDirectory = Environment.GetEnvironmentVariable(FixtureDirectoryEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(fixtureDirectory))
-        {
-            var fixturePath = Path.Combine(fixtureDirectory, $"{name}{extension}");
-            if (File.Exists(fixturePath))
-            {
-                content = File.ReadAllText(fixturePath);
-                return true;
-            }
-        }
-
-        content = string.Empty;
-        return false;
     }
 
     private static readonly TimeSpan s_defaultProcessTimeout = TimeSpan.FromMinutes(5);
@@ -440,5 +227,3 @@ public static class GitHubCli
         return File.Exists(fixturePath);
     }
 }
-
-public sealed record GitHubIssueInfo(int Number, string Url, string State);

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -12,6 +12,7 @@ namespace Aspire.TestTools;
 public static class GitHubCli
 {
     private const string FixtureDirectoryEnvironmentVariable = "ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR";
+    private const string DuplicateExemptMarker = "<!-- tracking-issue-duplicate-exempt -->";
 
     public static async Task<JsonDocument> GetJsonAsync(string endpoint, CancellationToken cancellationToken)
     {
@@ -112,69 +113,67 @@ public static class GitHubCli
     }
 
     /// <summary>
-    /// Searches for an existing failing-test issue by metadata marker.
-    /// Returns the first matching issue (prefers open, then closed), or null if none found.
+    /// Lists failing-test issues carrying an exact metadata marker, oldest first.
     /// </summary>
-    public static async Task<(int Number, string Url, string State)?> SearchExistingIssueAsync(
+    public static async Task<IReadOnlyList<GitHubIssueInfo>> FindIssuesByMarkerAsync(
         string repository,
+        string label,
         string metadataMarker,
         CancellationToken cancellationToken)
     {
-        if (TryGetFixtureContent("search-issue", ".json", out var fixtureContent))
+        string content;
+        if (TryGetFixtureContent("list-issues", ".json", out var fixtureContent))
         {
-            using var document = JsonDocument.Parse(fixtureContent);
-            var root = document.RootElement;
-            if (root.TryGetProperty("number", out var numberElement))
-            {
-                return (numberElement.GetInt32(), root.GetProperty("url").GetString()!, root.GetProperty("state").GetString()!);
-            }
-
-            return null;
+            content = fixtureContent;
+        }
+        else
+        {
+            var endpoint = $"repos/{repository}/issues?labels={Uri.EscapeDataString(label)}&state=all&per_page=100";
+            content = await RunGhAsync(
+                ["api", "-H", "Accept: application/vnd.github+json", "--paginate", "--slurp", endpoint],
+                cancellationToken).ConfigureAwait(false);
         }
 
-        var escapedMarker = metadataMarker.Replace("\"", "\\\"");
-        var query = $"repo:{repository} is:issue label:failing-test in:body \"{escapedMarker}\"";
+        using var document = JsonDocument.Parse(content);
+        List<GitHubIssueInfo> matches = [];
 
-        using var searchDocument = await GetJsonAsync(
-            $"search/issues?q={Uri.EscapeDataString(query)}&per_page=20",
-            cancellationToken).ConfigureAwait(false);
-
-        var items = searchDocument.RootElement.GetProperty("items");
-
-        // Prefer open issues, then closed issues (matching workflow JS logic).
-        JsonElement? openMatch = null;
-        JsonElement? closedMatch = null;
-
-        foreach (var item in items.EnumerateArray())
+        void AddMatches(JsonElement items)
         {
-            // Skip pull requests
-            if (item.TryGetProperty("pull_request", out _))
+            foreach (var item in items.EnumerateArray())
             {
-                continue;
-            }
+                if (item.TryGetProperty("pull_request", out _))
+                {
+                    continue;
+                }
 
-            var state = item.GetProperty("state").GetString();
-            if (state is "open" && openMatch is null)
-            {
-                openMatch = item;
-                break; // Open match is highest priority
-            }
-            else if (state is "closed" && closedMatch is null)
-            {
-                closedMatch = item;
+                var body = item.GetProperty("body").GetString() ?? string.Empty;
+                if (!body.Contains(metadataMarker, StringComparison.Ordinal)
+                    || body.Contains(DuplicateExemptMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                matches.Add(new GitHubIssueInfo(
+                    item.GetProperty("number").GetInt32(),
+                    item.GetProperty("html_url").GetString()!,
+                    item.GetProperty("state").GetString()!));
             }
         }
 
-        var match = openMatch ?? closedMatch;
-        if (match is null)
+        var root = document.RootElement;
+        if (root.GetArrayLength() > 0 && root[0].ValueKind is JsonValueKind.Array)
         {
-            return null;
+            foreach (var page in root.EnumerateArray())
+            {
+                AddMatches(page);
+            }
+        }
+        else
+        {
+            AddMatches(root);
         }
 
-        return (
-            match.Value.GetProperty("number").GetInt32(),
-            match.Value.GetProperty("html_url").GetString()!,
-            match.Value.GetProperty("state").GetString()!);
+        return matches.OrderBy(static issue => issue.Number).ToArray();
     }
 
     /// <summary>
@@ -193,6 +192,65 @@ public static class GitHubCli
         await RunGhAsync(
             ["api", "-X", "PATCH", $"repos/{repository}/issues/{issueNumberString}", "-f", "state=open"],
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Closes a duplicate issue without treating it as completed work.
+    /// </summary>
+    public static async Task CloseIssueAsNotPlannedAsync(string repository, int issueNumber, CancellationToken cancellationToken)
+    {
+        if (TryGetFixtureContent("close-issue", ".json", out _))
+        {
+            return;
+        }
+
+        await RunGhAsync(
+            [
+                "api",
+                "-X",
+                "PATCH",
+                $"repos/{repository}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}",
+                "-f",
+                "state=closed",
+                "-f",
+                "state_reason=not_planned",
+            ],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns whether an issue comment carries the exact marker.
+    /// </summary>
+    public static async Task<bool> IssueHasCommentMarkerAsync(
+        string repository,
+        int issueNumber,
+        string marker,
+        CancellationToken cancellationToken)
+    {
+        string content;
+        if (TryGetFixtureContent($"list-comments-{issueNumber.ToString(CultureInfo.InvariantCulture)}", ".json", out var fixtureContent))
+        {
+            content = fixtureContent;
+        }
+        else
+        {
+            var endpoint = $"repos/{repository}/issues/{issueNumber.ToString(CultureInfo.InvariantCulture)}/comments?per_page=100";
+            content = await RunGhAsync(
+                ["api", "-H", "Accept: application/vnd.github+json", "--paginate", "--slurp", endpoint],
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+        if (root.GetArrayLength() > 0 && root[0].ValueKind is JsonValueKind.Array)
+        {
+            return root.EnumerateArray()
+                .SelectMany(static page => page.EnumerateArray())
+                .Any(comment => (comment.GetProperty("body").GetString() ?? string.Empty).Contains(marker, StringComparison.Ordinal));
+        }
+
+        return root.EnumerateArray()
+            .Any(comment => (comment.GetProperty("body").GetString() ?? string.Empty).Contains(marker, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -382,3 +440,5 @@ public static class GitHubCli
         return File.Exists(fixturePath);
     }
 }
+
+public sealed record GitHubIssueInfo(int Number, string Url, string State);

--- a/tools/CreateFailingTestIssue/CreateFailingTestIssue.csproj
+++ b/tools/CreateFailingTestIssue/CreateFailingTestIssue.csproj
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <Compile Include="..\Aspire.TestTools\*.cs" LinkBase="Aspire.TestTools" />
+    <Content Include="..\..\.github\workflows\create-failing-test-issue-tracking.js" Link="create-failing-test-issue-tracking.js" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\.github\workflows\tracking-issue-gh-api.js" Link="tracking-issue-gh-api.js" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\.github\workflows\tracking-issue.js" Link="tracking-issue.js" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.IO.Hashing;
 using System.Net;
@@ -14,6 +15,8 @@ namespace CreateFailingTestIssue;
 
 internal static class FailingTestIssueCommand
 {
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
     private static readonly HashSet<string> s_failedOutcomes = new(StringComparer.OrdinalIgnoreCase)
     {
         "Failed",
@@ -197,110 +200,47 @@ internal static class FailingTestIssueCommand
             ExistingIssueInfo? existingIssue = null;
             if (input.Create)
             {
-                var runMarker = $"<!-- run:{resolutionSection.RunId.ToString(CultureInfo.InvariantCulture)} -->";
-                if (!input.ForceNew)
+                var result = await ReconcileIssueAsync(
+                    input.Repository,
+                    issueArtifacts,
+                    resolutionSection.RunId,
+                    input.ForceNew,
+                    cancellationToken).ConfigureAwait(false);
+
+                foreach (var message in result.Logs)
                 {
-                    Log("--create flag set. Listing all failing-test issues for an exact marker match...");
-                    var matchingIssues = await GitHubCli.FindIssuesByMarkerAsync(
-                        input.Repository,
-                        "failing-test",
-                        issueArtifacts.MetadataMarker,
-                        cancellationToken).ConfigureAwait(false);
-
-                    if (matchingIssues.Count > 0)
-                    {
-                        var canonicalIssue = matchingIssues[0];
-                        existingIssue = new ExistingIssueInfo(canonicalIssue.Number, canonicalIssue.Url);
-                        GitHubIssueInfo? occurrenceIssue = null;
-
-                        foreach (var matchingIssue in matchingIssues)
-                        {
-                            if (await GitHubCli.IssueHasCommentMarkerAsync(
-                                input.Repository,
-                                matchingIssue.Number,
-                                runMarker,
-                                cancellationToken).ConfigureAwait(false))
-                            {
-                                occurrenceIssue = matchingIssue;
-                                break;
-                            }
-                        }
-
-                        foreach (var duplicateIssue in matchingIssues.Skip(1).Where(static issue => issue.State is "open"))
-                        {
-                            Log($"Closing newer duplicate issue #{duplicateIssue.Number} in favor of #{canonicalIssue.Number}...");
-                            await GitHubCli.AddIssueCommentAsync(
-                                input.Repository,
-                                canonicalIssue.Number,
-                                $"[automated] Issue #{duplicateIssue.Number} was identified as a duplicate.",
-                                cancellationToken).ConfigureAwait(false);
-                            await GitHubCli.AddIssueCommentAsync(
-                                input.Repository,
-                                duplicateIssue.Number,
-                                $"[automated] Duplicate of #{canonicalIssue.Number}. Future occurrences are tracked there.",
-                                cancellationToken).ConfigureAwait(false);
-                            await GitHubCli.CloseIssueAsNotPlannedAsync(
-                                input.Repository,
-                                duplicateIssue.Number,
-                                cancellationToken).ConfigureAwait(false);
-                        }
-
-                        if (occurrenceIssue is not null)
-                        {
-                            if (canonicalIssue.State is "closed" && occurrenceIssue.Number != canonicalIssue.Number)
-                            {
-                                Log($"Run {resolutionSection.RunId} was recorded on duplicate issue #{occurrenceIssue.Number}. Reopening canonical issue #{canonicalIssue.Number}...");
-                                await GitHubCli.ReopenIssueAsync(input.Repository, canonicalIssue.Number, cancellationToken).ConfigureAwait(false);
-                            }
-
-                            Log($"Run {resolutionSection.RunId} is already recorded on issue #{occurrenceIssue.Number}; skipping duplicate comment.");
-                        }
-                        else
-                        {
-                            if (canonicalIssue.State is "closed")
-                            {
-                                Log($"Found closed issue #{canonicalIssue.Number}. Reopening...");
-                                await GitHubCli.ReopenIssueAsync(input.Repository, canonicalIssue.Number, cancellationToken).ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                Log($"Found open issue #{canonicalIssue.Number}. Adding comment...");
-                            }
-
-                            await GitHubCli.AddIssueCommentAsync(
-                                input.Repository,
-                                canonicalIssue.Number,
-                                $"{issueArtifacts.CommentBody}\n\n{runMarker}",
-                                cancellationToken).ConfigureAwait(false);
-                        }
-
-                        Log($"Updated existing issue #{canonicalIssue.Number}: {canonicalIssue.Url}");
-                    }
+                    Log(message);
                 }
 
-                if (existingIssue is null)
+                if (result.Created)
                 {
                     Log(input.ForceNew ? "--force-new flag set. Creating new issue on GitHub..." : "No existing issue found. Creating new issue on GitHub...");
-                    var issueBody = input.ForceNew
-                        ? $"{issueArtifacts.Body}\n\n<!-- tracking-issue-duplicate-exempt -->"
-                        : issueArtifacts.Body;
-                    var (issueNumber, issueUrl) = await GitHubCli.CreateIssueAsync(
-                        input.Repository,
-                        issueArtifacts.Title,
-                        issueBody,
-                        issueArtifacts.Labels,
-                        cancellationToken).ConfigureAwait(false);
-                    createdIssue = new CreatedIssueInfo(issueNumber, issueUrl);
+                    createdIssue = new CreatedIssueInfo(result.Number, result.Url);
                     if (!input.ForceNew)
                     {
-                        await GitHubCli.AddIssueCommentAsync(
-                            input.Repository,
-                            issueNumber,
-                            $"{issueArtifacts.CommentBody}\n\n{runMarker}",
-                            cancellationToken).ConfigureAwait(false);
-                        Log($"Recorded run {resolutionSection.RunId} on issue #{issueNumber}.");
+                        Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
                     }
-                    Log($"Created issue #{issueNumber}: {issueUrl}");
+                    Log($"Created issue #{result.Number}: {result.Url}");
+                }
+                else
+                {
+                    existingIssue = new ExistingIssueInfo(result.Number, result.Url);
+                    if (result.Skipped)
+                    {
+                        Log($"Run {resolutionSection.RunId} is already recorded on issue #{result.Number}; skipping duplicate comment.");
+                    }
+                    else
+                    {
+                        Log(result.PreviousState is "closed"
+                            ? $"Found closed issue #{result.Number}. Reopening..."
+                            : $"Found open issue #{result.Number}. Adding comment...");
+                        foreach (var duplicateNumber in result.DuplicatesClosed)
+                        {
+                            Log($"Closing newer duplicate issue #{duplicateNumber} in favor of #{result.Number}...");
+                        }
+                        Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
+                    }
+                    Log($"Updated existing issue #{result.Number}: {result.Url}");
                 }
             }
 
@@ -407,6 +347,75 @@ internal static class FailingTestIssueCommand
                 Warnings: warnings.ToArray(),
                 AvailableFailedTests: availableFailedTests)
         };
+    }
+
+    private static async Task<IssueReconciliationResult> ReconcileIssueAsync(
+        string repository,
+        IssueArtifacts issue,
+        long runId,
+        bool forceNew,
+        CancellationToken cancellationToken)
+    {
+        var adapterPath = Path.Combine(AppContext.BaseDirectory, "create-failing-test-issue-tracking.js");
+        ProcessStartInfo processStartInfo = new()
+        {
+            FileName = "node",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        processStartInfo.ArgumentList.Add(adapterPath);
+
+        using var process = new Process { StartInfo = processStartInfo };
+        process.Start();
+
+        var request = JsonSerializer.Serialize(new
+        {
+            repository,
+            runId,
+            forceNew,
+            issue
+        }, s_jsonOptions);
+
+        try
+        {
+            await process.StandardInput.WriteAsync(request.AsMemory(), cancellationToken).ConfigureAwait(false);
+            process.StandardInput.Close();
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failing-test issue reconciliation failed with exit code {process.ExitCode}: {stderr}");
+            }
+
+            return JsonSerializer.Deserialize<IssueReconciliationResult>(stdout, s_jsonOptions)
+                ?? throw new InvalidOperationException("Failing-test issue reconciliation returned an empty response.");
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException) when (process.HasExited)
+                {
+                    // The adapter exited after the HasExited check, so there is no process tree left to terminate.
+                }
+            }
+
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
     }
 
     private static CreateFailingTestIssueResult CreateFailureResult(
@@ -1109,6 +1118,16 @@ internal static class FailingTestIssueCommand
         GitHubActionsJob Job,
         HashSet<string> FailedTests,
         IReadOnlyList<FailedTestOccurrence> Occurrences);
+
+    private sealed record IssueReconciliationResult(
+        int Number,
+        string Url,
+        bool Created,
+        bool Reopened,
+        bool Skipped,
+        IReadOnlyList<int> DuplicatesClosed,
+        string? PreviousState,
+        IReadOnlyList<string> Logs);
 
     private static void ValidateZipEntries(string zipPath, string extractDirectory)
     {

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -197,49 +197,109 @@ internal static class FailingTestIssueCommand
             ExistingIssueInfo? existingIssue = null;
             if (input.Create)
             {
+                var runMarker = $"<!-- run:{resolutionSection.RunId.ToString(CultureInfo.InvariantCulture)} -->";
                 if (!input.ForceNew)
                 {
-                    Log("--create flag set. Searching for existing issue...");
-                    var existing = await GitHubCli.SearchExistingIssueAsync(
+                    Log("--create flag set. Listing all failing-test issues for an exact marker match...");
+                    var matchingIssues = await GitHubCli.FindIssuesByMarkerAsync(
                         input.Repository,
+                        "failing-test",
                         issueArtifacts.MetadataMarker,
                         cancellationToken).ConfigureAwait(false);
 
-                    if (existing is not null)
+                    if (matchingIssues.Count > 0)
                     {
-                        var (existingNumber, existingUrl, existingState) = existing.Value;
-                        existingIssue = new ExistingIssueInfo(existingNumber, existingUrl);
+                        var canonicalIssue = matchingIssues[0];
+                        existingIssue = new ExistingIssueInfo(canonicalIssue.Number, canonicalIssue.Url);
+                        GitHubIssueInfo? occurrenceIssue = null;
 
-                        if (existingState is "closed")
+                        foreach (var matchingIssue in matchingIssues)
                         {
-                            Log($"Found closed issue #{existingNumber}. Reopening...");
-                            await GitHubCli.ReopenIssueAsync(input.Repository, existingNumber, cancellationToken).ConfigureAwait(false);
+                            if (await GitHubCli.IssueHasCommentMarkerAsync(
+                                input.Repository,
+                                matchingIssue.Number,
+                                runMarker,
+                                cancellationToken).ConfigureAwait(false))
+                            {
+                                occurrenceIssue = matchingIssue;
+                                break;
+                            }
+                        }
+
+                        foreach (var duplicateIssue in matchingIssues.Skip(1).Where(static issue => issue.State is "open"))
+                        {
+                            Log($"Closing newer duplicate issue #{duplicateIssue.Number} in favor of #{canonicalIssue.Number}...");
+                            await GitHubCli.AddIssueCommentAsync(
+                                input.Repository,
+                                canonicalIssue.Number,
+                                $"[automated] Issue #{duplicateIssue.Number} was identified as a duplicate.",
+                                cancellationToken).ConfigureAwait(false);
+                            await GitHubCli.AddIssueCommentAsync(
+                                input.Repository,
+                                duplicateIssue.Number,
+                                $"[automated] Duplicate of #{canonicalIssue.Number}. Future occurrences are tracked there.",
+                                cancellationToken).ConfigureAwait(false);
+                            await GitHubCli.CloseIssueAsNotPlannedAsync(
+                                input.Repository,
+                                duplicateIssue.Number,
+                                cancellationToken).ConfigureAwait(false);
+                        }
+
+                        if (occurrenceIssue is not null)
+                        {
+                            if (canonicalIssue.State is "closed" && occurrenceIssue.Number != canonicalIssue.Number)
+                            {
+                                Log($"Run {resolutionSection.RunId} was recorded on duplicate issue #{occurrenceIssue.Number}. Reopening canonical issue #{canonicalIssue.Number}...");
+                                await GitHubCli.ReopenIssueAsync(input.Repository, canonicalIssue.Number, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            Log($"Run {resolutionSection.RunId} is already recorded on issue #{occurrenceIssue.Number}; skipping duplicate comment.");
                         }
                         else
                         {
-                            Log($"Found open issue #{existingNumber}. Adding comment...");
+                            if (canonicalIssue.State is "closed")
+                            {
+                                Log($"Found closed issue #{canonicalIssue.Number}. Reopening...");
+                                await GitHubCli.ReopenIssueAsync(input.Repository, canonicalIssue.Number, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                Log($"Found open issue #{canonicalIssue.Number}. Adding comment...");
+                            }
+
+                            await GitHubCli.AddIssueCommentAsync(
+                                input.Repository,
+                                canonicalIssue.Number,
+                                $"{issueArtifacts.CommentBody}\n\n{runMarker}",
+                                cancellationToken).ConfigureAwait(false);
                         }
 
-                        await GitHubCli.AddIssueCommentAsync(
-                            input.Repository,
-                            existingNumber,
-                            issueArtifacts.CommentBody,
-                            cancellationToken).ConfigureAwait(false);
-
-                        Log($"Updated existing issue #{existingNumber}: {existingUrl}");
+                        Log($"Updated existing issue #{canonicalIssue.Number}: {canonicalIssue.Url}");
                     }
                 }
 
                 if (existingIssue is null)
                 {
                     Log(input.ForceNew ? "--force-new flag set. Creating new issue on GitHub..." : "No existing issue found. Creating new issue on GitHub...");
+                    var issueBody = input.ForceNew
+                        ? $"{issueArtifacts.Body}\n\n<!-- tracking-issue-duplicate-exempt -->"
+                        : issueArtifacts.Body;
                     var (issueNumber, issueUrl) = await GitHubCli.CreateIssueAsync(
                         input.Repository,
                         issueArtifacts.Title,
-                        issueArtifacts.Body,
+                        issueBody,
                         issueArtifacts.Labels,
                         cancellationToken).ConfigureAwait(false);
                     createdIssue = new CreatedIssueInfo(issueNumber, issueUrl);
+                    if (!input.ForceNew)
+                    {
+                        await GitHubCli.AddIssueCommentAsync(
+                            input.Repository,
+                            issueNumber,
+                            $"{issueArtifacts.CommentBody}\n\n{runMarker}",
+                            cancellationToken).ConfigureAwait(false);
+                        Log($"Recorded run {resolutionSection.RunId} on issue #{issueNumber}.");
+                    }
                     Log($"Created issue #{issueNumber}: {issueUrl}");
                 }
             }

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -226,19 +226,24 @@ internal static class FailingTestIssueCommand
                 else
                 {
                     existingIssue = new ExistingIssueInfo(result.Number, result.Url);
+                    if (result.Reopened)
+                    {
+                        Log($"Found closed issue #{result.Number}. Reopening...");
+                    }
+                    else if (!result.Skipped)
+                    {
+                        Log($"Found open issue #{result.Number}. Adding comment...");
+                    }
+                    foreach (var duplicateNumber in result.DuplicatesClosed)
+                    {
+                        Log($"Closing newer duplicate issue #{duplicateNumber} in favor of #{result.Number}...");
+                    }
                     if (result.Skipped)
                     {
                         Log($"Run {resolutionSection.RunId} is already recorded on issue #{result.Number}; skipping duplicate comment.");
                     }
                     else
                     {
-                        Log(result.PreviousState is "closed"
-                            ? $"Found closed issue #{result.Number}. Reopening..."
-                            : $"Found open issue #{result.Number}. Adding comment...");
-                        foreach (var duplicateNumber in result.DuplicatesClosed)
-                        {
-                            Log($"Closing newer duplicate issue #{duplicateNumber} in favor of #{result.Number}...");
-                        }
                         Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
                     }
                     Log($"Updated existing issue #{result.Number}: {result.Url}");

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -246,9 +246,13 @@ internal static class FailingTestIssueCommand
                 {
                     Log($"Created issue #{result.Number}: {result.Url}");
                 }
-                else
+                else if (!result.Skipped || result.Reopened || result.DuplicatesClosed.Count > 0)
                 {
                     Log($"Updated existing issue #{result.Number}: {result.Url}");
+                }
+                else
+                {
+                    Log($"Found existing issue #{result.Number}: {result.Url}");
                 }
             }
 

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -217,11 +217,6 @@ internal static class FailingTestIssueCommand
                 {
                     Log(input.ForceNew ? "--force-new flag set. Creating new issue on GitHub..." : "No existing issue found. Creating new issue on GitHub...");
                     createdIssue = new CreatedIssueInfo(result.Number, result.Url);
-                    if (!input.ForceNew)
-                    {
-                        Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
-                    }
-                    Log($"Created issue #{result.Number}: {result.Url}");
                 }
                 else
                 {
@@ -234,18 +229,25 @@ internal static class FailingTestIssueCommand
                     {
                         Log($"Found open issue #{result.Number}. Adding comment...");
                     }
-                    foreach (var duplicateNumber in result.DuplicatesClosed)
-                    {
-                        Log($"Closing newer duplicate issue #{duplicateNumber} in favor of #{result.Number}...");
-                    }
-                    if (result.Skipped)
-                    {
-                        Log($"Run {resolutionSection.RunId} is already recorded on issue #{result.Number}; skipping duplicate comment.");
-                    }
-                    else
-                    {
-                        Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
-                    }
+                }
+                foreach (var duplicateNumber in result.DuplicatesClosed)
+                {
+                    Log($"Closing newer duplicate issue #{duplicateNumber} in favor of #{result.Number}...");
+                }
+                if (result.Skipped)
+                {
+                    Log($"Run {resolutionSection.RunId} is already recorded on issue #{result.Number}; skipping duplicate comment.");
+                }
+                else if (!input.ForceNew)
+                {
+                    Log($"Recorded run {resolutionSection.RunId} on issue #{result.Number}.");
+                }
+                if (result.Created)
+                {
+                    Log($"Created issue #{result.Number}: {result.Url}");
+                }
+                else
+                {
                     Log($"Updated existing issue #{result.Number}: {result.Url}");
                 }
             }

--- a/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
+++ b/tools/CreateFailingTestIssue/FailingTestIssueCommand.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Compression;
 using System.IO.Hashing;
 using System.Net;
@@ -16,6 +16,7 @@ namespace CreateFailingTestIssue;
 internal static class FailingTestIssueCommand
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly TimeSpan s_issueReconciliationTimeout = TimeSpan.FromMinutes(5);
 
     private static readonly HashSet<string> s_failedOutcomes = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -356,6 +357,9 @@ internal static class FailingTestIssueCommand
         bool forceNew,
         CancellationToken cancellationToken)
     {
+        using var reconciliationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        reconciliationCts.CancelAfter(s_issueReconciliationTimeout);
+
         var adapterPath = Path.Combine(AppContext.BaseDirectory, "create-failing-test-issue-tracking.js");
         ProcessStartInfo processStartInfo = new()
         {
@@ -381,12 +385,12 @@ internal static class FailingTestIssueCommand
 
         try
         {
-            await process.StandardInput.WriteAsync(request.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await process.StandardInput.WriteAsync(request.AsMemory(), reconciliationCts.Token).ConfigureAwait(false);
             process.StandardInput.Close();
 
-            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(reconciliationCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(reconciliationCts.Token);
+            await process.WaitForExitAsync(reconciliationCts.Token).ConfigureAwait(false);
             var stdout = await stdoutTask.ConfigureAwait(false);
             var stderr = await stderrTask.ConfigureAwait(false);
 
@@ -399,7 +403,7 @@ internal static class FailingTestIssueCommand
             return JsonSerializer.Deserialize<IssueReconciliationResult>(stdout, s_jsonOptions)
                 ?? throw new InvalidOperationException("Failing-test issue reconciliation returned an empty response.");
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             if (!process.HasExited)
             {
@@ -414,7 +418,8 @@ internal static class FailingTestIssueCommand
             }
 
             await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new TimeoutException("Failing-test issue reconciliation timed out after five minutes.", ex);
         }
     }
 


### PR DESCRIPTION
[automated] **Concurrent reporters and replayed runs could split one automated failure across multiple GitHub issues or record the same occurrence more than once.** Canonical selection and duplicate handling depended on which mutable issue a workflow or the C# failing-test tool observed first.

**Root cause:** Failure producers implemented their own lookup, comment, reopen, close, and dry-run behavior. Issue-list responses expose comment counts rather than comment bodies, creation races were not followed by a canonical relist, and close decisions could use stale issue state.

**The fix:** Route CI, pipeline, specialized-test, scheduled-workflow, and failing-test producers through one exact-marker reconciliation planner and shared live/dry-run transports. All-state label listings keep the oldest exact match canonical, hydrate comments before marker decisions, relist after creation so races converge, deduplicate occurrence comments across every match, and optionally close newer duplicates as `not_planned`.

Force-created issues remain exempt from duplicate reconciliation. Trusted auto-close policy is evaluated against refreshed state, and dry-run reports the same canonical and duplicate actions without mutating GitHub. Missing matches remain explicit no-ops rather than producing `#undefined` output.

The C# failing-test command now delegates issue lifecycle to the checked-in adapter while retaining its normalized XxHash3 identity contract. The repository skill and CI documentation define the shared identity, migration, replay, duplicate, and trusted-close contracts for future producers.

**Regression coverage:** Eight affected Infrastructure test classes pass 159 focused cases covering exact identity, REST comment hydration, create races, replay idempotence, force-new exemptions, canonical and duplicate closure results, dry-run parity, trusted auto-close, GitHub API transport behavior, and the C# adapter.

```text
dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.CreateFailingTestIssueToolTests" --filter-class "*.CreateFailingTestIssueWorkflowTests" --filter-class "*.MonitorScheduledWorkflowsIntegrationTests" --filter-class "*.ReportCiFailureIntegrationTests" --filter-class "*.ReportPipelineFailureIntegrationTests" --filter-class "*.SpecializedTestFailureRunnerTests" --filter-class "*.TrackingIssueTests" --filter-class "*.GitHubCliArgumentTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
actionlint .github/workflows/create-failing-test-issue.yml
```