### PR TITLE
Add dashboard run timeline annotations

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor
@@ -1,13 +1,81 @@
-<div class="application-run-select">
-    <AspireMenuButton Text="@SelectedRunText"
-                      Title="@RunSelectTitle"
-                      aria-label="@RunSelectAccessibleLabel"
-                      IconStart="@(new Icons.Filled.Size12.Circle())"
-                      IconStartClass="application-run-status"
-                      IconStartColor="@(SelectedRunIsCurrent ? Color.Success : Color.Warning)"
-                      ItemsProvider="@LoadRuns"
-                      ButtonAppearance="Appearance.Stealth"
-                      ButtonClass="application-run-select-button"
-                      HideIcon="true"
-                      RestoreFocusOnItemClick="true" />
+@using LayoutResources = Aspire.Dashboard.Resources.Layout
+
+<div class="application-run-timeline" role="group" aria-label="@TimelineTitle">
+    <div class="application-run-timeline-track">
+        @foreach (var run in Runs)
+        {
+            var runText = FormatRun(run);
+            var isSelected = string.Equals(run.RunId, SelectedRunId, StringComparison.Ordinal);
+            <div class="application-run-node-container"
+                 @onmouseenter="@(() => ShowBubbleAfterDelayAsync(run))"
+                 @onmouseleave="@CancelPendingBubble">
+                <button id="@GetNodeId(run)"
+                        class="@GetNodeClass(run, isSelected)"
+                        type="button"
+                        aria-label="@Loc[nameof(LayoutResources.DashboardRunTimelineSelect), runText]"
+                        aria-pressed="@(isSelected ? "true" : "false")"
+                        @onclick="@(() => SelectRunAsync(run))">
+                    <span class="application-run-node-dot">
+                        @if (run.IsPinned)
+                        {
+                            <FluentIcon Value="@(new Icons.Filled.Size12.Pin())"
+                                        Class="application-run-node-pin"
+                                        Color="Color.Custom"
+                                        CustomColor="@(isSelected
+                                            ? "#ffffff"
+                                            : "var(--accent-fill-rest)")"
+                                        aria-label="@Loc[nameof(LayoutResources.DashboardRunSelectUnpin)]" />
+                        }
+                    </span>
+                </button>
+                @if (run.Note is not null)
+                {
+                    <span class="application-run-node-note"
+                          role="img"
+                          aria-label="@Loc[nameof(LayoutResources.DashboardRunTimelineNoteLabel)]"></span>
+                }
+            </div>
+        }
+    </div>
+
+    @if (_activeRun is not null)
+    {
+        <FluentPopover AnchorId="@GetNodeId(_activeRun)"
+                       @bind-Open="_bubbleOpen"
+                       AutoFocus="false"
+                       FixedPlacement="true"
+                       Class="application-run-bubble">
+            <Body>
+                <div class="application-run-bubble-content">
+                    <div class="application-run-bubble-header">
+                        <div class="application-run-bubble-time">@FormatRunTimestamp(_activeRun)</div>
+                        <button class="application-run-bubble-pin"
+                                type="button"
+                                title="@Loc[_activeRun.IsPinned
+                                    ? nameof(LayoutResources.DashboardRunSelectUnpin)
+                                    : nameof(LayoutResources.DashboardRunSelectPin)]"
+                                aria-label="@Loc[_activeRun.IsPinned
+                                    ? nameof(LayoutResources.DashboardRunSelectUnpin)
+                                    : nameof(LayoutResources.DashboardRunSelectPin)]"
+                                disabled="@(_activeRun.Note is not null)"
+                                @onclick="@TogglePinned">
+                            <FluentIcon Value="@(_activeRun.IsPinned
+                                ? new Icons.Filled.Size16.Pin()
+                                : (Icon)new Icons.Regular.Size16.Pin())"
+                                        Color="Color.Custom"
+                                        CustomColor="var(--accent-fill-rest)" />
+                        </button>
+                    </div>
+                    <FluentTextArea Value="@_note"
+                                    ValueChanged="@SaveNote"
+                                    Placeholder="@Loc[nameof(LayoutResources.DashboardRunTimelineNotePlaceholder)]"
+                                    aria-label="@Loc[nameof(LayoutResources.DashboardRunTimelineNoteLabel)]"
+                                    Rows="3"
+                                    Immediate="true"
+                                    ImmediateDelay="@FluentUIExtensions.InputDelay"
+                                    Maxlength="@DashboardRunStore.MaxNoteLength" />
+                </div>
+            </Body>
+        </FluentPopover>
+    }
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
@@ -5,32 +5,28 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
-using Microsoft.FluentUI.AspNetCore.Components;
-using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using LayoutResources = Aspire.Dashboard.Resources.Layout;
 
 namespace Aspire.Dashboard.Components.Controls;
 
-public partial class DashboardRunSelect : ComponentBase
+public partial class DashboardRunSelect : ComponentBase, IDisposable
 {
-    private static readonly Icon s_checkmarkIcon = new Icons.Regular.Size16.Checkmark();
-    private static readonly Icon s_pinIcon = new Icons.Regular.Size16.Pin();
-    private static readonly Icon s_pinnedIcon = new Icons.Filled.Size16.Pin();
+    private static readonly TimeSpan s_bubbleShowDelay = TimeSpan.FromSeconds(1);
 
-    private string RunSelectTitle => Loc[nameof(LayoutResources.DashboardRunSelectTitle)];
-    private string RunSelectAccessibleLabel => Loc[nameof(LayoutResources.DashboardRunSelectAccessibleLabel), SelectedRunText];
-    private string SelectedRunText => SelectedRunIsCurrent
-        ? Loc[nameof(LayoutResources.DashboardRunSelectCurrent)]
-        : FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, SelectedRunStartedAtUtc.UtcDateTime);
+    private DashboardRunDescriptor? _activeRun;
+    private bool _bubbleOpen;
+    private string? _note;
+    private CancellationTokenSource? _showBubbleCancellation;
+
+    private string TimelineTitle => Loc[nameof(LayoutResources.DashboardRunTimelineTitle)];
+    private IReadOnlyList<DashboardRunDescriptor> Runs => RunStore.GetRuns()
+        .Where(run => !run.IsPruned)
+        .OrderByDescending(run => run.IsCurrent)
+        .ThenByDescending(run => run.StartedAtUtc)
+        .ToArray();
 
     [Parameter, EditorRequired]
     public required string SelectedRunId { get; set; }
-
-    [Parameter]
-    public bool SelectedRunIsCurrent { get; set; }
-
-    [Parameter]
-    public DateTimeOffset SelectedRunStartedAtUtc { get; set; }
 
     [Parameter]
     public EventCallback<string?> SelectedRunIdChanged { get; set; }
@@ -47,65 +43,106 @@ public partial class DashboardRunSelect : ComponentBase
     [Inject]
     public required ILogger<DashboardRunSelect> Logger { get; init; }
 
-    private IList<MenuButtonItem> LoadRuns()
-    {
-        var runs = RunStore.GetRuns()
-            .Where(run => !run.IsPruned)
-            .OrderByDescending(run => run.IsCurrent)
-            .ThenByDescending(run => run.IsPinned)
-            .ThenByDescending(run => run.StartedAtUtc)
-            .ToArray();
-        var menuItems = new List<MenuButtonItem>();
-        foreach (var run in runs)
-        {
-            var menuItem = new MenuButtonItem
-            {
-                Text = FormatRunOption(run),
-                Role = MenuItemRole.MenuItemRadio,
-                Checked = string.Equals(run.RunId, SelectedRunId, StringComparison.Ordinal),
-                Icon = s_checkmarkIcon,
-                SecondaryActionIcon = run.IsPinned ? s_pinnedIcon : s_pinIcon,
-                SecondaryActionAriaLabel = Loc[run.IsPinned
-                    ? nameof(LayoutResources.DashboardRunSelectUnpin)
-                    : nameof(LayoutResources.DashboardRunSelectPin)],
-                IsSecondaryActionSelected = run.IsPinned,
-                OnSecondaryActionClick = () =>
-                {
-                    SetRunPinned(run, !run.IsPinned);
-                    return Task.CompletedTask;
-                },
-                OnClick = () => SelectedRunIdChanged.InvokeAsync(run.IsCurrent ? null : run.RunId)
-            };
-            menuItems.Add(menuItem);
+    private Task SelectRunAsync(DashboardRunDescriptor run)
+        => SelectedRunIdChanged.InvokeAsync(run.IsCurrent ? null : run.RunId);
 
-            if (run.IsCurrent && runs.Any(candidate => !candidate.IsCurrent))
-            {
-                menuItems.Add(new MenuButtonItem { IsDivider = true });
-            }
+    private async Task ShowBubbleAfterDelayAsync(DashboardRunDescriptor run)
+    {
+        if (_bubbleOpen && ReferenceEquals(_activeRun, run))
+        {
+            return;
         }
 
-        return menuItems;
-    }
-
-    private void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
-    {
+        CancelAndDispose(ref _showBubbleCancellation);
+        var cancellation = _showBubbleCancellation = new();
         try
         {
-            RunStore.SetRunPinned(run, isPinned);
+            await Task.Delay(s_bubbleShowDelay, cancellation.Token);
+            _activeRun = run;
+            _note = run.Note;
+            _bubbleOpen = true;
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+    }
+
+    private void CancelPendingBubble() => CancelAndDispose(ref _showBubbleCancellation);
+
+    private void SaveNote(string? note)
+    {
+        if (_activeRun is null)
+        {
+            return;
+        }
+
+        _note = note;
+        try
+        {
+            RunStore.SetRunNote(_activeRun, _note);
+            _note = _activeRun.Note;
         }
         catch (Exception exception)
         {
-            Logger.LogError(exception, "Failed to update the pinned state of dashboard run '{RunId}'.", run.RunId);
+            Logger.LogError(exception, "Failed to save the note for dashboard run '{RunId}'.", _activeRun.RunId);
         }
     }
 
-    private string FormatRunOption(DashboardRunDescriptor run)
+    private void TogglePinned()
     {
-        if (run.IsCurrent)
+        if (_activeRun is null)
         {
-            return Loc[nameof(LayoutResources.DashboardRunSelectCurrent)];
+            return;
         }
 
-        return FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, run.StartedAtUtc.UtcDateTime);
+        try
+        {
+            RunStore.SetRunPinned(_activeRun, !_activeRun.IsPinned);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to update the pinned state of dashboard run '{RunId}'.", _activeRun.RunId);
+        }
+    }
+
+    private string FormatRun(DashboardRunDescriptor run) => run.IsCurrent
+        ? Loc[nameof(LayoutResources.DashboardRunSelectCurrent)]
+        : FormatRunTimestamp(run);
+
+    private string FormatRunTimestamp(DashboardRunDescriptor run)
+        => FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, run.StartedAtUtc.UtcDateTime);
+
+    private static string GetNodeId(DashboardRunDescriptor run) => $"dashboard-run-{run.RunId}";
+
+    private static string GetNodeClass(DashboardRunDescriptor run, bool isSelected)
+    {
+        var classes = "application-run-node";
+        if (run.IsCurrent)
+        {
+            classes += " current";
+        }
+        if (isSelected)
+        {
+            classes += " selected";
+        }
+        if (run.Note is not null)
+        {
+            classes += " annotated";
+        }
+
+        return classes;
+    }
+
+    private static void CancelAndDispose(ref CancellationTokenSource? cancellation)
+    {
+        cancellation?.Cancel();
+        cancellation?.Dispose();
+        cancellation = null;
+    }
+
+    public void Dispose()
+    {
+        CancelAndDispose(ref _showBubbleCancellation);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.css
@@ -1,8 +1,206 @@
-.application-run-select ::deep .application-run-select-button {
+.application-run-timeline {
+    min-width: 0;
+    max-width: min(44vw, 560px);
     margin-right: 8px;
+    background: transparent;
+    overflow-x: auto;
+    scrollbar-width: thin;
 }
 
-.application-run-select ::deep .application-run-select-button::part(control) {
-    padding-left: 8px;
-    padding-right: 8px;
+.application-run-timeline-track {
+    display: flex;
+    justify-content: flex-end;
+    min-width: max-content;
+    padding: 4px 6px;
+    background: transparent;
+}
+
+.application-run-node-container {
+    position: relative;
+    display: grid;
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    place-items: center;
+}
+
+.application-run-node-container:not(:last-child)::after {
+    position: absolute;
+    z-index: 0;
+    top: 19px;
+    left: 28px;
+    width: 24px;
+    height: 2px;
+    background: var(--neutral-stroke-rest);
+    content: "";
+}
+
+.application-run-node {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+    place-items: center;
+}
+
+.application-run-node-dot {
+    position: relative;
+    display: inline-flex;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--accent-fill-rest);
+    border-radius: 50%;
+    background: transparent;
+    transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.application-run-node:hover .application-run-node-dot {
+    border-color: var(--accent-fill-rest);
+    transform: scale(1.12);
+}
+
+.application-run-node:focus-visible {
+    outline: 2px solid var(--focus-stroke-outer);
+    outline-offset: 0;
+}
+
+.application-run-node.selected .application-run-node-dot {
+    border-color: var(--accent-fill-rest);
+    background: var(--accent-fill-rest);
+}
+
+.application-run-node.current .application-run-node-dot::before {
+    position: absolute;
+    inset: -5px;
+    border: 2px solid transparent;
+    border-top-color: var(--success);
+    border-right-color: var(--success);
+    border-radius: 50%;
+    animation: application-run-live-spin 1.4s linear infinite;
+    content: "";
+}
+
+.application-run-node.annotated .application-run-node-dot {
+    border-color: var(--accent-fill-rest);
+}
+
+.application-run-node-pin {
+    color: var(--accent-fill-rest);
+}
+
+.application-run-node.selected .application-run-node-pin {
+    color: #ffffff;
+}
+
+.application-run-node-note {
+    position: absolute;
+    top: 3px;
+    left: 5px;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--accent-fill-rest);
+}
+
+.application-run-bubble-content {
+    position: relative;
+    width: min(360px, 80vw);
+    color: var(--neutral-foreground-rest);
+    background: var(--neutral-layer-floating);
+}
+
+.application-run-bubble-content ::deep fluent-text-area {
+    width: 100%;
+}
+
+.application-run-bubble-content::before {
+    position: absolute;
+    top: -14px;
+    left: calc(50% - 6px);
+    width: 12px;
+    height: 12px;
+    border-top: 1px solid var(--neutral-stroke-rest);
+    border-left: 1px solid var(--neutral-stroke-rest);
+    background: var(--neutral-layer-floating);
+    content: "";
+    transform: rotate(45deg);
+}
+
+::deep .application-run-bubble .fluent-popover-content,
+::deep .application-run-bubble .fluent-popover-body {
+    color: var(--neutral-foreground-rest);
+    background: var(--neutral-layer-floating);
+}
+
+.application-run-bubble-header {
+    display: flex;
+    min-height: 28px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.application-run-bubble-time {
+    color: var(--neutral-foreground-rest);
+    font-weight: 600;
+}
+
+.application-run-bubble-pin {
+    display: grid;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 0;
+    border-radius: 4px;
+    color: var(--accent-fill-rest);
+    background: transparent;
+    cursor: pointer;
+    place-items: center;
+}
+
+.application-run-bubble-pin:hover:not(:disabled) {
+    background: var(--neutral-fill-stealth-hover);
+}
+
+.application-run-bubble-pin:disabled {
+    cursor: default;
+    opacity: 1;
+}
+
+@keyframes application-run-live-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .application-run-node.current .application-run-node-dot::before {
+        border: 2px solid var(--success);
+        animation: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .application-run-timeline {
+        max-width: min(52vw, 320px);
+    }
+
+    .application-run-node-container {
+        width: 36px;
+        flex-basis: 36px;
+    }
+
+    .application-run-node-container:not(:last-child)::after {
+        width: 20px;
+    }
 }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -28,8 +28,6 @@
             {
                 var selectedRun = RunSelection.SelectedRun;
                 <DashboardRunSelect SelectedRunId="@selectedRun.RunId"
-                                    SelectedRunIsCurrent="@selectedRun.IsCurrent"
-                                    SelectedRunStartedAtUtc="@selectedRun.StartedAtUtc"
                                     SelectedRunIdChanged="@SwitchDashboardRunAsync" />
             }
             <FluentAnchor Class="header-button"
@@ -103,8 +101,6 @@
             {
                 var selectedRun = RunSelection.SelectedRun;
                 <DashboardRunSelect SelectedRunId="@selectedRun.RunId"
-                                    SelectedRunIsCurrent="@selectedRun.IsCurrent"
-                                    SelectedRunStartedAtUtc="@selectedRun.StartedAtUtc"
                                     SelectedRunIdChanged="@SwitchDashboardRunAsync" />
             }
             <UserProfile/>

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -106,6 +106,42 @@ namespace Aspire.Dashboard.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Investigation note.
+        /// </summary>
+        public static string DashboardRunTimelineNoteLabel {
+            get {
+                return ResourceManager.GetString("DashboardRunTimelineNoteLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add an annotation....
+        /// </summary>
+        public static string DashboardRunTimelineNotePlaceholder {
+            get {
+                return ResourceManager.GetString("DashboardRunTimelineNotePlaceholder", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select and annotate {0}.
+        /// </summary>
+        public static string DashboardRunTimelineSelect {
+            get {
+                return ResourceManager.GetString("DashboardRunTimelineSelect", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Dashboard run timeline.
+        /// </summary>
+        public static string DashboardRunTimelineTitle {
+            get {
+                return ResourceManager.GetString("DashboardRunTimelineTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Aspire.
         /// </summary>
         public static string MainLayoutAspire {

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -201,4 +201,16 @@
   <data name="DashboardRunSelectUnpin" xml:space="preserve">
     <value>Unpin run</value>
   </data>
+  <data name="DashboardRunTimelineTitle" xml:space="preserve">
+    <value>Dashboard run timeline</value>
+  </data>
+  <data name="DashboardRunTimelineSelect" xml:space="preserve">
+    <value>Select and annotate {0}</value>
+  </data>
+  <data name="DashboardRunTimelineNoteLabel" xml:space="preserve">
+    <value>Investigation note</value>
+  </data>
+  <data name="DashboardRunTimelineNotePlaceholder" xml:space="preserve">
+    <value>Add an annotation...</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -27,6 +27,26 @@
         <target state="new">Unpin run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunTimelineNoteLabel">
+        <source>Investigation note</source>
+        <target state="new">Investigation note</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineNotePlaceholder">
+        <source>Add an annotation...</source>
+        <target state="new">Add an annotation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineSelect">
+        <source>Select and annotate {0}</source>
+        <target state="new">Select and annotate {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunTimelineTitle">
+        <source>Dashboard run timeline</source>
+        <target state="new">Dashboard run timeline</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -48,6 +48,13 @@ public interface IDashboardRunStore
     void SetRunPinned(DashboardRunDescriptor run, bool isPinned);
 
     /// <summary>
+    /// Sets the investigation note for the specified dashboard run.
+    /// </summary>
+    /// <param name="run">The dashboard run to update.</param>
+    /// <param name="note">The note to save, or an empty value to clear it.</param>
+    void SetRunNote(DashboardRunDescriptor run, string? note);
+
+    /// <summary>
     /// Attempts to acquire a lease that keeps the specified dashboard run available while it is selected.
     /// </summary>
     /// <param name="run">The dashboard run to lease.</param>
@@ -72,6 +79,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
     internal const string DatabaseFileName = "dashboard.db";
     internal const int MaxApplicationDirectoryNameLength = 80;
     internal const int MaxRuns = 10;
+    internal const int MaxNoteLength = 2000;
     internal const int SchemaVersion = DashboardSqliteDatabase.SchemaVersion;
 
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -243,6 +251,38 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
     {
+        UpdateRunMetadata(run, metadata =>
+        {
+            if (!isPinned && !string.IsNullOrEmpty(metadata.Note))
+            {
+                throw new InvalidOperationException($"Dashboard run '{run.RunId}' cannot be unpinned while it has a note.");
+            }
+
+            return metadata with { IsPinned = isPinned };
+        });
+    }
+
+    public void SetRunNote(DashboardRunDescriptor run, string? note)
+    {
+        var normalizedNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+        if (normalizedNote?.Length > MaxNoteLength)
+        {
+            throw new ArgumentException($"Dashboard run notes cannot exceed {MaxNoteLength} characters.", nameof(note));
+        }
+
+        UpdateRunMetadata(
+            run,
+            metadata => metadata with
+            {
+                Note = normalizedNote,
+                IsPinned = normalizedNote is not null || metadata.IsPinned
+            });
+    }
+
+    private void UpdateRunMetadata(
+        DashboardRunDescriptor run,
+        Func<DashboardRunMetadata, DashboardRunMetadata> update)
+    {
         var storedRun = GetRunById(run.RunId);
         if (storedRun is null)
         {
@@ -258,28 +298,24 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                 ? null
                 : TryOpenRunLock(runDirectory)
                     ?? throw new InvalidOperationException($"Dashboard run '{storedRun.RunId}' is no longer available.");
-            UpdatePinnedState(storedRun, runDirectory, isPinned);
-        }
-    }
+            var metadataPath = Path.Combine(runDirectory, "run.json");
+            var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
+            if (metadata is not { SchemaVersion: SchemaVersion } ||
+                !string.Equals(metadata.RunId, storedRun.RunId, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"Dashboard run metadata for '{storedRun.RunId}' is invalid.");
+            }
 
-    private void UpdatePinnedState(DashboardRunDescriptor run, string runDirectory, bool isPinned)
-    {
-        var metadataPath = Path.Combine(runDirectory, "run.json");
-        var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
-        if (metadata is not { SchemaVersion: SchemaVersion } ||
-            !string.Equals(metadata.RunId, run.RunId, StringComparison.Ordinal))
-        {
-            throw new InvalidDataException($"Dashboard run metadata for '{run.RunId}' is invalid.");
-        }
+            var updatedMetadata = update(metadata);
+            WriteMetadata(updatedMetadata, metadataPath);
+            if (string.Equals(storedRun.RunId, RunId, StringComparison.Ordinal))
+            {
+                _metadata = updatedMetadata;
+            }
 
-        var updatedMetadata = metadata with { IsPinned = isPinned };
-        WriteMetadata(updatedMetadata, metadataPath);
-        if (string.Equals(run.RunId, RunId, StringComparison.Ordinal))
-        {
-            _metadata = updatedMetadata;
+            storedRun.IsPinned = updatedMetadata.IsPinned;
+            storedRun.Note = updatedMetadata.Note;
         }
-
-        run.IsPinned = isPinned;
     }
 
     public void PublishRun()
@@ -531,7 +567,8 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             Path.Combine(runDirectory, metadata.DatabaseFileName),
             isCurrent)
         {
-            IsPinned = metadata.IsPinned
+            IsPinned = metadata.IsPinned,
+            Note = metadata.Note
         };
     }
 
@@ -620,6 +657,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         public string? ApplicationName { get; init; }
         public required string DatabaseFileName { get; init; }
         public bool IsPinned { get; init; }
+        public string? Note { get; init; }
     }
 }
 
@@ -655,6 +693,11 @@ public sealed record DashboardRunDescriptor(
     /// Gets a value indicating whether the dashboard run is pinned.
     /// </summary>
     public bool IsPinned { get; internal set; }
+
+    /// <summary>
+    /// Gets the investigation note associated with the dashboard run.
+    /// </summary>
+    public string? Note { get; internal set; }
 
     internal bool IsLeased { get; set; }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -13,6 +13,7 @@ using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,7 +22,6 @@ using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
 using Microsoft.JSInterop;
 using Xunit;
-using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
@@ -289,7 +289,7 @@ public partial class MainLayoutTests : DashboardTestContext
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void DashboardRunSelect_Supported_IsDisplayedBeforeHeaderButtons(bool isDesktop)
+    public void DashboardRunTimeline_Supported_IsDisplayedBeforeHeaderButtons(bool isDesktop)
     {
         SetupMainLayoutServices();
 
@@ -301,14 +301,14 @@ public partial class MainLayoutTests : DashboardTestContext
         var existingButtonId = isDesktop ? "dashboard-help-button" : "dashboard-navigation-button";
 
         Assert.Single(cut.FindComponents<DashboardRunSelect>());
-        Assert.Contains("class=\"application-run-select\"", cut.Markup, StringComparison.Ordinal);
+        Assert.Contains("class=\"application-run-timeline\"", cut.Markup, StringComparison.Ordinal);
         Assert.True(
-            cut.Markup.IndexOf("class=\"application-run-select\"", StringComparison.Ordinal) <
+            cut.Markup.IndexOf("class=\"application-run-timeline\"", StringComparison.Ordinal) <
             cut.Markup.IndexOf($"id=\"{existingButtonId}\"", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void DashboardRunSelect_PrunedHistoricalRunIsNotDisplayed()
+    public void DashboardRunTimeline_PrunedHistoricalRunIsNotDisplayed()
     {
         var historicalRun = new DashboardRunDescriptor(
             RunId: "historical",
@@ -332,6 +332,7 @@ public partial class MainLayoutTests : DashboardTestContext
                 IsCurrent: true),
             historicalRun
         ]);
+        historicalRun.IsPruned = true;
         SetupMainLayoutServices(dashboardRunStore: runStore);
         var cut = RenderComponent<MainLayout>(builder =>
         {
@@ -339,20 +340,16 @@ public partial class MainLayoutTests : DashboardTestContext
                 component => component.ViewportInformation,
                 new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
         });
-
-        historicalRun.IsPruned = true;
         var runSelect = cut.FindComponent<DashboardRunSelect>();
-        runSelect.Find("fluent-button").Click();
-
-        var menuItem = Assert.Single(runSelect.FindComponent<AspireMenu>().Instance.Items);
-        Assert.Equal("Live run", menuItem.Text);
-        Assert.True(menuItem.Checked);
+        var node = Assert.Single(runSelect.FindAll(".application-run-node"));
+        Assert.Equal("dashboard-run-current", node.Id);
+        Assert.Equal("true", node.GetAttribute("aria-pressed"));
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void DashboardRunSelect_Unsupported_IsHiddenAndStaleSelectionIsIgnored(bool isDesktop)
+    public void DashboardRunTimeline_Unsupported_IsHiddenAndStaleSelectionIsIgnored(bool isDesktop)
     {
         var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
         [
@@ -388,7 +385,7 @@ public partial class MainLayoutTests : DashboardTestContext
     }
 
     [Fact]
-    public async Task DashboardRunSelect_ChangeStoresAndAppliesSelectionWithoutNavigation()
+    public async Task DashboardRunTimeline_SelectAndAnnotate_StoresSelectionAndPinsRun()
     {
         var historicalRun = new DashboardRunDescriptor(
             RunId: "historical",
@@ -421,7 +418,6 @@ public partial class MainLayoutTests : DashboardTestContext
         var expectedHistoricalRunText = FormatHelpers.FormatTimeWithOptionalDate(
             Services.GetRequiredService<BrowserTimeProvider>(),
             historicalRun.StartedAtUtc.UtcDateTime);
-        JSInterop.SetupVoid("focusElement", _ => true).SetVoidResult();
         var initializedCount = 0;
         var disposedCount = 0;
         var cut = RenderComponent<MainLayout>(builder =>
@@ -437,118 +433,51 @@ public partial class MainLayoutTests : DashboardTestContext
         });
 
         var runSelect = cut.FindComponent<DashboardRunSelect>();
-        var menuButton = runSelect.FindComponent<AspireMenuButton>();
-        var statusIcon = runSelect.Find(".application-run-status");
-        Assert.Equal("start", statusIcon.GetAttribute("slot"));
-        Assert.Contains("fill: var(--success)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
-        Assert.Equal("Live run", menuButton.Instance.Text);
-        Assert.True(menuButton.Instance.HideIcon);
-        Assert.Empty(menuButton.FindComponents<AspireMenu>());
-        var menuButtonElement = runSelect.Find("fluent-button");
-        var menuButtonId = menuButtonElement.Id;
-        Assert.Equal("Select run: Live run", menuButtonElement.GetAttribute("aria-label"));
-
+        var nodes = runSelect.FindAll(".application-run-node");
+        Assert.Collection(
+            nodes,
+            node =>
+            {
+                Assert.Equal("dashboard-run-current", node.Id);
+                Assert.Equal("true", node.GetAttribute("aria-pressed"));
+                Assert.Equal("Select and annotate Live run", node.GetAttribute("aria-label"));
+            },
+            node =>
+            {
+                Assert.Equal("dashboard-run-historical", node.Id);
+                Assert.Equal("false", node.GetAttribute("aria-pressed"));
+                Assert.Equal($"Select and annotate {expectedHistoricalRunText}", node.GetAttribute("aria-label"));
+            });
         var navigationOccurred = false;
         Services.GetRequiredService<NavigationManager>().LocationChanged += (_, _) => navigationOccurred = true;
-        runSelect.Find("fluent-button").Click();
-        Assert.Collection(
-            menuButton.FindComponent<AspireMenu>().Instance.Items,
-            item =>
-            {
-                Assert.Equal("Live run", item.Text);
-                Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
-                Assert.True(item.Checked);
-                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
-                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
-                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
-                Assert.False(item.IsSecondaryActionSelected);
-            },
-            item => Assert.True(item.IsDivider),
-            item =>
-            {
-                Assert.Equal(expectedHistoricalRunText, item.Text);
-                Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
-                Assert.False(item.Checked);
-                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
-                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
-                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
-                Assert.False(item.IsSecondaryActionSelected);
-            });
+        nodes[1].Click();
 
-        var menuItems = cut.WaitForElements("fluent-menu-item");
-        Assert.Single(cut.FindAll("fluent-divider"));
-        Assert.Empty(menuItems[0].QuerySelectorAll("span[slot='start']"));
-        Assert.Empty(menuItems[1].QuerySelectorAll("span[slot='start']"));
-        Assert.Single(menuItems[0].QuerySelectorAll("[slot='radio-indicator']"));
-        Assert.Single(menuItems[1].QuerySelectorAll("[slot='radio-indicator']"));
-        Assert.Equal("menuitemradio", menuItems[0].GetAttribute("role"));
-        Assert.True(menuItems[0].HasAttribute("checked"));
-        Assert.Equal("menuitemradio", menuItems[1].GetAttribute("role"));
-        Assert.False(menuItems[1].HasAttribute("checked"));
         var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
-        var currentRun = runStore.GetRuns().Single(run => run.IsCurrent);
-        Assert.Single(menuItems[0].QuerySelectorAll("fluent-button")).Click();
-
-        Assert.True(currentRun.IsPinned);
-        Assert.Null(runSelection.SelectedRunId);
-        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
-        menuButton = runSelect.FindComponent<AspireMenuButton>();
-        Assert.IsType<Icons.Filled.Size16.Pin>(menuButton.Instance.Items[0].SecondaryActionIcon);
-        Assert.True(menuButton.Instance.Items[0].IsSecondaryActionSelected);
-
-        menuItems = cut.WaitForElements("fluent-menu-item");
-        var pinButton = Assert.Single(menuItems[1].QuerySelectorAll("fluent-button"));
-        pinButton.Click();
-
-        Assert.True(historicalRun.IsPinned);
-        Assert.Null(storedRunId);
-        Assert.Null(runSelection.SelectedRunId);
-        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
-        menuButton = runSelect.FindComponent<AspireMenuButton>();
-        var historicalItem = menuButton.Instance.Items[2];
-        Assert.IsType<Icons.Filled.Size16.Pin>(historicalItem.SecondaryActionIcon);
-        Assert.Equal("Unpin run", historicalItem.SecondaryActionAriaLabel);
-        Assert.True(historicalItem.IsSecondaryActionSelected);
-
-        menuItems = cut.WaitForElements("fluent-menu-item");
-        menuItems[1].Click();
-
         Assert.Equal("historical", storedRunId);
         Assert.Equal("historical", runSelection.SelectedRunId);
         Assert.False(navigationOccurred);
         Assert.Equal(2, initializedCount);
         Assert.Equal(1, disposedCount);
-        runSelect = cut.FindComponent<DashboardRunSelect>();
-        menuButton = runSelect.FindComponent<AspireMenuButton>();
-        statusIcon = runSelect.Find(".application-run-status");
-        Assert.Contains("fill: var(--warning)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
-        Assert.Equal(expectedHistoricalRunText, menuButton.Instance.Text);
-        Assert.False(menuButton.FindComponent<AspireMenu>().Instance.Open);
-        Assert.Equal(menuButtonId, runSelect.Find("fluent-button").Id);
-        Assert.Equal($"Select run: {expectedHistoricalRunText}", runSelect.Find("fluent-button").GetAttribute("aria-label"));
-        Assert.Contains(
-            JSInterop.Invocations,
-            invocation => invocation.Identifier == "focusElement" && invocation.Arguments.Single() is string id && id == menuButtonId);
 
-        runSelect.Find("fluent-button").Click();
-        Assert.Collection(
-            menuButton.FindComponent<AspireMenu>().Instance.Items,
-            item =>
-            {
-                Assert.False(item.Checked);
-                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
-            },
-            item => Assert.True(item.IsDivider),
-            item =>
-            {
-                Assert.True(item.Checked);
-                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
-            });
-        menuItems = cut.WaitForElements("fluent-menu-item");
-        Assert.Single(cut.FindAll("fluent-divider"));
-        Assert.Empty(menuItems[0].QuerySelectorAll("span[slot='start']"));
-        Assert.Empty(menuItems[1].QuerySelectorAll("span[slot='start']"));
-        menuItems[0].Click();
+        runSelect = cut.FindComponent<DashboardRunSelect>();
+        Assert.Equal("true", runSelect.Find("#dashboard-run-historical").GetAttribute("aria-pressed"));
+        Assert.Empty(runSelect.FindComponents<FluentPopover>());
+        await runSelect.Find("#dashboard-run-historical").ParentElement!.TriggerEventAsync("onmouseenter", new MouseEventArgs());
+        Assert.Equal(expectedHistoricalRunText, runSelect.Find(".application-run-bubble-time").TextContent);
+        var textArea = runSelect.FindComponent<FluentTextArea>();
+        Assert.Equal("Add an annotation...", textArea.Instance.Placeholder);
+        await runSelect.Find("#dashboard-run-historical").ParentElement!.TriggerEventAsync("onmouseleave", new MouseEventArgs());
+        Assert.True(runSelect.FindComponent<FluentPopover>().Instance.Open);
+        await cut.InvokeAsync(() => textArea.Instance.ValueChanged.InvokeAsync("Investigating a latency spike"));
+
+        Assert.Equal("Investigating a latency spike", historicalRun.Note);
+        Assert.True(historicalRun.IsPinned);
+        Assert.Contains("annotated", runSelect.Find("#dashboard-run-historical").ClassList);
+        Assert.Single(runSelect.Find("#dashboard-run-historical").QuerySelectorAll(".application-run-node-pin"));
+        Assert.Single(runSelect.Find("#dashboard-run-historical").ParentElement!.QuerySelectorAll(".application-run-node-note"));
+        Assert.Equal("Investigating a latency spike", runSelect.FindComponent<FluentTextArea>().Instance.Value);
+
+        runSelect.Find("#dashboard-run-current").Click();
 
         Assert.Equal(string.Empty, storedRunId);
         Assert.Null(runSelection.SelectedRunId);
@@ -556,15 +485,11 @@ public partial class MainLayoutTests : DashboardTestContext
         Assert.Equal(3, initializedCount);
         Assert.Equal(2, disposedCount);
         runSelect = cut.FindComponent<DashboardRunSelect>();
-        menuButton = runSelect.FindComponent<AspireMenuButton>();
-        statusIcon = runSelect.Find(".application-run-status");
-        Assert.Contains("fill: var(--success)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
-        Assert.Equal("Live run", menuButton.Instance.Text);
-        Assert.False(menuButton.FindComponent<AspireMenu>().Instance.Open);
+        Assert.Equal("true", runSelect.Find("#dashboard-run-current").GetAttribute("aria-pressed"));
     }
 
     [Fact]
-    public void DashboardRunSelect_SelectionFailure_KeepsCurrentRunAndCircuitActive()
+    public void DashboardRunTimeline_SelectionFailure_KeepsCurrentRunAndCircuitActive()
     {
         var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
         [
@@ -612,14 +537,12 @@ public partial class MainLayoutTests : DashboardTestContext
             builder.Add(component => component.Body, bodyBuilder => bodyBuilder.AddMarkupContent(0, "<div id=\"body-content\"></div>"));
         });
         var runSelect = cut.FindComponent<DashboardRunSelect>();
-        runSelect.Find("fluent-button").Click();
-
-        cut.WaitForElements("fluent-menu-item")[1].Click();
+        runSelect.Find("#dashboard-run-historical").Click();
 
         Assert.NotNull(cut.Find("#body-content"));
         Assert.True(runSelection.SelectedRun.IsCurrent);
         Assert.Equal(string.Empty, storedRunId);
-        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        Assert.Equal("true", cut.FindComponent<DashboardRunSelect>().Find("#dashboard-run-current").GetAttribute("aria-pressed"));
         var errorLog = Assert.Single(testSink.Writes);
         Assert.Equal(LogLevel.Error, errorLog.LogLevel);
         Assert.Equal("Failed to switch to dashboard run 'historical'. Keeping dashboard run 'current' selected.", errorLog.Message);
@@ -627,7 +550,7 @@ public partial class MainLayoutTests : DashboardTestContext
     }
 
     [Fact]
-    public void DashboardRunSelect_PinningFailure_KeepsMenuAndCircuitActive()
+    public async Task DashboardRunTimeline_NoteFailure_KeepsEditorAndCircuitActive()
     {
         var currentRun = new DashboardRunDescriptor(
             RunId: "current",
@@ -649,7 +572,7 @@ public partial class MainLayoutTests : DashboardTestContext
             IsCurrent: false);
         var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, historicalRun]);
         var exception = new IOException("The run metadata could not be written.");
-        runStore.OnSetRunPinned = (run, _) =>
+        runStore.OnSetRunNote = (run, _) =>
         {
             if (run.RunId == historicalRun.RunId)
             {
@@ -659,29 +582,26 @@ public partial class MainLayoutTests : DashboardTestContext
         SetupMainLayoutServices(dashboardRunStore: runStore);
         var testSink = new TestSink();
         Services.AddSingleton<ILogger<DashboardRunSelect>>(new TestLogger<DashboardRunSelect>(new TestLoggerFactory(testSink, enabled: true)));
-        var provider = RenderComponent<FluentMenuProvider>();
         var cut = RenderComponent<DashboardRunSelect>(builder =>
         {
             builder.Add(component => component.SelectedRunId, currentRun.RunId);
-            builder.Add(component => component.SelectedRunIsCurrent, true);
-            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
         });
-        cut.Find("fluent-button").Click();
-
-        var historicalMenuItem = provider.WaitForElements("fluent-menu-item")[1];
-        Assert.Single(historicalMenuItem.QuerySelectorAll("fluent-button")).Click();
+        await cut.Find("#dashboard-run-historical").ParentElement!.TriggerEventAsync("onmouseenter", new MouseEventArgs());
+        var textArea = cut.FindComponent<FluentTextArea>();
+        await cut.InvokeAsync(() => textArea.Instance.ValueChanged.InvokeAsync("A note that cannot be saved"));
 
         Assert.False(historicalRun.IsPinned);
-        Assert.True(cut.FindComponent<AspireMenu>().Instance.Open);
-        Assert.NotNull(cut.Find("fluent-button"));
+        Assert.Null(historicalRun.Note);
+        Assert.True(cut.FindComponent<FluentPopover>().Instance.Open);
+        Assert.NotNull(cut.Find(".application-run-bubble-pin"));
         var errorLog = Assert.Single(testSink.Writes);
         Assert.Equal(LogLevel.Error, errorLog.LogLevel);
-        Assert.Equal("Failed to update the pinned state of dashboard run 'historical'.", errorLog.Message);
+        Assert.Equal("Failed to save the note for dashboard run 'historical'.", errorLog.Message);
         Assert.Same(exception, errorLog.Exception);
     }
 
     [Fact]
-    public void DashboardRunSelect_SortsHistoricalRunsByPinnedThenDateDescendingAndUpdatesOrderWhenPinned()
+    public void DashboardRunTimeline_SortsCurrentThenHistoricalRunsByDateDescending()
     {
         var currentRun = new DashboardRunDescriptor(
             RunId: "current",
@@ -700,50 +620,23 @@ public partial class MainLayoutTests : DashboardTestContext
             new DashboardRunDescriptor("pinned-a", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 10, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false)
         };
         var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, .. historicalRuns]);
-        runStore.SetRunPinned(historicalRuns[1], isPinned: true);
-        runStore.SetRunPinned(historicalRuns[3], isPinned: true);
+        historicalRuns[1].IsPinned = true;
+        historicalRuns[3].IsPinned = true;
         SetupMainLayoutServices(dashboardRunStore: runStore);
-        var browserTimeProvider = Services.GetRequiredService<BrowserTimeProvider>();
-        var expectedHistoricalTexts = historicalRuns
-            .OrderByDescending(run => run.IsPinned)
-            .ThenByDescending(run => run.StartedAtUtc)
-            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
+        var expectedRunIds = new[] { currentRun }
+            .Concat(historicalRuns.OrderByDescending(run => run.StartedAtUtc))
+            .Select(run => $"dashboard-run-{run.RunId}")
             .ToArray();
-        var provider = RenderComponent<FluentMenuProvider>();
         var cut = RenderComponent<DashboardRunSelect>(builder =>
         {
             builder.Add(component => component.SelectedRunId, currentRun.RunId);
-            builder.Add(component => component.SelectedRunIsCurrent, true);
-            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
         });
 
-        cut.Find("fluent-button").Click();
-
-        var items = cut.FindComponent<AspireMenuButton>().Instance.Items;
-        Assert.Equal("Live run", items[0].Text);
-        Assert.IsType<Icons.Regular.Size16.Pin>(items[0].SecondaryActionIcon);
-        Assert.False(items[0].IsSecondaryActionSelected);
-        Assert.True(items[1].IsDivider);
-        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
-        Assert.All(items.Skip(2).Take(2), item => Assert.True(item.IsSecondaryActionSelected));
-        Assert.All(items.Skip(4), item => Assert.False(item.IsSecondaryActionSelected));
-
-        var menuItems = provider.WaitForElements("fluent-menu-item");
-        Assert.Single(menuItems[3].QuerySelectorAll("fluent-button")).Click();
-
-        expectedHistoricalTexts = historicalRuns
-            .OrderByDescending(run => run.IsPinned)
-            .ThenByDescending(run => run.StartedAtUtc)
-            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
-            .ToArray();
-        items = cut.FindComponent<AspireMenuButton>().Instance.Items;
-        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
-        Assert.All(items.Skip(2).Take(3), item => Assert.True(item.IsSecondaryActionSelected));
-        Assert.False(items[5].IsSecondaryActionSelected);
+        Assert.Equal(expectedRunIds, cut.FindAll(".application-run-node").Select(node => node.Id));
     }
 
     [Fact]
-    public async Task RunSelectionPending_RendersCurrentRunWithoutLoadingRuns()
+    public async Task RunSelectionPending_RendersCurrentRunTimeline()
     {
         var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
         [
@@ -764,8 +657,6 @@ public partial class MainLayoutTests : DashboardTestContext
         };
         SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
         var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
-        var getRunsCallCount = runStore.GetRunsCallCount;
-
         var cut = RenderComponent<MainLayout>(builder =>
         {
             builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
@@ -775,15 +666,9 @@ public partial class MainLayoutTests : DashboardTestContext
         Assert.NotNull(cut.Find("#body-content"));
         Assert.True(runSelection.SelectedRun.IsCurrent);
         var runSelect = cut.FindComponent<DashboardRunSelect>();
-        var menuButton = runSelect.FindComponent<AspireMenuButton>();
-        Assert.Equal("Live run", menuButton.Instance.Text);
-        Assert.Empty(menuButton.FindComponents<AspireMenu>());
-        Assert.Equal(getRunsCallCount, runStore.GetRunsCallCount);
-
-        runSelect.Find("fluent-button").Click();
-
-        Assert.Single(cut.WaitForElements("fluent-menu-item"));
-        Assert.Equal(getRunsCallCount + 1, runStore.GetRunsCallCount);
+        var node = Assert.Single(runSelect.FindAll(".application-run-node"));
+        Assert.Equal("Select and annotate Live run", node.GetAttribute("aria-label"));
+        Assert.Equal("true", node.GetAttribute("aria-pressed"));
 
         await cut.InvokeAsync(() => runSelectionSource.SetResult((false, null)));
     }
@@ -826,7 +711,7 @@ public partial class MainLayoutTests : DashboardTestContext
             builder.Add(p => p.Body, bodyBuilder => bodyBuilder.AddMarkupContent(0, "<div id=\"body-content\"></div>"));
         });
 
-        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        Assert.Equal("true", cut.FindComponent<DashboardRunSelect>().Find("#dashboard-run-current").GetAttribute("aria-pressed"));
 
         await cut.InvokeAsync(() => runSelectionSource.SetResult((true, "historical")));
 
@@ -835,8 +720,9 @@ public partial class MainLayoutTests : DashboardTestContext
             historicalRun.StartedAtUtc.UtcDateTime);
         cut.WaitForAssertion(() =>
         {
-            var menuButton = cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>();
-            Assert.Equal(expectedHistoricalRunText, menuButton.Instance.Text);
+            var historicalNode = cut.FindComponent<DashboardRunSelect>().Find("#dashboard-run-historical");
+            Assert.Equal("historical", Services.GetRequiredService<IDashboardRunSelection>().SelectedRun.RunId);
+            Assert.Equal($"Select and annotate {expectedHistoricalRunText}", historicalNode.GetAttribute("aria-label"));
         });
     }
 
@@ -894,7 +780,7 @@ public partial class MainLayoutTests : DashboardTestContext
         Assert.True(runSelection.SelectedRun.IsCurrent);
         Assert.Null(runSelection.SelectedRunId);
         Assert.Equal(string.Empty, storedRunId);
-        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        Assert.Equal("true", cut.FindComponent<DashboardRunSelect>().Find("#dashboard-run-current").GetAttribute("aria-pressed"));
         var errorLog = Assert.Single(testSink.Writes);
         Assert.Equal(LogLevel.Error, errorLog.LogLevel);
         Assert.Equal("Failed to restore dashboard run 'historical'. Falling back to the current run.", errorLog.Message);
@@ -941,15 +827,14 @@ public partial class MainLayoutTests : DashboardTestContext
             builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
         });
         var runSelect = cut.FindComponent<DashboardRunSelect>();
-        runSelect.Find("fluent-button").Click();
-        cut.WaitForElements("fluent-menu-item")[0].Click();
+        runSelect.Find("#dashboard-run-current").Click();
 
         Assert.Equal(string.Empty, storedRunId);
         await cut.InvokeAsync(() => runSelectionSource.SetResult((true, "historical")));
 
         var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
         Assert.True(runSelection.SelectedRun.IsCurrent);
-        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        Assert.Equal("true", cut.FindComponent<DashboardRunSelect>().Find("#dashboard-run-current").GetAttribute("aria-pressed"));
     }
 
     [Theory]
@@ -1099,6 +984,7 @@ public partial class MainLayoutTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
         FluentUISetupHelpers.SetupFluentInputLabel(this);
+        FluentUISetupHelpers.SetupFluentTextField(this);
         FluentUISetupHelpers.SetupFluentList(this);
         FluentUISetupHelpers.SetupFluentCombobox(this);
         FluentUISetupHelpers.SetupAspireMenuButtonModule(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -59,6 +59,7 @@ internal static class FluentUISetupHelpers
         var module = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js"));
         module.SetupVoid("goToNextFocusableElement", _ => true);
         module.SetupVoid("initializeKeyboardNavigation", _ => true);
+        module.SetupVoid("disposeKeyboardNavigation", _ => true);
         module.SetupVoid("removeKeyboardNavigation", _ => true);
     }
 
@@ -268,6 +269,7 @@ internal static class FluentUISetupHelpers
         public int GetRunsCallCount { get; private set; }
 
         public Action<DashboardRunDescriptor, bool>? OnSetRunPinned { get; set; }
+        public Action<DashboardRunDescriptor, string?>? OnSetRunNote { get; set; }
 
         public IReadOnlyList<DashboardRunDescriptor> GetRuns()
         {
@@ -284,6 +286,14 @@ internal static class FluentUISetupHelpers
         {
             OnSetRunPinned?.Invoke(run, isPinned);
             _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
+        }
+
+        public void SetRunNote(DashboardRunDescriptor run, string? note)
+        {
+            OnSetRunNote?.Invoke(run, note);
+            var storedRun = _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal));
+            storedRun.Note = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+            storedRun.IsPinned |= storedRun.Note is not null;
         }
 
         public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => null;

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -159,6 +159,58 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task CurrentRun_NotePersistsAndPinsRunWhenRunBecomesHistorical()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero);
+        string annotatedRunId;
+
+        using (var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt)))
+        {
+            await InitializeAndPublishRunAsync(currentRunStore);
+            var currentRun = Assert.Single(currentRunStore.GetRuns());
+
+            currentRunStore.SetRunNote(currentRun, "Investigate the startup latency spike.");
+
+            Assert.Equal("Investigate the startup latency spike.", currentRun.Note);
+            Assert.True(currentRun.IsPinned);
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(currentRunStore.RunDirectory, "run.json")));
+            Assert.Equal("Investigate the startup latency spike.", metadata.RootElement.GetProperty("Note").GetString());
+            Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+            annotatedRunId = currentRun.RunId;
+        }
+
+        using var nextRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(1)));
+        var historicalRun = nextRunStore.GetRuns().Single(run => string.Equals(run.RunId, annotatedRunId, StringComparison.Ordinal));
+        Assert.Equal("Investigate the startup latency spike.", historicalRun.Note);
+        Assert.True(historicalRun.IsPinned);
+    }
+
+    [Fact]
+    public async Task AnnotatedRun_CannotBeUnpinnedUntilNoteIsCleared()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        using var runStore = CreateRunStore(options);
+        await InitializeAndPublishRunAsync(runStore);
+        var run = Assert.Single(runStore.GetRuns());
+        runStore.SetRunNote(run, "Keep this run.");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => runStore.SetRunPinned(run, isPinned: false));
+
+        Assert.Equal($"Dashboard run '{run.RunId}' cannot be unpinned while it has a note.", exception.Message);
+        Assert.True(run.IsPinned);
+        Assert.Equal("Keep this run.", run.Note);
+
+        runStore.SetRunNote(run, note: null);
+        runStore.SetRunPinned(run, isPinned: false);
+
+        Assert.Null(run.Note);
+        Assert.False(run.IsPinned);
+    }
+
+    [Fact]
     public async Task RunMetadata_SchemaInitializationFailure_DoesNotPublishRun()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);

--- a/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
+++ b/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
@@ -61,6 +61,13 @@ internal sealed class TestDashboardRunStore(
         _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
     }
 
+    public void SetRunNote(DashboardRunDescriptor run, string? note)
+    {
+        var storedRun = _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal));
+        storedRun.Note = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+        storedRun.IsPinned |= storedRun.Note is not null;
+    }
+
     public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => tryAcquireRunLease?.Invoke(run);
 
     public void PublishRun()


### PR DESCRIPTION
## Description

The dashboard's run selector made historical investigations difficult to scan and provided no way to capture context about an interesting run. This change replaces it with a right-aligned timeline that keeps the current run at the left and older runs to the right.

Hovering over a node reveals an anchored Fluent popover with the run timestamp and an editable annotation field. Annotations autosave to run metadata and pin the run so retention does not delete investigation evidence. Users can still pin unannotated runs manually. The current run has an animated activity indicator, selected and unselected nodes have distinct styling, and annotated runs have a subtle marker.

Run metadata updates remain protected by the existing run locks and atomic file replacement. Annotated runs cannot be unpinned until their annotation is cleared.

### User-facing usage

Hover over a timeline node for one second to inspect its timestamp. Enter text in **Add an annotation...** to save investigation context automatically. Click a node to switch the dashboard to that run; click elsewhere to dismiss the popover.

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

TODO: Capture the dashboard header timeline, delayed hover popover, live-run animation, and annotation autosave flow.

<!-- Add screenshots/recordings here -->

Validation:

- `Aspire.Dashboard.Components.Tests.Layout.MainLayoutTests` (30 tests)
- `Aspire.Dashboard.Tests.Model.DashboardDataSourceTests` (44 tests)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
