### PR TITLE
Improve terminal sizing controls and defaults

### DIFF
--- a/docs/specs/with-terminal.md
+++ b/docs/specs/with-terminal.md
@@ -138,6 +138,17 @@ rendered inside the toolbar's options (⋯) `AspireMenuButton`:
   visible` transition the page calls `refreshLayout` on the JS terminal
   to guarantee xterm rebinds to the new available space.
 
+The terminal frame keeps font decrease/increase buttons, the current font
+size, and the live columns-by-rows selector together in its bottom-right
+footer. The selector offers Fit mode and predefined terminal dimensions,
+keeping both sizing operations available without opening the page options
+menu. A terminal starts at 132×50. A viewer adopts the producer's current
+dimensions, and taking control by typing preserves those dimensions; only an
+explicit footer sizing action or a resize from another controlling peer changes
+the grid. The bottom-left footer hint advertises <kbd>F6</kbd>, which moves
+keyboard focus from terminal input to the footer controls; <kbd>Shift+F6</kbd>
+moves focus to the preceding dashboard control.
+
 The console log stream is now subscribed to for terminal-enabled
 resources too (previously it was suppressed), which is what makes the
 Console view non-empty for a `WithTerminal()` resource.
@@ -161,8 +172,8 @@ when the executable (or container) spec carries a populated `terminal` block:
   "terminal": {
     "udsPath":    "/run/user/1000/aspire/trmnl/<run-id>/<resource>-<idx>/producer.sock",
     "socketMode": "connect",
-    "cols":       120,
-    "rows":       30
+    "cols":       132,
+    "rows":       50
   }
 }
 ```

--- a/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.cs
@@ -56,12 +56,29 @@ public sealed partial class TerminalView : ComponentBase, IAsyncDisposable
     [Parameter]
     public int ReplicaIndex { get; set; }
 
+    /// <summary>Gets or sets the accessible label for decreasing the font size.</summary>
+    [Parameter, EditorRequired]
+    public required string DecreaseFontSizeLabel { get; set; }
+
+    /// <summary>Gets or sets the accessible label for increasing the font size.</summary>
+    [Parameter, EditorRequired]
+    public required string IncreaseFontSizeLabel { get; set; }
+
+    /// <summary>Gets or sets the accessible label for the terminal dimensions selector.</summary>
+    [Parameter, EditorRequired]
+    public required string TerminalDimensionsLabel { get; set; }
+
+    /// <summary>Gets or sets the label for fitting the terminal to the available space.</summary>
+    [Parameter, EditorRequired]
+    public required string FitLabel { get; set; }
+
+    /// <summary>Gets or sets the hint describing how to move focus from the terminal to its controls.</summary>
+    [Parameter, EditorRequired]
+    public required string FocusControlsHintLabel { get; set; }
+
     /// <summary>
-    /// Raised when the JS side pushes a fresh toolbar state snapshot (role,
-    /// dims, font size, etc.). The host page subscribes so the chrome that
-    /// used to live inside the terminal frame — status badge, "Take control"
-    /// button, font controls, size dropdown, dims readout — can be rendered
-    /// in the page's existing toolbar instead.
+    /// Raised when the JS side pushes a fresh terminal state snapshot (role,
+    /// dimensions, font size, etc.) for hosts that need to observe it.
     /// </summary>
     [Parameter]
     public EventCallback<TerminalToolbarState> OnToolbarStateChanged { get; set; }
@@ -183,11 +200,25 @@ public sealed partial class TerminalView : ComponentBase, IAsyncDisposable
             _jsModule = await JS.InvokeAsync<IJSObjectReference>(
                 "import", "/Components/Controls/TerminalView.razor.js");
 
-            _selfRef ??= DotNetObjectReference.Create(this);
+            if (OnToolbarStateChanged.HasDelegate)
+            {
+                _selfRef ??= DotNetObjectReference.Create(this);
+            }
 
             _connectedGeneration = -1;
             _terminalId = await _jsModule.InvokeAsync<int>(
-                "initTerminal", _terminalElement, BuildWebSocketUrl(resourceName, replicaIndex), _selfRef);
+                "initTerminal",
+                _terminalElement,
+                BuildWebSocketUrl(resourceName, replicaIndex),
+                _selfRef,
+                new
+                {
+                    DecreaseFontSize = DecreaseFontSizeLabel,
+                    IncreaseFontSize = IncreaseFontSizeLabel,
+                    TerminalDimensions = TerminalDimensionsLabel,
+                    Fit = FitLabel,
+                    FocusControlsHint = FocusControlsHintLabel,
+                });
         }
         catch (JSDisconnectedException)
         {
@@ -259,8 +290,7 @@ public sealed partial class TerminalView : ComponentBase, IAsyncDisposable
     /// <summary>
     /// Invoked by the JS terminal whenever its role/size/font state changes.
     /// Forwards the snapshot to the host page via <see cref="OnToolbarStateChanged"/>.
-    /// JS remains the source of truth for terminal state — the toolbar
-    /// renders whatever the most recent snapshot says.
+    /// JS remains the source of truth for terminal state.
     /// </summary>
     [JSInvokable]
     public Task OnTerminalStateChanged(TerminalToolbarState state)
@@ -431,8 +461,7 @@ public sealed partial class TerminalView : ComponentBase, IAsyncDisposable
 }
 
 /// <summary>
-/// Snapshot of the JS terminal's current role, sizing, and dims, pushed up
-/// to the host page so the toolbar can render the right state.
+/// Snapshot of the JS terminal's current role, sizing, and dimensions.
 /// </summary>
 public sealed record TerminalToolbarState
 {

--- a/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.js
@@ -647,7 +647,7 @@ function moveFocusFromTerminal(state, reverse) {
 
 function attachTerminalFocusNavigation(state, term) {
     term.attachCustomKeyEventHandler((event) => {
-        if (event.key !== 'F6') {
+        if (event.key !== 'F6' || event.ctrlKey || event.altKey || event.metaKey) {
             return true;
         }
 
@@ -747,9 +747,9 @@ function getAvailableBodySpace(state) {
 // Record that grid as fixed sizing state so a later keyboard-driven promotion
 // keeps the existing resolution. Only an explicit footer action switches back
 // to Fit or selects another preset.
-function adoptProducerDimensions(state) {
+function adoptProducerDimensions(state, includePrimary = false) {
     const client = state.client;
-    if (!client || client.isPrimary || client.width <= 0 || client.height <= 0) {
+    if (!client || (!includePrimary && client.isPrimary) || client.width <= 0 || client.height <= 0) {
         return;
     }
 
@@ -1475,7 +1475,10 @@ function connectClient(state, wsUrl) {
     client.onHello = (payload) => {
         if (myGeneration !== state.reconnect.generation) return;
         dbg(state, 'client.onHello', payload);
-        adoptProducerDimensions(state);
+        // Hello is authoritative for the producer's current grid even when
+        // this peer is already primary. Otherwise the local default can resize
+        // an existing producer before the user asks to change its dimensions.
+        adoptProducerDimensions(state, true);
         notifyToolbar(state);
         // Now that we know producer dims + role, apply layout (fits the
         // role-aware path: secondary locks-and-scales to producer dims;

--- a/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/TerminalView.razor.js
@@ -132,7 +132,7 @@ function cancelPendingReconnect(state) {
 // In primary mode we drive the producer's PTY dims, so we expose a footer
 // with two mutually-exclusive sizing modes:
 //
-//   "font"   (Auto)  : user controls font size with +/- buttons; FitAddon
+//   "font"   (Fit)   : user controls font size with +/- buttons; FitAddon
 //                      picks cols×rows to fill the available stage at that
 //                      font. Window resize → fit → new cols×rows broadcast.
 //
@@ -141,33 +141,35 @@ function cancelPendingReconnect(state) {
 //                      fill the stage and lock cols×rows. Window resize →
 //                      recompute font, cols×rows stay fixed (no broadcast).
 //
-// In secondary mode (someone else is primary), both control groups hide
-// (.read-only) and we lock our xterm grid to the producer's cols×rows,
-// then pick the largest integer font size whose rendered grid fits the
-// viewport (letterboxing on whichever axis has spare room). This mirrors
-// primary fixed-mode; we deliberately avoid CSS transform: scale() here
-// because xterm.js computes mouse-to-cell coordinates from
-// getBoundingClientRect (which returns transformed dims) divided by its
-// internally-measured cell width (which is untransformed), so any
-// scale ≠ 1 offsets text selection by roughly the scale factor.
+// In secondary mode (someone else is primary), changing either control
+// promotes this peer to primary. Until then we lock our xterm grid to the
+// producer's cols×rows, then pick the largest integer font size whose
+// rendered grid fits the viewport (letterboxing on whichever axis has spare
+// room). This mirrors primary fixed-mode; we deliberately avoid CSS
+// transform: scale() here because xterm.js computes mouse-to-cell coordinates
+// from getBoundingClientRect (which returns transformed dims) divided by its
+// internally-measured cell width (which is untransformed), so any scale != 1
+// offsets text selection by roughly the scale factor.
 const MIN_FONT_PX = 4;
 const MAX_FONT_PX = 72;
 const DEFAULT_FONT_PX = 13;
+const DEFAULT_TERMINAL_COLS = 132;
+const DEFAULT_TERMINAL_ROWS = 50;
 const SIZE_PRESETS = [
-    // NOTE: The "Auto" label is overridden on the .NET side in
-    // ConsoleLogs.razor.cs (OnTerminalToolbarStateChangedAsync) using the
-    // dashboard's localized resource (ConsoleLogs.resx →
-    // TerminalToolbarGridSizeAuto). The English string here is only a
-    // fallback for the rare case where someone consumes the SIZE_PRESETS
-    // list directly from JS without going through GetSizePresetsAsync —
-    // we never bind it to the UI as-is.
-    { value: "auto",   label: "Auto",   cols: 0,   rows: 0  },
+    { value: "auto",   label: "Fit",    cols: 0,   rows: 0  },
     { value: "80x24",  label: "80×24",  cols: 80,  rows: 24 },
     { value: "80x30",  label: "80×30",  cols: 80,  rows: 30 },
     { value: "100x30", label: "100×30", cols: 100, rows: 30 },
     { value: "132x30", label: "132×30", cols: 132, rows: 30 },
     { value: "132x50", label: "132×50", cols: 132, rows: 50 },
 ];
+const DEFAULT_CONTROL_LABELS = {
+    decreaseFontSize: "Decrease font size",
+    increaseFontSize: "Increase font size",
+    terminalDimensions: "Terminal dimensions",
+    fit: "Fit",
+    focusControlsHint: "F6: Focus terminal controls",
+};
 
 // Inject the WebMuxerDemo terminal-frame styles into <head> exactly once
 // per page load. Lifted near-verbatim from samples/WebMuxerDemo/wwwroot/
@@ -318,19 +320,28 @@ function ensureTerminalStyles() {
   letter-spacing: 0.2px;
 }
 
-/*
- * Live cols × rows readout on the right side of the titlebar. Kept in
- * sync from term.onResize so it always shows the grid the PTY sees.
- */
+/* Live grid size and preset selector in the terminal footer. */
 .aspire-terminal-host #terminal-dims {
   flex: 0 0 auto;
-  margin-left: 12px;
-  padding-left: 12px;
-  border-left: 1px solid #30363d;
-  color: var(--aspire-term-fg-muted);
+  margin-left: 6px;
+  padding: 2px 22px 2px 8px;
+  background: #21262d;
+  border: 1px solid var(--aspire-term-border);
+  border-radius: 3px;
+  color: var(--aspire-term-fg);
+  font: inherit;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.2px;
   white-space: nowrap;
+  cursor: pointer;
+}
+.aspire-terminal-host #terminal-dims:hover:not(:disabled) {
+  background: #30363d;
+  border-color: #484f58;
+}
+.aspire-terminal-host #terminal-dims:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 .aspire-terminal-host #terminal-body {
@@ -348,6 +359,59 @@ function ensureTerminalStyles() {
    * natural rendered dims so the frame keeps hugging the grid.
    */
   padding: 6px;
+}
+
+.aspire-terminal-host #terminal-footer {
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 30px;
+  padding: 0 14px;
+  background: linear-gradient(180deg, #1a2029 0%, #161b22 100%);
+  border-top: 1px solid #30363d;
+  color: var(--aspire-term-fg-muted);
+  font: 12px ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  user-select: none;
+}
+.aspire-terminal-host #terminal-focus-hint {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aspire-terminal-host #terminal-controls {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.aspire-terminal-host #terminal-footer button {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: #21262d;
+  border: 1px solid var(--aspire-term-border);
+  border-radius: 3px;
+  color: var(--aspire-term-fg);
+  font: 14px/1 ui-monospace, monospace;
+  cursor: pointer;
+}
+.aspire-terminal-host #terminal-footer button:hover:not(:disabled) {
+  background: #30363d;
+  border-color: #484f58;
+}
+.aspire-terminal-host #terminal-footer button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.aspire-terminal-host #font-display {
+  min-width: 34px;
+  color: var(--aspire-term-fg);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
 }
 
 .aspire-terminal-host .xterm:focus,
@@ -403,13 +467,11 @@ function ensureTerminalStyles() {
 //         #terminal-frame           (the bordered/shadowed card)
 //           #terminal-titlebar      (title text from OSC 0/2)
 //           #terminal-body          (xterm host; sized by layout)
+//           #terminal-footer        (font size + dimensions controls)
 //
-// The status badge, "Take control" button, font controls, size dropdown
-// and live dims readout that used to sit inside the chrome have been
-// hoisted into the page's toolbar — see ConsoleLogs.razor for the host.
-// State snapshots flow up to .NET via `state.dotNetRef` (registered at
-// init time) and commands flow back in via the exported wrappers
-// `takePrimary`, `setFontSize`, `setSizeModeAuto`, `setSizeModeFixed`.
+// State snapshots can still flow up to .NET via `state.dotNetRef` when a
+// host subscribes, but the frequently used sizing controls stay beside the
+// terminal so they remain accessible without opening the page options menu.
 //
 // All lookup roots are scoped to state.host so the layout helpers can
 // run in pages that might (in the future) host multiple terminals.
@@ -456,15 +518,14 @@ function buildChrome(state) {
     const titleText = document.createElement('span');
     titleText.id = 'terminal-title';
     titleText.textContent = 'terminal';
-    const dimsText = document.createElement('span');
-    dimsText.id = 'terminal-dims';
-    dimsText.textContent = '';
-    titlebar.append(titleText, dimsText);
+    titlebar.appendChild(titleText);
 
     const body = document.createElement('div');
     body.id = 'terminal-body';
 
-    frame.append(titlebar, body);
+    const footer = buildFooter(state);
+
+    frame.append(titlebar, body, footer);
     terminalContainer.appendChild(frame);
     host.append(pane);
 
@@ -473,8 +534,133 @@ function buildChrome(state) {
     state.terminalFrame = frame;
     state.terminalTitlebar = titlebar;
     state.titleText = titleText;
-    state.dimsText = dimsText;
     state.terminalBody = body;
+    state.terminalFooter = footer;
+}
+
+function buildFooter(state) {
+    const footer = document.createElement('div');
+    footer.id = 'terminal-footer';
+    footer.tabIndex = -1;
+
+    const focusHint = document.createElement('span');
+    focusHint.id = 'terminal-focus-hint';
+    focusHint.textContent = state.labels.focusControlsHint;
+
+    const fontMinus = document.createElement('button');
+    fontMinus.id = 'font-minus';
+    fontMinus.type = 'button';
+    fontMinus.textContent = '-';
+    fontMinus.title = state.labels.decreaseFontSize;
+    fontMinus.setAttribute('aria-label', state.labels.decreaseFontSize);
+    fontMinus.disabled = true;
+    fontMinus.addEventListener('click', () => {
+        if (fontMinus.disabled) return;
+        setFontSize(state, state.currentFontPx - 1);
+        maybeAutoPromote(state);
+    });
+
+    const fontDisplay = document.createElement('span');
+    fontDisplay.id = 'font-display';
+    fontDisplay.textContent = `${state.currentFontPx}px`;
+
+    const fontPlus = document.createElement('button');
+    fontPlus.id = 'font-plus';
+    fontPlus.type = 'button';
+    fontPlus.textContent = '+';
+    fontPlus.title = state.labels.increaseFontSize;
+    fontPlus.setAttribute('aria-label', state.labels.increaseFontSize);
+    fontPlus.disabled = true;
+    fontPlus.addEventListener('click', () => {
+        if (fontPlus.disabled) return;
+        setFontSize(state, state.currentFontPx + 1);
+        maybeAutoPromote(state);
+    });
+
+    const sizeSelect = document.createElement('select');
+    sizeSelect.id = 'terminal-dims';
+    sizeSelect.title = state.labels.terminalDimensions;
+    sizeSelect.setAttribute('aria-label', state.labels.terminalDimensions);
+    for (const preset of SIZE_PRESETS) {
+        const option = document.createElement('option');
+        option.value = preset.value;
+        option.textContent = preset.value === 'auto' ? state.labels.fit : preset.label;
+        sizeSelect.appendChild(option);
+    }
+    sizeSelect.disabled = true;
+    sizeSelect.addEventListener('change', () => {
+        if (sizeSelect.disabled) return;
+        const selected = SIZE_PRESETS.find((preset) => preset.value === sizeSelect.value);
+        if (!selected) return;
+
+        if (selected.value === 'auto') {
+            setSizeMode(state, 'font', null);
+        } else {
+            setSizeMode(state, 'fixed', { cols: selected.cols, rows: selected.rows });
+        }
+        maybeAutoPromote(state);
+    });
+
+    const controls = document.createElement('div');
+    controls.id = 'terminal-controls';
+    controls.append(fontMinus, fontDisplay, fontPlus, sizeSelect);
+    footer.append(focusHint, controls);
+    state.terminalFocusHint = focusHint;
+    state.fontMinusBtn = fontMinus;
+    state.fontDisplay = fontDisplay;
+    state.fontPlusBtn = fontPlus;
+    state.sizeSelect = sizeSelect;
+
+    return footer;
+}
+
+const FOCUSABLE_ELEMENT_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function moveFocusFromTerminal(state, reverse) {
+    if (!reverse) {
+        const firstControl = [state.fontMinusBtn, state.fontPlusBtn, state.sizeSelect]
+            .find((element) => element && !element.disabled);
+        (firstControl || state.terminalFooter)?.focus();
+        return true;
+    }
+
+    const focusableElements = Array.from(document.querySelectorAll(FOCUSABLE_ELEMENT_SELECTOR))
+        .filter((element) => element.getClientRects().length > 0);
+    const activeIndex = focusableElements.indexOf(document.activeElement);
+    for (let index = activeIndex - 1; index >= 0; index--) {
+        const candidate = focusableElements[index];
+        if (!state.host?.contains(candidate)) {
+            candidate.focus();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function attachTerminalFocusNavigation(state, term) {
+    term.attachCustomKeyEventHandler((event) => {
+        if (event.key !== 'F6') {
+            return true;
+        }
+
+        if (event.type === 'keydown' && moveFocusFromTerminal(state, event.shiftKey)) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        // Returning false prevents xterm from forwarding F6 to the PTY. When
+        // there is no previous dashboard control, leaving the event's default
+        // action intact lets the browser apply its own Shift+F6 navigation.
+        return false;
+    });
 }
 
 function safeFit(state) {
@@ -495,13 +681,43 @@ function safeFit(state) {
     }
 }
 
-function updateDimsReadout(state) {
-    if (!state.dimsText || !state.term) return;
-    const cols = state.term.cols | 0;
-    const rows = state.term.rows | 0;
-    // xterm briefly reports 0x0 during teardown; suppress that instead of
-    // flashing a zero-sized readout at the user.
-    state.dimsText.textContent = cols > 0 && rows > 0 ? `${cols} × ${rows}` : '';
+function updateTerminalControls(state) {
+    const snapshot = buildToolbarSnapshot(state);
+
+    if (state.fontDisplay) {
+        state.fontDisplay.textContent = `${state.currentFontPx}px`;
+    }
+    if (state.fontMinusBtn) {
+        state.fontMinusBtn.disabled = !snapshot.fontControlsEnabled || state.currentFontPx <= MIN_FONT_PX;
+    }
+    if (state.fontPlusBtn) {
+        state.fontPlusBtn.disabled = !snapshot.fontControlsEnabled || state.currentFontPx >= MAX_FONT_PX;
+    }
+
+    if (!state.sizeSelect) return;
+
+    const cols = state.term?.cols | 0;
+    const rows = state.term?.rows | 0;
+    const previousCurrentOption = state.sizeSelect.querySelector('option[data-current-dimensions]');
+    if (previousCurrentOption) {
+        previousCurrentOption.remove();
+    }
+    if (snapshot.sizeKey !== 'auto' &&
+        !state.sizeSelect.querySelector(`option[value="${snapshot.sizeKey}"]`)) {
+        const currentOption = document.createElement('option');
+        currentOption.value = snapshot.sizeKey;
+        currentOption.textContent = `${state.fixedDims.cols}×${state.fixedDims.rows}`;
+        currentOption.dataset.currentDimensions = '';
+        state.sizeSelect.appendChild(currentOption);
+    }
+    const fitOption = state.sizeSelect.querySelector('option[value="auto"]');
+    if (fitOption) {
+        fitOption.textContent = cols > 0 && rows > 0 && snapshot.sizeKey === 'auto'
+            ? `${state.labels.fit} (${cols} × ${rows})`
+            : state.labels.fit;
+    }
+    state.sizeSelect.value = snapshot.sizeKey;
+    state.sizeSelect.disabled = !snapshot.sizeSelectEnabled;
 }
 
 const FRAME_BORDER_PX = 2;
@@ -516,14 +732,29 @@ const FRAME_BORDER_PX = 2;
 const TERMINAL_BODY_PADDING_PX = 6;
 function getAvailableBodySpace(state) {
     const titlebarH = state.terminalTitlebar ? state.terminalTitlebar.offsetHeight : 0;
+    const footerH = state.terminalFooter ? state.terminalFooter.offsetHeight : 0;
     const stageW = state.terminalContainer ? state.terminalContainer.clientWidth : 0;
     const stageH = state.terminalContainer ? state.terminalContainer.clientHeight : 0;
     const outerW = Math.max(0, stageW - FRAME_BORDER_PX * 2);
-    const outerH = Math.max(0, stageH - titlebarH - FRAME_BORDER_PX * 2);
+    const outerH = Math.max(0, stageH - titlebarH - footerH - FRAME_BORDER_PX * 2);
     return {
         width: Math.max(0, outerW - TERMINAL_BODY_PADDING_PX * 2),
         height: Math.max(0, outerH - TERMINAL_BODY_PADDING_PX * 2),
     };
+}
+
+// A secondary peer displays the producer's grid rather than choosing its own.
+// Record that grid as fixed sizing state so a later keyboard-driven promotion
+// keeps the existing resolution. Only an explicit footer action switches back
+// to Fit or selects another preset.
+function adoptProducerDimensions(state) {
+    const client = state.client;
+    if (!client || client.isPrimary || client.width <= 0 || client.height <= 0) {
+        return;
+    }
+
+    state.sizeMode = 'fixed';
+    state.fixedDims = { cols: client.width, rows: client.height };
 }
 
 // Sizes the xterm display based on the current role and (in primary
@@ -585,6 +816,13 @@ function applyRoleAwareLayout(state) {
             root.style.transformOrigin = '';
             root.style.width = '';
             root.style.height = '';
+        }
+
+        if (state.sizeMode === 'font') {
+            // Secondary layout temporarily replaces currentFontPx with the
+            // font that fits the producer grid. Restore the user's Fit-mode
+            // font when an explicit sizing action promotes this peer.
+            state.currentFontPx = state.fitFontPx;
         }
 
         if (state.sizeMode === 'fixed' && state.fixedDims) {
@@ -840,15 +1078,11 @@ function setSizeMode(state, mode, dims) {
     }
 }
 
-// Computes the current toolbar state snapshot and (when changed) pushes
-// it up to the Blazor host so the page-level toolbar can render the
-// status badge, "Take control" button, font controls, size dropdown and
-// dims readout. RAF-coalesced because callers include term.onResize,
-// applyRoleAwareLayout's RAF callbacks and ResizeObserver — they can
-// fire in rapid bursts during window/sidebar resize. Change-detected
-// so a no-op call (e.g. layout pass that produced identical dims) does
-// not round-trip to .NET.
+// Updates the in-frame controls and, when a host observer is registered,
+// pushes a state snapshot to .NET. Observer notifications are RAF-coalesced
+// and change-detected because layout callbacks can fire in rapid bursts.
 function notifyToolbar(state) {
+    updateTerminalControls(state);
     if (state._toolbarFlushPending) return;
     state._toolbarFlushPending = true;
     requestAnimationFrame(() => {
@@ -912,14 +1146,10 @@ function buildToolbarSnapshot(state) {
         sizeMode: state.sizeMode,
         sizeKey,
         fontPx: state.currentFontPx,
-        // Font/size controls are enabled whenever this tab is primary or
-        // could become primary on demand. If we're not primary yet, the
-        // setFontSizeFromHost / setSizeModeFromHost entry points will
-        // auto-promote before applying the change so the user doesn't have
-        // to click "Take control" first — this is especially important
-        // after a WS reconnect, which silently drops primary status.
-        // Connecting state still gates these off via canTakeControl=false.
-        fontControlsEnabled: (isPrimary && state.sizeMode === 'font') || canTakeControl,
+        // Sizing controls are enabled whenever this tab is primary or could
+        // become primary on demand. A font action explicitly switches fixed
+        // sizing to Fit mode before applying the requested font size.
+        fontControlsEnabled: isPrimary || canTakeControl,
         sizeSelectEnabled: isPrimary || canTakeControl,
         cols: term && term.cols ? term.cols : 0,
         rows: term && term.rows ? term.rows : 0,
@@ -953,7 +1183,7 @@ function takePrimary(state) {
     }
 }
 
-export async function initTerminal(element, wsUrl, dotNetRef) {
+export async function initTerminal(element, wsUrl, dotNetRef, labels) {
     await ensureXtermLoaded();
 
     const id = nextId++;
@@ -964,11 +1194,9 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
         fitAddon: null,
         element,
         wsUrl,
-        // Blazor host (TerminalView) — the JS side pushes state snapshots
-        // into [JSInvokable] OnTerminalStateChanged so the page-level
-        // toolbar can render the status badge / take-control button /
-        // font ± / size dropdown / dims readout. May be null if the
-        // host opted not to receive notifications.
+        labels: { ...DEFAULT_CONTROL_LABELS, ...(labels || {}) },
+        // Optional Blazor host observer for consumers that need terminal
+        // state beyond the controls rendered directly in the frame.
         dotNetRef: dotNetRef || null,
         utf8Decoder: new TextDecoder('utf-8', { fatal: false }),
         reconnect: {
@@ -978,8 +1206,8 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
             generation: 0,
         },
         // Layout / sizing state (per-instance — we never use globals).
-        sizeMode: 'font',
-        fixedDims: null,
+        sizeMode: 'fixed',
+        fixedDims: { cols: DEFAULT_TERMINAL_COLS, rows: DEFAULT_TERMINAL_ROWS },
         currentFontPx: DEFAULT_FONT_PX,
         // Font size that "Fit" mode uses, tracked separately from
         // currentFontPx because fixed-preset layout overwrites the latter
@@ -1001,8 +1229,13 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
         terminalFrame: null,
         terminalTitlebar: null,
         titleText: null,
-        dimsText: null,
+        sizeSelect: null,
         terminalBody: null,
+        terminalFooter: null,
+        terminalFocusHint: null,
+        fontMinusBtn: null,
+        fontDisplay: null,
+        fontPlusBtn: null,
     };
 
     // Build the chrome BEFORE creating the xterm — term.open(body)
@@ -1053,6 +1286,13 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
 
     state.term = term;
     state.fitAddon = fitAddon;
+    attachTerminalFocusNavigation(state, term);
+
+    const helperTextArea = state.terminalBody.querySelector('.xterm-helper-textarea');
+    if (helperTextArea && state.terminalFocusHint) {
+        helperTextArea.setAttribute('aria-keyshortcuts', 'F6 Shift+F6');
+        helperTextArea.setAttribute('aria-describedby', state.terminalFocusHint.id);
+    }
 
     // Defense in depth: if Cascadia hadn't entered the FontFace cache
     // by the time we constructed Terminal (preload above failed/timed
@@ -1082,7 +1322,7 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
     requestAnimationFrame(() => {
         calibrateRatios(state);
         applyRoleAwareLayout(state);
-        updateDimsReadout(state);
+        updateTerminalControls(state);
     });
 
     // OSC 0 / OSC 2 / OSC 1 — terminal apps push window/icon titles via
@@ -1097,18 +1337,18 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
     // term.onResize fires whenever fitAddon.fit() OR a manual term.resize()
     // changes the xterm grid. Forward to the producer via sendResize, but
     // Hmp1Client.sendResize() silently no-ops when we're not primary, so
-    // viewers' fit() calls don't disturb the producer. Push fresh dims to
-    // the toolbar and recalibrate ratios so future fixed-mode font calcs
-    // stay accurate.
+    // viewers' fit() calls don't disturb the producer. Refresh the live
+    // dimensions selector and recalibrate ratios so future fixed-mode font
+    // calculations stay accurate.
     //
     // Recalibration is deferred one RAF because xterm dispatches onResize
     // *before* it re-renders .xterm-screen; measuring offsetWidth here
     // would divide the old rendered width by the new cols count and yield
-    // a cellWRatio ~half of the true value. That in turn made the toolbar's
-    // Fit preview report roughly double the real cols×rows.
+    // a cellWRatio ~half of the true value. That in turn made the Fit
+    // dimensions report roughly double the real cols×rows.
     term.onResize(({ cols, rows }) => {
         if (state.client) state.client.sendResize(cols, rows);
-        updateDimsReadout(state);
+        updateTerminalControls(state);
         requestAnimationFrame(() => {
             if (state.term !== term) return;
             calibrateRatios(state);
@@ -1116,12 +1356,11 @@ export async function initTerminal(element, wsUrl, dotNetRef) {
         });
     });
 
-    // User input auto-promotes to primary. Consolidating the toolbar
-    // into the ⋯ menu removed the explicit "Take control" button, so we
-    // rely on the same auto-promote path as font/size changes: if the
-    // viewer types (or pastes, or hits Enter), they take primary before
-    // the input goes out. Server drops non-primary input, so promoting
-    // first ensures the keystroke lands. No-ops when we're already
+    // User input auto-promotes to primary. There is no explicit "Take
+    // control" button, so we rely on the same auto-promote path as font/size
+    // changes: if the viewer types (or pastes, or hits Enter), they take
+    // primary before the input goes out. Server drops non-primary input, so
+    // promoting first ensures the keystroke lands. No-ops when we're already
     // primary or the client isn't connected yet.
     term.onData((data) => {
         if (!state.client) return;
@@ -1236,6 +1475,7 @@ function connectClient(state, wsUrl) {
     client.onHello = (payload) => {
         if (myGeneration !== state.reconnect.generation) return;
         dbg(state, 'client.onHello', payload);
+        adoptProducerDimensions(state);
         notifyToolbar(state);
         // Now that we know producer dims + role, apply layout (fits the
         // role-aware path: secondary locks-and-scales to producer dims;
@@ -1246,6 +1486,7 @@ function connectClient(state, wsUrl) {
     client.onRoleChange = (payload) => {
         if (myGeneration !== state.reconnect.generation) return;
         dbg(state, 'client.onRoleChange', payload);
+        adoptProducerDimensions(state);
         notifyToolbar(state);
         // Run layout FIRST so fixed-mode (if active) can resize the grid
         // to fixedDims; the resulting term.onResize will sendResize the
@@ -1271,6 +1512,7 @@ function connectClient(state, wsUrl) {
     client.onResize = (cols, rows) => {
         if (myGeneration !== state.reconnect.generation) return;
         dbg(state, 'client.onResize', { cols, rows });
+        adoptProducerDimensions(state);
         // Producer's grid changed (only happens via primary's Resize).
         // For secondaries this is the trigger to re-fit the frame to
         // the new producer dims.
@@ -1391,15 +1633,11 @@ export function disposeTerminal(id) {
     terminals.delete(id);
 }
 
-// --- Toolbar commands ----------------------------------------------------
+// --- Host commands -------------------------------------------------------
 //
-// These wrappers let the page-level toolbar (ConsoleLogs.razor) drive the
-// same actions that used to live inside the terminal's own chrome. Each
-// is idempotent and silently no-ops if the terminal id is unknown or the
-// underlying client/term isn't ready — JS remains authoritative, so a
-// stale toolbar click can't put us into a bad state. Mode/role guards
-// match the disabled-state logic in flushToolbarState; we still re-check
-// here in case the .NET disabled flag hasn't reached the user's click yet.
+// These wrappers let a .NET host drive the same actions as the terminal's
+// in-frame controls. Each is idempotent and silently no-ops if the terminal
+// id is unknown or the underlying client/term isn't ready.
 
 export function getSizePresets() {
     // Return a copy so .NET-side callers can't accidentally mutate the

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -161,7 +161,11 @@
                         @ref="_terminalViewRef"
                         ResourceName="@_terminalResourceName"
                         ReplicaIndex="@_terminalReplicaIndex"
-                        OnToolbarStateChanged="OnTerminalToolbarStateChangedAsync" />
+                        DecreaseFontSizeLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarDecreaseFontSize)]"
+                        IncreaseFontSizeLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarIncreaseFontSize)]"
+                        TerminalDimensionsLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarGridSize)]"
+                        FitLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarGridSizeAuto)]"
+                        FocusControlsHintLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalFocusControlsHint)]" />
                 </div>
             }
             else

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -158,8 +158,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private bool _selectedResourceHasTerminal;
     private string? _terminalResourceName;
     private int _terminalReplicaIndex;
-    private Controls.TerminalToolbarState? _terminalToolbarState;
-    private IReadOnlyList<Controls.TerminalSizePreset> _terminalSizePresets = Array.Empty<Controls.TerminalSizePreset>();
 
     // View toggle for terminal resources. The page surfaces both LogViewer
     // and TerminalView in MainSection (both stay mounted so flipping does
@@ -460,21 +458,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // After a layout transition (e.g. mobile→desktop viewport flip moves
-        // the toolbar back inline from the mobile filter dialog) the toolbar
-        // RenderFragment re-evaluates against the page's current state. If
-        // _terminalToolbarState was cleared during the transition but the
-        // JS terminal is still alive in MainSection, the toolbar would not
-        // re-render until the JS side happens to push a new snapshot — and
-        // JS suppresses no-op pushes via change detection. Ask JS to re-push
-        // so the toolbar controls reappear.
-        if (_selectedResourceHasTerminal &&
-            _terminalViewRef is { } terminalView &&
-            _terminalToolbarState is null)
-        {
-            await terminalView.RefreshToolbarStateAsync();
-        }
-
         // Detect a view-flip TO Terminal and prod xterm to relayout. The
         // wrapper element transitions from display:none to visible on this
         // render and ResizeObserver is not guaranteed to fire for that
@@ -499,10 +482,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         _selectedResourceHasTerminal = false;
         _terminalResourceName = null;
         _terminalReplicaIndex = 0;
-        // Drop any prior terminal's toolbar state so we don't briefly render
-        // the wrong badge/dims/dropdown for the new resource while the JS
-        // terminal is initializing and pushing its first snapshot.
-        _terminalToolbarState = null;
 
         // Only (re)default the view on an actual resource-selection change.
         // SubscribeAsync also runs on filter changes (clearing the console logs
@@ -659,64 +638,16 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 Checked = _activeView == ConsoleLogsView.Terminal,
             });
 
-            _logsMenuItems.Add(new()
+            if (_activeView == ConsoleLogsView.Console)
             {
-                IsDivider = true
-            });
-        }
-
-        if (_activeView == ConsoleLogsView.Terminal)
-        {
-            // Terminal-only items: font +/- and a nested Terminal dimensions
-            // submenu carrying the same presets the old inline toolbar used.
-            // We render these unconditionally so the menu structure is stable
-            // even before the first toolbar-state snapshot arrives; enabled
-            // state and current font readout come from _terminalToolbarState
-            // when present.
-            var terminalState = _terminalToolbarState;
-            var fontPx = terminalState?.FontPx ?? 0;
-            var fontControlsEnabled = terminalState?.FontControlsEnabled ?? false;
-            var sizeSelectEnabled = terminalState?.SizeSelectEnabled ?? false;
-
-            _logsMenuItems.Add(new()
-            {
-                OnClick = TerminalFontMinusAsync,
-                Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarDecreaseFontSize)],
-                Icon = new Icons.Regular.Size16.Subtract(),
-                IsDisabled = !fontControlsEnabled || fontPx <= TerminalFontMin,
-            });
-
-            _logsMenuItems.Add(new()
-            {
-                OnClick = TerminalFontPlusAsync,
-                Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarIncreaseFontSize)],
-                Icon = new Icons.Regular.Size16.Add(),
-                IsDisabled = !fontControlsEnabled || fontPx >= TerminalFontMax,
-            });
-
-            if (_terminalSizePresets.Count > 0)
-            {
-                var nested = new List<MenuButtonItem>();
-                foreach (var preset in _terminalSizePresets)
-                {
-                    var value = preset.Value;
-                    nested.Add(new()
-                    {
-                        OnClick = () => TerminalSizeChangedAsync(value),
-                        Text = preset.Label,
-                        IsDisabled = !sizeSelectEnabled,
-                    });
-                }
-
                 _logsMenuItems.Add(new()
                 {
-                    Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarGridSize)],
-                    Icon = new Icons.Regular.Size16.ArrowExpand(),
-                    NestedMenuItems = nested,
+                    IsDivider = true
                 });
             }
         }
-        else
+
+        if (_activeView == ConsoleLogsView.Console)
         {
             // Console-view items: preserved from the original menu.
             _logsMenuItems.Add(new()
@@ -1366,47 +1297,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         return new ConsoleLogsPageState(selectedResourceName);
     }
 
-    // --- Terminal toolbar wiring -----------------------------------------
-    //
-    // The TerminalView component pushes a TerminalToolbarState snapshot up
-    // here whenever the underlying xterm/HMP1 state changes (role flips,
-    // resize, font change). Those snapshots drive the page-level toolbar
-    // that replaces the in-frame chrome the terminal used to render itself.
-    // JS remains the source of truth for terminal state; this layer just
-    // mirrors the latest snapshot and routes user actions back to JS via
-    // the TerminalView public methods.
-    private const int TerminalFontStep = 1;
-    private const int TerminalFontMin = 4;
-    private const int TerminalFontMax = 72;
-
-    private async Task OnTerminalToolbarStateChangedAsync(Controls.TerminalToolbarState state)
-    {
-        _terminalToolbarState = state;
-
-        // First snapshot after init — fetch the size preset list once so
-        // the dropdown stays in sync with whatever JS knows how to handle.
-        if (_terminalSizePresets.Count == 0 && _terminalViewRef is not null)
-        {
-            // The JS side ships labels as English string literals (it has no
-            // localization stack of its own). Numeric labels like "80×24" are
-            // language-neutral and pass through unchanged, but "Auto" is an
-            // English word and must come from the dashboard's .resx so it
-            // matches the rest of the terminal toolbar in every supported
-            // culture. Apply the localized label here, where we still have
-            // access to IStringLocalizer<Resources.ConsoleLogs>, before
-            // handing the list to FluentSelect.
-            var presets = await _terminalViewRef.GetSizePresetsAsync();
-            _terminalSizePresets = presets
-                .Select(p => p.Value == "auto"
-                    ? p with { Label = Loc[nameof(Dashboard.Resources.ConsoleLogs.TerminalToolbarGridSizeAuto)] }
-                    : p)
-                .ToList();
-        }
-
-        UpdateMenuButtons();
-        StateHasChanged();
-    }
-
     private Task HandleViewChangedAsync(string? newView)
     {
         if (newView is null)
@@ -1460,33 +1350,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     // because the update hasn't been processed yet.
     internal ResourceViewModel? GetResourceSnapshotForTest(string resourceName) =>
         _resourceByName.TryGetValue(resourceName, out var resource) ? resource : null;
-
-    private Task TerminalFontMinusAsync()
-    {
-        if (_terminalToolbarState is not { } s || _terminalViewRef is null)
-        {
-            return Task.CompletedTask;
-        }
-        return _terminalViewRef.SetFontSizeAsync(Math.Max(TerminalFontMin, s.FontPx - TerminalFontStep));
-    }
-
-    private Task TerminalFontPlusAsync()
-    {
-        if (_terminalToolbarState is not { } s || _terminalViewRef is null)
-        {
-            return Task.CompletedTask;
-        }
-        return _terminalViewRef.SetFontSizeAsync(Math.Min(TerminalFontMax, s.FontPx + TerminalFontStep));
-    }
-
-    private Task TerminalSizeChangedAsync(string? newKey)
-    {
-        if (newKey is null || _terminalViewRef is null)
-        {
-            return Task.CompletedTask;
-        }
-        return _terminalViewRef.SetSizeModeAsync(newKey);
-    }
 
     // IComponentWithTelemetry impl
     public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.ConsoleLogs);

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -291,7 +291,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddHostedService<DashboardDataSourceInitializer>();
         builder.Services.AddScoped<DashboardDataSource>();
         builder.Services.AddScoped<IDashboardRunSelection>(services => services.GetRequiredService<DashboardDataSource>());
-        builder.Services.AddScoped<IDashboardClient, SelectedDashboardClient>();
+        builder.Services.TryAddScoped<IDashboardClient, SelectedDashboardClient>();
 
         builder.Services.TryAddSingleton<INotificationService, NotificationService>();
         builder.Services.TryAddSingleton(TimeProvider.System);
@@ -319,7 +319,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddGrpc();
         builder.Services.AddSingleton<DashboardRunStore>();
         builder.Services.AddSingleton<IDashboardRunStore>(services => services.GetRequiredService<DashboardRunStore>());
-        builder.Services.AddSingleton<IRepositoryFactory, RepositoryFactory>();
+        builder.Services.TryAddSingleton<IRepositoryFactory, RepositoryFactory>();
         builder.Services.AddSingleton(services => services.GetRequiredService<DashboardDataSourcePool>().Current.TelemetryRepository);
         // OTLP ingestion and telemetry mutations always target the current dashboard run, even when a browser circuit selects a historical run.
         builder.Services.AddSingleton<ITelemetryRepositoryWriter>(services =>

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -218,6 +218,12 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TerminalToolbarGridSizeAuto", resourceCulture);
             }
         }
+
+        public static string TerminalFocusControlsHint {
+            get {
+                return ResourceManager.GetString("TerminalFocusControlsHint", resourceCulture);
+            }
+        }
         
         public static string ConsoleLogsViewConsoleOption {
             get {

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -208,6 +208,9 @@
   <data name="TerminalToolbarGridSizeAuto" xml:space="preserve">
     <value>Fit</value>
   </data>
+  <data name="TerminalFocusControlsHint" xml:space="preserve">
+    <value>F6: Focus terminal controls</value>
+  </data>
   <data name="ConsoleLogsViewConsoleOption" xml:space="preserve">
     <value>Console logs</value>
     <comment>Option in the View dropdown that shows the resource's console logs.</comment>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="new">Console logs capture paused at {0}</target>
         <note>{0} is a time</note>
       </trans-unit>
+      <trans-unit id="TerminalFocusControlsHint">
+        <source>F6: Focus terminal controls</source>
+        <target state="new">F6: Focus terminal controls</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalToolbarDecreaseFontSize">
         <source>Decrease font size</source>
         <target state="new">Decrease font size</target>

--- a/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
@@ -96,11 +96,11 @@ internal sealed class TerminalAnnotation : IResourceAnnotation
 [Experimental("ASPIRETERMINAL001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class TerminalOptions
 {
-    private int _columns = 120;
-    private int _rows = 30;
+    private int _columns = 132;
+    private int _rows = 50;
 
     /// <summary>
-    /// Gets or sets the initial number of columns for the terminal. The value must be greater than zero. Defaults to 120.
+    /// Gets or sets the initial number of columns for the terminal. The value must be greater than zero. Defaults to 132.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
     public int Columns
@@ -114,7 +114,7 @@ public sealed class TerminalOptions
     }
 
     /// <summary>
-    /// Gets or sets the initial number of rows for the terminal. The value must be greater than zero. Defaults to 30.
+    /// Gets or sets the initial number of rows for the terminal. The value must be greater than zero. Defaults to 50.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
     public int Rows

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -116,7 +116,7 @@ public static class TerminalResourceBuilderExtensions
     /// Polyglot dispatcher for <see cref="WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>.
     /// Exposed to non-C# AppHosts via ATS as <c>withTerminal</c> — they cannot pass a
     /// C# <see cref="Action{T}"/>, so this overload simply applies the defaults from
-    /// <see cref="TerminalOptions"/> (120×30). Polyglot AppHosts that need to customise
+    /// <see cref="TerminalOptions"/> (132×50). Polyglot AppHosts that need to customise
     /// the terminal dimensions can wait for a future overload that accepts a DTO.
     /// </summary>
     /// <ats-summary>Adds an interactive terminal session to a resource using the default terminal options.</ats-summary>

--- a/src/Aspire.TerminalHost/DcpUpstreamAdapter.cs
+++ b/src/Aspire.TerminalHost/DcpUpstreamAdapter.cs
@@ -470,6 +470,12 @@ internal sealed class DcpUpstreamAdapter : IHex1bTerminalWorkloadAdapter
         }
     }
 
+    internal void ReportConsumerListenerFailure(Exception error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        Complete(error);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_disposed)

--- a/src/Aspire.TerminalHost/Hmp1UdsServerListenerFilter.cs
+++ b/src/Aspire.TerminalHost/Hmp1UdsServerListenerFilter.cs
@@ -4,19 +4,37 @@
 using Hex1b;
 using Hex1b.Tokens;
 using Microsoft.Extensions.Logging;
+using System.Net.Sockets;
 
 namespace Aspire.TerminalHost;
 
 /// <summary>
 /// Hosts an HMP1 presentation adapter on a Unix domain socket for one terminal session.
 /// </summary>
-internal sealed class Hmp1UdsServerListenerFilter(
-    string socketPath,
-    Hmp1PresentationAdapter presentation,
-    ILogger<Hmp1UdsServerListenerFilter> logger) : IHex1bTerminalPresentationFilter
+internal sealed class Hmp1UdsServerListenerFilter : IHex1bTerminalPresentationFilter, IDisposable
 {
+    private readonly string _socketPath;
+    private readonly Hmp1PresentationAdapter _presentation;
+    private readonly ILogger<Hmp1UdsServerListenerFilter> _logger;
+    private readonly Action<Exception> _listenerFaulted;
+    private readonly object _gate = new();
+    private readonly HashSet<Task> _clientTasks = [];
     private CancellationTokenSource? _listenerCts;
     private Task? _listenerTask;
+    private Socket? _listener;
+
+    public Hmp1UdsServerListenerFilter(
+        string socketPath,
+        Hmp1PresentationAdapter presentation,
+        ILogger<Hmp1UdsServerListenerFilter> logger,
+        Action<Exception> listenerFaulted)
+    {
+        _socketPath = socketPath;
+        _presentation = presentation;
+        _logger = logger;
+        _listenerFaulted = listenerFaulted;
+        _listener = BindListener(socketPath);
+    }
 
     /// <inheritdoc />
     public ValueTask OnSessionStartAsync(
@@ -26,7 +44,9 @@ internal sealed class Hmp1UdsServerListenerFilter(
         CancellationToken ct = default)
     {
         _listenerCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _listenerTask = Task.Run(() => RunListenerAsync(_listenerCts.Token), _listenerCts.Token);
+        _listenerTask = RunListenerAsync(
+            _listener ?? throw new ObjectDisposedException(nameof(Hmp1UdsServerListenerFilter)),
+            _listenerCts.Token);
 
         return ValueTask.CompletedTask;
     }
@@ -69,6 +89,7 @@ internal sealed class Hmp1UdsServerListenerFilter(
         }
 
         await _listenerCts.CancelAsync().ConfigureAwait(false);
+        DisposeListener();
 
         if (_listenerTask is not null)
         {
@@ -79,22 +100,69 @@ internal sealed class Hmp1UdsServerListenerFilter(
             catch (OperationCanceledException)
             {
             }
+            catch (ObjectDisposedException) when (_listenerCts.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (_listenerCts.IsCancellationRequested)
+            {
+            }
         }
 
+        Task[] clientTasks;
+        lock (_gate)
+        {
+            clientTasks = [.. _clientTasks];
+        }
+        await Task.WhenAll(clientTasks).ConfigureAwait(false);
+
         _listenerCts.Dispose();
+        TryDeleteSocketFile();
     }
 
-    private async Task RunListenerAsync(CancellationToken ct)
+    private async Task RunListenerAsync(Socket listener, CancellationToken ct)
     {
         try
         {
-            await foreach (var stream in Hmp1Transports.ListenUnixSocket(socketPath, ct).ConfigureAwait(false))
+            while (!ct.IsCancellationRequested)
             {
-                _ = AddClientAsync(stream, ct);
+                var socket = await listener.AcceptAsync(ct).ConfigureAwait(false);
+                var stream = new NetworkStream(socket, ownsSocket: true);
+                var clientTask = AddClientAsync(stream, ct);
+                lock (_gate)
+                {
+                    _clientTasks.Add(clientTask);
+                }
+                _ = ObserveClientTaskAsync(clientTask);
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+        }
+        catch (ObjectDisposedException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "The HMP1 consumer listener failed.");
+            _listenerFaulted(ex);
+        }
+    }
+
+    private async Task ObserveClientTaskAsync(Task clientTask)
+    {
+        try
+        {
+            await clientTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _clientTasks.Remove(clientTask);
+            }
         }
     }
 
@@ -102,20 +170,89 @@ internal sealed class Hmp1UdsServerListenerFilter(
     {
         try
         {
-            await presentation.AddClient(stream, ct).ConfigureAwait(false);
+            _ = await _presentation.AddClient(stream, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (
             ex is IOException or ObjectDisposedException or OperationCanceledException or InvalidOperationException)
         {
-            try
+            await DisposeFailedClientStreamAsync(stream).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Adding an HMP1 consumer failed unexpectedly.");
+            await DisposeFailedClientStreamAsync(stream).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DisposeFailedClientStreamAsync(Stream stream)
+    {
+        try
+        {
+            await stream.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception disposeException) when (
+            disposeException is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            _logger.LogDebug(disposeException, "Failed to dispose an HMP1 consumer stream after its session ended.");
+        }
+    }
+
+    private static Socket BindListener(string socketPath)
+    {
+        var directory = Path.GetDirectoryName(socketPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        if (File.Exists(socketPath))
+        {
+            File.Delete(socketPath);
+        }
+
+        var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        try
+        {
+            listener.Bind(new UnixDomainSocketEndPoint(socketPath));
+            listener.Listen(backlog: 16);
+            return listener;
+        }
+        catch
+        {
+            listener.Dispose();
+            throw;
+        }
+    }
+
+    private void DisposeListener()
+    {
+        Socket? listener;
+        lock (_gate)
+        {
+            listener = _listener;
+            _listener = null;
+        }
+        listener?.Dispose();
+    }
+
+    private void TryDeleteSocketFile()
+    {
+        try
+        {
+            if (File.Exists(_socketPath))
             {
-                await stream.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (Exception disposeException) when (
-                disposeException is IOException or ObjectDisposedException or OperationCanceledException)
-            {
-                logger.LogDebug(disposeException, "Failed to dispose an HMP1 consumer stream after its session ended.");
+                File.Delete(_socketPath);
             }
         }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogDebug(ex, "Failed to delete the HMP1 consumer socket file '{SocketPath}'.", _socketPath);
+        }
+    }
+
+    public void Dispose()
+    {
+        DisposeListener();
+        TryDeleteSocketFile();
     }
 }

--- a/src/Aspire.TerminalHost/Hmp1UdsServerListenerFilter.cs
+++ b/src/Aspire.TerminalHost/Hmp1UdsServerListenerFilter.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Hex1b;
+using Hex1b.Tokens;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.TerminalHost;
+
+/// <summary>
+/// Hosts an HMP1 presentation adapter on a Unix domain socket for one terminal session.
+/// </summary>
+internal sealed class Hmp1UdsServerListenerFilter(
+    string socketPath,
+    Hmp1PresentationAdapter presentation,
+    ILogger<Hmp1UdsServerListenerFilter> logger) : IHex1bTerminalPresentationFilter
+{
+    private CancellationTokenSource? _listenerCts;
+    private Task? _listenerTask;
+
+    /// <inheritdoc />
+    public ValueTask OnSessionStartAsync(
+        int width,
+        int height,
+        DateTimeOffset timestamp,
+        CancellationToken ct = default)
+    {
+        _listenerCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _listenerTask = Task.Run(() => RunListenerAsync(_listenerCts.Token), _listenerCts.Token);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<AnsiToken>> OnOutputAsync(
+        IReadOnlyList<AppliedToken> appliedTokens,
+        TimeSpan elapsed,
+        CancellationToken ct = default)
+    {
+        return ValueTask.FromResult<IReadOnlyList<AnsiToken>>(
+            appliedTokens.Select(t => t.Token).ToList());
+    }
+
+    /// <inheritdoc />
+    public ValueTask OnInputAsync(
+        IReadOnlyList<AnsiToken> tokens,
+        TimeSpan elapsed,
+        CancellationToken ct = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask OnResizeAsync(
+        int width,
+        int height,
+        TimeSpan elapsed,
+        CancellationToken ct = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default)
+    {
+        if (_listenerCts is null)
+        {
+            return;
+        }
+
+        await _listenerCts.CancelAsync().ConfigureAwait(false);
+
+        if (_listenerTask is not null)
+        {
+            try
+            {
+                await _listenerTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        _listenerCts.Dispose();
+    }
+
+    private async Task RunListenerAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var stream in Hmp1Transports.ListenUnixSocket(socketPath, ct).ConfigureAwait(false))
+            {
+                _ = AddClientAsync(stream, ct);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task AddClientAsync(Stream stream, CancellationToken ct)
+    {
+        try
+        {
+            await presentation.AddClient(stream, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (
+            ex is IOException or ObjectDisposedException or OperationCanceledException or InvalidOperationException)
+        {
+            try
+            {
+                await stream.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception disposeException) when (
+                disposeException is IOException or ObjectDisposedException or OperationCanceledException)
+            {
+                logger.LogDebug(disposeException, "Failed to dispose an HMP1 consumer stream after its session ended.");
+            }
+        }
+    }
+}

--- a/src/Aspire.TerminalHost/TerminalHostArgs.cs
+++ b/src/Aspire.TerminalHost/TerminalHostArgs.cs
@@ -30,8 +30,8 @@ internal sealed class TerminalHostArgs
     public required string ProducerUdsPath { get; init; }
     public required string ConsumerUdsPath { get; init; }
     public required string ControlUdsPath { get; init; }
-    public int Columns { get; init; } = 120;
-    public int Rows { get; init; } = 30;
+    public int Columns { get; init; } = 132;
+    public int Rows { get; init; } = 50;
 
     /// <summary>
     /// Parses command-line arguments. The argument shape is:
@@ -39,8 +39,8 @@ internal sealed class TerminalHostArgs
     ///   <item><c>--producer-uds PATH</c> (required) — path the host LISTENS on; DCP dials.</item>
     ///   <item><c>--consumer-uds PATH</c> (required) — path the host LISTENS on; viewers dial.</item>
     ///   <item><c>--control-uds PATH</c> (required) — path the host LISTENS on; AppHost dials for status/shutdown RPC.</item>
-    ///   <item><c>--columns N</c> (optional, default 120)</item>
-    ///   <item><c>--rows N</c> (optional, default 30)</item>
+    ///   <item><c>--columns N</c> (optional, default 132)</item>
+    ///   <item><c>--rows N</c> (optional, default 50)</item>
     ///   <item><c>--shell NAME</c> (optional, accepted for compatibility and ignored)</item>
     /// </list>
     /// Every option is single-valued and may only be specified once; duplicates throw
@@ -60,9 +60,9 @@ internal sealed class TerminalHostArgs
             "Path the terminal host LISTENS on for the AppHost control RPC channel.");
 
         var columnsOption = SingleValueOption<int>("--columns", required: false,
-            "Initial PTY width in columns (default 120).", defaultValue: 120);
+            "Initial PTY width in columns (default 132).", defaultValue: 132);
         var rowsOption = SingleValueOption<int>("--rows", required: false,
-            "Initial PTY height in rows (default 30).", defaultValue: 30);
+            "Initial PTY height in rows (default 50).", defaultValue: 50);
         // Older Aspire.Hosting packages can run with a newer CLI-provided terminal host
         // and still emit --shell. Accept the argument so that mixed-version AppHosts start,
         // but ignore it because DCP launches the resource process that owns the PTY.

--- a/src/Aspire.TerminalHost/TerminalReplica.cs
+++ b/src/Aspire.TerminalHost/TerminalReplica.cs
@@ -47,6 +47,7 @@ internal sealed class TerminalReplica : IAsyncDisposable
 {
     private readonly ILogger<TerminalReplica> _logger;
     private readonly ILogger<DcpUpstreamAdapter> _upstreamLogger;
+    private readonly ILogger<Hmp1UdsServerListenerFilter> _consumerListenerLogger;
     private readonly Task _runTask;
     private readonly CancellationTokenSource _stopCts;
     private readonly object _gate = new();
@@ -179,6 +180,7 @@ internal sealed class TerminalReplica : IAsyncDisposable
         _currentRows = rows;
         _logger = loggerFactory.CreateLogger<TerminalReplica>();
         _upstreamLogger = loggerFactory.CreateLogger<DcpUpstreamAdapter>();
+        _consumerListenerLogger = loggerFactory.CreateLogger<Hmp1UdsServerListenerFilter>();
         _stopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _runTask = Task.Run(() => RecycleLoopAsync(_stopCts.Token), _stopCts.Token);
     }
@@ -417,111 +419,127 @@ internal sealed class TerminalReplica : IAsyncDisposable
             _logger.LogInformation("DCP producer disconnected; replica will rebind.");
         };
 
+        // Hex1b's convenience HMP server creates its presentation adapter with an
+        // 80x24 default, which then overrides WithDimensions during Build(). Construct
+        // the adapter directly so both its Hello frames and the upstream PTY start with
+        // the dimensions configured by WithTerminal.
+        var downstream = CreateDownstream(upstream);
+
         return Hex1bTerminal.CreateBuilder()
             .WithDimensions(Columns, Rows)
             .WithWorkload(upstream)
-            .WithHmp1UdsServer(
+            .WithPresentation(downstream)
+            .AddPresentationFilter(new Hmp1UdsServerListenerFilter(
                 ConsumerUdsPath,
-                srvOpts =>
-                {
-                    // Track every HMP1 peer that connects/disconnects so the host can answer
-                    // "who's currently attached to this replica?" via the control RPC. PeerId is
-                    // assigned by Hex1b at handshake time and is unique per connection; DisplayName
-                    // is the optional ClientHello label (e.g. "aspire.cli:1234", "dashboard:abc12345").
-                    srvOpts.OnClientConnected = (e, _) =>
-                    {
-                        lock (_gate)
-                        {
-                            _peers[e.PeerId] = new TerminalHostPeerInfo
-                            {
-                                PeerId = e.PeerId,
-                                DisplayName = e.DisplayName,
-                            };
-                        }
-                        // Tag with peer attributes — viewer counts are low (single digits in
-                        // practice: one dashboard tab + maybe a CLI attach), so high-cardinality
-                        // worries don't apply here. Helps diagnose "which viewer is causing the
-                        // resize storm" in the dashboard metric explorer.
-                        var tags = new TagList
-                        {
-                            { "peer.id", e.PeerId },
-                            { "peer.name", e.DisplayName ?? "" },
-                        };
-                        TerminalHostTelemetry.ConsumerConnections.Add(1, tags);
-                        TerminalHostTelemetry.ConsumerPeersActive.Add(1, tags);
-                        _logger.LogInformation(
-                            "Consumer peer connected. PeerId={PeerId}, DisplayName='{DisplayName}'.",
-                            e.PeerId, e.DisplayName);
-                        return Task.CompletedTask;
-                    };
-                    srvOpts.OnClientDisconnected = (e, _) =>
-                    {
-                        string? displayName;
-                        lock (_gate)
-                        {
-                            _peers.TryGetValue(e.PeerId, out var existing);
-                            displayName = existing?.DisplayName;
-                            _peers.Remove(e.PeerId);
-                        }
-                        var tags = new TagList
-                        {
-                            { "peer.id", e.PeerId },
-                            { "peer.name", displayName ?? "" },
-                        };
-                        TerminalHostTelemetry.ConsumerDisconnections.Add(1, tags);
-                        TerminalHostTelemetry.ConsumerPeersActive.Add(-1, tags);
-                        _logger.LogInformation(
-                            "Consumer peer disconnected. PeerId={PeerId}.", e.PeerId);
-                        return Task.CompletedTask;
-                    };
-
-                    // Bridge downstream → upstream resize. The consumer-side multi-head
-                    // server fires OnResized whenever the current primary peer's dims
-                    // change (RequestPrimary or explicit Resize from primary). Forward
-                    // those dims as a raw FrameResize upstream so DCP runs ConPty.Resize
-                    // and the underlying workload sees the new TIOCSWINSZ value. Without
-                    // this hook the consumer-side presentation reflects the new dims but
-                    // the actual PTY stays at whatever DCP started it at.
-                    //
-                    // Also persist the latest dimensions so `aspire terminal ps` and the
-                    // dashboard can report the current grid size without round-tripping to
-                    // every attached viewer.
-                    srvOpts.OnResized = async (e, ct) =>
-                    {
-                        lock (_gate)
-                        {
-                            _currentColumns = e.Width;
-                            _currentRows = e.Height;
-                        }
-
-                        TerminalHostTelemetry.ResizeRequests.Add(1, new TagList
-                        {
-                            { "direction", "downstream" },
-                        });
-                        _logger.LogDebug(
-                            "Downstream resize received from primary peer: {Width}x{Height}.",
-                            e.Width, e.Height);
-
-                        try
-                        {
-                            await upstream.ResizeAsync(e.Width, e.Height, ct).ConfigureAwait(false);
-                            _logger.LogDebug(
-                                "Replica: forwarded downstream resize ({Width}x{Height}) to upstream PTY.",
-                                e.Width, e.Height);
-                        }
-                        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-                        {
-                            // Recycle loop is shutting down; drop quietly.
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogDebug(ex,
-                                "Replica: forwarding downstream resize ({Width}x{Height}) upstream failed.",
-                                e.Width, e.Height);
-                        }
-                    };
-                })
+                downstream,
+                _consumerListenerLogger))
             .Build();
+    }
+
+    private Hmp1PresentationAdapter CreateDownstream(DcpUpstreamAdapter upstream)
+    {
+        var downstream = new Hmp1PresentationAdapter(Columns, Rows);
+
+        // Track every HMP1 peer that connects/disconnects so the host can answer
+        // "who's currently attached to this replica?" via the control RPC. PeerId is
+        // assigned by Hex1b at handshake time and is unique per connection; DisplayName
+        // is the optional ClientHello label (e.g. "aspire.cli:1234", "dashboard:abc12345").
+        downstream.OnClientConnected = (e, _) =>
+        {
+            lock (_gate)
+            {
+                _peers[e.PeerId] = new TerminalHostPeerInfo
+                {
+                    PeerId = e.PeerId,
+                    DisplayName = e.DisplayName,
+                };
+            }
+            // Tag with peer attributes — viewer counts are low (single digits in
+            // practice: one dashboard tab + maybe a CLI attach), so high-cardinality
+            // worries don't apply here. Helps diagnose "which viewer is causing the
+            // resize storm" in the dashboard metric explorer.
+            var tags = new TagList
+            {
+                { "peer.id", e.PeerId },
+                { "peer.name", e.DisplayName ?? "" },
+            };
+            TerminalHostTelemetry.ConsumerConnections.Add(1, tags);
+            TerminalHostTelemetry.ConsumerPeersActive.Add(1, tags);
+            _logger.LogInformation(
+                "Consumer peer connected. PeerId={PeerId}, DisplayName='{DisplayName}'.",
+                e.PeerId, e.DisplayName);
+
+            return Task.CompletedTask;
+        };
+        downstream.OnClientDisconnected = (e, _) =>
+        {
+            string? displayName;
+            lock (_gate)
+            {
+                _peers.TryGetValue(e.PeerId, out var existing);
+                displayName = existing?.DisplayName;
+                _peers.Remove(e.PeerId);
+            }
+            var tags = new TagList
+            {
+                { "peer.id", e.PeerId },
+                { "peer.name", displayName ?? "" },
+            };
+            TerminalHostTelemetry.ConsumerDisconnections.Add(1, tags);
+            TerminalHostTelemetry.ConsumerPeersActive.Add(-1, tags);
+            _logger.LogInformation(
+                "Consumer peer disconnected. PeerId={PeerId}.", e.PeerId);
+
+            return Task.CompletedTask;
+        };
+
+        // Bridge downstream → upstream resize. The consumer-side multi-head
+        // server fires OnResized whenever the current primary peer's dims
+        // change (RequestPrimary or explicit Resize from primary). Forward
+        // those dims as a raw FrameResize upstream so DCP runs ConPty.Resize
+        // and the underlying workload sees the new TIOCSWINSZ value. Without
+        // this hook the consumer-side presentation reflects the new dims but
+        // the actual PTY stays at whatever DCP started it at.
+        //
+        // Also persist the latest dimensions so `aspire terminal ps` and the
+        // dashboard can report the current grid size without round-tripping to
+        // every attached viewer.
+        downstream.OnResized = async (e, ct) =>
+        {
+            lock (_gate)
+            {
+                _currentColumns = e.Width;
+                _currentRows = e.Height;
+            }
+
+            TerminalHostTelemetry.ResizeRequests.Add(1, new TagList
+            {
+                { "direction", "downstream" },
+            });
+            _logger.LogDebug(
+                "Downstream resize received from primary peer: {Width}x{Height}.",
+                e.Width, e.Height);
+
+            try
+            {
+                await upstream.ResizeAsync(e.Width, e.Height, ct).ConfigureAwait(false);
+                _logger.LogDebug(
+                    "Replica: forwarded downstream resize ({Width}x{Height}) to upstream PTY.",
+                    e.Width, e.Height);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Recycle loop is shutting down; drop quietly.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex,
+                    "Replica: forwarding downstream resize ({Width}x{Height}) upstream failed.",
+                    e.Width, e.Height);
+            }
+        };
+
+        return downstream;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.TerminalHost/TerminalReplica.cs
+++ b/src/Aspire.TerminalHost/TerminalReplica.cs
@@ -357,6 +357,14 @@ internal sealed class TerminalReplica : IAsyncDisposable
     /// </summary>
     private Hex1bTerminal BuildTerminal()
     {
+        int currentColumns;
+        int currentRows;
+        lock (_gate)
+        {
+            currentColumns = _currentColumns;
+            currentRows = _currentRows;
+        }
+
         // Pre-delete any stale UDS files at our paths before Hex1b tries to bind. Without
         // this, a previous host that crashed (or a stuck previous cycle that didn't get
         // to clean teardown) leaves a file at the same path, and Hmp1Transports.ListenUnixSocket
@@ -388,7 +396,7 @@ internal sealed class TerminalReplica : IAsyncDisposable
             {
                 _logger.LogInformation(
                     "Awaiting DCP producer connection on '{ProducerUdsPath}' (cols={Cols}, rows={Rows}).",
-                    ProducerUdsPath, Columns, Rows);
+                    ProducerUdsPath, currentColumns, currentRows);
                 await foreach (var stream in Hmp1Transports.ListenUnixSocket(ProducerUdsPath, cct).ConfigureAwait(false))
                 {
                     int restartCount;
@@ -423,22 +431,35 @@ internal sealed class TerminalReplica : IAsyncDisposable
         // 80x24 default, which then overrides WithDimensions during Build(). Construct
         // the adapter directly so both its Hello frames and the upstream PTY start with
         // the dimensions configured by WithTerminal.
-        var downstream = CreateDownstream(upstream);
+        var downstream = CreateDownstream(upstream, currentColumns, currentRows);
+        var listener = new Hmp1UdsServerListenerFilter(
+            ConsumerUdsPath,
+            downstream,
+            _consumerListenerLogger,
+            upstream.ReportConsumerListenerFailure);
 
-        return Hex1bTerminal.CreateBuilder()
-            .WithDimensions(Columns, Rows)
-            .WithWorkload(upstream)
-            .WithPresentation(downstream)
-            .AddPresentationFilter(new Hmp1UdsServerListenerFilter(
-                ConsumerUdsPath,
-                downstream,
-                _consumerListenerLogger))
-            .Build();
+        try
+        {
+            return Hex1bTerminal.CreateBuilder()
+                .WithDimensions(currentColumns, currentRows)
+                .WithWorkload(upstream)
+                .WithPresentation(downstream)
+                .AddPresentationFilter(listener)
+                .Build();
+        }
+        catch
+        {
+            listener.Dispose();
+            throw;
+        }
     }
 
-    private Hmp1PresentationAdapter CreateDownstream(DcpUpstreamAdapter upstream)
+    private Hmp1PresentationAdapter CreateDownstream(
+        DcpUpstreamAdapter upstream,
+        int currentColumns,
+        int currentRows)
     {
-        var downstream = new Hmp1PresentationAdapter(Columns, Rows);
+        var downstream = new Hmp1PresentationAdapter(currentColumns, currentRows);
 
         // Track every HMP1 peer that connects/disconnects so the host can answer
         // "who's currently attached to this replica?" via the control RPC. PeerId is

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Threading.Channels;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
@@ -127,6 +128,7 @@ public partial class ConsoleLogsTests
         // the live resource defaults to Terminal, so only the Terminal item is
         // checked.
         cut.WaitForState(() => instance.ActiveViewForTest == ConsoleLogs.ConsoleLogsView.Terminal);
+        Assert.Equal(2, instance.LogsMenuItemsForTest.Count);
         Assert.Equal(MenuItemRole.MenuItemCheckbox, instance.LogsMenuItemsForTest[0].Role);
         Assert.Equal(MenuItemRole.MenuItemCheckbox, instance.LogsMenuItemsForTest[1].Role);
         Assert.False(instance.LogsMenuItemsForTest[0].Checked);
@@ -592,12 +594,22 @@ public partial class ConsoleLogsTests
         {
             builder.Add(p => p.ResourceName, "first-resource");
             builder.Add(p => p.ReplicaIndex, 0);
+            builder.Add(p => p.DecreaseFontSizeLabel, "Decrease font size");
+            builder.Add(p => p.IncreaseFontSizeLabel, "Increase font size");
+            builder.Add(p => p.TerminalDimensionsLabel, "Terminal dimensions");
+            builder.Add(p => p.FitLabel, "Fit");
+            builder.Add(p => p.FocusControlsHintLabel, "F6: Focus terminal controls");
         });
 
         cut.SetParametersAndRender(builder =>
         {
             builder.Add(p => p.ResourceName, "second-resource");
             builder.Add(p => p.ReplicaIndex, 1);
+            builder.Add(p => p.DecreaseFontSizeLabel, "Decrease font size");
+            builder.Add(p => p.IncreaseFontSizeLabel, "Increase font size");
+            builder.Add(p => p.TerminalDimensionsLabel, "Terminal dimensions");
+            builder.Add(p => p.FitLabel, "Fit");
+            builder.Add(p => p.FocusControlsHintLabel, "F6: Focus terminal controls");
         });
 
         initTerminal.SetResult(1);
@@ -608,9 +620,15 @@ public partial class ConsoleLogsTests
             var reconnect = Assert.Single(reconnectTerminal.Invocations);
             var initUrl = Assert.IsType<string>(init.Arguments[1]);
             var reconnectUrl = Assert.IsType<string>(reconnect.Arguments[1]);
+            var labels = JsonSerializer.SerializeToElement(init.Arguments[3], JsonSerializerOptions.Web);
 
             Assert.Contains("resource=first-resource", initUrl);
             Assert.Contains("replica=0", initUrl);
+            Assert.Equal("Decrease font size", labels.GetProperty("decreaseFontSize").GetString());
+            Assert.Equal("Increase font size", labels.GetProperty("increaseFontSize").GetString());
+            Assert.Equal("Terminal dimensions", labels.GetProperty("terminalDimensions").GetString());
+            Assert.Equal("Fit", labels.GetProperty("fit").GetString());
+            Assert.Equal("F6: Focus terminal controls", labels.GetProperty("focusControlsHint").GetString());
             Assert.Equal(1, reconnect.Arguments[0]);
             Assert.Contains("resource=second-resource", reconnectUrl);
             Assert.Contains("replica=1", reconnectUrl);
@@ -668,8 +686,6 @@ public partial class ConsoleLogsTests
         module.Setup<int>("reconnectTerminal", _ => true).SetResult(2);
         module.SetupVoid("disposeTerminal", _ => true).SetVoidResult();
         module.SetupVoid("refreshLayout", _ => true).SetVoidResult();
-        module.SetupVoid("refreshToolbarState", _ => true).SetVoidResult();
-        module.Setup<TerminalSizePreset[]>("getSizePresets").SetResult([]);
     }
 
     private static ResourceViewModel CreateTerminalResource(string resourceName, int replicaIndex, int replicaCount, KnownResourceState state = KnownResourceState.Running)

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -63,7 +63,10 @@ public class DashboardServerFixture : IAsyncLifetime
             preConfigureBuilder: builder =>
             {
                 builder.Configuration.AddConfiguration(config);
-                builder.Services.AddSingleton<IDashboardClient>(new MockDashboardClient(Resources));
+                var dashboardClient = new MockDashboardClient(Resources);
+                builder.Services.AddSingleton<IDashboardClient>(dashboardClient);
+                builder.Services.AddSingleton<IRepositoryFactory>(
+                    services => new MockRepositoryFactory(services, dashboardClient));
                 ConfigureServices(builder.Services);
             });
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -23,6 +23,10 @@ public class DashboardServerFixture : IAsyncLifetime
 
     protected virtual IReadOnlyList<ResourceViewModel>? Resources => null;
 
+    protected virtual void ConfigureServices(IServiceCollection services)
+    {
+    }
+
     public DashboardServerFixture()
     {
         PlaywrightFixture = new PlaywrightFixture();
@@ -60,6 +64,7 @@ public class DashboardServerFixture : IAsyncLifetime
             {
                 builder.Configuration.AddConfiguration(config);
                 builder.Services.AddSingleton<IDashboardClient>(new MockDashboardClient(Resources));
+                ConfigureServices(builder.Services);
             });
 
         await DashboardApp.StartAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -3,13 +3,14 @@
 
 using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.DashboardService.Proto.V1;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
-public sealed class MockDashboardClient : IDashboardClient
+public sealed class MockDashboardClient : IDashboardClient, IResourceRepositoryWriter
 {
     public static readonly ResourceViewModel TestResource1 = ModelTestHelpers.CreateResource(
         resourceName: "TestResource",
@@ -93,4 +94,25 @@ public sealed class MockDashboardClient : IDashboardClient
     public ResourceViewModel? GetResource(string resourceName) => null;
 
     public IReadOnlyList<ResourceViewModel> GetResources() => _resources ?? [];
+
+    public Task ReplaceResourcesAsync(IReadOnlyList<Resource> resources) => Task.CompletedTask;
+
+    public Task ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes) => Task.CompletedTask;
+
+    public Task MarkConsoleLogsLoadedAsync(string resourceName) => Task.CompletedTask;
+
+    public Task AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines) => Task.CompletedTask;
+}
+
+internal sealed class MockRepositoryFactory(
+    IServiceProvider serviceProvider,
+    IResourceRepository resourceRepository) : IRepositoryFactory
+{
+    private readonly RepositoryFactory _inner = new(serviceProvider);
+
+    public ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database) =>
+        _inner.CreateTelemetryRepository(database);
+
+    public IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database) =>
+        resourceRepository;
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
 using Aspire.DashboardService.Proto.V1;
 using Aspire.Tests.Shared.DashboardModel;
@@ -50,8 +51,17 @@ public sealed class MockDashboardClient : IDashboardClient
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
     public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
 
     /// <inheritdoc/>
     public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/TestTerminalConnectionResolver.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/TestTerminalConnectionResolver.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading.Channels;
+using Aspire.Dashboard.Terminal;
+
+namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+
+internal enum TestHmp1FrameType : byte
+{
+    Hello = 0x01,
+    StateSync = 0x02,
+    Input = 0x04,
+    RequestPrimary = 0x07,
+    ClientHello = 0x0B,
+}
+
+internal readonly record struct TestHmp1Frame(TestHmp1FrameType Type, byte[] Payload);
+
+internal sealed class TestTerminalConnectionResolver : ITerminalConnectionResolver
+{
+    private readonly Channel<TestTerminalConnection> _connections = Channel.CreateUnbounded<TestTerminalConnection>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    public async Task<Stream?> ConnectAsync(string resourceName, int replicaIndex, CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        Socket? proxySocket = null;
+        Socket? testSocket = null;
+
+        try
+        {
+            listener.Start();
+
+            proxySocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var connectTask = proxySocket.ConnectAsync(listener.LocalEndpoint, cancellationToken);
+            testSocket = await listener.AcceptSocketAsync(cancellationToken).ConfigureAwait(false);
+            await connectTask.ConfigureAwait(false);
+
+            var connection = new TestTerminalConnection(testSocket);
+            testSocket = null;
+            await _connections.Writer.WriteAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            var stream = new NetworkStream(proxySocket, ownsSocket: true);
+            proxySocket = null;
+            return stream;
+        }
+        finally
+        {
+            listener.Stop();
+            proxySocket?.Dispose();
+            testSocket?.Dispose();
+        }
+    }
+
+    public Task<TestTerminalConnection> AcceptConnectionAsync(CancellationToken cancellationToken)
+    {
+        return _connections.Reader.ReadAsync(cancellationToken).AsTask();
+    }
+
+    public async Task DiscardPendingConnectionsAsync()
+    {
+        while (_connections.Reader.TryRead(out var connection))
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+internal sealed class TestTerminalConnection : IAsyncDisposable
+{
+    private const int HeaderLength = 5;
+    private const int MaximumPayloadLength = 1024 * 1024;
+    private readonly NetworkStream _stream;
+
+    public TestTerminalConnection(Socket socket)
+    {
+        _stream = new NetworkStream(socket, ownsSocket: true);
+    }
+
+    public async Task<TestHmp1Frame> ReadFrameAsync(CancellationToken cancellationToken)
+    {
+        var header = new byte[HeaderLength];
+        await _stream.ReadExactlyAsync(header, cancellationToken).ConfigureAwait(false);
+
+        var payloadLength = BinaryPrimitives.ReadInt32LittleEndian(header.AsSpan(1));
+        if (payloadLength is < 0 or > MaximumPayloadLength)
+        {
+            throw new InvalidDataException($"Invalid HMP frame payload length: {payloadLength}.");
+        }
+
+        var payload = new byte[payloadLength];
+        await _stream.ReadExactlyAsync(payload, cancellationToken).ConfigureAwait(false);
+        return new TestHmp1Frame((TestHmp1FrameType)header[0], payload);
+    }
+
+    public async Task<TestHmp1Frame> ReadUntilFrameAsync(TestHmp1FrameType type, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var frame = await ReadFrameAsync(cancellationToken).ConfigureAwait(false);
+            if (frame.Type == type)
+            {
+                return frame;
+            }
+        }
+    }
+
+    public Task SendHelloAsync(int width, int height, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            peerId = "dashboard-peer",
+            primaryPeerId = "existing-primary",
+            width,
+            height,
+            peers = new[]
+            {
+                new { peerId = "dashboard-peer", displayName = "aspire-dashboard" },
+                new { peerId = "existing-primary", displayName = "existing-primary" },
+            },
+        });
+
+        return SendFrameAsync(TestHmp1FrameType.Hello, payload, cancellationToken);
+    }
+
+    public Task SendStateSyncAsync(CancellationToken cancellationToken)
+    {
+        return SendFrameAsync(TestHmp1FrameType.StateSync, [], cancellationToken);
+    }
+
+    private async Task SendFrameAsync(TestHmp1FrameType type, byte[] payload, CancellationToken cancellationToken)
+    {
+        var frame = new byte[HeaderLength + payload.Length];
+        frame[0] = (byte)type;
+        BinaryPrimitives.WriteInt32LittleEndian(frame.AsSpan(1), payload.Length);
+        payload.CopyTo(frame.AsSpan(HeaderLength));
+        await _stream.WriteAsync(frame, cancellationToken).ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return _stream.DisposeAsync();
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/TestTerminalConnectionResolver.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/TestTerminalConnectionResolver.cs
@@ -110,12 +110,16 @@ internal sealed class TestTerminalConnection : IAsyncDisposable
         }
     }
 
-    public Task SendHelloAsync(int width, int height, CancellationToken cancellationToken)
+    public Task SendHelloAsync(
+        int width,
+        int height,
+        CancellationToken cancellationToken,
+        bool makeClientPrimary = false)
     {
         var payload = JsonSerializer.SerializeToUtf8Bytes(new
         {
             peerId = "dashboard-peer",
-            primaryPeerId = "existing-primary",
+            primaryPeerId = makeClientPrimary ? "dashboard-peer" : "existing-primary",
             width,
             height,
             peers = new[]

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/TerminalTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/TerminalTests.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Terminal;
+using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.TestUtilities;
+using Aspire.Tests.Shared.DashboardModel;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration.Playwright;
+
+[RequiresFeature(TestFeature.Playwright)]
+public sealed class TerminalTests : PlaywrightTestsBase<TerminalTests.TerminalDashboardServerFixture>
+{
+    private const string ResourceName = "terminal-resource";
+    private const int ProducerColumns = 137;
+    private const int ProducerRows = 41;
+    private readonly TerminalDashboardServerFixture _dashboardServerFixture;
+
+    public TerminalTests(TerminalDashboardServerFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
+    {
+        _dashboardServerFixture = dashboardServerFixture;
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task TerminalFocusNavigation_MovesToExpectedControlsWithoutForwardingInput()
+    {
+        await RunTestAsync(async page =>
+        {
+            await using var connection = await OpenTerminalAsync(page);
+
+            var terminalScreen = page.Locator(".xterm-screen");
+            var decreaseFontButton = page.Locator("#font-minus");
+            var settingsButton = page.Locator($"fluent-button[title='{Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings}'][aria-haspopup='menu']").First;
+
+            await Assertions.Expect(terminalScreen).ToBeVisibleAsync();
+            await Assertions.Expect(decreaseFontButton).ToBeEnabledAsync();
+
+            await terminalScreen.ClickAsync();
+            await page.Keyboard.PressAsync("F6");
+            Assert.Equal("font-minus", await page.EvaluateAsync<string?>("() => document.activeElement?.id"));
+
+            var settingsButtonId = await settingsButton.GetAttributeAsync("id");
+            Assert.False(string.IsNullOrEmpty(settingsButtonId));
+
+            await terminalScreen.ClickAsync();
+            await page.Keyboard.PressAsync("Shift+F6");
+            Assert.Equal(settingsButtonId, await page.EvaluateAsync<string?>("() => document.activeElement?.id"));
+
+            // Follow the intercepted F6 events with ordinary input. HMP preserves
+            // frame ordering, so the first Input frame must be this character; an
+            // earlier F6 escape sequence would make the assertion fail.
+            await terminalScreen.ClickAsync();
+            await page.Keyboard.TypeAsync("x");
+
+            var input = await connection.ReadUntilFrameAsync(TestHmp1FrameType.Input, CancellationToken.None).DefaultTimeout();
+            Assert.Equal("x", Encoding.UTF8.GetString(input.Payload));
+        });
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task SecondaryTyping_RequestsPrimaryAtProducerDimensions()
+    {
+        await RunTestAsync(async page =>
+        {
+            await using var connection = await OpenTerminalAsync(page);
+
+            var dimensions = page.Locator("#terminal-dims");
+            await Assertions.Expect(dimensions).ToHaveValueAsync($"{ProducerColumns}x{ProducerRows}");
+
+            var terminalScreen = page.Locator(".xterm-screen");
+            await terminalScreen.ClickAsync();
+            await page.Keyboard.TypeAsync("x");
+
+            var requestPrimary = await connection.ReadUntilFrameAsync(TestHmp1FrameType.RequestPrimary, CancellationToken.None).DefaultTimeout();
+            using var payload = JsonDocument.Parse(requestPrimary.Payload);
+            Assert.Equal(ProducerColumns, payload.RootElement.GetProperty("cols").GetInt32());
+            Assert.Equal(ProducerRows, payload.RootElement.GetProperty("rows").GetInt32());
+
+            var input = await connection.ReadUntilFrameAsync(TestHmp1FrameType.Input, CancellationToken.None).DefaultTimeout();
+            Assert.Equal("x", Encoding.UTF8.GetString(input.Payload));
+        });
+    }
+
+    private async Task<TestTerminalConnection> OpenTerminalAsync(IPage page)
+    {
+        await _dashboardServerFixture.TerminalResolver.DiscardPendingConnectionsAsync();
+        await page.GotoAsync($"/consolelogs/resource/{ResourceName}").DefaultTimeout();
+
+        var connection = await _dashboardServerFixture.TerminalResolver.AcceptConnectionAsync(CancellationToken.None).DefaultTimeout();
+        var clientHello = await connection.ReadUntilFrameAsync(TestHmp1FrameType.ClientHello, CancellationToken.None).DefaultTimeout();
+        Assert.NotEmpty(clientHello.Payload);
+
+        await connection.SendHelloAsync(ProducerColumns, ProducerRows, CancellationToken.None).DefaultTimeout();
+        await connection.SendStateSyncAsync(CancellationToken.None).DefaultTimeout();
+        return connection;
+    }
+
+    public sealed class TerminalDashboardServerFixture : DashboardServerFixture
+    {
+        internal TestTerminalConnectionResolver TerminalResolver { get; } = new();
+
+        protected override IReadOnlyList<ResourceViewModel> Resources =>
+        [
+            ModelTestHelpers.CreateResource(
+                resourceName: ResourceName,
+                state: KnownResourceState.Running,
+                properties: new Dictionary<string, ResourcePropertyViewModel>
+                {
+                    [KnownProperties.Terminal.Enabled] = StringProperty(KnownProperties.Terminal.Enabled, "true"),
+                    [KnownProperties.Terminal.ReplicaIndex] = StringProperty(KnownProperties.Terminal.ReplicaIndex, "0"),
+                    [KnownProperties.Terminal.ReplicaCount] = StringProperty(KnownProperties.Terminal.ReplicaCount, "1"),
+                })
+        ];
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<ITerminalConnectionResolver>(TerminalResolver);
+        }
+
+        private static ResourcePropertyViewModel StringProperty(string name, string value)
+        {
+            return new ResourcePropertyViewModel(
+                name,
+                new Value { StringValue = value },
+                isValueSensitive: false,
+                knownProperty: null,
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false);
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/TerminalTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/TerminalTests.cs
@@ -40,7 +40,7 @@ public sealed class TerminalTests : PlaywrightTestsBase<TerminalTests.TerminalDa
 
             var terminalScreen = page.Locator(".xterm-screen");
             var decreaseFontButton = page.Locator("#font-minus");
-            var settingsButton = page.Locator($"fluent-button[title='{Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings}'][aria-haspopup='menu']").First;
+            var resourceSelect = page.Locator("[id^='resource-select-']");
 
             await Assertions.Expect(terminalScreen).ToBeVisibleAsync();
             await Assertions.Expect(decreaseFontButton).ToBeEnabledAsync();
@@ -49,12 +49,12 @@ public sealed class TerminalTests : PlaywrightTestsBase<TerminalTests.TerminalDa
             await page.Keyboard.PressAsync("F6");
             Assert.Equal("font-minus", await page.EvaluateAsync<string?>("() => document.activeElement?.id"));
 
-            var settingsButtonId = await settingsButton.GetAttributeAsync("id");
-            Assert.False(string.IsNullOrEmpty(settingsButtonId));
+            var resourceSelectId = await resourceSelect.GetAttributeAsync("id");
+            Assert.False(string.IsNullOrEmpty(resourceSelectId));
 
             await terminalScreen.ClickAsync();
             await page.Keyboard.PressAsync("Shift+F6");
-            Assert.Equal(settingsButtonId, await page.EvaluateAsync<string?>("() => document.activeElement?.id"));
+            Assert.Equal(resourceSelectId, await page.EvaluateAsync<string?>("() => document.activeElement?.id"));
 
             // Follow the intercepted F6 events with ordinary input. HMP preserves
             // frame ordering, so the first Input frame must be this character; an
@@ -92,7 +92,40 @@ public sealed class TerminalTests : PlaywrightTestsBase<TerminalTests.TerminalDa
         });
     }
 
-    private async Task<TestTerminalConnection> OpenTerminalAsync(IPage page)
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task InitialPrimaryHello_UsesProducerDimensions()
+    {
+        await RunTestAsync(async page =>
+        {
+            await using var connection = await OpenTerminalAsync(page, makeClientPrimary: true);
+
+            var dimensions = page.Locator("#terminal-dims");
+            await Assertions.Expect(dimensions).ToHaveValueAsync($"{ProducerColumns}x{ProducerRows}");
+        });
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task ModifiedF6_DoesNotMoveFocusFromTerminal()
+    {
+        await RunTestAsync(async page =>
+        {
+            await using var connection = await OpenTerminalAsync(page);
+
+            var terminalScreen = page.Locator(".xterm-screen");
+            var terminalInput = page.Locator(".xterm-helper-textarea");
+            foreach (var key in new[] { "Control+F6", "Alt+F6", "Meta+F6" })
+            {
+                await terminalScreen.ClickAsync();
+                await page.Keyboard.PressAsync(key);
+
+                await Assertions.Expect(terminalInput).ToBeFocusedAsync();
+            }
+        });
+    }
+
+    private async Task<TestTerminalConnection> OpenTerminalAsync(IPage page, bool makeClientPrimary = false)
     {
         await _dashboardServerFixture.TerminalResolver.DiscardPendingConnectionsAsync();
         await page.GotoAsync($"/consolelogs/resource/{ResourceName}").DefaultTimeout();
@@ -101,7 +134,11 @@ public sealed class TerminalTests : PlaywrightTestsBase<TerminalTests.TerminalDa
         var clientHello = await connection.ReadUntilFrameAsync(TestHmp1FrameType.ClientHello, CancellationToken.None).DefaultTimeout();
         Assert.NotEmpty(clientHello.Payload);
 
-        await connection.SendHelloAsync(ProducerColumns, ProducerRows, CancellationToken.None).DefaultTimeout();
+        await connection.SendHelloAsync(
+            ProducerColumns,
+            ProducerRows,
+            CancellationToken.None,
+            makeClientPrimary).DefaultTimeout();
         await connection.SendStateSyncAsync(CancellationToken.None).DefaultTimeout();
         return connection;
     }

--- a/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
@@ -43,8 +43,8 @@ public class WithTerminalTests : IAsyncLifetime
 
         var annotation = resource.Resource.Annotations.OfType<TerminalAnnotation>().SingleOrDefault();
         Assert.NotNull(annotation);
-        Assert.Equal(120, annotation.Options.Columns);
-        Assert.Equal(30, annotation.Options.Rows);
+        Assert.Equal(132, annotation.Options.Columns);
+        Assert.Equal(50, annotation.Options.Rows);
 
         // Until BeforeStartEvent fires the per-replica hosts are not yet materialized:
         // TerminalHosts is empty and IsInitialized is false. This deferral is what

--- a/tests/Aspire.TerminalHost.Tests/TerminalHostAppTests.cs
+++ b/tests/Aspire.TerminalHost.Tests/TerminalHostAppTests.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Shared.TerminalHost;
+using Hex1b;
 using Microsoft.Extensions.Logging.Abstractions;
 using StreamJsonRpc;
 
@@ -602,6 +603,147 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
             var observedHeight = payload[4] | (payload[5] << 8) | (payload[6] << 16) | (payload[7] << 24);
             Assert.Equal(requestedWidth, observedWidth);
             Assert.Equal(requestedHeight, observedHeight);
+        }
+        finally
+        {
+            app.RequestShutdown();
+            hostCts.Cancel();
+            await hostTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
+    public async Task ConsumerListenerBindFailureIsReportedBeforeTerminalStarts()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var parentFile = Path.Combine(workspace.Path, "not-a-directory");
+        await File.WriteAllTextAsync(parentFile, "");
+        await using var presentation = new Hmp1PresentationAdapter();
+
+        Assert.Throws<IOException>(() => new Hmp1UdsServerListenerFilter(
+            Path.Combine(parentFile, "consumer.sock"),
+            presentation,
+            NullLogger<Hmp1UdsServerListenerFilter>.Instance,
+            _ => { }));
+    }
+
+    [Fact]
+    public async Task ConsumerListenerWaitsForAcceptedClientHandshakeDuringTeardown()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var socketPath = Path.Combine(workspace.Path, "consumer.sock");
+        await using var presentation = new Hmp1PresentationAdapter();
+        var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        presentation.OnClientConnected = async (_, _) =>
+        {
+            callbackStarted.TrySetResult();
+            await releaseCallback.Task.ConfigureAwait(false);
+        };
+
+        using var listener = new Hmp1UdsServerListenerFilter(
+            socketPath,
+            presentation,
+            NullLogger<Hmp1UdsServerListenerFilter>.Instance,
+            _ => { });
+        await listener.OnSessionStartAsync(80, 24, DateTimeOffset.UtcNow);
+
+        Task? endTask = null;
+        try
+        {
+            await using var consumer = await TestHmp1Consumer.ConnectAsync(socketPath, TimeSpan.FromSeconds(5));
+            await consumer.SendClientHelloAsync("test-consumer", "secondary", default);
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            endTask = listener.OnSessionEndAsync(TimeSpan.Zero).AsTask();
+            var completed = await Task.WhenAny(endTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+            Assert.NotSame(endTask, completed);
+        }
+        finally
+        {
+            releaseCallback.TrySetResult();
+            if (endTask is null)
+            {
+                await listener.OnSessionEndAsync(TimeSpan.Zero);
+            }
+            else
+            {
+                await endTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CurrentDimensionsArePreservedAcrossProducerRecycle()
+    {
+        const int requestedWidth = 123;
+        const int requestedHeight = 45;
+        const byte frameResize = 0x05;
+        var (args, workspace, control) = BuildArgs();
+        using var disp = workspace;
+
+        await using var app = new TerminalHostApp(args, NullLoggerFactory.Instance);
+        using var hostCts = new CancellationTokenSource();
+        var hostTask = app.RunAsync(hostCts.Token);
+
+        try
+        {
+            await WaitForFileAsync(control, TimeSpan.FromSeconds(10));
+
+            await using (var producer = await ConnectProducerAsync(args.ProducerUdsPath, TimeSpan.FromSeconds(5)))
+            {
+                await producer.SendHelloAsync(80, 24, default);
+                await WaitForAsync(
+                    () => app.SnapshotSession().ProducerConnected,
+                    TimeSpan.FromSeconds(5),
+                    "The first producer should connect.");
+
+                await using var consumer = await TestHmp1Consumer.ConnectAsync(
+                    args.ConsumerUdsPath, TimeSpan.FromSeconds(5));
+                await consumer.SendClientHelloAsync("test-consumer", "primary", default);
+                await consumer.ReceiveHandshakeAsync(TimeSpan.FromSeconds(5));
+                await consumer.SendRequestPrimaryAsync(requestedWidth, requestedHeight, default);
+
+                _ = await producer.WaitForMatchingFrameAsync(
+                    frameResize,
+                    payload => payload.Length == 8
+                        && BitConverter.ToInt32(payload, 0) == requestedWidth
+                        && BitConverter.ToInt32(payload, 4) == requestedHeight,
+                    TimeSpan.FromSeconds(10));
+                await WaitForAsync(
+                    () =>
+                    {
+                        var session = app.SnapshotSession();
+                        return session.CurrentColumns == requestedWidth && session.CurrentRows == requestedHeight;
+                    },
+                    TimeSpan.FromSeconds(5),
+                    "The resized dimensions should become authoritative.");
+            }
+
+            await WaitForAsync(
+                () => app.SnapshotSession().RestartCount >= 1,
+                TimeSpan.FromSeconds(10),
+                "The terminal should recycle after the first producer disconnects.");
+
+            await using var replacementProducer = await ConnectProducerAsync(
+                args.ProducerUdsPath, TimeSpan.FromSeconds(10));
+            await replacementProducer.SendHelloAsync(80, 24, default);
+
+            _ = await replacementProducer.WaitForMatchingFrameAsync(
+                frameResize,
+                payload => payload.Length == 8
+                    && BitConverter.ToInt32(payload, 0) == requestedWidth
+                    && BitConverter.ToInt32(payload, 4) == requestedHeight,
+                TimeSpan.FromSeconds(10));
+
+            await using var replacementConsumer = await TestHmp1Consumer.ConnectAsync(
+                args.ConsumerUdsPath, TimeSpan.FromSeconds(5));
+            await replacementConsumer.SendClientHelloAsync("replacement-consumer", "secondary", default);
+            var helloPayload = await replacementConsumer.ReceiveHandshakeAsync(TimeSpan.FromSeconds(5));
+
+            using var hello = JsonDocument.Parse(helloPayload);
+            Assert.Equal(requestedWidth, hello.RootElement.GetProperty("width").GetInt32());
+            Assert.Equal(requestedHeight, hello.RootElement.GetProperty("height").GetInt32());
         }
         finally
         {

--- a/tests/Aspire.TerminalHost.Tests/TerminalHostAppTests.cs
+++ b/tests/Aspire.TerminalHost.Tests/TerminalHostAppTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using System.Text.Json;
 using Aspire.Shared.TerminalHost;
 using Microsoft.Extensions.Logging.Abstractions;
 using StreamJsonRpc;
@@ -20,7 +21,9 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
     /// producer/consumer/control UDS path triple. The replica index is opaque to the
     /// host — callers encode it however they like in the path layout.
     /// </summary>
-    private (TerminalHostArgs args, TemporaryWorkspace workspace, string controlPath) BuildArgs()
+    private (TerminalHostArgs args, TemporaryWorkspace workspace, string controlPath) BuildArgs(
+        int? columns = null,
+        int? rows = null)
     {
         var workspace = TemporaryWorkspace.Create(outputHelper);
         var dcpDir = Path.Combine(workspace.Path, "dcp");
@@ -34,11 +37,22 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
         var consumer = Path.Combine(hostDir, "r.sock");
         var control = Path.Combine(ctrlDir, "c.sock");
 
-        var args = TerminalHostArgs.Parse([
+        var commandLine = new List<string>
+        {
             "--producer-uds", producer,
             "--consumer-uds", consumer,
             "--control-uds", control,
-        ]);
+        };
+        if (columns is not null)
+        {
+            commandLine.AddRange(["--columns", columns.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)]);
+        }
+        if (rows is not null)
+        {
+            commandLine.AddRange(["--rows", rows.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)]);
+        }
+
+        var args = TerminalHostArgs.Parse([.. commandLine]);
 
         return (args, workspace, control);
     }
@@ -454,6 +468,56 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ConfiguredDimensionsAreAppliedUpstreamAndReportedToConsumers()
+    {
+        const int configuredWidth = 137;
+        const int configuredHeight = 41;
+        var (args, workspace, control) = BuildArgs(configuredWidth, configuredHeight);
+        using var disp = workspace;
+
+        await using var app = new TerminalHostApp(args, NullLoggerFactory.Instance);
+        using var hostCts = new CancellationTokenSource();
+        var hostTask = app.RunAsync(hostCts.Token);
+
+        try
+        {
+            await WaitForFileAsync(control, TimeSpan.FromSeconds(10));
+
+            await using var producer = await ConnectProducerAsync(args.ProducerUdsPath, TimeSpan.FromSeconds(5));
+            await producer.SendHelloAsync(80, 24, default);
+
+            await WaitForAsync(
+                () => app.SnapshotSession().ProducerConnected,
+                TimeSpan.FromSeconds(5),
+                "ProducerConnected should flip to true after producer dials in.");
+
+            const byte FrameResize = 0x05;
+            using var frameCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var (type, payload) = await producer.ReadFrameAsync(frameCts.Token);
+
+            Assert.Equal(FrameResize, type);
+            Assert.Equal(configuredWidth, BitConverter.ToInt32(payload, 0));
+            Assert.Equal(configuredHeight, BitConverter.ToInt32(payload, 4));
+
+            await WaitForFileAsync(args.ConsumerUdsPath, TimeSpan.FromSeconds(5));
+            await using var consumer = await TestHmp1Consumer.ConnectAsync(
+                args.ConsumerUdsPath, TimeSpan.FromSeconds(5));
+            await consumer.SendClientHelloAsync("test-consumer", "secondary", default);
+            var helloPayload = await consumer.ReceiveHandshakeAsync(TimeSpan.FromSeconds(5));
+
+            using var hello = JsonDocument.Parse(helloPayload);
+            Assert.Equal(configuredWidth, hello.RootElement.GetProperty("width").GetInt32());
+            Assert.Equal(configuredHeight, hello.RootElement.GetProperty("height").GetInt32());
+        }
+        finally
+        {
+            app.RequestShutdown();
+            hostCts.Cancel();
+            await hostTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+    }
+
+    [Fact]
     public async Task DownstreamPrimaryResizeIsForwardedUpstreamAsRawResizeFrame()
     {
         // Regression: the consumer-side multi-head server fires its OnResized
@@ -503,6 +567,7 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
             await using var consumer = await TestHmp1Consumer.ConnectAsync(
                 args.ConsumerUdsPath, TimeSpan.FromSeconds(5));
             await consumer.SendClientHelloAsync("test-consumer", "primary", default);
+            await consumer.ReceiveHandshakeAsync(TimeSpan.FromSeconds(5));
             await consumer.SendRequestPrimaryAsync(requestedWidth, requestedHeight, default);
 
             // The frame the test producer should observe upstream:
@@ -697,6 +762,8 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
     /// </summary>
     private sealed class TestHmp1Consumer : IAsyncDisposable
     {
+        private const byte FrameHello = 0x01;
+        private const byte FrameStateSync = 0x02;
         private const byte FrameRequestPrimary = 0x07;
         private const byte FrameClientHello = 0x0B;
 
@@ -741,10 +808,61 @@ public class TerminalHostAppTests(ITestOutputHelper outputHelper)
             await SendFrameAsync(FrameClientHello, System.Text.Encoding.UTF8.GetBytes(json), ct).ConfigureAwait(false);
         }
 
+        public async Task<byte[]> ReceiveHandshakeAsync(TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var (helloType, helloPayload) = await ReadFrameAsync(cts.Token).ConfigureAwait(false);
+            var (stateSyncType, _) = await ReadFrameAsync(cts.Token).ConfigureAwait(false);
+
+            if (helloType != FrameHello || stateSyncType != FrameStateSync)
+            {
+                throw new InvalidDataException(
+                    $"Expected Hello and StateSync frames, received 0x{helloType:X2} and 0x{stateSyncType:X2}.");
+            }
+
+            return helloPayload;
+        }
+
         public async Task SendRequestPrimaryAsync(int cols, int rows, CancellationToken ct)
         {
             var json = $"{{\"cols\":{cols},\"rows\":{rows}}}";
             await SendFrameAsync(FrameRequestPrimary, System.Text.Encoding.UTF8.GetBytes(json), ct).ConfigureAwait(false);
+        }
+
+        private async Task<(byte Type, byte[] Payload)> ReadFrameAsync(CancellationToken ct)
+        {
+            // HMP1 frames are [type:1B][length:4B LE][payload:N bytes].
+            var header = new byte[5];
+            await ReadExactlyAsync(header, ct).ConfigureAwait(false);
+
+            var length = header[1] | (header[2] << 8) | (header[3] << 16) | (header[4] << 24);
+            if (length < 0 || length > 16 * 1024 * 1024)
+            {
+                throw new InvalidDataException($"Consumer-side reader received invalid frame length {length}.");
+            }
+
+            var payload = new byte[length];
+            if (payload.Length > 0)
+            {
+                await ReadExactlyAsync(payload, ct).ConfigureAwait(false);
+            }
+
+            return (header[0], payload);
+        }
+
+        private async Task ReadExactlyAsync(byte[] buffer, CancellationToken ct)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                var read = await _stream.ReadAsync(buffer.AsMemory(offset), ct).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException(
+                        $"Consumer-side reader: stream EOF after {offset} of {buffer.Length} bytes.");
+                }
+                offset += read;
+            }
         }
 
         private async Task SendFrameAsync(byte type, byte[] payload, CancellationToken ct)

--- a/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
+++ b/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
@@ -17,8 +17,8 @@ public class TerminalHostArgsTests
         Assert.Equal("/tmp/p.sock", args.ProducerUdsPath);
         Assert.Equal("/tmp/c.sock", args.ConsumerUdsPath);
         Assert.Equal("/tmp/ctrl.sock", args.ControlUdsPath);
-        Assert.Equal(120, args.Columns);
-        Assert.Equal(30, args.Rows);
+        Assert.Equal(132, args.Columns);
+        Assert.Equal(50, args.Rows);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Terminal sizing in the dashboard currently requires opening the page toolbar, and interacting with a terminal can unexpectedly switch its resolution to Fit. New terminals can also start at `80x24` even when `WithTerminal` specifies another size.

This change:

- Moves font decrease/current size/increase and resolution selection into the terminal footer.
- Keeps sizing controls on the bottom-right and adds an `F6` focus hint on the bottom-left.
- Uses `F6` and `Shift+F6` to move focus between the terminal and dashboard controls without consuming Escape.
- Preserves the producer's current resolution when a dashboard or peer session takes control.
- Defaults terminals to `132x50`, while continuing to honor explicit `WithTerminal` column and row overrides.
- Initializes both the DCP PTY and HMP consumer handshake with the configured dimensions instead of Hex1b's `80x24` presentation default.

### User-facing usage

Terminals now start at `132x50` by default:

```csharp
builder.AddExecutable("shell", "/bin/bash", ".")
    .WithTerminal();
```

Existing overrides remain authoritative:

```csharp
builder.AddProject<Projects.Terminals_Repl>("repl")
    .WithTerminal(options =>
    {
        options.Columns = 120;
        options.Rows = 32;
    });
```

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

<!-- Add screenshots/recordings here -->

TODO: Capture the terminal footer showing the `F6` hint, resolution selector, and font controls.

### Validation

- `Aspire.Hosting.Tests` `WithTerminalTests`: 46 passed, 1 platform skip.
- `Aspire.TerminalHost.Tests`: 27 passed.
- `Aspire.Dashboard.Components.Tests` `ConsoleLogsTerminalTests`: 32 passed.
- Built the Terminals playground AppHost successfully.
- Confirmed the live shell PTY reports `50 132` by default and both overridden REPL PTYs report `32 120`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
