### PR TITLE
Add a csi volume source to VolumeV1 (Aspire.Hosting.Kubernetes)

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Resources/CsiVolumeSourceV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/CsiVolumeSourceV1.cs
@@ -30,8 +30,9 @@ public sealed class CsiVolumeSourceV1
     /// Gets or sets a value indicating whether the volume should be mounted read-only.
     /// </summary>
     /// <remarks>
-    /// If set to true, Kubernetes requests a read-only mount from the CSI driver.
-    /// If omitted, the driver's default mount behavior is used.
+    /// If set to <see langword="true"/>, Kubernetes requests a read-only mount from the
+    /// CSI driver. When omitted, Kubernetes treats the value as <see langword="false"/>,
+    /// so the volume is mounted read/write.
     /// </remarks>
     [YamlMember(Alias = "readOnly")]
     public bool? ReadOnly { get; set; }

--- a/src/Aspire.Hosting.Kubernetes/Resources/CsiVolumeSourceV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/CsiVolumeSourceV1.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Kubernetes.Resources;
+
+/// <summary>
+/// Represents a CSI (Container Storage Interface) volume source in Kubernetes.
+/// </summary>
+/// <remarks>
+/// CSI volumes are inline ephemeral volumes that are served by a CSI driver.
+/// They can be used by drivers to project external storage, secrets, or certificates
+/// into a pod at mount time.
+/// </remarks>
+[YamlSerializable]
+public sealed class CsiVolumeSourceV1
+{
+    /// <summary>
+    /// Gets or sets the name of the CSI driver that handles the volume.
+    /// </summary>
+    /// <remarks>
+    /// The driver name identifies the CSI driver registered in the cluster that
+    /// should publish this volume for the pod.
+    /// </remarks>
+    [YamlMember(Alias = "driver")]
+    public string Driver { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the volume should be mounted read-only.
+    /// </summary>
+    /// <remarks>
+    /// If set to true, Kubernetes requests a read-only mount from the CSI driver.
+    /// If omitted, the driver's default mount behavior is used.
+    /// </remarks>
+    [YamlMember(Alias = "readOnly")]
+    public bool? ReadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the filesystem type to mount.
+    /// </summary>
+    /// <remarks>
+    /// This value is passed to the CSI driver for volume publishing. It is used by
+    /// filesystem-backed CSI drivers and may be ignored by drivers that do not mount
+    /// a filesystem.
+    /// </remarks>
+    [YamlMember(Alias = "fsType")]
+    public string? FsType { get; set; }
+
+    /// <summary>
+    /// Gets the driver-specific volume attributes.
+    /// </summary>
+    /// <remarks>
+    /// Each key-value pair is passed to the CSI driver. For example, the Secrets Store
+    /// CSI driver uses this collection to identify the SecretProviderClass for the pod.
+    /// </remarks>
+    [YamlMember(Alias = "volumeAttributes")]
+    public Dictionary<string, string> VolumeAttributes { get; } = [];
+
+    /// <summary>
+    /// Gets or sets a reference to the secret that contains node publish credentials.
+    /// </summary>
+    /// <remarks>
+    /// Some CSI drivers use this reference to authenticate node publish operations.
+    /// The referenced object is a Kubernetes Secret in the same namespace as the pod.
+    /// </remarks>
+    [YamlMember(Alias = "nodePublishSecretRef")]
+    public LocalObjectReferenceV1? NodePublishSecretRef { get; set; }
+}

--- a/src/Aspire.Hosting.Kubernetes/Resources/VolumeV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/VolumeV1.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Kubernetes.Resources;
 /// <summary>
 /// Represents a volume configuration definition within a Kubernetes pod.
 /// This class allows specifying different types of volume sources such as Image, HostPath,
-/// Persistent Volume Claim, ConfigMap, Secret, Projected, and others, enabling configuration of data storage in a pod.
+/// Persistent Volume Claim, ConfigMap, Secret, Projected, CSI, and others, enabling configuration of data storage in a pod.
 /// </summary>
 [YamlSerializable]
 public sealed class VolumeV1
@@ -83,6 +83,16 @@ public sealed class VolumeV1
     /// </summary>
     [YamlMember(Alias = "secret")]
     public SecretVolumeSourceV1? Secret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CSI volume source for the volume.
+    /// </summary>
+    /// <remarks>
+    /// CSI volume sources are served by Container Storage Interface drivers and can be
+    /// used to project external storage, secrets, or certificates into a pod.
+    /// </remarks>
+    [YamlMember(Alias = "csi")]
+    public CsiVolumeSourceV1? Csi { get; set; }
 
     /// <summary>
     /// Gets or sets the configuration for a projected volume source.

--- a/src/Aspire.Hosting.Kubernetes/api/Aspire.Hosting.Kubernetes.cs
+++ b/src/Aspire.Hosting.Kubernetes/api/Aspire.Hosting.Kubernetes.cs
@@ -702,6 +702,25 @@ namespace Aspire.Hosting.Kubernetes.Resources
     }
 
     [YamlDotNet.Serialization.YamlSerializable]
+    public sealed partial class CsiVolumeSourceV1
+    {
+        [YamlDotNet.Serialization.YamlMember(Alias = "driver")]
+        public string Driver { get { throw null; } set { } }
+
+        [YamlDotNet.Serialization.YamlMember(Alias = "fsType")]
+        public string? FsType { get { throw null; } set { } }
+
+        [YamlDotNet.Serialization.YamlMember(Alias = "nodePublishSecretRef")]
+        public LocalObjectReferenceV1? NodePublishSecretRef { get { throw null; } set { } }
+
+        [YamlDotNet.Serialization.YamlMember(Alias = "readOnly")]
+        public bool? ReadOnly { get { throw null; } set { } }
+
+        [YamlDotNet.Serialization.YamlMember(Alias = "volumeAttributes")]
+        public System.Collections.Generic.Dictionary<string, string> VolumeAttributes { get { throw null; } }
+    }
+
+    [YamlDotNet.Serialization.YamlSerializable]
     public sealed partial class Deployment : Workload
     {
         public Deployment() : base(default!, default!) { }
@@ -2926,6 +2945,9 @@ namespace Aspire.Hosting.Kubernetes.Resources
     {
         [YamlDotNet.Serialization.YamlMember(Alias = "configMap")]
         public ConfigMapVolumeSourceV1? ConfigMap { get { throw null; } set { } }
+
+        [YamlDotNet.Serialization.YamlMember(Alias = "csi")]
+        public CsiVolumeSourceV1? Csi { get { throw null; } set { } }
 
         [YamlDotNet.Serialization.YamlMember(Alias = "emptyDir")]
         public EmptyDirVolumeSourceV1? EmptyDir { get { throw null; } set { } }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -457,6 +457,90 @@ public class KubernetesPublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PublishAsync_SupportsCsiVolumes()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
+            .PublishAsKubernetesService(serviceResource =>
+            {
+                var podTemplate = serviceResource.Workload!.PodTemplate;
+                podTemplate.Spec.Volumes.Add(new()
+                {
+                    Name = "secrets-store",
+                    Csi = new()
+                    {
+                        Driver = "secrets-store.csi.k8s.io",
+                        ReadOnly = true,
+                        FsType = "ext4",
+                        VolumeAttributes =
+                        {
+                            ["secretProviderClass"] = "my-spc"
+                        },
+                        NodePublishSecretRef = new()
+                        {
+                            Name = "secrets-store-creds"
+                        }
+                    }
+                });
+
+                podTemplate.Spec.Containers[0].VolumeMounts.Add(new()
+                {
+                    Name = "secrets-store",
+                    MountPath = "/mnt/secrets-store",
+                    ReadOnly = true
+                });
+            });
+
+        var app = builder.Build();
+
+        app.Run();
+
+        var deploymentPath = Path.Combine(workspace.Path, "templates/myapp/deployment.yaml");
+        var deployment = await File.ReadAllTextAsync(deploymentPath);
+
+        await Verify(deployment, "yaml");
+    }
+
+    [Fact]
+    public async Task PublishAsync_OmitsCsiVolumeSourceWhenUnset()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
+            .PublishAsKubernetesService(serviceResource =>
+            {
+                var podTemplate = serviceResource.Workload!.PodTemplate;
+                podTemplate.Spec.Volumes.Add(new()
+                {
+                    Name = "scratch",
+                    EmptyDir = new()
+                });
+
+                podTemplate.Spec.Containers[0].VolumeMounts.Add(new()
+                {
+                    Name = "scratch",
+                    MountPath = "/mnt/scratch"
+                });
+            });
+
+        var app = builder.Build();
+
+        app.Run();
+
+        var deploymentPath = Path.Combine(workspace.Path, "templates/myapp/deployment.yaml");
+        var deployment = await File.ReadAllTextAsync(deploymentPath);
+
+        await Verify(deployment, "yaml");
+    }
+
+    [Fact]
     public async Task PublishAsync_SupportsProjectedConfigMapDownwardApiAndServiceAccountTokenVolumes()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_OmitsCsiVolumeSourceWhenUnset.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_OmitsCsiVolumeSourceWhenUnset.verified.yaml
@@ -1,0 +1,39 @@
+﻿---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "myapp-deployment"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "myapp"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/component: "myapp"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "mcr.microsoft.com/dotnet/aspnet:8.0"
+          name: "myapp"
+          volumeMounts:
+            - name: "scratch"
+              mountPath: "/mnt/scratch"
+          imagePullPolicy: "IfNotPresent"
+      volumes:
+        - name: "scratch"
+          emptyDir: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
+      app.kubernetes.io/component: "myapp"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_SupportsCsiVolumes.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_SupportsCsiVolumes.verified.yaml
@@ -1,0 +1,47 @@
+﻿---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "myapp-deployment"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "myapp"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/component: "myapp"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "mcr.microsoft.com/dotnet/aspnet:8.0"
+          name: "myapp"
+          volumeMounts:
+            - name: "secrets-store"
+              mountPath: "/mnt/secrets-store"
+              readOnly: true
+          imagePullPolicy: "IfNotPresent"
+      volumes:
+        - name: "secrets-store"
+          csi:
+            driver: "secrets-store.csi.k8s.io"
+            readOnly: true
+            fsType: "ext4"
+            volumeAttributes:
+              secretProviderClass: "my-spc"
+            nodePublishSecretRef:
+              name: "secrets-store-creds"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
+      app.kubernetes.io/component: "myapp"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"


### PR DESCRIPTION
## Description

`VolumeV1` modeled every `v1.Volume` source except `csi`. The Kubernetes `csi` source is how inline ephemeral CSI volumes are expressed, including how the Secrets Store CSI driver projects secrets and certificates into a pod. Because `VolumeV1` and `PodSpecV1` are sealed and the chart serializer is inaccessible, this shape could not be expressed from outside the package.

This adds a `CsiVolumeSourceV1` type (`driver`, `readOnly`, `fsType`, `volumeAttributes`, `nodePublishSecretRef`) and a `csi` property on `VolumeV1`, mirroring the Kubernetes API object. The public API baseline is updated and publisher tests cover the rendered `csi` block and its omission when unset.

Fixes #19816

> **API review status:** This adds public API that implements the proposal in #19816. That proposal is currently **open and has not yet been API-reviewed or approved** (no `api-approved` label, no API-review sign-off). This PR should not merge until the API review is held and the proposal is approved. The checklist below reflects that honestly.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No