### PR TITLE
Hide Azure environment when all resources use emulators

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE003
+#pragma warning disable ASPIREAZURE001
 #pragma warning disable ASPIREPIPELINES002
 
 using Aspire.Dashboard.Model;
@@ -32,6 +33,13 @@ internal sealed class AzureResourcePreparer(
         var azureResources = GetAzureResourcesFromAppModel(model);
         if (azureResources.Count == 0)
         {
+            if (executionContext.IsRunMode &&
+                model.Resources.OfType<AzureEnvironmentResource>().SingleOrDefault() is { } environmentResource &&
+                !environmentResource.HasAnnotationOfType<HiddenAnnotation>())
+            {
+                environmentResource.Annotations.Add(new HiddenAnnotation(HiddenBehavior.Always));
+            }
+
             return;
         }
 

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -33,6 +33,8 @@ internal sealed class AzureResourcePreparer(
         var azureResources = GetAzureResourcesFromAppModel(model);
         if (azureResources.Count == 0)
         {
+            // AddAzureProvisioning creates the environment before resources are configured, so wait until
+            // preparation to hide it when the final run-mode model contains only local emulators.
             if (executionContext.IsRunMode &&
                 model.Resources.OfType<AzureEnvironmentResource>().SingleOrDefault() is { } environmentResource &&
                 !environmentResource.HasAnnotationOfType<HiddenAnnotation>())

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRunAsEmulatorModeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRunAsEmulatorModeTests.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -47,5 +50,41 @@ public class AzureRunAsEmulatorModeTests
         Assert.False(resource.IsEmulator(), $"{resourceType} should not be configured as an emulator in publish mode.");
         Assert.False(resource.IsContainer(), $"{resourceType} should not be configured as a local container in publish mode.");
         Assert.DoesNotContain(builder.Resources, resource => resource.Annotations.OfType<ContainerImageAnnotation>().Any());
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_WhenAllAzureResourcesUseEmulators_HidesAzureEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+        builder.AddAzureStorage("storage").RunAsEmulator();
+        builder.AddAzureEventHubs("eventhubs").RunAsEmulator();
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var preparer = app.Services.GetRequiredService<AzureResourcePreparer>();
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var environment = Assert.Single(model.Resources.OfType<AzureEnvironmentResource>());
+        var hidden = Assert.Single(environment.Annotations.OfType<HiddenAnnotation>());
+        Assert.Equal(HiddenBehavior.Always, hidden.Behavior);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_WhenAzureResourceRequiresProvisioning_ShowsAzureEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureStorage("emulated-storage").RunAsEmulator();
+        builder.AddAzureStorage("provisioned-storage");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var preparer = app.Services.GetRequiredService<AzureResourcePreparer>();
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var environment = Assert.Single(model.Resources.OfType<AzureEnvironmentResource>());
+        Assert.Empty(environment.Annotations.OfType<HiddenAnnotation>());
     }
 }


### PR DESCRIPTION
## Description

AppHosts that run every Azure resource through a local emulator currently show an `azure-environment` resource stuck in the **Not started** state. This hides that control resource when the completed run-mode model has no Azure resources requiring provisioning, while keeping it visible for mixed emulator/cloud models.

The visibility decision runs during Azure resource preparation, after fluent emulator configuration is complete, and uses the existing provisionable-resource filtering.

### User-facing usage

Existing emulator-only AppHosts require no changes. For example:

```csharp
builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
builder.AddAzureStorage("storage").RunAsEmulator();
builder.AddAzureEventHubs("eventhubs").RunAsEmulator();
```

The dashboard now omits `azure-environment` for this model. Adding any Azure resource that requires provisioning keeps `azure-environment` visible.

Validation:

- `AzureRunAsEmulatorModeTests` (18 tests)
- `AzureResourcePreparerTests` (26 tests)

Fixes #19617

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
