### PR TITLE
Clarify VS Code CLI debug log location

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -88,11 +88,17 @@
     <trans-unit id="aspire-vscode.strings.aspireTerminalName">
       <source xml:lang="en">Aspire terminal</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.aspireTerminalClosedBeforeProcessStarted">
+      <source xml:lang="en">Aspire terminal closed before its process started.</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.terminalCommandArgumentControlCharacters">
       <source xml:lang="en">Aspire terminal command arguments cannot contain control characters.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.terminalCommandUnsafeLiteral">
       <source xml:lang="en">Aspire terminal command syntax can only contain command names and flags.</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.aspireTerminalProcessFailedToStart">
+      <source xml:lang="en">Aspire terminal process failed to start.</source>
     </trans-unit>
     <trans-unit id="extension.debug.defaultConfiguration.name">
       <source xml:lang="en">Aspire: Launch default AppHost</source>
@@ -329,7 +335,7 @@
       <source xml:lang="en">Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace&apos;s .aspire/dcp/logs-{debugSessionId} folder.</source>
     </trans-unit>
     <trans-unit id="configuration.aspire.enableAspireCliDebugLogging">
-      <source xml:lang="en">Enable console debug logging for Aspire CLI commands executed by the extension.</source>
+      <source xml:lang="en">Enable console debug logging for Aspire CLI commands executed by the extension. CLI log files are stored in the Aspire home directory&apos;s logs folder (~/.aspire/logs by default).</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.encounteredErrorStartingResource">
       <source xml:lang="en">Encountered an error starting resource: {0}.</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -28,7 +28,7 @@
   "command.openGlobalSettings": "Open global Aspire settings",
   "configuration.aspire.enableSettingsFileCreationPromptOnStartup": "Enable AppHost discovery on extension activation and prompt to setup .aspire/settings.json.appHostPath if it does not exist in the workspace.",
   "configuration.aspire.aspireCliExecutablePath": "The path to the Aspire CLI executable. Use '${workspaceFolder}' for the operation's workspace folder or '${workspaceFolder:name}' for a named folder. If not set, the extension will attempt to use 'aspire' from the system PATH.",
-  "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension.",
+  "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension. CLI log files are stored in the Aspire home directory's logs folder (~/.aspire/logs by default).",
   "configuration.aspire.enableAspireDcpDebugLogging": "Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace's .aspire/dcp/logs-{debugSessionId} folder.",
   "configuration.aspire.enableHotReloadNotification": "Controls whether the Aspire extension shows a notification when C# Dev Kit Hot Reload is disabled.",
   "configuration.aspire.enableAspireDashboardAutoLaunch": "Legacy setting for Aspire Dashboard launch behavior. Use Aspire: Dashboard Browser instead. Explicit Aspire: Dashboard Browser none or notification values win. Otherwise, legacy notification or off values override browser-opening choices; launch uses Aspire: Dashboard Browser, falling back to VS Code's integrated browser for compatibility.",


### PR DESCRIPTION
## Description

The `Enable Aspire Cli Debug Logging` setting enables CLI debug output but does not tell users where the persisted CLI logs are written. This update documents that CLI log files are stored in the Aspire home directory's `logs` folder (`~/.aspire/logs` by default), matching the location guidance already provided by the DCP debug logging setting.

The extension localization catalog is regenerated from the updated source string.

### User-facing usage

Before:

```text
Enable console debug logging for Aspire CLI commands executed by the extension.
```

After:

```text
Enable console debug logging for Aspire CLI commands executed by the extension. CLI log files are stored in the Aspire home directory's logs folder (~/.aspire/logs by default).
```

### Validation

- Built the Aspire CLI and VS Code extension with `.\extension\build.ps1`.
- Ran the extension lint task.
- Ran the focused extension string and CLI debug-flag tests.
- Verified with an isolated `ASPIRE_HOME` that the built CLI creates `cli_*.log` under `<ASPIRE_HOME>\logs`.

Fixes #19739

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
