### PR TITLE
Bound AppHost auxiliary backchannel handshake

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -196,6 +196,7 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
         {
             ActivityTracingStrategy = new ActivityTracingStrategy()
         };
+        Task? pendingHandshakeRpcTask = null;
 
         try
         {
@@ -207,13 +208,18 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
             handshakeCancellation.CancelAfter(handshakeTimeout);
 
             // Fetch all connection info
-            var appHostInfo = await rpc.InvokeWithProfilingAsync<AppHostInformation?>(
+            var appHostInfoTask = rpc.InvokeWithProfilingAsync<AppHostInformation?>(
                 profilingTelemetry,
                 "auxiliary",
                 "GetAppHostInformationAsync",
                 [],
-                handshakeCancellation.Token).ConfigureAwait(false);
-            var capabilities = await FetchCapabilitiesAsync(rpc, logger, profilingTelemetry, handshakeCancellation.Token).ConfigureAwait(false);
+                handshakeCancellation.Token);
+            pendingHandshakeRpcTask = appHostInfoTask;
+            var appHostInfo = await appHostInfoTask.WaitAsync(handshakeCancellation.Token).ConfigureAwait(false);
+
+            var capabilitiesTask = FetchCapabilitiesAsync(rpc, logger, profilingTelemetry, handshakeCancellation.Token);
+            pendingHandshakeRpcTask = capabilitiesTask;
+            var capabilities = await capabilitiesTask.WaitAsync(handshakeCancellation.Token).ConfigureAwait(false);
 
             var capabilitiesSet = capabilities?.ToImmutableHashSet() ?? ImmutableHashSet.Create(AuxiliaryBackchannelCapabilities.V1);
 
@@ -224,8 +230,24 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
             // JsonRpc owns the message handler, stream, and socket, so failed initialization must release
             // that chain before propagating.
             rpc.Dispose();
+            if (pendingHandshakeRpcTask is not null)
+            {
+                // WaitAsync can abandon the invocation when the local deadline wins. JsonRpc disposal
+                // completes it independently, so observe any later fault without extending cleanup.
+                ObserveFaults(pendingHandshakeRpcTask);
+            }
+
             throw;
         }
+    }
+
+    private static void ObserveFaults(Task task)
+    {
+        _ = task.ContinueWith(
+            static completedTask => _ = completedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -27,6 +27,7 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
         AuxiliaryBackchannelCapabilities.V3,
         AuxiliaryBackchannelCapabilities.ResourceSnapshotVersions_V1
     ];
+    private static readonly TimeSpan s_handshakeTimeout = TimeSpan.FromSeconds(10);
 
     private readonly ILogger _logger;
     private JsonRpc? _rpc;
@@ -154,8 +155,18 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
     /// <param name="logger">Logger.</param>
     /// <param name="profilingTelemetry">Profiling service.</param>
     /// <param name="socket">Optional already-connected socket. If null, a new connection will be established.</param>
-    /// <param name="cancellationToken">Cancellation token (only used when socket is null).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A connected AppHostAuxiliaryBackchannel instance.</returns>
+    internal static Task<AppHostAuxiliaryBackchannel> CreateFromSocketAsync(
+        string hash,
+        string socketPath,
+        bool isInScope,
+        ILogger logger,
+        ProfilingTelemetry profilingTelemetry,
+        Socket? socket,
+        CancellationToken cancellationToken) =>
+        CreateFromSocketAsync(hash, socketPath, isInScope, logger, profilingTelemetry, socket, s_handshakeTimeout, cancellationToken);
+
     internal static async Task<AppHostAuxiliaryBackchannel> CreateFromSocketAsync(
         string hash,
         string socketPath,
@@ -163,9 +174,11 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
         ILogger logger,
         ProfilingTelemetry profilingTelemetry,
         Socket? socket,
+        TimeSpan handshakeTimeout,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(handshakeTimeout, TimeSpan.Zero);
 
         // Connect if no socket provided
         if (socket is null)
@@ -183,22 +196,36 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
         {
             ActivityTracingStrategy = new ActivityTracingStrategy()
         };
-        rpc.StartListening();
 
-        logger.LogDebug("Connected to auxiliary backchannel at {SocketPath}", socketPath);
+        try
+        {
+            rpc.StartListening();
 
-        // Fetch all connection info
-        var appHostInfo = await rpc.InvokeWithProfilingAsync<AppHostInformation?>(
-            profilingTelemetry,
-            "auxiliary",
-            "GetAppHostInformationAsync",
-            [],
-            cancellationToken).ConfigureAwait(false);
-        var capabilities = await FetchCapabilitiesAsync(rpc, logger, profilingTelemetry, cancellationToken).ConfigureAwait(false);
+            logger.LogDebug("Connected to auxiliary backchannel at {SocketPath}", socketPath);
 
-        var capabilitiesSet = capabilities?.ToImmutableHashSet() ?? ImmutableHashSet.Create(AuxiliaryBackchannelCapabilities.V1);
+            using var handshakeCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            handshakeCancellation.CancelAfter(handshakeTimeout);
 
-        return new AppHostAuxiliaryBackchannel(hash, socketPath, rpc, appHostInfo, isInScope, capabilitiesSet, logger, profilingTelemetry);
+            // Fetch all connection info
+            var appHostInfo = await rpc.InvokeWithProfilingAsync<AppHostInformation?>(
+                profilingTelemetry,
+                "auxiliary",
+                "GetAppHostInformationAsync",
+                [],
+                handshakeCancellation.Token).ConfigureAwait(false);
+            var capabilities = await FetchCapabilitiesAsync(rpc, logger, profilingTelemetry, handshakeCancellation.Token).ConfigureAwait(false);
+
+            var capabilitiesSet = capabilities?.ToImmutableHashSet() ?? ImmutableHashSet.Create(AuxiliaryBackchannelCapabilities.V1);
+
+            return new AppHostAuxiliaryBackchannel(hash, socketPath, rpc, appHostInfo, isInScope, capabilitiesSet, logger, profilingTelemetry);
+        }
+        catch
+        {
+            // JsonRpc owns the message handler, stream, and socket, so failed initialization must release
+            // that chain before propagating.
+            rpc.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -224,6 +251,10 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
             var capabilities = response?.Capabilities;
             logger.LogDebug("AppHost capabilities: {Capabilities}", capabilities is not null ? string.Join(", ", capabilities) : "null");
             return capabilities;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (RemoteMethodNotFoundException)
         {

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
@@ -91,28 +91,45 @@ public class AppHostAuxiliaryBackchannelTests
         Assert.Empty(response.Terminals);
     }
 
+    [Theory]
+    [InlineData(nameof(TestAppHostRpcTarget.GetAppHostInformationAsync))]
+    [InlineData(nameof(TestAppHostRpcTarget.GetCapabilitiesAsync))]
+    public async Task ConnectAsync_WhenHandshakeRpcStalls_TimesOutAndDisposesConnection(string stalledMethod)
+    {
+        using var server = TestAppHostBackchannelServer.Start(stalledMethod);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => server.ConnectAsync(TimeSpan.FromMilliseconds(100))).DefaultTimeout();
+        await server.WaitForClientDisconnectAsync().DefaultTimeout();
+    }
+
     private sealed class TestAppHostBackchannelServer : IDisposable
     {
         private readonly TcpListener _listener;
         private readonly List<IDisposable> _disposables = [];
+        private readonly TaskCompletionSource _clientDisconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        private TestAppHostBackchannelServer()
+        private TestAppHostBackchannelServer(string? stalledMethod)
         {
             _listener = new TcpListener(IPAddress.Loopback, 0);
-            Target = new TestAppHostRpcTarget();
+            Target = new TestAppHostRpcTarget(stalledMethod);
         }
 
         public TestAppHostRpcTarget Target { get; }
 
-        public static TestAppHostBackchannelServer Start()
+        public static TestAppHostBackchannelServer Start(string? stalledMethod = null)
         {
-            var server = new TestAppHostBackchannelServer();
+            var server = new TestAppHostBackchannelServer(stalledMethod);
             server._listener.Start();
 
             return server;
         }
 
-        public async Task<AppHostAuxiliaryBackchannel> ConnectAsync()
+        public Task<AppHostAuxiliaryBackchannel> ConnectAsync() => ConnectAsyncCore(handshakeTimeout: null);
+
+        public Task<AppHostAuxiliaryBackchannel> ConnectAsync(TimeSpan handshakeTimeout) => ConnectAsyncCore(handshakeTimeout);
+
+        private async Task<AppHostAuxiliaryBackchannel> ConnectAsyncCore(TimeSpan? handshakeTimeout)
         {
             var clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             var acceptTask = _listener.AcceptSocketAsync();
@@ -121,13 +138,21 @@ public class AppHostAuxiliaryBackchannelTests
             var serverStream = new NetworkStream(serverSocket, ownsSocket: true);
             var messageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, BackchannelJsonSerializerContext.CreateRpcMessageFormatter());
             var rpc = new JsonRpc(messageHandler, Target);
+            rpc.Disconnected += (_, _) => _clientDisconnected.TrySetResult();
             rpc.StartListening();
             _disposables.Add(rpc);
             _disposables.Add(messageHandler);
             _disposables.Add(serverStream);
 
+            if (handshakeTimeout is { } timeout)
+            {
+                return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, new ProfilingTelemetry(new ConfigurationBuilder().Build()), clientSocket, timeout, CancellationToken.None).DefaultTimeout();
+            }
+
             return await AppHostAuxiliaryBackchannel.CreateFromSocketAsync("hash1", "socket.hash1", isInScope: true, NullLogger.Instance, new ProfilingTelemetry(new ConfigurationBuilder().Build()), clientSocket, CancellationToken.None).DefaultTimeout();
         }
+
+        public Task WaitForClientDisconnectAsync() => _clientDisconnected.Task;
 
         public void Dispose()
         {
@@ -143,6 +168,7 @@ public class AppHostAuxiliaryBackchannelTests
     private sealed class TestAppHostRpcTarget
     {
         private readonly int _processId = Environment.ProcessId;
+        private readonly string? _stalledMethod;
         private readonly string[] _capabilities =
         [
             AuxiliaryBackchannelCapabilities.V1,
@@ -150,30 +176,35 @@ public class AppHostAuxiliaryBackchannelTests
             AuxiliaryBackchannelCapabilities.ResourceSnapshotVersions_V1
         ];
 
+        public TestAppHostRpcTarget(string? stalledMethod)
+        {
+            _stalledMethod = stalledMethod;
+        }
+
         public GetResourcesRequest? GetResourcesRequest { get; private set; }
 
         public WatchResourcesRequest? WatchResourcesRequest { get; private set; }
 
-        public Task<AppHostInformation> GetAppHostInformationAsync(CancellationToken cancellationToken = default)
+        public async Task<AppHostInformation> GetAppHostInformationAsync(CancellationToken cancellationToken = default)
         {
-            _ = cancellationToken;
+            await StallIfRequestedAsync(nameof(GetAppHostInformationAsync), cancellationToken);
 
-            return Task.FromResult(new AppHostInformation
+            return new AppHostInformation
             {
                 AppHostPath = "/path/to/AppHost.csproj",
                 ProcessId = _processId
-            });
+            };
         }
 
-        public Task<GetCapabilitiesResponse> GetCapabilitiesAsync(GetCapabilitiesRequest? request = null, CancellationToken cancellationToken = default)
+        public async Task<GetCapabilitiesResponse> GetCapabilitiesAsync(GetCapabilitiesRequest? request = null, CancellationToken cancellationToken = default)
         {
             _ = request;
-            _ = cancellationToken;
+            await StallIfRequestedAsync(nameof(GetCapabilitiesAsync), cancellationToken);
 
-            return Task.FromResult(new GetCapabilitiesResponse
+            return new GetCapabilitiesResponse
             {
                 Capabilities = _capabilities
-            });
+            };
         }
 
         public Task<GetResourcesResponse> GetResourcesAsync(GetResourcesRequest? request = null, CancellationToken cancellationToken = default)
@@ -200,5 +231,13 @@ public class AppHostAuxiliaryBackchannelTests
                 Name = "api",
                 ResourceType = "Project"
             };
+
+        private async Task StallIfRequestedAsync(string method, CancellationToken cancellationToken)
+        {
+            if (_stalledMethod == method)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+        }
     }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostAuxiliaryBackchannelTests.cs
@@ -98,8 +98,10 @@ public class AppHostAuxiliaryBackchannelTests
     {
         using var server = TestAppHostBackchannelServer.Start(stalledMethod);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => server.ConnectAsync(TimeSpan.FromMilliseconds(100))).DefaultTimeout();
+        var connectTask = server.ConnectAsync(TimeSpan.FromSeconds(3));
+        await server.WaitForStalledMethodEntryAsync().DefaultTimeout();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connectTask).DefaultTimeout();
         await server.WaitForClientDisconnectAsync().DefaultTimeout();
     }
 
@@ -154,8 +156,12 @@ public class AppHostAuxiliaryBackchannelTests
 
         public Task WaitForClientDisconnectAsync() => _clientDisconnected.Task;
 
+        public Task WaitForStalledMethodEntryAsync() => Target.WaitForStalledMethodEntryAsync();
+
         public void Dispose()
         {
+            Target.ReleaseStall();
+
             foreach (var disposable in _disposables)
             {
                 disposable.Dispose();
@@ -169,6 +175,8 @@ public class AppHostAuxiliaryBackchannelTests
     {
         private readonly int _processId = Environment.ProcessId;
         private readonly string? _stalledMethod;
+        private readonly TaskCompletionSource _stalledMethodEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseStall = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly string[] _capabilities =
         [
             AuxiliaryBackchannelCapabilities.V1,
@@ -187,7 +195,8 @@ public class AppHostAuxiliaryBackchannelTests
 
         public async Task<AppHostInformation> GetAppHostInformationAsync(CancellationToken cancellationToken = default)
         {
-            await StallIfRequestedAsync(nameof(GetAppHostInformationAsync), cancellationToken);
+            _ = cancellationToken;
+            await StallIfRequestedAsync(nameof(GetAppHostInformationAsync));
 
             return new AppHostInformation
             {
@@ -199,7 +208,8 @@ public class AppHostAuxiliaryBackchannelTests
         public async Task<GetCapabilitiesResponse> GetCapabilitiesAsync(GetCapabilitiesRequest? request = null, CancellationToken cancellationToken = default)
         {
             _ = request;
-            await StallIfRequestedAsync(nameof(GetCapabilitiesAsync), cancellationToken);
+            _ = cancellationToken;
+            await StallIfRequestedAsync(nameof(GetCapabilitiesAsync));
 
             return new GetCapabilitiesResponse
             {
@@ -232,12 +242,19 @@ public class AppHostAuxiliaryBackchannelTests
                 ResourceType = "Project"
             };
 
-        private async Task StallIfRequestedAsync(string method, CancellationToken cancellationToken)
+        public void ReleaseStall() => _releaseStall.TrySetResult();
+
+        public Task WaitForStalledMethodEntryAsync() => _stalledMethodEntered.Task;
+
+        private Task StallIfRequestedAsync(string method)
         {
-            if (_stalledMethod == method)
+            if (_stalledMethod != method)
             {
-                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return Task.CompletedTask;
             }
+
+            _stalledMethodEntered.TrySetResult();
+            return _releaseStall.Task;
         }
     }
 }


### PR DESCRIPTION
## Description

An AppHost that accepts its auxiliary socket but never answers JSON-RPC can no longer hang `aspire run`, `aspire ps`, `aspire stop`, or other backchannel-scanning commands indefinitely.

This adds a 10-second deadline around the shared AppHost information/capabilities handshake. The deadline is enforced locally even when the remote AppHost ignores RPC cancellation, and failed initialization now disposes `JsonRpc` and its owned stream/socket before returning the failure to the existing caller flow.

The tests cover an AppHost that stalls during either handshake RPC and verify that the client both times out and closes the connection. The separate issue where `CliOrphanDetector` allowed the original AppHost to survive is not changed here.

### User-facing behavior

Commands such as:

```bash
aspire run --start-debug-session
aspire ps
aspire stop
```

now stop waiting for an unresponsive AppHost handshake after 10 seconds instead of hanging indefinitely.

Validation:

- `AppHostAuxiliaryBackchannelTests`: 7 passed
- `Aspire.Cli.Tests`: 5,482 passed, 35 skipped

Fixes #19269

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
