### PR TITLE
Fix opening Visual Studio

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -600,6 +600,7 @@
     <Project Path="tools/CreateFailingTestIssue/CreateFailingTestIssue.csproj" />
     <Project Path="tools/CreateLayout/CreateLayout.csproj" />
     <Project Path="tools/GenerateTestSummary/GenerateTestSummary.csproj" />
+    <Project Path="tools/SelectTests/SelectTests.csproj" />
     <Project Path="tools/TypeScriptApiCompat/TypeScriptApiCompat.csproj" />
   </Folder>
   <Folder Name="/Tools/QuarantineTools/">

--- a/playground/FoundryAgents/DotNetInvocationHostedAgent/Properties/launchSettings.json
+++ b/playground/FoundryAgents/DotNetInvocationHostedAgent/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DotNetInvocationHostedAgent": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:49409;http://localhost:49410"
+    }
+  }
+}


### PR DESCRIPTION
- launchSettings.json file gets automatically created each time VS is opened since it doesn't exist.
- Add a necessary tool project to the .slnx
