### PR TITLE
Keep Aspire CLI notification claim timestamps consistent

### DIFF
--- a/extension/src/test/outdatedCliSuppressionStore.test.ts
+++ b/extension/src/test/outdatedCliSuppressionStore.test.ts
@@ -4,7 +4,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { FileSystemOutdatedCliSuppressionStore } from '../utils/outdatedCliSuppressionStore';
+import {
+    FileSystemOutdatedCliSuppressionStore,
+    OutdatedCliNotificationClaim,
+} from '../utils/outdatedCliSuppressionStore';
 
 suite('outdatedCliSuppressionStore', () => {
     let directory: string;
@@ -37,10 +40,11 @@ suite('outdatedCliSuppressionStore', () => {
         nowStub.returns(1_001);
         const first = new FileSystemOutdatedCliSuppressionStore(directory);
         const second = new FileSystemOutdatedCliSuppressionStore(directory);
-        const claim = await first.tryClaimNotification('/cli/a\u000013.5.0');
-        assert.ok(claim);
+        let claim: OutdatedCliNotificationClaim | undefined;
 
         try {
+            claim = await first.tryClaimNotification('/cli/a\u000013.5.0');
+            assert.ok(claim);
             const storageDirectory = path.join(directory, 'outdated-cli-suppressions');
             const claimMarker = fs.readdirSync(storageDirectory)
                 .find(entry => entry.startsWith('notification-claim-'));
@@ -50,7 +54,7 @@ suite('outdatedCliSuppressionStore', () => {
             assert.deepStrictEqual(await second.readAll(), ['/cli/b\u000013.5.0']);
         }
         finally {
-            await claim.release();
+            await claim?.release();
             nowStub.restore();
         }
     });

--- a/extension/src/test/outdatedCliSuppressionStore.test.ts
+++ b/extension/src/test/outdatedCliSuppressionStore.test.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as sinon from 'sinon';
 import { FileSystemOutdatedCliSuppressionStore } from '../utils/outdatedCliSuppressionStore';
 
 suite('outdatedCliSuppressionStore', () => {
@@ -28,6 +29,30 @@ suite('outdatedCliSuppressionStore', () => {
         assert.deepStrictEqual(
             (await first.readAll()).sort(),
             ['/cli/a\u000013.5.0', '/cli/b\u000013.5.0']);
+    });
+
+    test('uses one timestamp for a claim marker and payload', async () => {
+        const nowStub = sinon.stub(Date, 'now');
+        nowStub.onFirstCall().returns(1_000);
+        nowStub.returns(1_001);
+        const first = new FileSystemOutdatedCliSuppressionStore(directory);
+        const second = new FileSystemOutdatedCliSuppressionStore(directory);
+        const claim = await first.tryClaimNotification('/cli/a\u000013.5.0');
+        assert.ok(claim);
+
+        try {
+            const storageDirectory = path.join(directory, 'outdated-cli-suppressions');
+            const claimMarker = fs.readdirSync(storageDirectory)
+                .find(entry => entry.startsWith('notification-claim-'));
+            assert.ok(claimMarker?.startsWith('notification-claim-1000-'));
+
+            await second.add('/cli/b\u000013.5.0');
+            assert.deepStrictEqual(await second.readAll(), ['/cli/b\u000013.5.0']);
+        }
+        finally {
+            await claim.release();
+            nowStub.restore();
+        }
     });
 
     test('serializes a suppression written after the final notification check', async () => {

--- a/extension/src/utils/outdatedCliSuppressionStore.ts
+++ b/extension/src/utils/outdatedCliSuppressionStore.ts
@@ -56,7 +56,7 @@ export class FileSystemOutdatedCliSuppressionStore implements OutdatedCliSuppres
             notificationKey,
             processId: process.pid,
             createdAt,
-        });
+        }, createdAt);
         let released = false;
         const claim: OutdatedCliNotificationClaim = {
             isValid: () => isLeaseCurrent(createdAt),
@@ -178,9 +178,13 @@ export class FileSystemOutdatedCliSuppressionStore implements OutdatedCliSuppres
         }
     }
 
-    private async _publishMarker(prefix: string, value: unknown): Promise<string> {
+    private async _publishMarker(
+        prefix: string,
+        value: unknown,
+        createdAt = Date.now(),
+    ): Promise<string> {
         await mkdir(this._directoryPath, { recursive: true });
-        const generation = `${Date.now()}-${process.pid}-${markerSequence++}`;
+        const generation = `${createdAt}-${process.pid}-${markerSequence++}`;
         const fileName = `${prefix}${generation}${markerFileSuffix}`;
         const temporaryPath = path.join(this._directoryPath, `.${fileName}.tmp`);
         const finalPath = path.join(this._directoryPath, fileName);


### PR DESCRIPTION
## Description

PR #19670 was merged by @adamint before the final CCR-discovered timestamp fix could be included, so this follow-up carries only that isolated correction.

The cross-window suppression handshake wrote notification claims in two places:

- the JSON payload stored a captured `createdAt` value; and
- the marker filename used a second `Date.now()` call after filesystem setup.

If those values differed by even 1 ms, the valid claim was classified as malformed. A live malformed claim was conservatively treated as active without first matching its CLI/version key, so selecting **Don't Show Again** for one CLI/version could wait behind an unrelated notification claim until that claim was released or expired.

This change passes the original captured timestamp into marker publication so the payload and filename always agree. The regression deliberately makes the two ambient clock reads differ and verifies that suppression for an unrelated CLI/version completes while the first claim remains active.

Relates to #17354. This PR intentionally does not close the issue.

Validation:

- `corepack yarn run compile-tests`
- `corepack yarn run unit-test --grep "outdatedCliSuppressionStore"`: 7 passed
- `corepack yarn run lint`
- Latest CI: 63 successful checks and 15 expected skips
- Three-model CCR: clean
- Latest Copilot review: zero new comments

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No