### PR TITLE
Add review-waiting alerts to the Aspire Team App canvas

### DIFF
--- a/.github/extensions/aspire-team-app/README.md
+++ b/.github/extensions/aspire-team-app/README.md
@@ -159,10 +159,11 @@ never sits unreviewed past budget.
 
 - **Who it applies to** — a PR qualifies for the SLA clock when **all** of these hold:
   it lives on an SLA repo (`devdiv-microsoft/aspire-1p`), it already qualifies for the
-  focused **Needs attention** queue, its author is **not** on the core team (enterprise
-  `_microsoft` aliases count as core team), and it has had **zero human reviews** so far
-  (Copilot/bot reviews don't stop the clock). The first human review — comment or
-  approval — stops the clock immediately.
+  focused **Needs attention** queue, its author is **not** on the core team (core-team
+  membership on the mirror is an explicit allowlist of enterprise `_microsoft` accounts —
+  see `coreTeamEmuLogins` in `constants.mjs`; any other `_microsoft` author is a review
+  target), and it has had **zero human reviews** so far (Copilot/bot reviews don't stop
+  the clock). The first human review — comment or approval — stops the clock immediately.
 - **Business-time budget** — the budget is **8 business hours**, measured Mon–Fri
   09:00–17:00 **Pacific**. Overnight, weekend, and holiday-adjacent hours don't burn
   budget, and the window tracks Pacific daylight/standard transitions automatically. A

--- a/.github/extensions/aspire-team-app/README.md
+++ b/.github/extensions/aspire-team-app/README.md
@@ -60,8 +60,13 @@ card shows are driven by its lane and its signal pills:
   explanations for watched GitHub repositories and Azure DevOps delivery pipelines.
   Related provider sources are grouped by repository and each group can be dragged
   into a preferred order that persists across reloads.
+- **Review SLA (aspire-1p)** — a pinned panel and per-card countdown that track the
+  1-business-day review SLA on the first-party `devdiv-microsoft/aspire-1p` repo, so
+  ready, externally-authored PRs don't sit unreviewed past budget. See
+  [Review SLA](#review-sla-aspire-1p).
 - **Signal pills** — Draft, CI failing, Merge conflicts, Changes requested,
-  N unresolved, Approved, Ready to merge, Needs review, Quick win, Stalled.
+  N unresolved, Approved, Ready to merge, Needs review, Quick win, Stalled,
+  Review SLA, Out of SLA.
 - **Notifications** — review requested, your PR ready to merge, changes requested,
   CI failing, with per-category preferences. Live updates over SSE.
 - **Stable background refresh** — GitHub data is assembled into a complete snapshot
@@ -146,7 +151,41 @@ arrow keys. Every source in the group moves together. The app saves the flattene
 order in durable preferences and broadcasts changes to other open canvas instances
 without refetching provider data.
 
-## How it works
+## Review SLA (aspire-1p)
+
+The private first-party mirror `devdiv-microsoft/aspire-1p` carries a **1-business-day
+review SLA**. Review mode tracks it so a genuinely-ready PR from outside the core team
+never sits unreviewed past budget.
+
+- **Who it applies to** — a PR qualifies for the SLA clock when **all** of these hold:
+  it lives on an SLA repo (`devdiv-microsoft/aspire-1p`), it already qualifies for the
+  focused **Needs attention** queue, its author is **not** on the core team (enterprise
+  `_microsoft` aliases count as core team), and it has had **zero human reviews** so far
+  (Copilot/bot reviews don't stop the clock). The first human review — comment or
+  approval — stops the clock immediately.
+- **Business-time budget** — the budget is **8 business hours**, measured Mon–Fri
+  09:00–17:00 **Pacific**. Overnight, weekend, and holiday-adjacent hours don't burn
+  budget, and the window tracks Pacific daylight/standard transitions automatically. A
+  PR is flagged **approaching** at 6 business hours elapsed and **breached** at 8.
+- **Pinned SLA panel** — the top of the review board shows an at-a-glance panel: how
+  many tracked PRs are OK, approaching, or already out of SLA, with the breached and
+  approaching PRs listed by soonest deadline first.
+- **Per-card countdown** — every tracked card shows a live note (e.g. *"Review SLA: due
+  in 2h 40m"* or *"Out of SLA by 1h 10m"*) that ticks against your browser clock, plus a
+  **Review SLA** (approaching) or **Out of SLA** (breached) pill.
+- **Stable anchors, live text** — only the fixed anchors (first-qualified, warn, and
+  deadline instants) and a stepwise state are stored on the dashboard; the "due in"/
+  "overdue" text is computed client-side so the countdown ticks without churning the
+  cached snapshot. The tracking store lives at
+  `artifacts/sla-tracking.json` under the extension's Copilot home directory and records
+  only when each PR first qualified, so restarts and refreshes never reset a clock.
+- **Hourly Teams alerts** — a local scheduled workflow runs `sla-cli.mjs` every hour and
+  posts consolidated Teams messages when a new external PR appears and when a tracked PR
+  transitions into *approaching* or *breached*, so the team is nudged even with the
+  canvas closed. It de-dupes against a small tracker so it stays silent when nothing
+  changed.
+
+
 
 | File | Responsibility |
 | --- | --- |
@@ -157,6 +196,8 @@ without refetching provider data.
 | `health.mjs` | GitHub default-branch health and provider-neutral health aggregation. |
 | `azure-devops.mjs` | Pipeline URL validation, read-only Azure CLI queries, build timelines, Azure health inference. |
 | `model.mjs` | Attention buckets, focus queue, core-team / community classification. |
+| `sla.mjs` | Review-SLA engine: business-hours math, candidate rule, tracking store, dashboard annotation. |
+| `sla-cli.mjs` | Headless JSON emitter (`node sla-cli.mjs`) consumed by the hourly Teams-alert workflow. |
 | `constants.mjs` | Configuration: core-team members, release milestone, personal picks. |
 | `render.mjs` | Iframe HTML / CSS / client JS, styled with Copilot theme tokens. |
 | `agent.mjs` | Card-action prompt/log builders (Test, Review, Resolve conflicts, Address review, Evaluate CI failures, Discuss review, Address feedback) with untrusted-PR hardening. |
@@ -183,6 +224,8 @@ No credential is written to the extension preferences.
 - `accounts` — list every detected credential, its active state, and repo access.
 - `summary` — return PR/issue counts or Health status counts and reasons without
   opening the canvas.
+- `sla_report` — return the current aspire-1p review-SLA status (counts plus the
+  breached and approaching PRs, soonest deadline first) without opening the canvas.
 
 ## Install
 

--- a/.github/extensions/aspire-team-app/README.md
+++ b/.github/extensions/aspire-team-app/README.md
@@ -180,11 +180,11 @@ never sits unreviewed past budget.
   cached snapshot. The tracking store lives at
   `artifacts/sla-tracking.json` under the extension's Copilot home directory and records
   only when each PR first qualified, so restarts and refreshes never reset a clock.
-- **Hourly Teams alerts** — a local scheduled workflow runs `sla-cli.mjs` every hour and
-  posts consolidated Teams messages when a new external PR appears and when a tracked PR
-  transitions into *approaching* or *breached*, so the team is nudged even with the
-  canvas closed. It de-dupes against a small tracker so it stays silent when nothing
-  changed.
+- **Headless report for external automation** — `sla-cli.mjs` computes the same review-SLA
+  snapshot outside the canvas and prints it as a single JSON document (tracked PRs with their
+  stable anchors and state, plus every open external PR). An external scheduled automation can
+  consume that output to nudge reviewers even with the canvas closed; the report is a plain
+  read-only projection and takes no action itself.
 
 
 
@@ -198,7 +198,7 @@ never sits unreviewed past budget.
 | `azure-devops.mjs` | Pipeline URL validation, read-only Azure CLI queries, build timelines, Azure health inference. |
 | `model.mjs` | Attention buckets, focus queue, core-team / community classification. |
 | `sla.mjs` | Review-SLA engine: business-hours math, candidate rule, tracking store, dashboard annotation. |
-| `sla-cli.mjs` | Headless JSON emitter (`node sla-cli.mjs`) consumed by the hourly Teams-alert workflow. |
+| `sla-cli.mjs` | Headless JSON emitter (`node sla-cli.mjs`) that prints a read-only review-SLA snapshot for an external scheduled automation to consume. |
 | `constants.mjs` | Configuration: core-team members, release milestone, personal picks. |
 | `render.mjs` | Iframe HTML / CSS / client JS, styled with Copilot theme tokens. |
 | `agent.mjs` | Card-action prompt/log builders (Test, Review, Resolve conflicts, Address review, Evaluate CI failures, Discuss review, Address feedback) with untrusted-PR hardening. |

--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -22,10 +22,39 @@ export const coreTeamMembers = [
 ];
 
 // Author login suffixes that mark a core-team member's alt/enterprise alias (e.g.
-// "dapine_microsoft"). Any author ending in one of these is treated as core team,
-// and if the base login (with the suffix stripped) matches a coreTeamMembers entry
-// it is attributed to that member. Ported from pr-dashboard Dashboard config (#95).
+// "dapine_microsoft"). When the base login (with the suffix stripped) matches a
+// coreTeamMembers entry the PR is attributed to that member. Ported from pr-dashboard
+// Dashboard config (#95). NOTE: carrying a suffix is NOT by itself proof of core-team
+// membership — see coreTeamEmuLogins below. This list is also consumed by accounts.mjs
+// (isEmuLogin) to detect Enterprise Managed User accounts for per-account repo defaults.
 export const coreTeamMemberAliasSuffixes = ["_microsoft"];
+
+// Explicit allowlist of Enterprise Managed User (EMU) logins that ARE the Aspire core
+// team on the private first-party mirror (devdiv-microsoft/aspire-1p). Membership here
+// is authoritative for EMU-form authors: on the mirror every author is an EMU account,
+// and an EMU login is treated as core team ONLY if it appears in this list. Any other
+// "*_microsoft" author is a review target (a candidate for the review SLA queue).
+//
+// This is deliberately explicit rather than "anything ending in _microsoft", because the
+// EMU base often differs from the person's public GitHub login (e.g. David Pine is
+// @IEvangelist publicly but "dapine_microsoft" on the mirror), so a suffix-strip against
+// the public coreTeamMembers roster can't recognize them. Keep in sync with the team's
+// EMU roster. Logins are compared case-insensitively.
+export const coreTeamEmuLogins = [
+  "eerhardt_microsoft",     // Eric Erhardt
+  "ankj_microsoft",         // Ankit Jain
+  "dapine_microsoft",       // David Pine
+  "midenn_microsoft",       // Mitch Denny
+  "adamratzman_microsoft",  // Adam Ratzman
+  "danegsta_microsoft",     // David Negstad
+  "jamesnk_microsoft",      // James Newton-King
+  "karolz_microsoft",       // Karol Zadora-Przylecki
+  "sebros_microsoft",       // Sebastien Ros
+  "ellahathaway_microsoft", // Ella Hathaway
+  "joperezr_microsoft",     // Jose Perez Rodriguez
+  "dedward_microsoft",      // Damian Edwards
+  "maleger_microsoft",      // Maddy Montaquila
+];
 
 // Repos where specific check failures are non-blocking (informational only), so an
 // aggregate "failure" rollup driven solely by these checks should not read as red CI.

--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -29,31 +29,24 @@ export const coreTeamMembers = [
 // (isEmuLogin) to detect Enterprise Managed User accounts for per-account repo defaults.
 export const coreTeamMemberAliasSuffixes = ["_microsoft"];
 
-// Explicit allowlist of Enterprise Managed User (EMU) logins that ARE the Aspire core
-// team on the private first-party mirror (devdiv-microsoft/aspire-1p). Membership here
-// is authoritative for EMU-form authors: on the mirror every author is an EMU account,
-// and an EMU login is treated as core team ONLY if it appears in this list. Any other
-// "*_microsoft" author is a review target (a candidate for the review SLA queue).
-//
-// This is deliberately explicit rather than "anything ending in _microsoft", because the
-// EMU base often differs from the person's public GitHub login (e.g. David Pine is
-// @IEvangelist publicly but "dapine_microsoft" on the mirror), so a suffix-strip against
-// the public coreTeamMembers roster can't recognize them. Keep in sync with the team's
-// EMU roster. Logins are compared case-insensitively.
+// Allowlist of first-party logins that count as Aspire core team. An author in this
+// list is treated as core team; anyone else is a review-SLA candidate. This is an
+// explicit roster (not a suffix rule) because these logins don't always match a
+// person's public login. Compared case-insensitively; keep in sync with the roster.
 export const coreTeamEmuLogins = [
-  "eerhardt_microsoft",     // Eric Erhardt
-  "ankj_microsoft",         // Ankit Jain
-  "dapine_microsoft",       // David Pine
-  "midenn_microsoft",       // Mitch Denny
-  "adamratzman_microsoft",  // Adam Ratzman
-  "danegsta_microsoft",     // David Negstad
-  "jamesnk_microsoft",      // James Newton-King
-  "karolz_microsoft",       // Karol Zadora-Przylecki
-  "sebros_microsoft",       // Sebastien Ros
-  "ellahathaway_microsoft", // Ella Hathaway
-  "joperezr_microsoft",     // Jose Perez Rodriguez
-  "dedward_microsoft",      // Damian Edwards
-  "maleger_microsoft",      // Maddy Montaquila
+  "eerhardt_microsoft",
+  "ankj_microsoft",
+  "dapine_microsoft",
+  "midenn_microsoft",
+  "adamratzman_microsoft",
+  "danegsta_microsoft",
+  "jamesnk_microsoft",
+  "karolz_microsoft",
+  "sebros_microsoft",
+  "ellahathaway_microsoft",
+  "joperezr_microsoft",
+  "dedward_microsoft",
+  "maleger_microsoft",
 ];
 
 // Repos where specific check failures are non-blocking (informational only), so an

--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -43,6 +43,38 @@ export const nonBlockingCheckFailureRules = [
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Review SLA (first-party aspire-1p repo).
+// ---------------------------------------------------------------------------
+//
+// The private first-party mirror carries a 1-business-day review SLA: a PR that
+// is genuinely ready (i.e. it qualifies for the "Needs attention" focused queue),
+// was authored by someone outside the core team, and has not yet had a single
+// human review must not sit unreviewed past the budget. The clock is measured in
+// *business time* (Mon-Fri, 09:00-17:00 Pacific) so overnight and weekend hours do
+// not burn the budget. See sla.mjs for the business-hours math and tracking store.
+
+// Repos the SLA applies to. Matched case-insensitively against pr.repository.
+export const SLA_REPOS = ["devdiv-microsoft/aspire-1p"];
+
+// Total business-time budget before a ready, un-reviewed external PR is "out of SLA".
+export const SLA_BUDGET_HOURS = 8;
+
+// Business-time elapsed at which a PR is flagged "approaching" (early warning) so the
+// team can prioritize it before it breaches. Must be < SLA_BUDGET_HOURS.
+export const SLA_WARN_HOURS = 6;
+
+// IANA timezone the business-hours window is expressed in. Intl handles DST, so the
+// 09:00-17:00 window tracks Pacific daylight/standard transitions automatically.
+export const SLA_TIMEZONE = "America/Los_Angeles";
+
+// Business-day window [start, end) in whole local hours. 9 => 09:00, 17 => 17:00.
+export const SLA_WORK_START_HOUR = 9;
+export const SLA_WORK_END_HOUR = 17;
+
+// Weekdays counted as business days (0 = Sunday .. 6 = Saturday). Mon-Fri.
+export const SLA_WORK_DAYS = [1, 2, 3, 4, 5];
+
 // Markers for the Issues focus buckets (ported from pr-dashboard models.ts). These
 // are matched case-insensitively via substring (title/label) or login equality.
 export const ctiTeamTitleMarker = "[aspiree2e]";

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -183,6 +183,47 @@ const session = await joinSession({
           },
         },
         {
+          name: "sla_report",
+          description: "Return the aspire-1p review SLA report (breached and approaching non-team PRs) plus the list of open external PRs, without opening the canvas. Intended for the hourly Teams notifier workflow.",
+          handler: async () => {
+            const { dashboard } = await getDashboard(false);
+            if (!dashboard.authenticated) {
+              return { authenticated: false, message: dashboard.message, sla: null, externalOpenPrs: [] };
+            }
+            const sla = dashboard.sla ?? null;
+            // Flatten SLA cards to lean rows so the notifier gets stable, small payloads
+            // (the full card carries signals/avatars the workflow does not need).
+            const leanCard = (c) => ({
+              repo: c.pr.repository,
+              number: c.pr.number,
+              title: c.pr.title,
+              url: c.pr.url,
+              author: c.pr.author,
+              state: c.sla?.state ?? null,
+              firstQualifiedAt: c.sla?.firstQualifiedAt ?? null,
+              warnAt: c.sla?.warnAt ?? null,
+              deadlineAt: c.sla?.deadlineAt ?? null,
+            });
+            return {
+              authenticated: true,
+              viewer: dashboard.viewer,
+              sla: sla
+                ? {
+                    repos: sla.repos,
+                    budgetHours: sla.budgetHours,
+                    warnHours: sla.warnHours,
+                    tz: sla.tz,
+                    total: sla.total,
+                    okCount: sla.okCount,
+                    breached: (sla.breached ?? []).map(leanCard),
+                    approaching: (sla.approaching ?? []).map(leanCard),
+                  }
+                : null,
+              externalOpenPrs: dashboard.externalOpenPrs ?? [],
+            };
+          },
+        },
+        {
           name: "accounts",
           description: "List every detected GitHub credential, whether it is active, and whether it can read its watched repos. Re-probes all accounts.",
           handler: async () => {

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -9,6 +9,7 @@
 import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
 import {
   addAzurePipelineSource,
+  computeSlaReport,
   forceRefresh,
   getDashboard,
   removeAzurePipelineSource,
@@ -186,17 +187,26 @@ const session = await joinSession({
           name: "sla_report",
           description: "Return the aspire-1p review SLA report (breached and approaching non-team PRs) plus the list of open external PRs, without opening the canvas. Intended for the hourly Teams notifier workflow.",
           handler: async () => {
-            const { dashboard } = await getDashboard(false);
-            if (!dashboard.authenticated) {
-              return { authenticated: false, message: dashboard.message, sla: null, externalOpenPrs: [] };
+            // Force a private review-mode SLA compute (see computeSlaReport): dashboard.sla is
+            // only produced in review mode, so reading the user's last-viewed mode would return
+            // no SLA data whenever the canvas was on Issues/Ship/Health.
+            const report = await computeSlaReport();
+            if (!report.authenticated) {
+              return { authenticated: false, message: report.message, sla: null, externalOpenPrs: [] };
             }
-            const sla = dashboard.sla ?? null;
+            const sla = report.sla ?? null;
             // Flatten SLA cards to lean rows so the notifier gets stable, small payloads
             // (the full card carries signals/avatars the workflow does not need).
+            //
+            // SECURITY: this result is agent-facing (the notifier LLM reads it), so it must NOT
+            // carry provider-controlled free text. A PR `title` is attacker-influenced and could
+            // smuggle instructions into the agent's context, so it is dropped here — the notifier
+            // references PRs by url/number instead. The headless sla-cli.mjs, whose output is not
+            // fed back into an agent, may keep the title for display. Same rationale as the
+            // provider-text stripping in health.mjs.
             const leanCard = (c) => ({
               repo: c.pr.repository,
               number: c.pr.number,
-              title: c.pr.title,
               url: c.pr.url,
               author: c.pr.author,
               state: c.sla?.state ?? null,
@@ -204,9 +214,17 @@ const session = await joinSession({
               warnAt: c.sla?.warnAt ?? null,
               deadlineAt: c.sla?.deadlineAt ?? null,
             });
+            const leanExternal = (p) => ({
+              repo: p.repo,
+              number: p.number,
+              url: p.url,
+              author: p.author,
+              draft: !!p.draft,
+              createdAt: p.createdAt,
+            });
             return {
               authenticated: true,
-              viewer: dashboard.viewer,
+              viewer: report.viewer,
               sla: sla
                 ? {
                     repos: sla.repos,
@@ -219,7 +237,7 @@ const session = await joinSession({
                     approaching: (sla.approaching ?? []).map(leanCard),
                   }
                 : null,
-              externalOpenPrs: dashboard.externalOpenPrs ?? [],
+              externalOpenPrs: (report.externalOpenPrs ?? []).map(leanExternal),
             };
           },
         },

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -225,6 +225,12 @@ const session = await joinSession({
             return {
               authenticated: true,
               viewer: report.viewer,
+              // partial = a watched SLA repo failed to fetch this run, so the lists below are
+              // known-incomplete. Only the boolean + our own repo slugs are exposed here (NOT the
+              // raw error text, which is provider-controlled) to keep this agent-facing result
+              // free of smuggled instructions — same rationale as dropping PR titles above.
+              partial: !!report.partial,
+              unfetchedRepos: report.unfetchedRepos ?? [],
               sla: sla
                 ? {
                     repos: sla.repos,

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -903,7 +903,16 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
       const repo = entry.slice(entry.indexOf("\n") + 1).toLowerCase();
       if (isSlaRepo(repo)) authoritativeRepos.add(repo);
     }
-    await annotateDashboardSla(snap, { now: Date.now(), authoritativeRepos });
+    // The SLA repos this run was actually supposed to fetch (watched by some active account).
+    // annotateDashboardSla compares this against authoritativeRepos to flag a partial fetch, so
+    // the report can distinguish a genuinely empty queue from a run where the watched repo failed.
+    const expectedSlaRepos = new Set();
+    for (const acct of usable) {
+      for (const repo of acct.repos ?? []) {
+        if (isSlaRepo(repo)) expectedSlaRepos.add(repo.toLowerCase());
+      }
+    }
+    await annotateDashboardSla(snap, { now: Date.now(), authoritativeRepos, expectedSlaRepos });
   }
   return snap;
 }

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -17,11 +17,13 @@ import {
   computeFocusExclusionItems,
   computeCommunityItems,
   isChecksFailing,
+  isCoreTeamAuthor,
   isReviewDebt,
   shouldHideFromSharedPullRequestLists,
   visibleCheckState,
 } from "./model.mjs";
 import { currentRelease } from "./constants.mjs";
+import { annotateDashboardSla, isSlaCandidatePr, isSlaRepo } from "./sla.mjs";
 
 // The current milestone has a single source of truth in constants.mjs
 // (`currentRelease`). Re-export it here under the name the run-mode lane logic
@@ -823,9 +825,31 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
         community: computeCommunityItems(allPrs).map((c) => card(c.pullRequest, "Community")),
         developerCounts: createDeveloperPullRequestCounts(allPrs),
       };
+      // SLA candidates = the full (uncapped) focused "Needs attention" queue, narrowed to
+      // PRs the review SLA applies to: on an SLA repo, authored outside the core team, and
+      // not yet reviewed by a human. annotateDashboardSla() consumes this scratch field to
+      // stamp anchors/state and then removes it from the broadcast payload.
+      attention.slaCandidates = focusAll
+        .map((f) => card(f.pullRequest, f.reason, { bucketLabel: f.bucketLabel, bucketTone: f.bucketTone }))
+        .filter((c) => isSlaCandidatePr(c.pr));
     }
 
     const notifications = buildNotifications(allPrs, prefs ?? {}, dismissed ?? []);
+
+    // Lean list of every open, non-team PR on an SLA repo (drafts included). The hourly
+    // notifier uses this to detect brand-new external PRs; it is intentionally independent
+    // of the capped focus queue so a new PR is announced even before it surfaces there.
+    const externalOpenPrs = allPrs
+      .filter((p) => isSlaRepo(p.repository) && p.state === "open" && !isCoreTeamAuthor(p.author))
+      .map((p) => ({
+        repo: p.repository,
+        number: p.number,
+        title: p.title,
+        url: p.url,
+        author: p.author,
+        draft: !!p.draft,
+        createdAt: p.createdAt,
+      }));
 
     const counts = {
       prs: visiblePrs.length,
@@ -852,6 +876,7 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
       showDrafts,
       reviewLimit,
       errors,
+      externalOpenPrs,
       fetchedAt: new Date().toISOString(),
     };
   }
@@ -859,5 +884,11 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   await Promise.all(jobs);
   // Final, authoritative progress tick so the deterministic bar completes with the snapshot.
   if (typeof onProgress === "function") onProgress({ done: total, total, phase: "done" });
-  return snapshot();
+  const snap = snapshot();
+  // Stamp SLA anchors/state and attach dashboard.sla (review mode only). This also
+  // reconciles + persists the durable firstQualifiedAt tracking store.
+  if (snap.mode === "review") {
+    await annotateDashboardSla(snap, { now: Date.now() });
+  }
+  return snap;
 }

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -209,9 +209,15 @@ function resolveAuthor(login, assignees) {
 // Server-parity review summary (mirrors GitHubClient.CreateReviewStatusFromGraphQlAsync).
 // `rawUnresolved` is the count of unresolved review threads before policy gating.
 const RESOLUTION_REQUIRED_REPOS = new Set(["microsoft/aspire"]);
-function deriveReview(reviews, requestedReviewers, viewers, repo, rawUnresolved) {
+export function deriveReview(reviews, requestedReviewers, viewers, repo, rawUnresolved) {
+  // Copilot's code-review bot submits real REVIEW nodes whose GraphQL author.login is
+  // "copilot-pull-request-reviewer" (bot logins come back WITHOUT the "[bot]" suffix over
+  // GraphQL). It is not a human sign-off, so it must be kept out of the human review set --
+  // otherwise it inflates reviewerCount to 1, mislabels the PR as "Review started", and (on
+  // the aspire-1p mirror) wrongly clears the review SLA clock. isBotReviewer doesn't catch
+  // this login, so exclude Copilot reviewers explicitly; copilotReviewed still tracks it.
   const human = reviews
-    .filter((r) => r.author?.login && !isBotReviewer(r.author.login) && r.submittedAt)
+    .filter((r) => r.author?.login && !isBotReviewer(r.author.login) && !isCopilotReviewer(r.author.login) && r.submittedAt)
     .sort((a, b) => new Date(a.submittedAt) - new Date(b.submittedAt));
   const copilotReviewed = reviews.some((r) => isCopilotReviewer(r.author?.login));
 

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -894,7 +894,16 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   // Stamp SLA anchors/state and attach dashboard.sla (review mode only). This also
   // reconciles + persists the durable firstQualifiedAt tracking store.
   if (snap.mode === "review") {
-    await annotateDashboardSla(snap, { now: Date.now() });
+    // Tell the SLA reconciler which SLA repos actually fetched OK this run so a transient
+    // failure can't prune tracked PRs and reset their breach clock (#5). okRepos holds
+    // hostRepoKey(graphql, repo) = `${graphql??""}\n${repo}`, so the repo slug is the text
+    // after the newline; keep only the ones under SLA, lowercased to match slaCandidateKey.
+    const authoritativeRepos = new Set();
+    for (const entry of okRepos) {
+      const repo = entry.slice(entry.indexOf("\n") + 1).toLowerCase();
+      if (isSlaRepo(repo)) authoritativeRepos.add(repo);
+    }
+    await annotateDashboardSla(snap, { now: Date.now(), authoritativeRepos });
   }
   return snap;
 }

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { capFocusKeepingDebt, loadDashboard } from "./github.mjs";
+import { capFocusKeepingDebt, deriveReview, loadDashboard } from "./github.mjs";
 
 const originalFetch = globalThis.fetch;
 
@@ -31,6 +31,30 @@ test("capFocusKeepingDebt keeps the head cap plus review-debt cards that spill p
 
   // No spillover at all when everything fits under the cap.
   assert.deepEqual(capFocusKeepingDebt(cards.slice(0, 2), 5).map((c) => c.pr.number), [1, 2]);
+});
+
+test("deriveReview: Copilot's code-review bot does not count as a human reviewer", () => {
+  const viewers = new Set();
+  // GraphQL returns the Copilot reviewer bot's login WITHOUT the "[bot]" suffix.
+  const copilotOnly = deriveReview(
+    [{ author: { login: "copilot-pull-request-reviewer" }, state: "COMMENTED", submittedAt: "2026-07-01T10:00:00Z" }],
+    [], viewers, "devdiv-microsoft/aspire-1p", 0,
+  );
+  assert.equal(copilotOnly.reviewerCount, 0);
+  assert.equal(copilotOnly.state, "waiting");
+  // The side-flag still records that Copilot weighed in.
+  assert.equal(copilotOnly.copilotReviewed, true);
+
+  // A genuine human review is still counted and sets the headline state.
+  const withHuman = deriveReview(
+    [
+      { author: { login: "copilot-pull-request-reviewer" }, state: "COMMENTED", submittedAt: "2026-07-01T10:00:00Z" },
+      { author: { login: "octocat" }, state: "APPROVED", submittedAt: "2026-07-01T11:00:00Z" },
+    ],
+    [], viewers, "devdiv-microsoft/aspire-1p", 0,
+  );
+  assert.equal(withHuman.reviewerCount, 1);
+  assert.equal(withHuman.state, "approved");
 });
 
 test("loadDashboard paginates open pull requests for each watched repo", async () => {

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -84,7 +84,7 @@ function isBotAuthor(author, authorType) {
   if (knownBotAuthors.has(n)) return true;
   return n.endsWith("[bot]") || n.includes("bot") || n === "copilot" || n === "github-actions";
 }
-function isCoreTeamAuthor(author) {
+export function isCoreTeamAuthor(author) {
   return coreTeamOwnershipActor(author) !== null;
 }
 // Resolves the core-team actor that "owns" a PR by an author, honoring alias

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -7,6 +7,7 @@
 
 import {
   afscromeIssueAuthor,
+  coreTeamEmuLogins,
   coreTeamMembers,
   coreTeamMemberAliasSuffixes,
   ctiTeamTitleMarker,
@@ -87,15 +88,19 @@ function isBotAuthor(author, authorType) {
 export function isCoreTeamAuthor(author) {
   return coreTeamOwnershipActor(author) !== null;
 }
-// Resolves the core-team actor that "owns" a PR by an author, honoring alias
-// suffixes (#95). Returns a canonical coreTeamMembers login when the author
-// matches directly or via a stripped alias suffix; otherwise returns the alias
-// login itself when the author carries a configured suffix (an MSFT alt account
-// not individually listed); null for everyone else.
+const coreTeamEmuLoginSet = new Set(coreTeamEmuLogins.map((login) => login.toLowerCase()));
+
+// Resolves the core-team actor that "owns" a PR by an author. Returns a canonical
+// coreTeamMembers login when the author matches a listed member directly or via a
+// stripped alias suffix (a member's "*_microsoft" alt whose base is a public login,
+// e.g. "eerhardt_microsoft" -> "eerhardt"). Otherwise, an EMU-form login counts as core
+// team only when it is on the explicit coreTeamEmuLogins allowlist (the mirror roster,
+// whose bases frequently differ from public logins). Everyone else -- including any
+// unlisted "*_microsoft" account -- returns null so they remain review targets.
 function coreTeamOwnershipActor(author) {
   const member = matchingCoreTeamMember(author);
   if (member) return member;
-  return isConfiguredTeamAlias(author) ? author : null;
+  return coreTeamEmuLoginSet.has(String(author || "").toLowerCase()) ? author : null;
 }
 function matchingCoreTeamMember(author) {
   const authorKey = actorIdentityKey(author);
@@ -113,9 +118,6 @@ function configuredTeamAliasBase(author) {
     return s.length > 0 && normalized.endsWith(s) && normalized.length > s.length;
   });
   return suffix ? String(author).slice(0, -suffix.length) : null;
-}
-function isConfiguredTeamAlias(author) {
-  return configuredTeamAliasBase(author) !== null;
 }
 function isCommunityToolkitPullRequest(pr) {
   return pr.repository.toLowerCase() === "communitytoolkit/aspire";

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -75,6 +75,17 @@ function isCopilotAttributedAuthor(author) {
   // punctuation) as part of keying to the human owner, so it can never end with "/copilot".
   return String(author || "").toLowerCase().endsWith("/copilot");
 }
+// Strip a trailing "/copilot" attribution so ownership checks compare the human base.
+// A Copilot-agent PR started by a team member surfaces as "{human}/copilot" (e.g.
+// "someone_microsoft/copilot"); the human owns it, so core-team matching must run against
+// the base. actorIdentityKey already drops "/copilot" on its direct-match path, but the
+// alias-suffix strip and the explicit roster allowlist compare raw logins -- without this
+// normalization those two checks miss and a team member's Copilot PR is wrongly treated as
+// external, landing it in the review queue.
+function copilotHumanBase(author) {
+  const raw = String(author || "");
+  return raw.toLowerCase().endsWith("/copilot") ? raw.slice(0, -"/copilot".length) : raw;
+}
 function isBotAuthor(author, authorType) {
   if (isCopilotAttributedAuthor(author)) return false;
   // GraphQL __typename is the most precise signal when present; the string checks mirror
@@ -98,9 +109,13 @@ const coreTeamEmuLoginSet = new Set(coreTeamEmuLogins.map((login) => login.toLow
 // whose bases frequently differ from public logins). Everyone else -- including any
 // unlisted "*_microsoft" account -- returns null so they remain review targets.
 function coreTeamOwnershipActor(author) {
-  const member = matchingCoreTeamMember(author);
+  // Resolve ownership against the human base so a "{member}/copilot" mirror PR isn't treated
+  // as external: both the alias-suffix strip (via matchingCoreTeamMember) and the roster
+  // allowlist below otherwise compare the raw "/copilot"-suffixed login and miss.
+  const base = copilotHumanBase(author);
+  const member = matchingCoreTeamMember(base);
   if (member) return member;
-  return coreTeamEmuLoginSet.has(String(author || "").toLowerCase()) ? author : null;
+  return coreTeamEmuLoginSet.has(base.toLowerCase()) ? base : null;
 }
 function matchingCoreTeamMember(author) {
   const authorKey = actorIdentityKey(author);

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -15,6 +15,7 @@ import {
   createIssueSignals,
   filterCheckFailureRules,
   isChecksFailing,
+  isCoreTeamAuthor,
   isReviewDebt,
   shouldHideFromSharedPullRequestLists,
   visibleCheckState,
@@ -295,6 +296,27 @@ test("createDeveloperPullRequestCounts attributes open PRs to core-team members 
   // The "_microsoft" alias attributes to the canonical core-team login.
   assert.equal(byActor.get("IEvangelist"), 1);
   assert.equal(byActor.has("randocontributor"), false);
+});
+
+test("isCoreTeamAuthor: EMU logins are core team only via the explicit allowlist", () => {
+  // Public core-team login and a member alt whose base matches the public roster.
+  assert.equal(isCoreTeamAuthor("davidfowl"), true);
+  assert.equal(isCoreTeamAuthor("eerhardt_microsoft"), true);
+
+  // Listed EMU logins whose base does NOT match a public login (e.g. David Pine is
+  // @IEvangelist publicly but dapine_microsoft on the mirror) still resolve via the
+  // allowlist, not a suffix-strip.
+  assert.equal(isCoreTeamAuthor("dapine_microsoft"), true);
+  assert.equal(isCoreTeamAuthor("midenn_microsoft"), true);
+  assert.equal(isCoreTeamAuthor("karolz_microsoft"), true);
+
+  // An unlisted "*_microsoft" account is NOT core team — carrying the suffix is not
+  // enough. These are the review targets the SLA queue is meant to catch.
+  assert.equal(isCoreTeamAuthor("andreas_microsoft"), false);
+  assert.equal(isCoreTeamAuthor("someexternal_microsoft"), false);
+
+  // Non-Microsoft community author.
+  assert.equal(isCoreTeamAuthor("randocontributor"), false);
 });
 
 function isoAgoIssue(ms) {

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -437,3 +437,23 @@ test("createIssueSignals leads with the highest-priority action pill", () => {
   const botTyped = makeIssue({ number: 6, author: "dependa", authorType: "Bot" });
   assert.ok(createIssueSignals(botTyped).some((s) => s.label === "bot"));
 });
+
+test("isCoreTeamAuthor treats a '/copilot'-attributed team author as core team", () => {
+  // A Copilot-agent PR started by a team member comes back as "{human}/copilot". Ownership
+  // must resolve the human base for BOTH the alias-suffix strip and the roster allowlist,
+  // otherwise the "/copilot" suffix makes both miss and the PR is misclassified as external.
+  // "eerhardt_microsoft" resolves via the alias-suffix strip (base "eerhardt" is a public
+  // member login); "dapine_microsoft" resolves via the explicit roster allowlist (its public
+  // login differs), so the two cases exercise both ownership paths.
+  assert.equal(isCoreTeamAuthor("eerhardt_microsoft/copilot"), true);
+  assert.equal(isCoreTeamAuthor("dapine_microsoft/copilot"), true);
+
+  // Plain (non-"/copilot") team authors and the bare aliases keep resolving as core team.
+  assert.equal(isCoreTeamAuthor("eerhardt_microsoft"), true);
+  assert.equal(isCoreTeamAuthor("dapine_microsoft"), true);
+
+  // A non-roster account stays external whether or not it carries the "/copilot" attribution,
+  // so its PRs still qualify for the review queue.
+  assert.equal(isCoreTeamAuthor("someone_microsoft/copilot"), false);
+  assert.equal(isCoreTeamAuthor("someone_microsoft"), false);
+});

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -1329,6 +1329,18 @@ function updateRefreshControls() {
   }
 }
 
+// Recompute every pinned/inline SLA note's countdown text against the browser clock. Only the
+// textContent changes; the server-stamped state class (color) still flips on the next poll.
+// Cheap enough to run each second because there are only ever a handful of tracked cards.
+function tickSlaNotes() {
+  const notes = document.querySelectorAll(".sla-note[data-sla-deadline]");
+  for (const el of notes) {
+    const deadlineAt = el.dataset.slaDeadline;
+    if (!deadlineAt) continue;
+    el.textContent = slaNoteText({ state: el.dataset.slaState, deadlineAt });
+  }
+}
+
 /* ---- deterministic progress bar ----
    Driven by SSE 'progress' events ({ done, total }). beginProgress shows a small sliver
    for instant feedback; setProgress advances the fill; endProgress completes to 100% then
@@ -1445,7 +1457,7 @@ function onPollSchedule(payload) {
   if (!Number.isFinite(value) || value <= 0) return;
   nextPollAt = value;
   if (!pollCountdownTimer) {
-    pollCountdownTimer = setInterval(updateRefreshControls, 1000);
+    pollCountdownTimer = setInterval(() => { updateRefreshControls(); tickSlaNotes(); }, 1000);
   }
   updateRefreshControls();
 }
@@ -2333,7 +2345,13 @@ function prCard(item, actions) {
     (item.reason ? '<div class="reason">' + esc(item.reason) + "</div>" : "") +
     ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
     ((item.sla && item.sla.state)
-      ? '<div class="sla-note ' + item.sla.state + '">' + esc(slaNoteText(item.sla)) + "</div>"
+      // data-sla-* anchors let tickSlaNotes() recompute the "due in"/"overdue" text every
+      // second against the browser clock without a full re-render. deadlineAt is a fixed
+      // instant, so the countdown stays live between the ~90s server polls.
+      ? '<div class="sla-note ' + item.sla.state +
+          '" data-sla-state="' + esc(item.sla.state) +
+          '" data-sla-deadline="' + esc(item.sla.deadlineAt || "") + '">' +
+          esc(slaNoteText(item.sla)) + "</div>"
       : "") +
   "</a>";
   const acts = (actions && actions.length)

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -485,6 +485,7 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 /* Live SLA countdown note under a card's pills. Colored by state; the "due in Xh" /
    "overdue" text is recomputed client-side against the browser clock. */
 .sla-note { margin-top: 6px; font-size: 11px; font-weight: 600; line-height: 1.3; letter-spacing: 0.01em; }
+.sla-note.ok { color: var(--muted); font-weight: 500; }
 .sla-note.approaching { color: color-mix(in srgb, var(--warning), var(--fg) 20%); }
 .sla-note.breached { color: color-mix(in srgb, var(--danger), var(--fg) 12%); }
 
@@ -2331,8 +2332,8 @@ function prCard(item, actions) {
     "</div>" +
     (item.reason ? '<div class="reason">' + esc(item.reason) + "</div>" : "") +
     ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
-    ((item.sla && item.sla.state && item.sla.state !== "ok")
-      ? '<div class="sla-note ' + (item.sla.state === "breached" ? "breached" : "approaching") + '">' + esc(slaNoteText(item.sla)) + "</div>"
+    ((item.sla && item.sla.state)
+      ? '<div class="sla-note ' + item.sla.state + '">' + esc(slaNoteText(item.sla)) + "</div>"
       : "") +
   "</a>";
   const acts = (actions && actions.length)
@@ -2500,25 +2501,42 @@ function slaNoteText(sla) {
       ? "\u23f0 Review within SLA \u00b7 due in " + fmtDur(left)
       : "\u23f0 Out of SLA \u00b7 due now";
   }
+  if (sla.state === "ok") {
+    // Comfortable candidates still show a calm live countdown so the panel conveys the
+    // queue at a glance. The server never emits "ok" once the deadline passes, but guard
+    // the clock-skew edge anyway.
+    const left = new Date(sla.deadlineAt).getTime() - Date.now();
+    return left > 0
+      ? "\ud83d\udd52 On SLA clock \u00b7 due in " + fmtDur(left)
+      : "\u23f0 Out of SLA \u00b7 due now";
+  }
   return "";
 }
 
-// The pinned SLA panel: breached PRs first, then approaching. Renders nothing when
-// nothing is at risk. Reuses the standard focus card actions so a reviewer can act inline.
+// The pinned SLA panel: breached PRs first, then approaching, then comfortable "ok"
+// candidates. Stays visible whenever at least one candidate is tracked (so the team
+// always sees the live queue) and renders nothing only when there are zero candidates.
+// Reuses the standard focus card actions so a reviewer can act inline.
 function slaPanelHtml() {
   const s = state.sla;
   if (!s) return "";
   const breached = s.breached || [];
   const approaching = s.approaching || [];
-  const items = breached.concat(approaching);
+  const ok = s.ok || [];
+  // Actionable first (breached, then approaching), comfortable "ok" candidates last so the
+  // panel is always present when anything is tracked, not just when something is at risk.
+  const items = breached.concat(approaching).concat(ok);
   if (!items.length) return "";
-  const tone = breached.length ? "danger" : "warning";
+  const tone = breached.length ? "danger" : approaching.length ? "warning" : "muted";
   const repoLabel = (s.repos && s.repos.length) ? s.repos.map(shortRepo).join(", ") : "aspire-1p";
   const parts = [];
   if (breached.length) parts.push(breached.length + " out of SLA");
   if (approaching.length) parts.push(approaching.length + " approaching");
+  if (ok.length) parts.push(ok.length + " within budget");
+  const atRisk = breached.length || approaching.length;
   const subtitle = "Non-team PRs in " + repoLabel + " on the " + s.budgetHours +
-    " business-hour review SLA \u00b7 " + parts.join(" \u00b7 ") + ". Review these first.";
+    " business-hour review SLA \u00b7 " + parts.join(" \u00b7 ") +
+    (atRisk ? ". Review these first." : ". All within budget \u2014 clear the top ones early.");
   return queuePanel({
     id: "review-sla",
     title: "Review SLA",

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -482,6 +482,12 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .pill.info    { --pill-tone: var(--blue); background: color-mix(in srgb, var(--blue) 14%, transparent);   border-color: color-mix(in srgb, var(--blue) 42%, transparent); }
 .pill.muted   { background: color-mix(in srgb, var(--muted) 10%, transparent); border-color: color-mix(in srgb, var(--muted) 20%, transparent); }
 
+/* Live SLA countdown note under a card's pills. Colored by state; the "due in Xh" /
+   "overdue" text is recomputed client-side against the browser clock. */
+.sla-note { margin-top: 6px; font-size: 11px; font-weight: 600; line-height: 1.3; letter-spacing: 0.01em; }
+.sla-note.approaching { color: color-mix(in srgb, var(--warning), var(--fg) 20%); }
+.sla-note.breached { color: color-mix(in srgb, var(--danger), var(--fg) 12%); }
+
 /* Repository and delivery health */
 .health-shell {
   min-height: calc(100dvh - 106px); padding: 18px 20px 32px;
@@ -2325,6 +2331,9 @@ function prCard(item, actions) {
     "</div>" +
     (item.reason ? '<div class="reason">' + esc(item.reason) + "</div>" : "") +
     ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
+    ((item.sla && item.sla.state && item.sla.state !== "ok")
+      ? '<div class="sla-note ' + (item.sla.state === "breached" ? "breached" : "approaching") + '">' + esc(slaNoteText(item.sla)) + "</div>"
+      : "") +
   "</a>";
   const acts = (actions && actions.length)
     ? '<div class="card-actions">' + actions.map((a) => cardActionBtn(pr, a)).join("") + "</div>"
@@ -2461,6 +2470,68 @@ function collapsibleSect(opts) {
 
 // A clean, always-expanded primary queue (For you / Needs attention / Your PRs
 // outside). Masonry cards with a title, count metric, and descriptive subtitle.
+// ---- Review SLA (client-side live rendering) ----
+//
+// The server stores only STABLE anchors (deadlineAt is a fixed wall-clock instant that
+// already accounts for business hours). The live "due in Xh" / "overdue" text is computed
+// here against the browser clock, so it ticks without re-fetching and never churns the
+// broadcast payload. deadlineAt is the true moment the SLA expires in real time.
+
+function fmtDur(ms) {
+  const m = Math.floor(ms / 60000);
+  if (m < 60) return m + "m";
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  if (h < 24) return rm ? h + "h " + rm + "m" : h + "h";
+  const d = Math.floor(h / 24);
+  const rh = h % 24;
+  return rh ? d + "d " + rh + "h" : d + "d";
+}
+
+// One-line SLA status note shown under a card's pills.
+function slaNoteText(sla) {
+  if (!sla) return "";
+  if (sla.state === "breached") {
+    return "\u23f0 Out of SLA \u00b7 was due " + timeAgo(sla.deadlineAt);
+  }
+  if (sla.state === "approaching") {
+    const left = new Date(sla.deadlineAt).getTime() - Date.now();
+    return left > 0
+      ? "\u23f0 Review within SLA \u00b7 due in " + fmtDur(left)
+      : "\u23f0 Out of SLA \u00b7 due now";
+  }
+  return "";
+}
+
+// The pinned SLA panel: breached PRs first, then approaching. Renders nothing when
+// nothing is at risk. Reuses the standard focus card actions so a reviewer can act inline.
+function slaPanelHtml() {
+  const s = state.sla;
+  if (!s) return "";
+  const breached = s.breached || [];
+  const approaching = s.approaching || [];
+  const items = breached.concat(approaching);
+  if (!items.length) return "";
+  const tone = breached.length ? "danger" : "warning";
+  const repoLabel = (s.repos && s.repos.length) ? s.repos.map(shortRepo).join(", ") : "aspire-1p";
+  const parts = [];
+  if (breached.length) parts.push(breached.length + " out of SLA");
+  if (approaching.length) parts.push(approaching.length + " approaching");
+  const subtitle = "Non-team PRs in " + repoLabel + " on the " + s.budgetHours +
+    " business-hour review SLA \u00b7 " + parts.join(" \u00b7 ") + ". Review these first.";
+  return queuePanel({
+    id: "review-sla",
+    title: "Review SLA",
+    tone,
+    icon: ICONS.alertSm,
+    subtitle,
+    items,
+    exactCount: true,
+    cardActions: focusCardActions,
+    emptyText: "Nothing at risk right now.",
+  });
+}
+
 function queuePanel(opts) {
   const items = opts.items || [];
   const n = items.length;
@@ -2493,6 +2564,11 @@ function reviewBoardHtml() {
   const att = state.attention;
   seedReviewCollapse(att);
   let html = "";
+
+  // 0. Review SLA — pinned above everything. First-party aspire-1p PRs from outside the
+  //    team that are on the 1 business-day review SLA and in danger (approaching) or past
+  //    it (breached). Rendered first so at-risk reviews are impossible to miss.
+  html += slaPanelHtml();
 
   // 1. For you — personalized headline of your highest-leverage actions.
   if (att.forMe && att.forMe.length) {
@@ -2921,6 +2997,7 @@ function filtersView() {
         '<div class="policy-row">' + ICONS.pr + "<span><b>Drafts, merge conflicts, and needs-author-action</b> PRs are routed out of the shared lists, so reviewers only see PRs that are genuinely ready.</span></div>" +
         '<div class="policy-row">' + ICONS.xcircle + "<span><b>CI-failing</b> PRs are held out of Needs attention. A failure driven only by informational <b>aspire-1p checks</b> (proof of presence) is not counted as red.</span></div>" +
         '<div class="policy-row">' + ICONS.usersSm + "<span>PRs you authored <b>as yourself or via Copilot</b> both count as yours, so delegated work still lands in your lanes and developer totals.</span></div>" +
+        '<div class="policy-row">' + ICONS.clock + "<span><b>Review SLA:</b> non-team PRs in <b>aspire-1p</b> that reach Needs attention and have <b>no human review yet</b> carry a <b>1 business-day</b> (8 business-hour, Mon\u2013Fri 9\u20135 Pacific) review SLA. They are pinned to a <b>Review SLA</b> panel at the top, flagged <b>Review SLA</b> when approaching (6h) and <b>Out of SLA</b> once breached (8h). The clock stops the moment any human reviews.</span></div>" +
       "</div>" +
     "</div>" +
 

--- a/.github/extensions/aspire-team-app/render.test.mjs
+++ b/.github/extensions/aspire-team-app/render.test.mjs
@@ -707,6 +707,33 @@ test("refresh tooltip counts down to the server's next background poll", () => {
   assert.equal(intervalMs, 1000);
 });
 
+test("the poll-countdown interval re-renders live SLA note text from each note's stored deadline", () => {
+  // The 1s interval onPollSchedule registers drives BOTH the refresh tooltip and the per-card
+  // SLA countdown (updateRefreshControls + tickSlaNotes). Merely asserting the interval is
+  // registered wouldn't catch a regression that drops the SLA tick, so capture the handler,
+  // run it, and prove a note whose deadline is still in the future gets rewritten from a stale
+  // label to a freshly-computed "due in ..." string sourced from its own data-sla-deadline.
+  const note = {
+    dataset: { slaState: "approaching", slaDeadline: new Date(Date.now() + 90 * 60_000).toISOString() },
+    textContent: "STALE",
+  };
+  const refreshButton = { dataset: {}, classList: classList(), setAttribute() {} };
+  let handler;
+  const { api } = createRendererHarness({
+    elements: { "refresh-btn": refreshButton },
+    setInterval(fn) { handler = fn; return 1; },
+    querySelectorAll: (selector) => (selector === ".sla-note[data-sla-deadline]" ? [note] : []),
+  });
+
+  api.onPollSchedule({ nextPollAt: Date.now() + 34_000 });
+  assert.equal(typeof handler, "function", "onPollSchedule should register a 1s interval handler");
+
+  handler();
+
+  assert.notEqual(note.textContent, "STALE", "the interval tick must recompute the SLA note text");
+  assert.match(note.textContent, /Review within SLA \u00b7 due in 1h/);
+});
+
 test("issueCard renders linked pull requests as separate safe new-tab links below the pills", () => {
   const { api } = createRendererHarness();
   const html = api.issueCard({

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -920,10 +920,10 @@ export async function forceRefresh() {
 
 // Compute an SLA snapshot for the headless notifier / agent action WITHOUT mutating the
 // user's persisted canvas mode or the shared dashboard cache. dashboard.sla is only produced
-// on the review-mode code path (see loadDashboard), so reading whatever mode the user last
-// viewed — the previous behavior — silently emitted no SLA data whenever they were on Issues,
-// Ship, or Health. Forcing a private review-mode load here keeps the hourly notifier correct
-// regardless of what the canvas currently shows.
+// on the review-mode code path (see loadDashboard), so this MUST force review mode: using the
+// persisted mode would emit no SLA data whenever the canvas is on Issues, Ship, or Health.
+// Forcing a private review-mode load here keeps the hourly notifier correct regardless of what
+// the canvas currently shows.
 export async function computeSlaReport() {
   const prefs = await loadPrefs();
   const auth = await resolveAuth(prefs);
@@ -950,12 +950,20 @@ export async function computeSlaReport() {
     dismissed: prefs.dismissedNotifications,
     showDrafts: prefs.showDrafts,
   });
+  // Surface fetch health so the notifier can tell an empty queue apart from a failed fetch of
+  // the watched repo. dashboard.sla.partial is SLA-scoped (see annotateDashboardSla); errors is
+  // the raw per-repo failure list for diagnostics. On a partial run the notifier should leave
+  // its tracker untouched rather than clearing/announcing against known-incomplete data.
+  const partial = !!(dashboard.sla && dashboard.sla.partial);
   return {
     authenticated: true,
     viewer: dashboard.viewer,
     sla: dashboard.sla ?? null,
     externalOpenPrs: dashboard.externalOpenPrs ?? [],
     fetchedAt: dashboard.fetchedAt,
+    partial,
+    unfetchedRepos: dashboard.sla?.unfetchedRepos ?? [],
+    errors: dashboard.errors ?? [],
   };
 }
 

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -918,6 +918,47 @@ export async function forceRefresh() {
   return getDashboard(true);
 }
 
+// Compute an SLA snapshot for the headless notifier / agent action WITHOUT mutating the
+// user's persisted canvas mode or the shared dashboard cache. dashboard.sla is only produced
+// on the review-mode code path (see loadDashboard), so reading whatever mode the user last
+// viewed — the previous behavior — silently emitted no SLA data whenever they were on Issues,
+// Ship, or Health. Forcing a private review-mode load here keeps the hourly notifier correct
+// regardless of what the canvas currently shows.
+export async function computeSlaReport() {
+  const prefs = await loadPrefs();
+  const auth = await resolveAuth(prefs);
+  const active = auth.accounts.filter((a) => a.active && a.status !== "failed");
+  const accountsForLoad = active
+    .map((a) => ({ token: auth.tokenById.get(a.id), login: a.login, repos: a.repos, graphql: a.graphql }))
+    .filter((a) => a.token && a.login);
+  if (accountsForLoad.length === 0) {
+    const anyDetected = auth.accounts.length > 0;
+    return {
+      authenticated: false,
+      message: !anyDetected
+        ? "No GitHub credentials detected. Run `gh auth login` so the SLA report can read the review queue."
+        : "The active GitHub account can't read its watched repositories.",
+      sla: null,
+      externalOpenPrs: [],
+    };
+  }
+  const dashboard = await loadDashboard({
+    accounts: accountsForLoad,
+    mode: "review",
+    release: prefs.release,
+    prefs: prefs.notifications,
+    dismissed: prefs.dismissedNotifications,
+    showDrafts: prefs.showDrafts,
+  });
+  return {
+    authenticated: true,
+    viewer: dashboard.viewer,
+    sla: dashboard.sla ?? null,
+    externalOpenPrs: dashboard.externalOpenPrs ?? [],
+    fetchedAt: dashboard.fetchedAt,
+  };
+}
+
 export async function refreshInBackground() {
   return startCompute({ progress: false, background: true });
 }

--- a/.github/extensions/aspire-team-app/server.test.mjs
+++ b/.github/extensions/aspire-team-app/server.test.mjs
@@ -5,6 +5,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { SLA_REPOS } from "./constants.mjs";
+
 const artifactsRoot = fileURLToPath(new URL("../../../artifacts/copilot-extension-server-tests/", import.meta.url));
 const copilotHome = join(artifactsRoot, "copilot-home");
 const preferencesPath = join(copilotHome, "extensions", "aspire-team-app", "artifacts", "preferences.json");
@@ -429,6 +431,38 @@ test("dashboard load retries after an inflight account probe rejection", async (
   assert.equal(retried.status, 200);
   const payload = await retried.json();
   assert.equal(payload.dashboard.authenticated, true);
+});
+
+test("computeSlaReport forces the review path without mutating the persisted mode", async (t) => {
+  // The user is on a non-review mode ("health"); the hourly notifier still needs SLA data.
+  // computeSlaReport must run a private review-mode load (so dashboard.sla is produced) while
+  // leaving the user's persisted canvas mode untouched.
+  await resetTestHome({
+    mode: "health",
+    accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  globalThis.fetch = makeGitHubMock();
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const server = await import(`./server.mjs?test=sla-report-${Date.now()}`);
+  const report = await server.computeSlaReport();
+
+  // The review path ran: dashboard.sla is always attached in review mode, so its dedicated
+  // panel shape (scoped to SLA_REPOS) is present even when nothing is currently at risk.
+  assert.equal(report.authenticated, true);
+  assert.ok(report.sla, "expected an SLA report object from the forced review-mode load");
+  assert.deepEqual(report.sla.repos, SLA_REPOS);
+  assert.ok(Array.isArray(report.sla.breached));
+  assert.ok(Array.isArray(report.sla.approaching));
+  assert.ok(Array.isArray(report.externalOpenPrs));
+
+  // The persisted preference must still be the mode the user actually chose, not "review".
+  const persisted = JSON.parse(await readFile(preferencesPath, "utf8"));
+  assert.equal(persisted.mode, "health");
 });
 
 test("card action route bridges { prompt, log } to the session and echoes the queued flag", async (t) => {

--- a/.github/extensions/aspire-team-app/sla-cli.mjs
+++ b/.github/extensions/aspire-team-app/sla-cli.mjs
@@ -50,6 +50,13 @@ export async function main() {
     authenticated: true,
     viewer: report.viewer,
     generatedAt: new Date().toISOString(),
+    // partial = at least one watched SLA repo did not fetch authoritatively this run. The
+    // workflow should treat the queue below as known-incomplete and leave its tracker alone
+    // (don't clear or announce) rather than reacting to a transient outage. errors carries the
+    // raw per-repo failure text for diagnostics — this stream is not fed back into an agent.
+    partial: !!report.partial,
+    unfetchedRepos: report.unfetchedRepos ?? [],
+    errors: report.errors ?? [],
     sla: sla
       ? {
           repos: sla.repos,

--- a/.github/extensions/aspire-team-app/sla-cli.mjs
+++ b/.github/extensions/aspire-team-app/sla-cli.mjs
@@ -1,19 +1,24 @@
 // Headless SLA report emitter for the hourly Teams notifier workflow.
 //
-// Runs OUTSIDE the canvas: it computes a fresh dashboard via forceRefresh() (which does
-// NOT start the loopback HTTP server) and prints a single JSON document describing the
-// aspire-1p review SLA state plus every open external PR. The workflow diffs this against
-// its own tracker file to decide what to announce.
+// Runs OUTSIDE the canvas: it computes a fresh review-mode SLA snapshot via computeSlaReport()
+// (which does NOT start the loopback HTTP server, and does NOT depend on / mutate whatever mode
+// the user last viewed in the canvas) and prints a single JSON document describing the review
+// SLA state plus every open external PR. The workflow diffs this against its own tracker file to
+// decide what to announce.
 //
 // Usage:  node sla-cli.mjs
 // Output (stdout): one JSON object; see shape below. Non-JSON diagnostics go to stderr.
 
-import { forceRefresh } from "./server.mjs";
+import { pathToFileURL } from "node:url";
+import { computeSlaReport } from "./server.mjs";
 
 function leanCard(c) {
   return {
     repo: c.pr.repository,
     number: c.pr.number,
+    // The CLI output is consumed by a deterministic workflow (not injected into an agent's
+    // reasoning), so it may carry display text like the PR title. The agent-facing sla_report
+    // action deliberately omits free-text fields — see extension.mjs.
     title: c.pr.title,
     url: c.pr.url,
     author: c.pr.author,
@@ -24,14 +29,14 @@ function leanCard(c) {
   };
 }
 
-async function main() {
-  const { dashboard } = await forceRefresh();
-  if (!dashboard || !dashboard.authenticated) {
+export async function main() {
+  const report = await computeSlaReport();
+  if (!report || !report.authenticated) {
     // Emit a well-formed, clearly-unauthenticated payload so the workflow can bail quietly
     // instead of tripping on a parse error.
     process.stdout.write(JSON.stringify({
       authenticated: false,
-      message: dashboard?.message ?? "not authenticated",
+      message: report?.message ?? "not authenticated",
       generatedAt: new Date().toISOString(),
       sla: null,
       externalOpenPrs: [],
@@ -39,10 +44,10 @@ async function main() {
     return;
   }
 
-  const sla = dashboard.sla ?? null;
+  const sla = report.sla ?? null;
   const payload = {
     authenticated: true,
-    viewer: dashboard.viewer,
+    viewer: report.viewer,
     generatedAt: new Date().toISOString(),
     sla: sla
       ? {
@@ -56,17 +61,23 @@ async function main() {
           approaching: (sla.approaching ?? []).map(leanCard),
         }
       : null,
-    externalOpenPrs: dashboard.externalOpenPrs ?? [],
+    externalOpenPrs: report.externalOpenPrs ?? [],
   };
   process.stdout.write(JSON.stringify(payload) + "\n");
 }
 
-main()
-  .then(() => {
-    // Background pollers/timers are unref'd, but exit explicitly so the CLI never hangs.
-    process.exit(0);
-  })
-  .catch((err) => {
-    process.stderr.write("sla-cli failed: " + (err?.stack || err?.message || String(err)) + "\n");
-    process.exit(1);
-  });
+// Only self-execute when invoked directly (`node sla-cli.mjs`). The extension validator
+// dynamically imports every .mjs to smoke-test it; without this guard the import would run
+// main() and call process.exit(), aborting validation of the whole extension.
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] || "").href;
+if (invokedDirectly) {
+  main()
+    .then(() => {
+      // Background pollers/timers are unref'd, but exit explicitly so the CLI never hangs.
+      process.exit(0);
+    })
+    .catch((err) => {
+      process.stderr.write("sla-cli failed: " + (err?.stack || err?.message || String(err)) + "\n");
+      process.exit(1);
+    });
+}

--- a/.github/extensions/aspire-team-app/sla-cli.mjs
+++ b/.github/extensions/aspire-team-app/sla-cli.mjs
@@ -29,19 +29,20 @@ function leanCard(c) {
   };
 }
 
+// Returns the report as a single JSON string rather than writing it, so the caller controls
+// flushing (see the entrypoint) and tests can assert the payload without capturing stdout.
 export async function main() {
   const report = await computeSlaReport();
   if (!report || !report.authenticated) {
     // Emit a well-formed, clearly-unauthenticated payload so the workflow can bail quietly
     // instead of tripping on a parse error.
-    process.stdout.write(JSON.stringify({
+    return JSON.stringify({
       authenticated: false,
       message: report?.message ?? "not authenticated",
       generatedAt: new Date().toISOString(),
       sla: null,
       externalOpenPrs: [],
-    }) + "\n");
-    return;
+    });
   }
 
   const sla = report.sla ?? null;
@@ -63,21 +64,29 @@ export async function main() {
       : null,
     externalOpenPrs: report.externalOpenPrs ?? [],
   };
-  process.stdout.write(JSON.stringify(payload) + "\n");
+  return JSON.stringify(payload);
+}
+
+// process.exit() abandons any not-yet-flushed writes to a piped (i.e. async, non-TTY) stdout,
+// which can truncate the JSON mid-document when a consumer reads it through a pipe. So wait for
+// the write to drain via its completion callback, then force the exit from inside that callback.
+// Forcing the exit (rather than relying on a natural event-loop drain) keeps the CLI from
+// hanging if any background handle isn't unref'd. See
+// https://nodejs.org/api/process.html#processexitcode — "process.exit() will force the process
+// to exit as quickly as possible even if there are still asynchronous operations pending that
+// have not yet completed fully, including I/O operations to process.stdout and process.stderr."
+function writeThenExit(stream, text, code) {
+  stream.write(text, () => process.exit(code));
 }
 
 // Only self-execute when invoked directly (`node sla-cli.mjs`). The extension validator
 // dynamically imports every .mjs to smoke-test it; without this guard the import would run
-// main() and call process.exit(), aborting validation of the whole extension.
+// main() and exit the process, aborting validation of the whole extension.
 const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] || "").href;
 if (invokedDirectly) {
   main()
-    .then(() => {
-      // Background pollers/timers are unref'd, but exit explicitly so the CLI never hangs.
-      process.exit(0);
-    })
+    .then((json) => writeThenExit(process.stdout, json + "\n", 0))
     .catch((err) => {
-      process.stderr.write("sla-cli failed: " + (err?.stack || err?.message || String(err)) + "\n");
-      process.exit(1);
+      writeThenExit(process.stderr, "sla-cli failed: " + (err?.stack || err?.message || String(err)) + "\n", 1);
     });
 }

--- a/.github/extensions/aspire-team-app/sla-cli.mjs
+++ b/.github/extensions/aspire-team-app/sla-cli.mjs
@@ -1,0 +1,72 @@
+// Headless SLA report emitter for the hourly Teams notifier workflow.
+//
+// Runs OUTSIDE the canvas: it computes a fresh dashboard via forceRefresh() (which does
+// NOT start the loopback HTTP server) and prints a single JSON document describing the
+// aspire-1p review SLA state plus every open external PR. The workflow diffs this against
+// its own tracker file to decide what to announce.
+//
+// Usage:  node sla-cli.mjs
+// Output (stdout): one JSON object; see shape below. Non-JSON diagnostics go to stderr.
+
+import { forceRefresh } from "./server.mjs";
+
+function leanCard(c) {
+  return {
+    repo: c.pr.repository,
+    number: c.pr.number,
+    title: c.pr.title,
+    url: c.pr.url,
+    author: c.pr.author,
+    state: c.sla?.state ?? null,
+    firstQualifiedAt: c.sla?.firstQualifiedAt ?? null,
+    warnAt: c.sla?.warnAt ?? null,
+    deadlineAt: c.sla?.deadlineAt ?? null,
+  };
+}
+
+async function main() {
+  const { dashboard } = await forceRefresh();
+  if (!dashboard || !dashboard.authenticated) {
+    // Emit a well-formed, clearly-unauthenticated payload so the workflow can bail quietly
+    // instead of tripping on a parse error.
+    process.stdout.write(JSON.stringify({
+      authenticated: false,
+      message: dashboard?.message ?? "not authenticated",
+      generatedAt: new Date().toISOString(),
+      sla: null,
+      externalOpenPrs: [],
+    }) + "\n");
+    return;
+  }
+
+  const sla = dashboard.sla ?? null;
+  const payload = {
+    authenticated: true,
+    viewer: dashboard.viewer,
+    generatedAt: new Date().toISOString(),
+    sla: sla
+      ? {
+          repos: sla.repos,
+          budgetHours: sla.budgetHours,
+          warnHours: sla.warnHours,
+          tz: sla.tz,
+          total: sla.total,
+          okCount: sla.okCount,
+          breached: (sla.breached ?? []).map(leanCard),
+          approaching: (sla.approaching ?? []).map(leanCard),
+        }
+      : null,
+    externalOpenPrs: dashboard.externalOpenPrs ?? [],
+  };
+  process.stdout.write(JSON.stringify(payload) + "\n");
+}
+
+main()
+  .then(() => {
+    // Background pollers/timers are unref'd, but exit explicitly so the CLI never hangs.
+    process.exit(0);
+  })
+  .catch((err) => {
+    process.stderr.write("sla-cli failed: " + (err?.stack || err?.message || String(err)) + "\n");
+    process.exit(1);
+  });

--- a/.github/extensions/aspire-team-app/sla.mjs
+++ b/.github/extensions/aspire-team-app/sla.mjs
@@ -384,12 +384,23 @@ export async function annotateDashboardSla(dashboard, opts = {}) {
   // so the SLA pill rides along wherever the PR appears.
   if (attention) decorateAttention(attention, statusByKey);
 
-  // The dedicated panel shows only actionable states (approaching / breached),
-  // breached first then approaching, each group by soonest deadline.
+  // snapshot() builds attention.slaCandidates as *fresh* card objects, so they are not
+  // the same references decorateAttention() just stamped in the focus/bucket lists. Stamp
+  // them directly here — the panel arrays below read c.sla, so without this the panel
+  // would report a non-zero total/okCount but render no rows.
+  for (const card of cards) {
+    const status = statusByKey.get(slaCandidateKey(card.pr));
+    if (status) decorateCard(card, status);
+  }
+
+  // The dedicated panel shows every tracked candidate so the team always has visibility
+  // into the SLA queue. Actionable states sort first (breached, then approaching), each
+  // group by soonest deadline; comfortable "ok" candidates follow with a live countdown.
   const byDeadline = (a, b) => new Date(a.sla.deadlineAt) - new Date(b.sla.deadlineAt);
   const panelCards = cards.filter((c) => c.sla && c.sla.state !== "ok");
   const breached = panelCards.filter((c) => c.sla.state === "breached").sort(byDeadline);
   const approaching = panelCards.filter((c) => c.sla.state === "approaching").sort(byDeadline);
+  const ok = cards.filter((c) => c.sla && c.sla.state === "ok").sort(byDeadline);
 
   dashboard.sla = {
     repos: SLA_REPOS,
@@ -398,7 +409,9 @@ export async function annotateDashboardSla(dashboard, opts = {}) {
     tz: SLA_TIMEZONE,
     breached,
     approaching,
-    // Count of tracked-but-comfortable candidates, for a quiet "N within budget" note.
+    // Tracked-but-comfortable candidates, shown with a quiet countdown so the panel
+    // stays useful even when nothing is at risk yet.
+    ok,
     okCount: cards.length - panelCards.length,
     total: cards.length,
   };

--- a/.github/extensions/aspire-team-app/sla.mjs
+++ b/.github/extensions/aspire-team-app/sla.mjs
@@ -425,6 +425,19 @@ export async function annotateDashboardSla(dashboard, opts = {}) {
   const approaching = panelCards.filter((c) => c.sla.state === "approaching").sort(byDeadline);
   const ok = cards.filter((c) => c.sla && c.sla.state === "ok").sort(byDeadline);
 
+  // Flag a *partial* fetch: an in-scope SLA repo that did not come back authoritatively this
+  // run (transient GitHub outage, throttling, etc.). Consumers such as the hourly notifier use
+  // this to tell "the queue is genuinely empty" apart from "the watched repo failed to fetch",
+  // so they don't clear or miss alerts on a run that never saw the repo. Absent expectedSlaRepos
+  // (e.g. focused unit tests), assume a complete fetch.
+  const authoritative = opts.authoritativeRepos instanceof Set
+    ? opts.authoritativeRepos
+    : new Set(opts.authoritativeRepos || []);
+  const expected = opts.expectedSlaRepos instanceof Set
+    ? opts.expectedSlaRepos
+    : new Set(opts.expectedSlaRepos || []);
+  const unfetchedRepos = [...expected].filter((r) => !authoritative.has(r));
+
   dashboard.sla = {
     repos: SLA_REPOS,
     budgetHours: SLA_BUDGET_HOURS,
@@ -437,6 +450,10 @@ export async function annotateDashboardSla(dashboard, opts = {}) {
     ok,
     okCount: cards.length - panelCards.length,
     total: cards.length,
+    // True when at least one watched SLA repo did not fetch authoritatively this run, so the
+    // panels/lists above are known-incomplete and must not be treated as a clean empty queue.
+    partial: unfetchedRepos.length > 0,
+    unfetchedRepos,
   };
 
   // Drop the scratch field so it doesn't bloat the broadcast payload.

--- a/.github/extensions/aspire-team-app/sla.mjs
+++ b/.github/extensions/aspire-team-app/sla.mjs
@@ -1,0 +1,410 @@
+// Review SLA engine for the first-party aspire-1p repo.
+//
+// The private mirror carries a 1-business-day review SLA: a PR that is genuinely
+// ready (qualifies for the "Needs attention" focused queue), was authored by
+// someone outside the core team, and has had no human review yet must be reviewed
+// within a business-time budget. This module owns:
+//
+//   * Timezone-aware business-hours math (no external libraries) — the budget is
+//     only consumed during Mon-Fri 09:00-17:00 Pacific, so nights and weekends
+//     never burn the clock.
+//   * A durable per-PR tracking store (firstQualifiedAt) so the clock survives
+//     process restarts and is shared across the canvas server and the headless
+//     CLI used by the hourly notifier workflow.
+//   * annotateDashboardSla(), which reconciles tracking, computes stable anchors,
+//     derives each PR's SLA state, decorates the dashboard cards with SLA pills,
+//     and attaches the dedicated SLA panel data (dashboard.sla).
+//
+// CHURN CONSTRAINT (critical): server.dashboardChanged() JSON-stringifies the
+// whole dashboard (minus seq/fetchedAt) to detect changes and re-broadcast. So we
+// must only ever store STABLE anchors (firstQualifiedAt / warnAt / deadlineAt are
+// fixed given fixed inputs) and a stepwise `state` that flips only at threshold
+// crossings — never a live "waiting Xh" delta or a per-run timestamp. The live
+// "due in ~2h" text is computed client-side in render.mjs from deadlineAt.
+
+import { mkdir, readFile, writeFile, rename } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SLA_REPOS,
+  SLA_BUDGET_HOURS,
+  SLA_WARN_HOURS,
+  SLA_TIMEZONE,
+  SLA_WORK_START_HOUR,
+  SLA_WORK_END_HOUR,
+  SLA_WORK_DAYS,
+  hourMs,
+} from "./constants.mjs";
+import { isCoreTeamAuthor } from "./model.mjs";
+
+const COPILOT_HOME = process.env.COPILOT_HOME || join(homedir(), ".copilot");
+const ARTIFACT_DIR = join(COPILOT_HOME, "extensions", "aspire-team-app", "artifacts");
+const TRACKING_FILE = join(ARTIFACT_DIR, "sla-tracking.json");
+
+const SLA_REPO_SET = new Set(SLA_REPOS.map((r) => r.toLowerCase()));
+const WORK_DAY_SET = new Set(SLA_WORK_DAYS);
+
+// ---------------------------------------------------------------------------
+// Candidate predicates
+// ---------------------------------------------------------------------------
+
+// Whether a repository is under the review SLA (case-insensitive).
+export function isSlaRepo(repo) {
+  return SLA_REPO_SET.has(String(repo || "").toLowerCase());
+}
+
+// A PR is SLA-eligible when it is on an SLA repo, authored outside the core team,
+// and has not yet had a single *human* review (reviewerCount counts distinct human
+// reviewers; Copilot/bot reviews are excluded upstream in deriveReview). The clock
+// stops the moment any human comments on or approves the PR.
+export function isSlaCandidatePr(pr) {
+  if (!pr) return false;
+  if (!isSlaRepo(pr.repository)) return false;
+  if (isCoreTeamAuthor(pr.author)) return false;
+  return (pr.review?.reviewerCount ?? 0) === 0;
+}
+
+// Stable key for a PR across runs and stores. "repo#number", lowercased repo.
+export function slaCandidateKey(pr) {
+  return `${String(pr.repository).toLowerCase()}#${pr.number}`;
+}
+
+// ---------------------------------------------------------------------------
+// Timezone-aware business-hours math (pure, no libraries)
+// ---------------------------------------------------------------------------
+//
+// All instants are epoch-millisecond numbers. "wall" refers to the local clock in
+// SLA_TIMEZONE. Intl.DateTimeFormat resolves the timezone (including DST) for us;
+// the 09:00-17:00 window never straddles the ambiguous 02:00 DST hour, so a simple
+// two-pass offset correction is exact for our purposes.
+
+// Break an instant into its wall-clock calendar parts in the given timezone.
+function tzParts(instant, tz) {
+  // en-US + h23 gives a stable, parseable 24-hour breakdown regardless of host locale.
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hourCycle: "h23",
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+  });
+  const parts = dtf.formatToParts(new Date(instant));
+  const m = {};
+  for (const p of parts) {
+    if (p.type !== "literal") m[p.type] = Number(p.value);
+  }
+  // Intl emits hour "24" at midnight under some engines/versions; normalize to 0.
+  if (m.hour === 24) m.hour = 0;
+  return m;
+}
+
+// Milliseconds to add to `instant` to get the wall clock as if it were UTC, i.e.
+// the timezone offset at that instant. offset = wallAsUTC - instant.
+export function getTzOffsetMs(instant, tz) {
+  const m = tzParts(instant, tz);
+  const asUtc = Date.UTC(m.year, m.month - 1, m.day, m.hour, m.minute, m.second);
+  // Strip sub-second precision from instant so the (second-granular) asUtc lines up;
+  // real timezone offsets are always whole minutes, so nothing is lost.
+  const base = instant - (((instant % 1000) + 1000) % 1000);
+  return asUtc - base;
+}
+
+// Resolve a local wall-clock time (y, mo[1-12], d, h, mi) in `tz` to an instant.
+// Two-pass: guess treating the wall time as UTC, correct by the offset, then
+// re-check the offset at the resolved instant to absorb a DST transition.
+export function wallToInstant(y, mo, d, h, mi, tz) {
+  const guess = Date.UTC(y, mo - 1, d, h, mi, 0);
+  const offset1 = getTzOffsetMs(guess, tz);
+  let inst = guess - offset1;
+  const offset2 = getTzOffsetMs(inst, tz);
+  if (offset2 !== offset1) inst = guess - offset2;
+  return inst;
+}
+
+// UTC weekday (0=Sun..6=Sat) of a calendar date. Weekday is timezone-independent
+// for a whole date, so a plain UTC construction is correct here.
+function weekdayOf(y, mo, d) {
+  return new Date(Date.UTC(y, mo - 1, d)).getUTCDay();
+}
+
+function isWorkDay(y, mo, d) {
+  return WORK_DAY_SET.has(weekdayOf(y, mo, d));
+}
+
+// The [start, end) business-hours window (as instants) for a given local date.
+function windowForDay(y, mo, d, tz) {
+  return {
+    start: wallToInstant(y, mo, d, SLA_WORK_START_HOUR, 0, tz),
+    end: wallToInstant(y, mo, d, SLA_WORK_END_HOUR, 0, tz),
+  };
+}
+
+// The business-hours start instant of the calendar day *after* (y, mo, d).
+function nextDayWorkStart(y, mo, d, tz) {
+  const n = new Date(Date.UTC(y, mo - 1, d + 1));
+  return windowForDay(n.getUTCFullYear(), n.getUTCMonth() + 1, n.getUTCDate(), tz).start;
+}
+
+// Add `budgetMs` of *business time* to `start`, returning the deadline instant.
+// Walks day by day: skips weekends, clamps into each day's [09:00,17:00) window,
+// and consumes the available window until the budget is exhausted.
+export function addBusinessMs(start, budgetMs, tz = SLA_TIMEZONE) {
+  if (budgetMs <= 0) return start;
+  let remaining = budgetMs;
+  let cur = start;
+  // Safety bound: ~10 years of days. A positive budget always resolves far sooner.
+  for (let i = 0; i < 3660; i++) {
+    const p = tzParts(cur, tz);
+    if (isWorkDay(p.year, p.month, p.day)) {
+      const win = windowForDay(p.year, p.month, p.day, tz);
+      let cursor = cur < win.start ? win.start : cur;
+      if (cursor < win.end) {
+        const avail = win.end - cursor;
+        if (remaining <= avail) return cursor + remaining;
+        remaining -= avail;
+      }
+    }
+    cur = nextDayWorkStart(p.year, p.month, p.day, tz);
+  }
+  return cur;
+}
+
+// Business time elapsed between two instants (used for human-readable message text
+// in the notifier; NOT stored on the dashboard).
+export function businessMsBetween(start, end, tz = SLA_TIMEZONE) {
+  if (end <= start) return 0;
+  let total = 0;
+  let cur = start;
+  for (let i = 0; i < 3660 && cur < end; i++) {
+    const p = tzParts(cur, tz);
+    if (isWorkDay(p.year, p.month, p.day)) {
+      const win = windowForDay(p.year, p.month, p.day, tz);
+      const lo = Math.max(cur, win.start);
+      const hi = Math.min(end, win.end);
+      if (hi > lo) total += hi - lo;
+    }
+    cur = nextDayWorkStart(p.year, p.month, p.day, tz);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Anchors + state
+// ---------------------------------------------------------------------------
+
+// Precompute the stable warn/deadline instants for a PR from when it first
+// qualified. Given a fixed firstQualifiedAt these never move, so they don't churn
+// the dashboard JSON.
+export function slaAnchors(firstQualifiedAtIso, opts = {}) {
+  const tz = opts.tz ?? SLA_TIMEZONE;
+  const budgetHours = opts.budgetHours ?? SLA_BUDGET_HOURS;
+  const warnHours = opts.warnHours ?? SLA_WARN_HOURS;
+  const start = new Date(firstQualifiedAtIso).getTime();
+  return {
+    firstQualifiedAt: firstQualifiedAtIso,
+    warnAt: new Date(addBusinessMs(start, warnHours * hourMs, tz)).toISOString(),
+    deadlineAt: new Date(addBusinessMs(start, budgetHours * hourMs, tz)).toISOString(),
+  };
+}
+
+// Derive the stepwise SLA state by comparing wall-clock `nowMs` to the anchors.
+// Stepwise: only flips at threshold crossings, so storing it does not cause churn.
+export function slaState(anchors, nowMs) {
+  const deadline = new Date(anchors.deadlineAt).getTime();
+  const warn = new Date(anchors.warnAt).getTime();
+  if (nowMs >= deadline) return "breached";
+  if (nowMs >= warn) return "approaching";
+  return "ok";
+}
+
+// ---------------------------------------------------------------------------
+// Tracking store (durable firstQualifiedAt per PR)
+// ---------------------------------------------------------------------------
+//
+// Shape: { prs: { "repo#num": { firstQualifiedAt: ISO } } }. Writes are serialized
+// in-process and atomic (temp file + rename) to reduce cross-process races between
+// the canvas session and the hourly workflow session. A rare lost update is
+// self-healing: at worst firstQualifiedAt resets later, which pushes the deadline
+// out — it never causes a false breach.
+
+let trackingUpdate = Promise.resolve();
+
+export async function loadTracking() {
+  try {
+    const raw = await readFile(TRACKING_FILE, "utf8");
+    const parsed = JSON.parse(raw);
+    return { prs: parsed && typeof parsed.prs === "object" && parsed.prs ? parsed.prs : {} };
+  } catch {
+    return { prs: {} };
+  }
+}
+
+async function saveTracking(tracking) {
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  const tmp = `${TRACKING_FILE}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, JSON.stringify(tracking, null, 2) + "\n", "utf8");
+  await rename(tmp, TRACKING_FILE);
+  return tracking;
+}
+
+// Add newly-qualifying keys (stamping firstQualifiedAt=nowIso) and prune keys that
+// no longer qualify. Returns whether anything changed so callers can skip the write
+// on the common no-op poll. Pure over its inputs (mutates the passed tracking).
+export function reconcileTracking(tracking, candidateKeys, nowIso) {
+  const prs = tracking.prs || (tracking.prs = {});
+  const want = new Set(candidateKeys);
+  let changed = false;
+  for (const key of want) {
+    if (!prs[key]) {
+      prs[key] = { firstQualifiedAt: nowIso };
+      changed = true;
+    }
+  }
+  for (const key of Object.keys(prs)) {
+    if (!want.has(key)) {
+      delete prs[key];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+// Serialized load -> reconcile -> (persist if changed). Returns a snapshot of the
+// per-key firstQualifiedAt map for the current candidates.
+function reconcileAndPersist(candidateKeys, nowIso) {
+  const run = trackingUpdate
+    .catch(() => {})
+    .then(async () => {
+      const tracking = await loadTracking();
+      const changed = reconcileTracking(tracking, candidateKeys, nowIso);
+      if (changed) await saveTracking(tracking);
+      return tracking.prs;
+    });
+  trackingUpdate = run.then(() => {}, () => {});
+  return run;
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard annotation
+// ---------------------------------------------------------------------------
+
+function slaPill(state) {
+  if (state === "breached") return { label: "Out of SLA", tone: "danger", kind: "sla" };
+  if (state === "approaching") return { label: "Review SLA", tone: "warning", kind: "sla" };
+  return null;
+}
+
+// Prepend the SLA pill to a card's signals (dropping any prior SLA pill so repeat
+// annotations don't stack) and stamp the card with its SLA status for the renderer.
+function decorateCard(card, status) {
+  const pill = slaPill(status.state);
+  card.sla = status;
+  if (pill) {
+    const rest = (card.signals || []).filter((s) => s && s.kind !== "sla");
+    card.signals = [pill, ...rest];
+  }
+}
+
+// Walk every card list in the attention model and decorate matching cards by key.
+function decorateAttention(attention, statusByKey) {
+  const lists = [];
+  if (Array.isArray(attention.focus)) lists.push(attention.focus);
+  if (Array.isArray(attention.forMe)) lists.push(attention.forMe);
+  if (Array.isArray(attention.focusExclusions)) lists.push(attention.focusExclusions);
+  for (const b of attention.buckets || []) {
+    if (Array.isArray(b.items)) lists.push(b.items);
+  }
+  for (const list of lists) {
+    for (const card of list) {
+      const pr = card && card.pr;
+      if (!pr) continue;
+      const status = statusByKey.get(slaCandidateKey(pr));
+      if (status) decorateCard(card, status);
+    }
+  }
+}
+
+function statusFor(pr, firstQualifiedAt, nowMs, opts) {
+  const anchors = slaAnchors(firstQualifiedAt, opts);
+  const state = slaState(anchors, nowMs);
+  return {
+    key: slaCandidateKey(pr),
+    repository: pr.repository,
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    author: pr.author,
+    firstQualifiedAt: anchors.firstQualifiedAt,
+    warnAt: anchors.warnAt,
+    deadlineAt: anchors.deadlineAt,
+    state,
+  };
+}
+
+// Reconcile tracking, compute SLA state for every candidate, decorate the dashboard
+// cards, and attach dashboard.sla (the dedicated panel data). snapshot() attaches
+// `attention.slaCandidates` (full cards for qualifying PRs); this removes that
+// scratch field afterward to keep the broadcast JSON lean.
+//
+// opts: { now?: epoch ms, persist?: bool (default true) }.
+export async function annotateDashboardSla(dashboard, opts = {}) {
+  const attention = dashboard && dashboard.attention;
+  const candidates = (attention && attention.slaCandidates) || [];
+  const nowMs = opts.now ?? Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const anchorOpts = {
+    tz: SLA_TIMEZONE,
+    budgetHours: SLA_BUDGET_HOURS,
+    warnHours: SLA_WARN_HOURS,
+  };
+
+  // Re-filter defensively so this module remains the single source of truth for
+  // who is under SLA, regardless of what snapshot() attached.
+  const cards = candidates.filter((c) => c && c.pr && isSlaCandidatePr(c.pr));
+  const keys = cards.map((c) => slaCandidateKey(c.pr));
+
+  const persist = opts.persist !== false;
+  const trackedPrs = persist
+    ? await reconcileAndPersist(keys, nowIso)
+    : (() => {
+        const tracking = { prs: {} };
+        reconcileTracking(tracking, keys, nowIso);
+        return tracking.prs;
+      })();
+
+  const statusByKey = new Map();
+  for (const card of cards) {
+    const key = slaCandidateKey(card.pr);
+    const firstQualifiedAt = trackedPrs[key]?.firstQualifiedAt || nowIso;
+    const status = statusFor(card.pr, firstQualifiedAt, nowMs, anchorOpts);
+    statusByKey.set(key, status);
+  }
+
+  // Decorate cards across the whole attention model (focus/forMe/exclusions/buckets)
+  // so the SLA pill rides along wherever the PR appears.
+  if (attention) decorateAttention(attention, statusByKey);
+
+  // The dedicated panel shows only actionable states (approaching / breached),
+  // breached first then approaching, each group by soonest deadline.
+  const byDeadline = (a, b) => new Date(a.sla.deadlineAt) - new Date(b.sla.deadlineAt);
+  const panelCards = cards.filter((c) => c.sla && c.sla.state !== "ok");
+  const breached = panelCards.filter((c) => c.sla.state === "breached").sort(byDeadline);
+  const approaching = panelCards.filter((c) => c.sla.state === "approaching").sort(byDeadline);
+
+  dashboard.sla = {
+    repos: SLA_REPOS,
+    budgetHours: SLA_BUDGET_HOURS,
+    warnHours: SLA_WARN_HOURS,
+    tz: SLA_TIMEZONE,
+    breached,
+    approaching,
+    // Count of tracked-but-comfortable candidates, for a quiet "N within budget" note.
+    okCount: cards.length - panelCards.length,
+    total: cards.length,
+  };
+
+  // Drop the scratch field so it doesn't bloat the broadcast payload.
+  if (attention && "slaCandidates" in attention) delete attention.slaCandidates;
+
+  return dashboard;
+}

--- a/.github/extensions/aspire-team-app/sla.mjs
+++ b/.github/extensions/aspire-team-app/sla.mjs
@@ -250,7 +250,14 @@ async function saveTracking(tracking) {
 // Add newly-qualifying keys (stamping firstQualifiedAt=nowIso) and prune keys that
 // no longer qualify. Returns whether anything changed so callers can skip the write
 // on the common no-op poll. Pure over its inputs (mutates the passed tracking).
-export function reconcileTracking(tracking, candidateKeys, nowIso) {
+//
+// authoritativeRepos (optional): a Set of lowercased repo slugs whose PR list was fetched
+// SUCCESSFULLY this run. When provided, a tracked key is pruned only if its repo is in the
+// set — i.e. we actually have a trustworthy candidate list for it. This prevents a transient
+// fetch failure (which yields zero candidateKeys for that repo) from deleting still-open
+// tracked PRs and thereby resetting their firstQualifiedAt / breach clock on the next success.
+// When omitted (tests / back-compat) every absent key is pruned as before.
+export function reconcileTracking(tracking, candidateKeys, nowIso, authoritativeRepos) {
   const prs = tracking.prs || (tracking.prs = {});
   const want = new Set(candidateKeys);
   let changed = false;
@@ -261,22 +268,29 @@ export function reconcileTracking(tracking, candidateKeys, nowIso) {
     }
   }
   for (const key of Object.keys(prs)) {
-    if (!want.has(key)) {
-      delete prs[key];
-      changed = true;
+    if (want.has(key)) continue;
+    // Only prune when we have an authoritative candidate list for this key's repo. The key
+    // format is "repo#number" (see slaCandidateKey), so the repo is everything before the
+    // last '#'. Guard against absurd keys by keeping them if the repo can't be parsed.
+    if (authoritativeRepos) {
+      const hash = key.lastIndexOf("#");
+      const repo = hash === -1 ? "" : key.slice(0, hash);
+      if (!repo || !authoritativeRepos.has(repo)) continue;
     }
+    delete prs[key];
+    changed = true;
   }
   return changed;
 }
 
 // Serialized load -> reconcile -> (persist if changed). Returns a snapshot of the
 // per-key firstQualifiedAt map for the current candidates.
-function reconcileAndPersist(candidateKeys, nowIso) {
+function reconcileAndPersist(candidateKeys, nowIso, authoritativeRepos) {
   const run = trackingUpdate
     .catch(() => {})
     .then(async () => {
       const tracking = await loadTracking();
-      const changed = reconcileTracking(tracking, candidateKeys, nowIso);
+      const changed = reconcileTracking(tracking, candidateKeys, nowIso, authoritativeRepos);
       if (changed) await saveTracking(tracking);
       return tracking.prs;
     });
@@ -346,7 +360,14 @@ function statusFor(pr, firstQualifiedAt, nowMs, opts) {
 // `attention.slaCandidates` (full cards for qualifying PRs); this removes that
 // scratch field afterward to keep the broadcast JSON lean.
 //
-// opts: { now?: epoch ms, persist?: bool (default true) }.
+// opts: { now?: epoch ms, persist?: bool (default true), authoritativeRepos?: Set<string>,
+//         seedTracking?: { [key]: { firstQualifiedAt } } }.
+// authoritativeRepos (lowercased repo slugs that fetched successfully this run) is forwarded
+// to reconcileTracking so a failed SLA-repo fetch never prunes still-tracked PRs (#5).
+// seedTracking is a test-only seam: with persist:false the tracking store is in-memory and
+// would otherwise stamp firstQualifiedAt=now for every key (always "ok"). Seeding lets a test
+// start the clock in the past to exercise the approaching/breached panel arrays without
+// touching the durable on-disk store. It is ignored when persist is true (the real path).
 export async function annotateDashboardSla(dashboard, opts = {}) {
   const attention = dashboard && dashboard.attention;
   const candidates = (attention && attention.slaCandidates) || [];
@@ -365,10 +386,12 @@ export async function annotateDashboardSla(dashboard, opts = {}) {
 
   const persist = opts.persist !== false;
   const trackedPrs = persist
-    ? await reconcileAndPersist(keys, nowIso)
+    ? await reconcileAndPersist(keys, nowIso, opts.authoritativeRepos)
     : (() => {
-        const tracking = { prs: {} };
-        reconcileTracking(tracking, keys, nowIso);
+        // reconcileTracking preserves existing keys' firstQualifiedAt, so a seeded past
+        // stamp survives here and drives approaching/breached states.
+        const tracking = { prs: { ...(opts.seedTracking || {}) } };
+        reconcileTracking(tracking, keys, nowIso, opts.authoritativeRepos);
         return tracking.prs;
       })();
 

--- a/.github/extensions/aspire-team-app/sla.test.mjs
+++ b/.github/extensions/aspire-team-app/sla.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hourMs } from "./constants.mjs";
+import { hourMs, SLA_REPOS } from "./constants.mjs";
 import {
   addBusinessMs,
+  annotateDashboardSla,
   businessMsBetween,
   isSlaCandidatePr,
   isSlaRepo,
@@ -151,4 +152,50 @@ test("reconcileTracking: adds new keys, preserves firstQualifiedAt, prunes gone 
   assert.equal(tracking.prs["r#3"].firstQualifiedAt, now2);
   // r#1 keeps its original clock start throughout.
   assert.equal(tracking.prs["r#1"].firstQualifiedAt, now1);
+});
+
+test("annotateDashboardSla: freshly-qualified candidates populate the ok panel list", async () => {
+  const repo = SLA_REPOS[0];
+  const mk = (number, author) => ({
+    pr: {
+      repository: repo,
+      number,
+      author,
+      title: `PR ${number}`,
+      url: `https://example/${number}`,
+      review: { reviewerCount: 0 },
+    },
+  });
+  // A focus card sharing PR #1's key proves the SLA record also rides the attention
+  // lists, which are *different object references* than attention.slaCandidates.
+  const focusCard = mk(1, "external-one");
+  const dashboard = {
+    attention: {
+      focus: [focusCard],
+      slaCandidates: [mk(1, "external-one"), mk(2, "external-two")],
+    },
+  };
+  // Mon 2025-01-06 10:00 PT: both PRs are freshly qualified, so with a same-run start
+  // stamp they sit comfortably inside the 8h budget (warn at 16:00, due Tue).
+  const now = pt(2025, 1, 6, 10);
+  await annotateDashboardSla(dashboard, { now, persist: false });
+
+  const s = dashboard.sla;
+  assert.equal(s.total, 2);
+  assert.equal(s.okCount, 2);
+  assert.equal(s.breached.length, 0);
+  assert.equal(s.approaching.length, 0);
+  // The regression guard: candidate cards are stamped directly, so the ok list is
+  // populated even though slaCandidates are not the same references as focus/buckets.
+  assert.equal(s.ok.length, 2);
+  for (const c of s.ok) {
+    assert.equal(c.sla.state, "ok");
+    assert.ok(c.sla.deadlineAt);
+    assert.ok(c.sla.firstQualifiedAt);
+  }
+  // The scratch field is stripped from the broadcast payload.
+  assert.equal("slaCandidates" in dashboard.attention, false);
+  // The focus card (separate reference, same PR) is decorated too.
+  assert.ok(focusCard.sla);
+  assert.equal(focusCard.sla.state, "ok");
 });

--- a/.github/extensions/aspire-team-app/sla.test.mjs
+++ b/.github/extensions/aspire-team-app/sla.test.mjs
@@ -154,6 +154,85 @@ test("reconcileTracking: adds new keys, preserves firstQualifiedAt, prunes gone 
   assert.equal(tracking.prs["r#1"].firstQualifiedAt, now1);
 });
 
+test("reconcileTracking: does not prune keys whose repo was not authoritatively fetched", () => {
+  const tracking = { prs: {} };
+  const now1 = "2025-01-06T17:00:00.000Z";
+  // Two SLA PRs on the same repo start the clock.
+  reconcileTracking(tracking, ["devdiv-microsoft/aspire-1p#1", "devdiv-microsoft/aspire-1p#2"], now1);
+  const now2 = "2025-01-06T18:00:00.000Z";
+
+  // Simulate a failed fetch this run: candidateKeys is empty and the repo is NOT authoritative.
+  // Nothing should be pruned, so the breach clocks survive the transient outage.
+  const auth = new Set(); // no repo fetched successfully
+  assert.equal(reconcileTracking(tracking, [], now2, auth), false);
+  assert.equal(tracking.prs["devdiv-microsoft/aspire-1p#1"].firstQualifiedAt, now1);
+  assert.equal(tracking.prs["devdiv-microsoft/aspire-1p#2"].firstQualifiedAt, now1);
+
+  // Now the repo fetched OK and only #1 still qualifies (#2 got reviewed) => #2 is pruned,
+  // #1 keeps its original stamp.
+  const authOk = new Set(["devdiv-microsoft/aspire-1p"]);
+  assert.equal(reconcileTracking(tracking, ["devdiv-microsoft/aspire-1p#1"], now2, authOk), true);
+  assert.equal("devdiv-microsoft/aspire-1p#2" in tracking.prs, false);
+  assert.equal(tracking.prs["devdiv-microsoft/aspire-1p#1"].firstQualifiedAt, now1);
+});
+
+test("annotateDashboardSla: seeded past clocks populate the breached and approaching panels", async () => {
+  const repo = SLA_REPOS[0];
+  const mk = (number, author) => ({
+    pr: {
+      repository: repo,
+      number,
+      author,
+      title: `PR ${number}`,
+      url: `https://example/${number}`,
+      review: { reviewerCount: 0 },
+    },
+  });
+  // Three external PRs, each qualified at a different past time so they land in distinct states
+  // at the evaluation instant. Budget is 8h business, warn at 6h (see constants).
+  const breachedKey = slaCandidateKey(mk(10).pr);
+  const approachingKey = slaCandidateKey(mk(11).pr);
+  const okKey = slaCandidateKey(mk(12).pr);
+  // Evaluate Tue 2025-01-07 11:00 PT.
+  const now = pt(2025, 1, 7, 11);
+  const seedTracking = {
+    // Qualified Mon 09:00 => deadline Mon 17:00, already past => breached.
+    [breachedKey]: { firstQualifiedAt: new Date(pt(2025, 1, 6, 9)).toISOString() },
+    // Qualified Mon 12:00 => by Tue 11:00 that is 5h Mon + 2h Tue = 7h business elapsed,
+    // past the 6h warn but short of the 8h deadline => approaching.
+    [approachingKey]: { firstQualifiedAt: new Date(pt(2025, 1, 6, 12)).toISOString() },
+    // Qualified Tue 10:30 => only 30m in => ok.
+    [okKey]: { firstQualifiedAt: new Date(pt(2025, 1, 7, 10, 30)).toISOString() },
+  };
+
+  const focusBreached = mk(10, "external-a");
+  const dashboard = {
+    attention: {
+      focus: [focusBreached],
+      slaCandidates: [mk(10, "external-a"), mk(11, "external-b"), mk(12, "external-c")],
+    },
+  };
+  await annotateDashboardSla(dashboard, { now, persist: false, seedTracking });
+
+  const s = dashboard.sla;
+  assert.equal(s.total, 3);
+  assert.equal(s.breached.length, 1);
+  assert.equal(s.breached[0].pr.number, 10);
+  assert.equal(s.breached[0].sla.state, "breached");
+  assert.equal(s.approaching.length, 1);
+  assert.equal(s.approaching[0].pr.number, 11);
+  assert.equal(s.approaching[0].sla.state, "approaching");
+  assert.equal(s.ok.length, 1);
+  assert.equal(s.ok[0].pr.number, 12);
+  assert.equal(s.okCount, 1);
+  // The breached PR's focus card (a distinct reference) is decorated with the SLA pill too.
+  assert.ok(focusBreached.sla);
+  assert.equal(focusBreached.sla.state, "breached");
+  const pill = (focusBreached.signals ?? []).find((sig) => sig.kind === "sla");
+  assert.ok(pill);
+  assert.equal(pill.label, "Out of SLA");
+});
+
 test("annotateDashboardSla: freshly-qualified candidates populate the ok panel list", async () => {
   const repo = SLA_REPOS[0];
   const mk = (number, author) => ({

--- a/.github/extensions/aspire-team-app/sla.test.mjs
+++ b/.github/extensions/aspire-team-app/sla.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hourMs } from "./constants.mjs";
+import {
+  addBusinessMs,
+  businessMsBetween,
+  isSlaCandidatePr,
+  isSlaRepo,
+  reconcileTracking,
+  slaAnchors,
+  slaCandidateKey,
+  slaState,
+  wallToInstant,
+} from "./sla.mjs";
+
+const TZ = "America/Los_Angeles";
+
+// Resolve a Pacific wall-clock time to an instant for readable expectations. This is the
+// same primitive addBusinessMs is built on, so comparing instants keeps the tests exact
+// across DST without hardcoding UTC offsets.
+function pt(y, mo, d, h, mi = 0) {
+  return wallToInstant(y, mo, d, h, mi, TZ);
+}
+
+test("addBusinessMs: whole budget inside one workday", () => {
+  // Mon 2025-01-06 09:00 PT + 8h = Mon 17:00 PT (a full business day).
+  const start = pt(2025, 1, 6, 9);
+  assert.equal(addBusinessMs(start, 8 * hourMs, TZ), pt(2025, 1, 6, 17));
+  assert.equal(addBusinessMs(start, 4 * hourMs, TZ), pt(2025, 1, 6, 13));
+});
+
+test("addBusinessMs: rolls onto the next workday when the day runs out", () => {
+  // Mon 15:00 has 2h left; +4h consumes 2h Mon then 2h Tue 09:00-11:00.
+  const start = pt(2025, 1, 6, 15);
+  assert.equal(addBusinessMs(start, 4 * hourMs, TZ), pt(2025, 1, 7, 11));
+});
+
+test("addBusinessMs: clamps a pre-work start up to 09:00", () => {
+  // Mon 06:00 (before work) + 8h should behave like starting at 09:00 => Mon 17:00.
+  assert.equal(addBusinessMs(pt(2025, 1, 6, 6), 8 * hourMs, TZ), pt(2025, 1, 6, 17));
+});
+
+test("addBusinessMs: an after-hours start rolls to the next morning", () => {
+  // Mon 20:00 + 2h => Tue 09:00-11:00.
+  assert.equal(addBusinessMs(pt(2025, 1, 6, 20), 2 * hourMs, TZ), pt(2025, 1, 7, 11));
+});
+
+test("addBusinessMs: skips the weekend", () => {
+  // Fri 2025-01-10 15:00 + 4h => 2h Fri, skip Sat/Sun, 2h Mon 09:00-11:00.
+  assert.equal(addBusinessMs(pt(2025, 1, 10, 15), 4 * hourMs, TZ), pt(2025, 1, 13, 11));
+});
+
+test("addBusinessMs: a weekend start begins Monday morning", () => {
+  // Sat 2025-01-11 12:00 + 8h => the clock only starts Mon 09:00 => Mon 17:00.
+  assert.equal(addBusinessMs(pt(2025, 1, 11, 12), 8 * hourMs, TZ), pt(2025, 1, 13, 17));
+});
+
+test("addBusinessMs: weekend spanning the spring-forward DST transition", () => {
+  // US DST 2025 begins Sun 2025-03-09. Fri 2025-03-07 15:00 PST + 4h => 2h Fri, skip the
+  // weekend (incl. the transition), 2h Mon 09:00-11:00 PDT. Comparing wall-clock instants
+  // proves the result is 11:00 *local* on Monday regardless of the offset change.
+  assert.equal(addBusinessMs(pt(2025, 3, 7, 15), 4 * hourMs, TZ), pt(2025, 3, 10, 11));
+});
+
+test("businessMsBetween: only counts in-window business time", () => {
+  // Mon 15:00 -> Tue 11:00 spans 2h Mon + overnight (0) + 2h Tue = 4 business hours.
+  assert.equal(businessMsBetween(pt(2025, 1, 6, 15), pt(2025, 1, 7, 11), TZ), 4 * hourMs);
+  // Fri 16:00 -> Mon 10:00 = 1h Fri + weekend (0) + 1h Mon = 2 business hours.
+  assert.equal(businessMsBetween(pt(2025, 1, 10, 16), pt(2025, 1, 13, 10), TZ), 2 * hourMs);
+  assert.equal(businessMsBetween(pt(2025, 1, 6, 12), pt(2025, 1, 6, 12), TZ), 0);
+});
+
+test("slaAnchors: warn and deadline are stable and correctly spaced", () => {
+  const first = new Date(pt(2025, 1, 6, 9)).toISOString();
+  const a = slaAnchors(first, { tz: TZ, budgetHours: 8, warnHours: 6 });
+  assert.equal(a.firstQualifiedAt, first);
+  assert.equal(new Date(a.warnAt).getTime(), pt(2025, 1, 6, 15)); // +6h
+  assert.equal(new Date(a.deadlineAt).getTime(), pt(2025, 1, 6, 17)); // +8h
+  // Recomputing from the same input yields identical anchors (no churn).
+  const b = slaAnchors(first, { tz: TZ, budgetHours: 8, warnHours: 6 });
+  assert.deepEqual(a, b);
+});
+
+test("slaState: flips only at the warn and deadline thresholds", () => {
+  const first = new Date(pt(2025, 1, 6, 9)).toISOString();
+  const a = slaAnchors(first, { tz: TZ, budgetHours: 8, warnHours: 6 });
+  const warn = new Date(a.warnAt).getTime();
+  const deadline = new Date(a.deadlineAt).getTime();
+  assert.equal(slaState(a, warn - 1), "ok");
+  assert.equal(slaState(a, warn), "approaching");
+  assert.equal(slaState(a, deadline - 1), "approaching");
+  assert.equal(slaState(a, deadline), "breached");
+  assert.equal(slaState(a, deadline + hourMs), "breached");
+});
+
+test("isSlaRepo: case-insensitive match against the configured repos", () => {
+  assert.equal(isSlaRepo("devdiv-microsoft/aspire-1p"), true);
+  assert.equal(isSlaRepo("DevDiv-Microsoft/Aspire-1p"), true);
+  assert.equal(isSlaRepo("microsoft/aspire"), false);
+  assert.equal(isSlaRepo(""), false);
+  assert.equal(isSlaRepo(null), false);
+});
+
+test("slaCandidateKey: lowercased repo plus number", () => {
+  assert.equal(slaCandidateKey({ repository: "DevDiv-Microsoft/Aspire-1p", number: 42 }), "devdiv-microsoft/aspire-1p#42");
+});
+
+function candidatePr(overrides = {}) {
+  return {
+    repository: "devdiv-microsoft/aspire-1p",
+    number: 1,
+    author: "external-dev",
+    review: { reviewerCount: 0 },
+    ...overrides,
+  };
+}
+
+test("isSlaCandidatePr: only non-team, un-reviewed PRs on an SLA repo qualify", () => {
+  assert.equal(isSlaCandidatePr(candidatePr()), true);
+  // A core-team author is exempt (they are not the review target).
+  assert.equal(isSlaCandidatePr(candidatePr({ author: "joperezr" })), false);
+  // A core-team enterprise alias is exempt too.
+  assert.equal(isSlaCandidatePr(candidatePr({ author: "joperezr_microsoft" })), false);
+  // Any human review stops the clock.
+  assert.equal(isSlaCandidatePr(candidatePr({ review: { reviewerCount: 1 } })), false);
+  // Repos outside the SLA never qualify.
+  assert.equal(isSlaCandidatePr(candidatePr({ repository: "microsoft/aspire" })), false);
+  assert.equal(isSlaCandidatePr(null), false);
+});
+
+test("reconcileTracking: adds new keys, preserves firstQualifiedAt, prunes gone keys", () => {
+  const tracking = { prs: {} };
+  const now1 = "2025-01-06T17:00:00.000Z";
+  assert.equal(reconcileTracking(tracking, ["r#1", "r#2"], now1), true);
+  assert.equal(tracking.prs["r#1"].firstQualifiedAt, now1);
+  assert.equal(tracking.prs["r#2"].firstQualifiedAt, now1);
+
+  // Same candidates on the next poll: no change, original stamp preserved.
+  const now2 = "2025-01-06T18:00:00.000Z";
+  assert.equal(reconcileTracking(tracking, ["r#1", "r#2"], now2), false);
+  assert.equal(tracking.prs["r#1"].firstQualifiedAt, now1);
+
+  // r#2 stops qualifying (got reviewed) => pruned; r#3 appears => added.
+  assert.equal(reconcileTracking(tracking, ["r#1", "r#3"], now2), true);
+  assert.equal("r#2" in tracking.prs, false);
+  assert.equal(tracking.prs["r#3"].firstQualifiedAt, now2);
+  // r#1 keeps its original clock start throughout.
+  assert.equal(tracking.prs["r#1"].firstQualifiedAt, now1);
+});

--- a/.github/extensions/aspire-team-app/sla.test.mjs
+++ b/.github/extensions/aspire-team-app/sla.test.mjs
@@ -278,3 +278,40 @@ test("annotateDashboardSla: freshly-qualified candidates populate the ok panel l
   assert.ok(focusCard.sla);
   assert.equal(focusCard.sla.state, "ok");
 });
+
+test("annotateDashboardSla: an unfetched SLA repo marks the report partial", async () => {
+  const repo = SLA_REPOS[0];
+  // An empty candidate list is ambiguous on its own: it can mean "nothing to review" OR "the
+  // watched repo failed to fetch this run". expectedSlaRepos vs authoritativeRepos disambiguates.
+  const dashboard = { attention: { focus: [], slaCandidates: [] } };
+  await annotateDashboardSla(dashboard, {
+    now: pt(2025, 1, 6, 10),
+    persist: false,
+    expectedSlaRepos: new Set([repo.toLowerCase()]),
+    authoritativeRepos: new Set(),
+  });
+  assert.equal(dashboard.sla.partial, true);
+  assert.deepEqual(dashboard.sla.unfetchedRepos, [repo.toLowerCase()]);
+});
+
+test("annotateDashboardSla: a fully-fetched run is not partial", async () => {
+  const repo = SLA_REPOS[0];
+  const dashboard = { attention: { focus: [], slaCandidates: [] } };
+  await annotateDashboardSla(dashboard, {
+    now: pt(2025, 1, 6, 10),
+    persist: false,
+    expectedSlaRepos: new Set([repo.toLowerCase()]),
+    authoritativeRepos: new Set([repo.toLowerCase()]),
+  });
+  assert.equal(dashboard.sla.partial, false);
+  assert.deepEqual(dashboard.sla.unfetchedRepos, []);
+});
+
+test("annotateDashboardSla: absent expectedSlaRepos defaults to a complete fetch", async () => {
+  // Focused callers (unit tests, persist:false paths) omit the fetch-scope sets entirely; the
+  // report must default to partial:false so they don't spuriously look incomplete.
+  const dashboard = { attention: { focus: [], slaCandidates: [] } };
+  await annotateDashboardSla(dashboard, { now: pt(2025, 1, 6, 10), persist: false });
+  assert.equal(dashboard.sla.partial, false);
+  assert.deepEqual(dashboard.sla.unfetchedRepos, []);
+});

--- a/.github/extensions/aspire-team-app/sla.test.mjs
+++ b/.github/extensions/aspire-team-app/sla.test.mjs
@@ -122,6 +122,10 @@ test("isSlaCandidatePr: only non-team, un-reviewed PRs on an SLA repo qualify", 
   assert.equal(isSlaCandidatePr(candidatePr({ author: "joperezr" })), false);
   // A core-team enterprise alias is exempt too.
   assert.equal(isSlaCandidatePr(candidatePr({ author: "joperezr_microsoft" })), false);
+  // A listed EMU login whose base differs from the public login is exempt via the allowlist.
+  assert.equal(isSlaCandidatePr(candidatePr({ author: "dapine_microsoft" })), false);
+  // An UNLISTED "*_microsoft" account is a review target — the suffix alone is not core team.
+  assert.equal(isSlaCandidatePr(candidatePr({ author: "andreas_microsoft" })), true);
   // Any human review stops the clock.
   assert.equal(isSlaCandidatePr(candidatePr({ review: { reviewerCount: 1 } })), false);
   // Repos outside the SLA never qualify.


### PR DESCRIPTION
## Description

Small enhancement to the personal Aspire Team App canvas extension so it can surface pull requests that are waiting on a review, plus some light alerting when one has been waiting a while.

Canvas-extension-only change under `.github/extensions/aspire-team-app/`. No shipping product code or public API is touched.

## Checklist

- Is this feature complete?
  - [x] Yes
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
