### PR TITLE
Fix Rust AppHost run-session notification routing

### DIFF
--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -815,12 +815,13 @@ export default class AspireDcpServer {
     }
 
     sendNotification(notification: RunSessionNotification): void {
-        if (notification.session_id.length > 0) {
-            this._runSessions.notify(notification);
+        if (notification.session_id.length === 0) {
+            extensionLogOutputChannel.warn(
+                `Dropping ${notification.notification_type} DCP notification because the run-session ID is empty.`);
             return;
         }
 
-        this._deliver(notification.dcp_id, notification);
+        this._runSessions.notify(notification);
     }
 
     private _deliver(ownerDcpId: string, notification: RunSessionNotification): void {

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -41,6 +41,10 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
             if (configuration.isApphost && !isOwnedAppHostSession) {
                 return undefined;
             }
+            // The AppHost child is tracked for output and restart handling, but it is not
+            // a DCP resource run. Its run ID is intentionally empty, and forwarding its
+            // lifecycle would make DCP reject the notification and recycle the shared socket.
+            const hasDcpRunSession = configuration.isApphost !== true;
 
             let debuggeeExitCode: number | undefined;
 
@@ -90,6 +94,10 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                         }
                     }
 
+                    if (!hasDcpRunSession) {
+                        return;
+                    }
+
                     // Listen for process event with isRestart (if supported by adapter)
                     if (message.type === 'event' && message.event === 'process') {
                         // A new debuggee process invalidates any exit code captured from a prior run.
@@ -121,6 +129,10 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                     }
                 },
                 onExit(code: number | undefined) {
+                    if (!hasDcpRunSession) {
+                        return;
+                    }
+
                     let exitCode = debuggeeExitCode ?? code;
 
                     // Exit code 143 should be treated as normal exit (SIGTERM) on macOS and Linux

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -545,7 +545,7 @@ suite('Debug Adapter Tracker Tests', () => {
         unrelatedDisposable.dispose();
     });
 
-    test('apphost lifecycle only feeds the tracker that owns its debug session', async () => {
+    test('apphost lifecycle events are not sent as DCP run-session notifications', async () => {
         const unrelatedDcpServer = sinon.createStubInstance(AspireDcpServer);
         const owningDisposable = createDebugAdapterTracker(dcpServer as any, 'coreclr', {
             debugSessionId: 'debug-456'
@@ -557,51 +557,28 @@ suite('Debug Adapter Tracker Tests', () => {
         const unrelatedFactory = registerFactoryStub.lastCall.args[1];
         const appHostSession = {
             ...debugSession,
-            configuration: { ...debugSession.configuration, isApphost: true }
+            configuration: { ...debugSession.configuration, runId: '', isApphost: true }
         };
         const owningTracker = owningFactory.createDebugAdapterTracker(appHostSession);
         const unrelatedTracker = unrelatedFactory.createDebugAdapterTracker(appHostSession);
-        const trackers = [owningTracker, unrelatedTracker];
 
-        for (const tracker of trackers) {
-            tracker?.onDidSendMessage({
-                type: 'event',
-                event: 'process',
-                body: { systemProcessId: 4242 }
-            });
-        }
-        for (const tracker of trackers) {
-            tracker?.onDidSendMessage({
-                type: 'event',
-                event: 'exited',
-                body: { exitCode: 7 }
-            });
-        }
-        for (const tracker of trackers) {
-            tracker?.onExit(0);
-        }
-
-        assert.deepStrictEqual(
-            dcpServer.sendNotification.getCalls().map(call => call.args[0]),
-            [
-                {
-                    notification_type: 'processRestarted',
-                    session_id: 'run-123',
-                    dcp_id: 'debug-456',
-                    pid: 4242
-                },
-                {
-                    notification_type: 'sessionTerminated',
-                    session_id: 'run-123',
-                    dcp_id: 'debug-456',
-                    exit_code: 7
-                }
-            ]);
-        assert.strictEqual(
-            unrelatedDcpServer.sendNotification.callCount,
-            0,
-            'The unowned factory must not duplicate AppHost lifecycle notifications');
+        assert.notStrictEqual(owningTracker, undefined);
         assert.strictEqual(unrelatedTracker, undefined);
+
+        owningTracker.onDidSendMessage({
+            type: 'event',
+            event: 'process',
+            body: { systemProcessId: 4242 }
+        });
+        owningTracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: { exitCode: 7 }
+        });
+        owningTracker.onExit(0);
+
+        assert.strictEqual(dcpServer.sendNotification.callCount, 0);
+        assert.strictEqual(unrelatedDcpServer.sendNotification.callCount, 0);
 
         owningDisposable.dispose();
         unrelatedDisposable.dispose();

--- a/extension/src/test/aspireDcpServer.test.ts
+++ b/extension/src/test/aspireDcpServer.test.ts
@@ -117,6 +117,28 @@ suite('Aspire DCP run session lifecycle', () => {
         await stopHarness(harness);
     });
 
+    test('empty run-session IDs are rejected before wire delivery', async () => {
+        const client = await openNotificationClient(harness);
+        const sendCore = sinon.spy(AspireDcpServer, 'sendNotificationCore');
+        const warning = sinon.stub(extensionLogOutputChannel, 'warn');
+
+        const notification = {
+            notification_type: 'processRestarted',
+            session_id: '',
+            dcp_id: harness.dcpId,
+            pid: 42,
+        } satisfies ProcessRestartedNotification;
+        harness.dcpServer.sendNotification(notification);
+        await drainNotifications(client);
+
+        assert.strictEqual(sendCore.callCount, 0);
+        assert.deepStrictEqual(client.notifications, []);
+        assert.strictEqual(
+            warning.calledOnceWithExactly(
+                'Dropping processRestarted DCP notification because the run-session ID is empty.'),
+            true);
+    });
+
     test('process DELETE terminates before blocked teardown and suppresses all later notifications', async () => {
         const stopSession = sinon.stub().returns(new Promise<void>(() => { }));
         const client = await openNotificationClient(harness);


### PR DESCRIPTION
## Description

Rust AppHosts launched through CodeLLDB or cppvsdbg could send an empty run-session ID to DCP before the real Rust resource started. DCP rejected that notification and recycled the shared connection, which could leave the resource at PID 0 with no logs or proxy while the adapter-owned process kept running.

This keeps AppHost adapter events on the AppHost lifecycle path instead of reporting them as resource events. It also rejects empty run-session IDs at the extension's DCP boundary so another producer cannot send the same invalid payload.

The Rust `NoDebug` launch path remains unchanged. We still use the configured adapter to launch the AppHost; we just no longer treat that AppHost child as a DCP resource run.

Validation:

- Extension lint passed.
- Full extension unit suite: 2,754 passing, 5 pending.
- Focused AppHost lifecycle and DCP wire regressions: 2 passing after rebasing onto current `main`.

Fixes #19750

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
