### PR TITLE
Use supported Cosmos emulator API in consumers

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/AppHost.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/AppHost.cs
@@ -4,7 +4,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos")
-       .RunAsPreviewEmulator();
+       .RunAsEmulator();
 
 var db = cosmos.AddCosmosDatabase("db");
 var entries = db.AddContainer("entries", "/id", "staging-entries");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -574,7 +574,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var cosmos = builder.AddAzureCosmosDB("cosmos")
-                           .RunAsPreviewEmulator();
+                           .RunAsEmulator();
 
         Assert.NotEmpty(cosmos.Resource.Annotations.OfType<OtlpExporterAnnotation>());
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -570,7 +570,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task RunAsPreviewEmulatorAppliesOtlpExporterAnnotation()
+    public async Task RunAsEmulatorAppliesOtlpExporterAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var cosmos = builder.AddAzureCosmosDB("cosmos")


### PR DESCRIPTION
## Description

Main CI and deployment end-to-end builds are blocked because warnings are treated as errors and two consumers still call the obsolete `RunAsPreviewEmulator` API.

This replaces those calls with the supported `RunAsEmulator` API in the Azure Cosmos hosting test and the Cosmos end-to-end playground AppHost. The intentional obsolete-API compatibility test remains unchanged.

Validation:

- `MSBUILDTERMINALLOGGER=false dotnet build playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj --no-restore`
- `MSBUILDTERMINALLOGGER=false dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-method "*.RunAsPreviewEmulatorAppliesOtlpExporterAnnotation" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
