### PR TITLE
Fix Python callback handle wrapping

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/AtsPythonCodeGenerator.cs
@@ -270,7 +270,7 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
     {
         if (param.IsCallback)
         {
-            return $"self._client.register_callback({paramName})";
+            return $"self._client.register_callback({paramName}{GetCallbackParameterTypeIds(param)})";
         }
         if (param.Type?.TypeId == AtsConstants.CancellationToken)
         {
@@ -283,13 +283,30 @@ internal sealed class AtsPythonCodeGenerator : ICodeGenerator
     {
         if (param.IsCallback)
         {
-            return $"client.register_callback({paramName})";
+            return $"client.register_callback({paramName}{GetCallbackParameterTypeIds(param)})";
         }
         if (param.Type?.TypeId == AtsConstants.CancellationToken)
         {
             return $"client.register_cancellation_token({paramName})";
         }
         return paramName;
+    }
+
+    private static string GetCallbackParameterTypeIds(AtsParameterInfo parameter)
+    {
+        if (parameter.CallbackParameters is not { Count: > 0 } callbackParameters ||
+            !callbackParameters.Any(callbackParameter => IsHandleType(callbackParameter.Type)))
+        {
+            return string.Empty;
+        }
+
+        var typeIds = callbackParameters.Select(callbackParameter =>
+            IsHandleType(callbackParameter.Type)
+                ? JsonValue.Create(callbackParameter.Type.TypeId)!.ToJsonString()
+                : "None");
+        var tupleSuffix = callbackParameters.Count == 1 ? "," : string.Empty;
+
+        return $", ({string.Join(", ", typeIds)}{tupleSuffix})";
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.CodeGeneration.Python/PythonModuleBuilder.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/PythonModuleBuilder.cs
@@ -590,10 +590,17 @@ internal sealed class PythonModuleBuilder
             _handle_wrapper_registry[type_id] = factory
 
 
-        def _wrap_if_handle(value: typing.Any, client: AspireClient | None = None, kwargs: typing.Mapping[str, typing.Any] | None = None) -> typing.Any:
+        def _wrap_if_handle(
+            value: typing.Any,
+            client: AspireClient | None = None,
+            kwargs: typing.Mapping[str, typing.Any] | None = None,
+            fallback_type_id: str | None = None
+        ) -> typing.Any:
             '''
             Checks if a value is a marshalled handle and wraps it appropriately.
-            Uses the wrapper registry to create typed wrapper instances when available.
+            Uses the wrapper registry to create typed wrapper instances when available. The fallback
+            type ID lets callbacks use their generated parameter type when .NET marshals a handle
+            using its declared generic builder type.
             '''
             if isinstance(value, dict) and _is_marshalled_handle(value):
                 handle = Handle(value)
@@ -602,6 +609,8 @@ internal sealed class PythonModuleBuilder
                 # Try to find a registered wrapper factory for this type
                 if type_id and client:
                     factory = _handle_wrapper_registry.get(type_id)
+                    if factory is None and fallback_type_id:
+                        factory = _handle_wrapper_registry.get(fallback_type_id)
                     if factory:
                         if kwargs:
                             return factory(handle, client, **kwargs)
@@ -1242,13 +1251,19 @@ internal sealed class PythonModuleBuilder
                     if thread.is_alive():
                         thread.join(timeout=1.0)
 
-            def register_callback(self, callback: typing.Callable[..., typing.Any] | None) -> str | None:
+            def register_callback(
+                self,
+                callback: typing.Callable[..., typing.Any] | None,
+                parameter_type_ids: typing.Sequence[str | None] | None = None
+            ) -> str | None:
                 '''
                 Register a callback function that can be invoked from the .NET side.
                 Returns a callback ID that should be passed to methods accepting callbacks.
 
                 .NET passes arguments as an object with positional keys: { p0: value0, p1: value1, ... }
-                This function automatically extracts positional parameters and wraps handles.
+                This function automatically extracts positional parameters and wraps handles. Generated
+                callback parameter type IDs provide a fallback when the marshalled handle uses a declared
+                generic type ID instead of the concrete type registered by the Python SDK.
                 '''
                 if callback is None:
                     return None
@@ -1265,7 +1280,14 @@ internal sealed class PythonModuleBuilder
                         while True:
                             key = f"p{i}"
                             if key in args:
-                                arg_array.append(_wrap_if_handle(args[key], client))
+                                fallback_type_id = (
+                                    parameter_type_ids[i]
+                                    if parameter_type_ids is not None and i < len(parameter_type_ids)
+                                    else None
+                                )
+                                arg_array.append(
+                                    _wrap_if_handle(args[key], client, fallback_type_id=fallback_type_id)
+                                )
                                 i += 1
                             else:
                                 break

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/AtsPythonCodeGeneratorTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.RemoteHost;
+using Aspire.TestUtilities;
 using Aspire.TypeSystem;
 using Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes;
 
@@ -350,6 +352,87 @@ public class AtsPythonCodeGeneratorTests
                     rpc_args['nullableUnion'] = nullable_union
             """,
             aspirePy);
+    }
+
+    [Fact]
+    [RequiresTools(["python3"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "Uses the Unix Python executable.")]
+    public Task GeneratedCallback_WrapsGenericResourceBuilderHandleOnUnix()
+        => GeneratedCallback_WrapsGenericResourceBuilderHandle("python3");
+
+    [Fact]
+    [RequiresTools(["python"])]
+    [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD, "Uses the Windows Python executable.")]
+    public Task GeneratedCallback_WrapsGenericResourceBuilderHandleOnWindows()
+        => GeneratedCallback_WrapsGenericResourceBuilderHandle("python");
+
+    private async Task GeneratedCallback_WrapsGenericResourceBuilderHandle(string pythonExecutable)
+    {
+        var files = _generator.GenerateDistributedApplication(CreateContextFromTestAssembly());
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var modulePath = Path.Combine(tempDirectory.FullName, "aspire_app.py");
+            var testPath = Path.Combine(tempDirectory.FullName, "test_callback.py");
+            await File.WriteAllTextAsync(modulePath, files["aspire_app.py"]);
+            await File.WriteAllTextAsync(
+                testPath,
+                """
+                import aspire_app
+
+                client = aspire_app.AspireClient("unused")
+                invocations = []
+
+                def invoke_capability(capability_id, args, kwargs=None):
+                    invocations.append(capability_id)
+                    if capability_id.endswith("/withPythonBuilderCallback"):
+                        callback = client._callback_registry[args["configure"]]
+                        callback({
+                            "p0": {
+                                "$handle": "callback-resource",
+                                "$type": "Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceBuilder`1[[Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource, Aspire.Hosting.CodeGeneration.Python.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                            }
+                        }, client)
+                    return args["builder"]
+
+                client.invoke_capability = invoke_capability
+                resource = aspire_app.TestRedisResource(
+                    aspire_app.Handle({
+                        "$handle": "resource",
+                        "$type": "Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource"
+                    }),
+                    client
+                )
+                resource.with_python_builder_callback(lambda configured: configured.with_persistence())
+
+                assert invocations == [
+                    "Aspire.Hosting.CodeGeneration.Python.Tests/withPythonBuilderCallback",
+                    "Aspire.Hosting.CodeGeneration.Python.Tests/withPersistence",
+                ]
+                """);
+
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo(pythonExecutable)
+            {
+                WorkingDirectory = tempDirectory.FullName,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+            process.StartInfo.ArgumentList.Add(testPath);
+            process.Start();
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            Assert.True(
+                process.ExitCode == 0,
+                $"Python callback validation failed.{Environment.NewLine}{await standardOutput}{await standardError}");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
     }
 
     private static List<AtsCapabilityInfo> ScanCapabilitiesFromTestAssembly()

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/PythonTestExtensions.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/PythonTestExtensions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.CodeGeneration.Python.Tests.TestTypes;
+
+public static class PythonTestExtensions
+{
+    /// <summary>
+    /// Configures a test resource through a resource builder callback.
+    /// </summary>
+    /// <param name="builder">The test resource builder.</param>
+    /// <param name="configure">The callback used to configure the test resource.</param>
+    /// <returns>The test resource builder.</returns>
+    [AspireExport]
+    public static IResourceBuilder<TestRedisResource> WithPythonBuilderCallback(
+        this IResourceBuilder<TestRedisResource> builder,
+        Action<IResourceBuilder<TestRedisResource>> configure)
+    {
+        configure(builder);
+
+        return builder;
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AtsGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AtsGeneratedAspire.verified.py
@@ -355,10 +355,17 @@ def _register_handle_wrapper(type_id: str, factory: _HandleWrapperFactory) -> No
     _handle_wrapper_registry[type_id] = factory
 
 
-def _wrap_if_handle(value: typing.Any, client: AspireClient | None = None, kwargs: typing.Mapping[str, typing.Any] | None = None) -> typing.Any:
+def _wrap_if_handle(
+    value: typing.Any,
+    client: AspireClient | None = None,
+    kwargs: typing.Mapping[str, typing.Any] | None = None,
+    fallback_type_id: str | None = None
+) -> typing.Any:
     '''
     Checks if a value is a marshalled handle and wraps it appropriately.
-    Uses the wrapper registry to create typed wrapper instances when available.
+    Uses the wrapper registry to create typed wrapper instances when available. The fallback
+    type ID lets callbacks use their generated parameter type when .NET marshals a handle
+    using its declared generic builder type.
     '''
     if isinstance(value, dict) and _is_marshalled_handle(value):
         handle = Handle(value)
@@ -367,6 +374,8 @@ def _wrap_if_handle(value: typing.Any, client: AspireClient | None = None, kwarg
         # Try to find a registered wrapper factory for this type
         if type_id and client:
             factory = _handle_wrapper_registry.get(type_id)
+            if factory is None and fallback_type_id:
+                factory = _handle_wrapper_registry.get(fallback_type_id)
             if factory:
                 if kwargs:
                     return factory(handle, client, **kwargs)
@@ -1007,13 +1016,19 @@ class AspireClient:
             if thread.is_alive():
                 thread.join(timeout=1.0)
 
-    def register_callback(self, callback: typing.Callable[..., typing.Any] | None) -> str | None:
+    def register_callback(
+        self,
+        callback: typing.Callable[..., typing.Any] | None,
+        parameter_type_ids: typing.Sequence[str | None] | None = None
+    ) -> str | None:
         '''
         Register a callback function that can be invoked from the .NET side.
         Returns a callback ID that should be passed to methods accepting callbacks.
 
         .NET passes arguments as an object with positional keys: { p0: value0, p1: value1, ... }
-        This function automatically extracts positional parameters and wraps handles.
+        This function automatically extracts positional parameters and wraps handles. Generated
+        callback parameter type IDs provide a fallback when the marshalled handle uses a declared
+        generic type ID instead of the concrete type registered by the Python SDK.
         '''
         if callback is None:
             return None
@@ -1030,7 +1045,14 @@ class AspireClient:
                 while True:
                     key = f"p{i}"
                     if key in args:
-                        arg_array.append(_wrap_if_handle(args[key], client))
+                        fallback_type_id = (
+                            parameter_type_ids[i]
+                            if parameter_type_ids is not None and i < len(parameter_type_ids)
+                            else None
+                        )
+                        arg_array.append(
+                            _wrap_if_handle(args[key], client, fallback_type_id=fallback_type_id)
+                        )
                         i += 1
                     else:
                         break
@@ -2193,7 +2215,7 @@ class _BaseResource(AbstractResource):
         """Configures with optional callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if callback is not None:
-            rpc_args['callback'] = self._client.register_callback(callback)
+            rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withOptionalCallback',
             rpc_args,
@@ -2226,7 +2248,7 @@ class _BaseResource(AbstractResource):
     def with_validator(self, validator: typing.Callable[[TestResourceContext], bool]) -> typing.Self:
         """Adds validation callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['validator'] = self._client.register_callback(validator)
+        rpc_args['validator'] = self._client.register_callback(validator, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withValidator',
             rpc_args,
@@ -2396,7 +2418,7 @@ class _BaseResource(AbstractResource):
         if _optional_callback := kwargs.pop("optional_callback", None):
             if _validate_type(_optional_callback, typing.Callable[[TestCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext], None], _optional_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext], None], _optional_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withOptionalCallback', rpc_args))
             elif _optional_callback is True:
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -2420,7 +2442,7 @@ class _BaseResource(AbstractResource):
         if _validator := kwargs.pop("validator", None):
             if _validate_type(_validator, typing.Callable[[TestResourceContext], bool]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["validator"] = client.register_callback(typing.cast(typing.Callable[[TestResourceContext], bool], _validator))
+                rpc_args["validator"] = client.register_callback(typing.cast(typing.Callable[[TestResourceContext], bool], _validator), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withValidator', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'validator'. Expected: Callable[[TestResourceContext], bool]")
@@ -2534,7 +2556,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def test_with_env_callback(self, callback: typing.Callable[[TestEnvironmentContext], None]) -> typing.Self:
         """Configures environment with callback (test version)"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback',
             rpc_args,
@@ -2557,7 +2579,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _test_with_env_callback := kwargs.pop("test_with_env_callback", None):
             if _validate_type(_test_with_env_callback, typing.Callable[[TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'test_with_env_callback'. Expected: Callable[[TestEnvironmentContext], None]")
@@ -2620,6 +2642,7 @@ class TestRedisResourceKwargs(ContainerResourceKwargs, total=False):
     multi_param_handle_callback: typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]
     data_volume: DataVolumeParameters | typing.Literal[True]
     concrete_vault_resource: TestVaultResource
+    python_builder_callback: typing.Callable[[TestRedisResource], None]
 
 class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString):
     """TestRedisResource resource."""
@@ -2760,7 +2783,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
     def with_multi_param_handle_callback(self, callback: typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]) -> typing.Self:
         """Tests multi-param callback destructuring"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", "Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext"))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withMultiParamHandleCallback',
             rpc_args,
@@ -2788,6 +2811,17 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
         rpc_args['resource'] = resource
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withConcreteVaultResource',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
+    def with_python_builder_callback(self, configure: typing.Callable[[TestRedisResource], None]) -> typing.Self:
+        """Configures a test resource through a resource builder callback."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['configure'] = self._client.register_callback(configure, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource",))
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.CodeGeneration.Python.Tests/withPythonBuilderCallback',
             rpc_args,
         )
         self._handle = self._wrap_builder(result)
@@ -2844,7 +2878,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
         if _multi_param_handle_callback := kwargs.pop("multi_param_handle_callback", None):
             if _validate_type(_multi_param_handle_callback, typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext, TestEnvironmentContext], None], _multi_param_handle_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext, TestEnvironmentContext], None], _multi_param_handle_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", "Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext"))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withMultiParamHandleCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'multi_param_handle_callback'. Expected: Callable[[TestCallbackContext, TestEnvironmentContext], None]")
@@ -2866,6 +2900,13 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withConcreteVaultResource', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'concrete_vault_resource'. Expected: TestVaultResource")
+        if _python_builder_callback := kwargs.pop("python_builder_callback", None):
+            if _validate_type(_python_builder_callback, typing.Callable[[TestRedisResource], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[TestRedisResource], None], _python_builder_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource",))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withPythonBuilderCallback', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'python_builder_callback'. Expected: Callable[[TestRedisResource], None]")
         super().__init__(handle, client, **kwargs)
 
 

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -355,10 +355,17 @@ def _register_handle_wrapper(type_id: str, factory: _HandleWrapperFactory) -> No
     _handle_wrapper_registry[type_id] = factory
 
 
-def _wrap_if_handle(value: typing.Any, client: AspireClient | None = None, kwargs: typing.Mapping[str, typing.Any] | None = None) -> typing.Any:
+def _wrap_if_handle(
+    value: typing.Any,
+    client: AspireClient | None = None,
+    kwargs: typing.Mapping[str, typing.Any] | None = None,
+    fallback_type_id: str | None = None
+) -> typing.Any:
     '''
     Checks if a value is a marshalled handle and wraps it appropriately.
-    Uses the wrapper registry to create typed wrapper instances when available.
+    Uses the wrapper registry to create typed wrapper instances when available. The fallback
+    type ID lets callbacks use their generated parameter type when .NET marshals a handle
+    using its declared generic builder type.
     '''
     if isinstance(value, dict) and _is_marshalled_handle(value):
         handle = Handle(value)
@@ -367,6 +374,8 @@ def _wrap_if_handle(value: typing.Any, client: AspireClient | None = None, kwarg
         # Try to find a registered wrapper factory for this type
         if type_id and client:
             factory = _handle_wrapper_registry.get(type_id)
+            if factory is None and fallback_type_id:
+                factory = _handle_wrapper_registry.get(fallback_type_id)
             if factory:
                 if kwargs:
                     return factory(handle, client, **kwargs)
@@ -1007,13 +1016,19 @@ class AspireClient:
             if thread.is_alive():
                 thread.join(timeout=1.0)
 
-    def register_callback(self, callback: typing.Callable[..., typing.Any] | None) -> str | None:
+    def register_callback(
+        self,
+        callback: typing.Callable[..., typing.Any] | None,
+        parameter_type_ids: typing.Sequence[str | None] | None = None
+    ) -> str | None:
         '''
         Register a callback function that can be invoked from the .NET side.
         Returns a callback ID that should be passed to methods accepting callbacks.
 
         .NET passes arguments as an object with positional keys: { p0: value0, p1: value1, ... }
-        This function automatically extracts positional parameters and wraps handles.
+        This function automatically extracts positional parameters and wraps handles. Generated
+        callback parameter type IDs provide a fallback when the marshalled handle uses a declared
+        generic type ID instead of the concrete type registered by the Python SDK.
         '''
         if callback is None:
             return None
@@ -1030,7 +1045,14 @@ class AspireClient:
                 while True:
                     key = f"p{i}"
                     if key in args:
-                        arg_array.append(_wrap_if_handle(args[key], client))
+                        fallback_type_id = (
+                            parameter_type_ids[i]
+                            if parameter_type_ids is not None and i < len(parameter_type_ids)
+                            else None
+                        )
+                        arg_array.append(
+                            _wrap_if_handle(args[key], client, fallback_type_id=fallback_type_id)
+                        )
                         i += 1
                     else:
                         break
@@ -2412,7 +2434,7 @@ class DistributedApplicationBuilder:
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['name'] = name
         rpc_args['contextPath'] = context_path
-        rpc_args['dockerfileFactory'] = self._client.register_callback(dockerfile_factory)
+        rpc_args['dockerfileFactory'] = self._client.register_callback(dockerfile_factory, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileFactoryContext",))
         if stage is not None:
             rpc_args['stage'] = stage
         result = self._client.invoke_capability(
@@ -2427,7 +2449,7 @@ class DistributedApplicationBuilder:
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['name'] = name
         rpc_args['contextPath'] = context_path
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext",))
         if stage is not None:
             rpc_args['stage'] = stage
         result = self._client.invoke_capability(
@@ -2574,7 +2596,7 @@ class DistributedApplicationBuilder:
     def subscribe_before_start(self, callback: typing.Callable[[BeforeStartEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the BeforeStart event, which fires before the application starts."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/subscribeBeforeStart',
             rpc_args,
@@ -2584,7 +2606,7 @@ class DistributedApplicationBuilder:
     def subscribe_before_publish(self, callback: typing.Callable[[BeforePublishEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the BeforePublish event, which fires before the application is published."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Publishing.BeforePublishEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/subscribeBeforePublish',
             rpc_args,
@@ -2594,7 +2616,7 @@ class DistributedApplicationBuilder:
     def subscribe_after_publish(self, callback: typing.Callable[[AfterPublishEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the AfterPublish event, which fires after the application is published."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Publishing.AfterPublishEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/subscribeAfterPublish',
             rpc_args,
@@ -2604,7 +2626,7 @@ class DistributedApplicationBuilder:
     def subscribe_after_resources_created(self, callback: typing.Callable[[AfterResourcesCreatedEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the AfterResourcesCreated event, which fires after all resources are created."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/subscribeAfterResourcesCreated',
             rpc_args,
@@ -2614,7 +2636,7 @@ class DistributedApplicationBuilder:
     def add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
         """Adds an ATS-friendly eventing subscriber callback to the distributed-application builder."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        rpc_args['subscribe'] = self._client.register_callback(subscribe, ("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext",))
         self._client.invoke_capability(
             'Aspire.Hosting/addEventingSubscriber',
             rpc_args
@@ -2623,7 +2645,7 @@ class DistributedApplicationBuilder:
     def try_add_eventing_subscriber(self, subscribe: typing.Callable[[EventingSubscriberRegistrationContext], None]) -> None:
         """Attempts to add an ATS-friendly eventing subscriber callback to the distributed-application builder."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['subscribe'] = self._client.register_callback(subscribe)
+        rpc_args['subscribe'] = self._client.register_callback(subscribe, ("Aspire.Hosting/Aspire.Hosting.Ats.EventingSubscriberRegistrationContext",))
         self._client.invoke_capability(
             'Aspire.Hosting/tryAddEventingSubscriber',
             rpc_args
@@ -2719,7 +2741,7 @@ class AbstractDistributedApplicationPipeline:
         """Adds an application-level pipeline step in a TypeScript-friendly shape."""
         rpc_args: dict[str, typing.Any] = {'pipeline': self._handle}
         rpc_args['stepName'] = step_name
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepContext",))
         if depends_on is not None:
             rpc_args['dependsOn'] = depends_on
         if required_by is not None:
@@ -2732,7 +2754,7 @@ class AbstractDistributedApplicationPipeline:
     def configure(self, callback: typing.Callable[[PipelineConfigurationContext], None]) -> None:
         """Registers a pipeline configuration callback in a TypeScript-friendly shape."""
         rpc_args: dict[str, typing.Any] = {'pipeline': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext",))
         self._client.invoke_capability(
             'Aspire.Hosting/configure',
             rpc_args
@@ -5339,7 +5361,7 @@ class EventingSubscriberRegistrationContext:
     def on_before_start(self, callback: typing.Callable[[BeforeStartEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the BeforeStart event from an eventing subscriber registration context."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeStartEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/eventingSubscriberOnBeforeStart',
             rpc_args,
@@ -5349,7 +5371,7 @@ class EventingSubscriberRegistrationContext:
     def on_before_publish(self, callback: typing.Callable[[BeforePublishEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the BeforePublish event from an eventing subscriber registration context."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Publishing.BeforePublishEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/eventingSubscriberOnBeforePublish',
             rpc_args,
@@ -5359,7 +5381,7 @@ class EventingSubscriberRegistrationContext:
     def on_after_publish(self, callback: typing.Callable[[AfterPublishEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the AfterPublish event from an eventing subscriber registration context."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Publishing.AfterPublishEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/eventingSubscriberOnAfterPublish',
             rpc_args,
@@ -5369,7 +5391,7 @@ class EventingSubscriberRegistrationContext:
     def on_after_resources_created(self, callback: typing.Callable[[AfterResourcesCreatedEvent], None]) -> DistributedApplicationEventSubscription:
         """Subscribes to the AfterResourcesCreated event from an eventing subscriber registration context."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/eventingSubscriberOnAfterResourcesCreated',
             rpc_args,
@@ -5828,7 +5850,7 @@ class InteractionInputBuilder:
     def with_dynamic_loading(self, callback: typing.Callable[[InteractionInputLoadContext], None], *, options: DynamicLoadingOptions | None = None) -> InteractionInputBuilder:
         """Attaches a callback that dynamically loads or updates the input after the prompt starts."""
         rpc_args: dict[str, typing.Any] = {'context': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Ats.InteractionInputLoadContext",))
         if options is not None:
             rpc_args['options'] = options
         result = self._client.invoke_capability(
@@ -7926,7 +7948,7 @@ class _BaseResource(AbstractResource):
         """Declares that a resource requires a specific command/executable to be available on the local machine PATH before it can start, with custom validation logic."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['command'] = command
-        rpc_args['validationCallback'] = self._client.register_callback(validation_callback)
+        rpc_args['validationCallback'] = self._client.register_callback(validation_callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext",))
         if help_link is not None:
             rpc_args['helpLink'] = help_link
         result = self._client.invoke_capability(
@@ -7981,7 +8003,7 @@ class _BaseResource(AbstractResource):
     def with_urls(self, callback: typing.Callable[[ResourceUrlsCallbackContext], None]) -> typing.Self:
         """Registers a callback to customize the URLs displayed for the resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withUrls',
             rpc_args,
@@ -8050,7 +8072,7 @@ class _BaseResource(AbstractResource):
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['name'] = name
         rpc_args['displayName'] = display_name
-        rpc_args['executeCommand'] = self._client.register_callback(execute_command)
+        rpc_args['executeCommand'] = self._client.register_callback(execute_command, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
         if command_options is not None:
             rpc_args['commandOptions'] = command_options
         result = self._client.invoke_capability(
@@ -8078,7 +8100,7 @@ class _BaseResource(AbstractResource):
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['commandName'] = command_name
         rpc_args['displayName'] = display_name
-        rpc_args['createProcessSpec'] = self._client.register_callback(create_process_spec)
+        rpc_args['createProcessSpec'] = self._client.register_callback(create_process_spec, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
         if options is not None:
             rpc_args['options'] = options
         result = self._client.invoke_capability(
@@ -8091,7 +8113,7 @@ class _BaseResource(AbstractResource):
     def subscribe_https_endpoints_update(self, callback: typing.Callable[[HttpsEndpointUpdateCallbackContext], None]) -> typing.Self:
         """Subscribes to the `BeforeStartEvent` and invokes the specified callback when an HTTPS certificate is determined to be available for the resource. This is used to conditionally update endpoint URI schemes or perform other HTTPS-related configuration at startup."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/subscribeHttpsEndpointsUpdate',
             rpc_args,
@@ -8194,7 +8216,7 @@ class _BaseResource(AbstractResource):
         """Adds a pipeline step to the resource that will be executed during deployment."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['stepName'] = step_name
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepContext",))
         if depends_on is not None:
             rpc_args['dependsOn'] = depends_on
         if required_by is not None:
@@ -8213,7 +8235,7 @@ class _BaseResource(AbstractResource):
     def with_pipeline_config(self, callback: typing.Callable[[PipelineConfigurationContext], None]) -> typing.Self:
         """Registers a callback to be executed during the pipeline configuration phase, allowing modification of step dependencies and relationships."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withPipelineConfiguration',
             rpc_args,
@@ -8233,7 +8255,7 @@ class _BaseResource(AbstractResource):
     def on_before_resource_started(self, callback: typing.Callable[[BeforeResourceStartedEvent], None]) -> typing.Self:
         """Subscribes to the BeforeResourceStarted event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeResourceStartedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onBeforeResourceStarted',
             rpc_args,
@@ -8244,7 +8266,7 @@ class _BaseResource(AbstractResource):
     def on_resource_stopped(self, callback: typing.Callable[[ResourceStoppedEvent], None]) -> typing.Self:
         """Subscribes to the ResourceStopped event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceStoppedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onResourceStopped',
             rpc_args,
@@ -8255,7 +8277,7 @@ class _BaseResource(AbstractResource):
     def on_initialize_resource(self, callback: typing.Callable[[InitializeResourceEvent], None]) -> typing.Self:
         """Subscribes to the InitializeResource event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onInitializeResource',
             rpc_args,
@@ -8266,7 +8288,7 @@ class _BaseResource(AbstractResource):
     def on_resource_ready(self, callback: typing.Callable[[ResourceReadyEvent], None]) -> typing.Self:
         """Subscribes to the ResourceReady event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceReadyEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onResourceReady',
             rpc_args,
@@ -8286,7 +8308,7 @@ class _BaseResource(AbstractResource):
     def with_container_build_options(self, callback: typing.Callable[[ContainerBuildOptionsCallbackContext], None]) -> typing.Self:
         """Configures container build options for a compute resource using an async callback."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withContainerBuildOptions',
             rpc_args,
@@ -8356,7 +8378,7 @@ class _BaseResource(AbstractResource):
         """Configures with optional callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if callback is not None:
-            rpc_args['callback'] = self._client.register_callback(callback)
+            rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withOptionalCallback',
             rpc_args,
@@ -8389,7 +8411,7 @@ class _BaseResource(AbstractResource):
     def with_validator(self, validator: typing.Callable[[TestResourceContext], bool]) -> typing.Self:
         """Adds validation callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['validator'] = self._client.register_callback(validator)
+        rpc_args['validator'] = self._client.register_callback(validator, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withValidator',
             rpc_args,
@@ -8551,12 +8573,12 @@ class _BaseResource(AbstractResource):
             if _validate_tuple_types(_required_command_validation, (str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["command"] = typing.cast(tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]], _required_command_validation)[0]
-                rpc_args["validationCallback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]], _required_command_validation)[1])
+                rpc_args["validationCallback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[RequiredCommandValidationContext], RequiredCommandValidationResult]], _required_command_validation)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommandValidation', rpc_args))
             elif _validate_dict_types(_required_command_validation, RequiredCommandValidationParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["command"] = typing.cast(RequiredCommandValidationParameters, _required_command_validation)["command"]
-                rpc_args["validationCallback"] = client.register_callback(typing.cast(RequiredCommandValidationParameters, _required_command_validation)["validation_callback"])
+                rpc_args["validationCallback"] = client.register_callback(typing.cast(RequiredCommandValidationParameters, _required_command_validation)["validation_callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.RequiredCommandValidationContext",))
                 rpc_args["helpLink"] = typing.cast(RequiredCommandValidationParameters, _required_command_validation).get("help_link")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withRequiredCommandValidation', rpc_args))
             else:
@@ -8590,7 +8612,7 @@ class _BaseResource(AbstractResource):
         if _urls := kwargs.pop("urls", None):
             if _validate_type(_urls, typing.Callable[[ResourceUrlsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceUrlsCallbackContext], None], _urls))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceUrlsCallbackContext], None], _urls), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withUrls', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'urls'. Expected: Callable[[ResourceUrlsCallbackContext], None]")
@@ -8638,13 +8660,13 @@ class _BaseResource(AbstractResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["name"] = typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]], _command)[0]
                 rpc_args["displayName"] = typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]], _command)[1]
-                rpc_args["executeCommand"] = client.register_callback(typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]], _command)[2])
+                rpc_args["executeCommand"] = client.register_callback(typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ExecuteCommandResult]], _command)[2], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withCommand', rpc_args))
             elif _validate_dict_types(_command, CommandParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["name"] = typing.cast(CommandParameters, _command)["name"]
                 rpc_args["displayName"] = typing.cast(CommandParameters, _command)["display_name"]
-                rpc_args["executeCommand"] = client.register_callback(typing.cast(CommandParameters, _command)["execute_command"])
+                rpc_args["executeCommand"] = client.register_callback(typing.cast(CommandParameters, _command)["execute_command"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
                 rpc_args["commandOptions"] = typing.cast(CommandParameters, _command).get("command_options")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withCommand', rpc_args))
             else:
@@ -8663,13 +8685,13 @@ class _BaseResource(AbstractResource):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["commandName"] = typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]], _process_command_factory)[0]
                 rpc_args["displayName"] = typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]], _process_command_factory)[1]
-                rpc_args["createProcessSpec"] = client.register_callback(typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]], _process_command_factory)[2])
+                rpc_args["createProcessSpec"] = client.register_callback(typing.cast(tuple[str, str, typing.Callable[[ExecuteCommandContext], ProcessCommandSpecExportData]], _process_command_factory)[2], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withProcessCommandFactory', rpc_args))
             elif _validate_dict_types(_process_command_factory, ProcessCommandFactoryParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["commandName"] = typing.cast(ProcessCommandFactoryParameters, _process_command_factory)["command_name"]
                 rpc_args["displayName"] = typing.cast(ProcessCommandFactoryParameters, _process_command_factory)["display_name"]
-                rpc_args["createProcessSpec"] = client.register_callback(typing.cast(ProcessCommandFactoryParameters, _process_command_factory)["create_process_spec"])
+                rpc_args["createProcessSpec"] = client.register_callback(typing.cast(ProcessCommandFactoryParameters, _process_command_factory)["create_process_spec"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext",))
                 rpc_args["options"] = typing.cast(ProcessCommandFactoryParameters, _process_command_factory).get("options")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withProcessCommandFactory', rpc_args))
             else:
@@ -8677,7 +8699,7 @@ class _BaseResource(AbstractResource):
         if _subscribe_https_endpoints_update := kwargs.pop("subscribe_https_endpoints_update", None):
             if _validate_type(_subscribe_https_endpoints_update, typing.Callable[[HttpsEndpointUpdateCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsEndpointUpdateCallbackContext], None], _subscribe_https_endpoints_update))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsEndpointUpdateCallbackContext], None], _subscribe_https_endpoints_update), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/subscribeHttpsEndpointsUpdate', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'subscribe_https_endpoints_update'. Expected: Callable[[HttpsEndpointUpdateCallbackContext], None]")
@@ -8748,12 +8770,12 @@ class _BaseResource(AbstractResource):
             if _validate_tuple_types(_pipeline_step_factory, (str, typing.Callable[[PipelineStepContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["stepName"] = typing.cast(tuple[str, typing.Callable[[PipelineStepContext], None]], _pipeline_step_factory)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[PipelineStepContext], None]], _pipeline_step_factory)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[PipelineStepContext], None]], _pipeline_step_factory)[1], ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withPipelineStepFactory', rpc_args))
             elif _validate_dict_types(_pipeline_step_factory, PipelineStepFactoryParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["stepName"] = typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory)["step_name"]
-                rpc_args["callback"] = client.register_callback(typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory)["callback"], ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepContext",))
                 rpc_args["dependsOn"] = typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory).get("depends_on")
                 rpc_args["requiredBy"] = typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory).get("required_by")
                 rpc_args["tags"] = typing.cast(PipelineStepFactoryParameters, _pipeline_step_factory).get("tags")
@@ -8764,42 +8786,42 @@ class _BaseResource(AbstractResource):
         if _pipeline_config := kwargs.pop("pipeline_config", None):
             if _validate_type(_pipeline_config, typing.Callable[[PipelineConfigurationContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[PipelineConfigurationContext], None], _pipeline_config))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[PipelineConfigurationContext], None], _pipeline_config), ("Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withPipelineConfiguration', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'pipeline_config'. Expected: Callable[[PipelineConfigurationContext], None]")
         if _on_before_resource_started := kwargs.pop("on_before_resource_started", None):
             if _validate_type(_on_before_resource_started, typing.Callable[[BeforeResourceStartedEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[BeforeResourceStartedEvent], None], _on_before_resource_started))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[BeforeResourceStartedEvent], None], _on_before_resource_started), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.BeforeResourceStartedEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onBeforeResourceStarted', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_before_resource_started'. Expected: Callable[[BeforeResourceStartedEvent], None]")
         if _on_resource_stopped := kwargs.pop("on_resource_stopped", None):
             if _validate_type(_on_resource_stopped, typing.Callable[[ResourceStoppedEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceStoppedEvent], None], _on_resource_stopped))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceStoppedEvent], None], _on_resource_stopped), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceStoppedEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceStopped', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_stopped'. Expected: Callable[[ResourceStoppedEvent], None]")
         if _on_initialize_resource := kwargs.pop("on_initialize_resource", None):
             if _validate_type(_on_initialize_resource, typing.Callable[[InitializeResourceEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[InitializeResourceEvent], None], _on_initialize_resource))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[InitializeResourceEvent], None], _on_initialize_resource), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.InitializeResourceEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onInitializeResource', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_initialize_resource'. Expected: Callable[[InitializeResourceEvent], None]")
         if _on_resource_ready := kwargs.pop("on_resource_ready", None):
             if _validate_type(_on_resource_ready, typing.Callable[[ResourceReadyEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceReadyEvent], None], _on_resource_ready))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceReadyEvent], None], _on_resource_ready), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceReadyEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceReady', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_ready'. Expected: Callable[[ResourceReadyEvent], None]")
         if _container_build_options := kwargs.pop("container_build_options", None):
             if _validate_type(_container_build_options, typing.Callable[[ContainerBuildOptionsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerBuildOptionsCallbackContext], None], _container_build_options))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerBuildOptionsCallbackContext], None], _container_build_options), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerBuildOptionsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerBuildOptions', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'container_build_options'. Expected: Callable[[ContainerBuildOptionsCallbackContext], None]")
@@ -8845,7 +8867,7 @@ class _BaseResource(AbstractResource):
         if _optional_callback := kwargs.pop("optional_callback", None):
             if _validate_type(_optional_callback, typing.Callable[[TestCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext], None], _optional_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext], None], _optional_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withOptionalCallback', rpc_args))
             elif _optional_callback is True:
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -8869,7 +8891,7 @@ class _BaseResource(AbstractResource):
         if _validator := kwargs.pop("validator", None):
             if _validate_type(_validator, typing.Callable[[TestResourceContext], bool]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["validator"] = client.register_callback(typing.cast(typing.Callable[[TestResourceContext], bool], _validator))
+                rpc_args["validator"] = client.register_callback(typing.cast(typing.Callable[[TestResourceContext], bool], _validator), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withValidator', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'validator'. Expected: Callable[[TestResourceContext], bool]")
@@ -9182,7 +9204,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         """Builds the specified container image from a Dockerfile generated by an asynchronous factory function."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['contextPath'] = context_path
-        rpc_args['dockerfileFactory'] = self._client.register_callback(dockerfile_factory)
+        rpc_args['dockerfileFactory'] = self._client.register_callback(dockerfile_factory, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileFactoryContext",))
         if stage is not None:
             rpc_args['stage'] = stage
         result = self._client.invoke_capability(
@@ -9261,7 +9283,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         """Creates or updates files and/or folders at the destination path in the container using entries produced by a callback."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['destinationPath'] = destination_path
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", None))
         if options is not None:
             rpc_args['options'] = options
         result = self._client.invoke_capability(
@@ -9275,7 +9297,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         """Configures the resource to use a programmatically generated Dockerfile"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['contextPath'] = context_path
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext",))
         if stage is not None:
             rpc_args['stage'] = stage
         result = self._client.invoke_capability(
@@ -9347,7 +9369,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_env_callback(self, callback: typing.Callable[[EnvironmentCallbackContext], None]) -> typing.Self:
         """Allows for the population of environment variables on a resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
             rpc_args,
@@ -9369,7 +9391,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_args_callback(self, callback: typing.Callable[[CommandLineArgsCallbackContext], None]) -> typing.Self:
         """Adds a callback to be executed with a list of command-line arguments when a resource is started."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withArgsCallback',
             rpc_args,
@@ -9409,7 +9431,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         """Updates a named endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['endpointName'] = endpoint_name
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if create_if_not_exists is not None:
             rpc_args['createIfNotExists'] = create_if_not_exists
         result = self._client.invoke_capability(
@@ -9422,7 +9444,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_http_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTP endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -9437,7 +9459,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_https_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTPS endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -9672,7 +9694,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
         """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withHttpsCertificateConfiguration',
             rpc_args,
@@ -9719,7 +9741,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
         """Adds an asynchronous callback to configure container image push options for the resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withImagePushOptions',
             rpc_args,
@@ -9767,7 +9789,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def on_resource_endpoints_allocated(self, callback: typing.Callable[[ResourceEndpointsAllocatedEvent], None]) -> typing.Self:
         """Subscribes to the ResourceEndpointsAllocated event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onResourceEndpointsAllocated',
             rpc_args,
@@ -9778,7 +9800,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
     def test_with_env_callback(self, callback: typing.Callable[[TestEnvironmentContext], None]) -> typing.Self:
         """Configures environment with callback (test version)"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback',
             rpc_args,
@@ -9896,12 +9918,12 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
             if _validate_tuple_types(_dockerfile_factory, (str, typing.Callable[[DockerfileFactoryContext], str])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["contextPath"] = typing.cast(tuple[str, typing.Callable[[DockerfileFactoryContext], str]], _dockerfile_factory)[0]
-                rpc_args["dockerfileFactory"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[DockerfileFactoryContext], str]], _dockerfile_factory)[1])
+                rpc_args["dockerfileFactory"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[DockerfileFactoryContext], str]], _dockerfile_factory)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileFactoryContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withDockerfileFactory', rpc_args))
             elif _validate_dict_types(_dockerfile_factory, DockerfileFactoryParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["contextPath"] = typing.cast(DockerfileFactoryParameters, _dockerfile_factory)["context_path"]
-                rpc_args["dockerfileFactory"] = client.register_callback(typing.cast(DockerfileFactoryParameters, _dockerfile_factory)["dockerfile_factory"])
+                rpc_args["dockerfileFactory"] = client.register_callback(typing.cast(DockerfileFactoryParameters, _dockerfile_factory)["dockerfile_factory"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileFactoryContext",))
                 rpc_args["stage"] = typing.cast(DockerfileFactoryParameters, _dockerfile_factory).get("stage")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withDockerfileFactory', rpc_args))
             else:
@@ -9959,12 +9981,12 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
             if _validate_tuple_types(_container_files_callback, (str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["destinationPath"] = typing.cast(tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]], _container_files_callback)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]], _container_files_callback)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[ContainerFileSystemCallbackContext, CancellationToken], typing.Iterable[ContainerFileSystemItem]]], _container_files_callback)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", None))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerFilesCallback', rpc_args))
             elif _validate_dict_types(_container_files_callback, ContainerFilesCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["destinationPath"] = typing.cast(ContainerFilesCallbackParameters, _container_files_callback)["destination_path"]
-                rpc_args["callback"] = client.register_callback(typing.cast(ContainerFilesCallbackParameters, _container_files_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(ContainerFilesCallbackParameters, _container_files_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerFileSystemCallbackContext", None))
                 rpc_args["options"] = typing.cast(ContainerFilesCallbackParameters, _container_files_callback).get("options")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withContainerFilesCallback', rpc_args))
             else:
@@ -9973,12 +9995,12 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
             if _validate_tuple_types(_dockerfile_builder, (str, typing.Callable[[DockerfileBuilderCallbackContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["contextPath"] = typing.cast(tuple[str, typing.Callable[[DockerfileBuilderCallbackContext], None]], _dockerfile_builder)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[DockerfileBuilderCallbackContext], None]], _dockerfile_builder)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[DockerfileBuilderCallbackContext], None]], _dockerfile_builder)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withDockerfileBuilder', rpc_args))
             elif _validate_dict_types(_dockerfile_builder, DockerfileBuilderParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["contextPath"] = typing.cast(DockerfileBuilderParameters, _dockerfile_builder)["context_path"]
-                rpc_args["callback"] = client.register_callback(typing.cast(DockerfileBuilderParameters, _dockerfile_builder)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(DockerfileBuilderParameters, _dockerfile_builder)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext",))
                 rpc_args["stage"] = typing.cast(DockerfileBuilderParameters, _dockerfile_builder).get("stage")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withDockerfileBuilder', rpc_args))
             else:
@@ -10028,7 +10050,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _env_callback := kwargs.pop("env_callback", None):
             if _validate_type(_env_callback, typing.Callable[[EnvironmentCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
@@ -10042,7 +10064,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _args_callback := kwargs.pop("args_callback", None):
             if _validate_type(_args_callback, typing.Callable[[CommandLineArgsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withArgsCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'args_callback'. Expected: Callable[[CommandLineArgsCallbackContext], None]")
@@ -10071,12 +10093,12 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
             if _validate_tuple_types(_endpoint_callback, (str, typing.Callable[[EndpointUpdateContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             elif _validate_dict_types(_endpoint_callback, EndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(EndpointCallbackParameters, _endpoint_callback)["endpoint_name"]
-                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["createIfNotExists"] = typing.cast(EndpointCallbackParameters, _endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             else:
@@ -10084,11 +10106,11 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _http_endpoint_callback := kwargs.pop("http_endpoint_callback", None):
             if _validate_type(_http_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
             elif _validate_dict_types(_http_endpoint_callback, HttpEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
@@ -10097,11 +10119,11 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _https_endpoint_callback := kwargs.pop("https_endpoint_callback", None):
             if _validate_type(_https_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
             elif _validate_dict_types(_https_endpoint_callback, HttpsEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
@@ -10266,7 +10288,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _https_certificate_config := kwargs.pop("https_certificate_config", None):
             if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
@@ -10298,7 +10320,7 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _image_push_options := kwargs.pop("image_push_options", None):
             if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
@@ -10332,14 +10354,14 @@ class ContainerResource(_BaseResource, AbstractResourceWithEnvironment, Abstract
         if _on_resource_endpoints_allocated := kwargs.pop("on_resource_endpoints_allocated", None):
             if _validate_type(_on_resource_endpoints_allocated, typing.Callable[[ResourceEndpointsAllocatedEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceEndpointsAllocated', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_endpoints_allocated'. Expected: Callable[[ResourceEndpointsAllocatedEvent], None]")
         if _test_with_env_callback := kwargs.pop("test_with_env_callback", None):
             if _validate_type(_test_with_env_callback, typing.Callable[[TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'test_with_env_callback'. Expected: Callable[[TestEnvironmentContext], None]")
@@ -10455,7 +10477,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         """Publishes a project as a Docker file with optional container configuration"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         if configure is not None:
-            rpc_args['configure'] = self._client.register_callback(configure)
+            rpc_args['configure'] = self._client.register_callback(configure, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/publishProjectAsDockerFileWithConfigure',
             rpc_args,
@@ -10478,7 +10500,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_env_callback(self, callback: typing.Callable[[EnvironmentCallbackContext], None]) -> typing.Self:
         """Allows for the population of environment variables on a resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
             rpc_args,
@@ -10500,7 +10522,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_args_callback(self, callback: typing.Callable[[CommandLineArgsCallbackContext], None]) -> typing.Self:
         """Adds a callback to be executed with a list of command-line arguments when a resource is started."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withArgsCallback',
             rpc_args,
@@ -10540,7 +10562,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         """Updates a named endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['endpointName'] = endpoint_name
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if create_if_not_exists is not None:
             rpc_args['createIfNotExists'] = create_if_not_exists
         result = self._client.invoke_capability(
@@ -10553,7 +10575,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_http_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTP endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -10568,7 +10590,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_https_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTPS endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -10815,7 +10837,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
         """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withHttpsCertificateConfiguration',
             rpc_args,
@@ -10862,7 +10884,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
         """Adds an asynchronous callback to configure container image push options for the resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withImagePushOptions',
             rpc_args,
@@ -10921,7 +10943,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def on_resource_endpoints_allocated(self, callback: typing.Callable[[ResourceEndpointsAllocatedEvent], None]) -> typing.Self:
         """Subscribes to the ResourceEndpointsAllocated event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onResourceEndpointsAllocated',
             rpc_args,
@@ -10932,7 +10954,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
     def test_with_env_callback(self, callback: typing.Callable[[TestEnvironmentContext], None]) -> typing.Self:
         """Configures environment with callback (test version)"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback',
             rpc_args,
@@ -10989,7 +11011,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _publish_as_docker_file := kwargs.pop("publish_as_docker_file", None):
             if _validate_type(_publish_as_docker_file, typing.Callable[[ContainerResource], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[ContainerResource], None], _publish_as_docker_file))
+                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[ContainerResource], None], _publish_as_docker_file), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/publishProjectAsDockerFileWithConfigure', rpc_args))
             elif _publish_as_docker_file is True:
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
@@ -11007,7 +11029,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _env_callback := kwargs.pop("env_callback", None):
             if _validate_type(_env_callback, typing.Callable[[EnvironmentCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
@@ -11021,7 +11043,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _args_callback := kwargs.pop("args_callback", None):
             if _validate_type(_args_callback, typing.Callable[[CommandLineArgsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withArgsCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'args_callback'. Expected: Callable[[CommandLineArgsCallbackContext], None]")
@@ -11050,12 +11072,12 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
             if _validate_tuple_types(_endpoint_callback, (str, typing.Callable[[EndpointUpdateContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             elif _validate_dict_types(_endpoint_callback, EndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(EndpointCallbackParameters, _endpoint_callback)["endpoint_name"]
-                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["createIfNotExists"] = typing.cast(EndpointCallbackParameters, _endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             else:
@@ -11063,11 +11085,11 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _http_endpoint_callback := kwargs.pop("http_endpoint_callback", None):
             if _validate_type(_http_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
             elif _validate_dict_types(_http_endpoint_callback, HttpEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
@@ -11076,11 +11098,11 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _https_endpoint_callback := kwargs.pop("https_endpoint_callback", None):
             if _validate_type(_https_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
             elif _validate_dict_types(_https_endpoint_callback, HttpsEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
@@ -11253,7 +11275,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _https_certificate_config := kwargs.pop("https_certificate_config", None):
             if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
@@ -11285,7 +11307,7 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _image_push_options := kwargs.pop("image_push_options", None):
             if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
@@ -11329,14 +11351,14 @@ class ProjectResource(_BaseResource, AbstractResourceWithEnvironment, AbstractRe
         if _on_resource_endpoints_allocated := kwargs.pop("on_resource_endpoints_allocated", None):
             if _validate_type(_on_resource_endpoints_allocated, typing.Callable[[ResourceEndpointsAllocatedEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceEndpointsAllocated', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_endpoints_allocated'. Expected: Callable[[ResourceEndpointsAllocatedEvent], None]")
         if _test_with_env_callback := kwargs.pop("test_with_env_callback", None):
             if _validate_type(_test_with_env_callback, typing.Callable[[TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'test_with_env_callback'. Expected: Callable[[TestEnvironmentContext], None]")
@@ -11416,7 +11438,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def publish_as_docker_file(self, configure: typing.Callable[[ContainerResource], None]) -> typing.Self:
         """Publishes an executable as a Docker file"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['configure'] = self._client.register_callback(configure)
+        rpc_args['configure'] = self._client.register_callback(configure, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/publishAsDockerFile',
             rpc_args,
@@ -11487,7 +11509,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_env_callback(self, callback: typing.Callable[[EnvironmentCallbackContext], None]) -> typing.Self:
         """Allows for the population of environment variables on a resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withEnvironmentCallback',
             rpc_args,
@@ -11509,7 +11531,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_args_callback(self, callback: typing.Callable[[CommandLineArgsCallbackContext], None]) -> typing.Self:
         """Adds a callback to be executed with a list of command-line arguments when a resource is started."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withArgsCallback',
             rpc_args,
@@ -11549,7 +11571,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         """Updates a named endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
         rpc_args['endpointName'] = endpoint_name
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if create_if_not_exists is not None:
             rpc_args['createIfNotExists'] = create_if_not_exists
         result = self._client.invoke_capability(
@@ -11562,7 +11584,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_http_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTP endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -11577,7 +11599,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_https_endpoint_callback(self, callback: typing.Callable[[EndpointUpdateContext], None], *, name: str | None = None, create_if_not_exists: bool = True) -> typing.Self:
         """Updates an HTTPS endpoint via callback"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
         if name is not None:
             rpc_args['name'] = name
         if create_if_not_exists is not None:
@@ -11812,7 +11834,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_https_certificate_config(self, callback: typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]) -> typing.Self:
         """Adds a callback that allows configuring the resource to use a specific HTTPS/TLS certificate key pair for server authentication."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withHttpsCertificateConfiguration',
             rpc_args,
@@ -11859,7 +11881,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def with_image_push_options(self, callback: typing.Callable[[ContainerImagePushOptionsCallbackContext], None]) -> typing.Self:
         """Adds an asynchronous callback to configure container image push options for the resource."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/withImagePushOptions',
             rpc_args,
@@ -11907,7 +11929,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def on_resource_endpoints_allocated(self, callback: typing.Callable[[ResourceEndpointsAllocatedEvent], None]) -> typing.Self:
         """Subscribes to the ResourceEndpointsAllocated event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onResourceEndpointsAllocated',
             rpc_args,
@@ -11918,7 +11940,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
     def test_with_env_callback(self, callback: typing.Callable[[TestEnvironmentContext], None]) -> typing.Self:
         """Configures environment with callback (test version)"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback',
             rpc_args,
@@ -11941,7 +11963,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _publish_as_docker_file := kwargs.pop("publish_as_docker_file", None):
             if _validate_type(_publish_as_docker_file, typing.Callable[[ContainerResource], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[ContainerResource], None], _publish_as_docker_file))
+                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[ContainerResource], None], _publish_as_docker_file), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/publishAsDockerFile', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'publish_as_docker_file'. Expected: Callable[[ContainerResource], None]")
@@ -11991,7 +12013,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _env_callback := kwargs.pop("env_callback", None):
             if _validate_type(_env_callback, typing.Callable[[EnvironmentCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EnvironmentCallbackContext], None], _env_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'env_callback'. Expected: Callable[[EnvironmentCallbackContext], None]")
@@ -12005,7 +12027,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _args_callback := kwargs.pop("args_callback", None):
             if _validate_type(_args_callback, typing.Callable[[CommandLineArgsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[CommandLineArgsCallbackContext], None], _args_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withArgsCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'args_callback'. Expected: Callable[[CommandLineArgsCallbackContext], None]")
@@ -12034,12 +12056,12 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
             if _validate_tuple_types(_endpoint_callback, (str, typing.Callable[[EndpointUpdateContext], None])):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[0]
-                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1])
+                rpc_args["callback"] = client.register_callback(typing.cast(tuple[str, typing.Callable[[EndpointUpdateContext], None]], _endpoint_callback)[1], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             elif _validate_dict_types(_endpoint_callback, EndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
                 rpc_args["endpointName"] = typing.cast(EndpointCallbackParameters, _endpoint_callback)["endpoint_name"]
-                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(EndpointCallbackParameters, _endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["createIfNotExists"] = typing.cast(EndpointCallbackParameters, _endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withEndpointCallback', rpc_args))
             else:
@@ -12047,11 +12069,11 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _http_endpoint_callback := kwargs.pop("http_endpoint_callback", None):
             if _validate_type(_http_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _http_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
             elif _validate_dict_types(_http_endpoint_callback, HttpEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpEndpointCallbackParameters, _http_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpEndpointCallback', rpc_args))
@@ -12060,11 +12082,11 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _https_endpoint_callback := kwargs.pop("https_endpoint_callback", None):
             if _validate_type(_https_endpoint_callback, typing.Callable[[EndpointUpdateContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[EndpointUpdateContext], None], _https_endpoint_callback), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
             elif _validate_dict_types(_https_endpoint_callback, HttpsEndpointCallbackParameters):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"])
+                rpc_args["callback"] = client.register_callback(typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback)["callback"], ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.EndpointUpdateContext",))
                 rpc_args["name"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("name")
                 rpc_args["createIfNotExists"] = typing.cast(HttpsEndpointCallbackParameters, _https_endpoint_callback).get("create_if_not_exists")
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsEndpointCallback', rpc_args))
@@ -12229,7 +12251,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _https_certificate_config := kwargs.pop("https_certificate_config", None):
             if _validate_type(_https_certificate_config, typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None], _https_certificate_config), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.HttpsCertificateConfigurationCallbackAnnotationContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withHttpsCertificateConfiguration', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'https_certificate_config'. Expected: Callable[[HttpsCertificateConfigurationCallbackAnnotationContext], None]")
@@ -12261,7 +12283,7 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _image_push_options := kwargs.pop("image_push_options", None):
             if _validate_type(_image_push_options, typing.Callable[[ContainerImagePushOptionsCallbackContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ContainerImagePushOptionsCallbackContext], None], _image_push_options), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerImagePushOptionsCallbackContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/withImagePushOptions', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'image_push_options'. Expected: Callable[[ContainerImagePushOptionsCallbackContext], None]")
@@ -12298,14 +12320,14 @@ class ExecutableResource(_BaseResource, AbstractResourceWithEnvironment, Abstrac
         if _on_resource_endpoints_allocated := kwargs.pop("on_resource_endpoints_allocated", None):
             if _validate_type(_on_resource_endpoints_allocated, typing.Callable[[ResourceEndpointsAllocatedEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ResourceEndpointsAllocatedEvent], None], _on_resource_endpoints_allocated), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceEndpointsAllocatedEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onResourceEndpointsAllocated', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_resource_endpoints_allocated'. Expected: Callable[[ResourceEndpointsAllocatedEvent], None]")
         if _test_with_env_callback := kwargs.pop("test_with_env_callback", None):
             if _validate_type(_test_with_env_callback, typing.Callable[[TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestEnvironmentContext], None], _test_with_env_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/testWithEnvironmentCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'test_with_env_callback'. Expected: Callable[[TestEnvironmentContext], None]")
@@ -12571,6 +12593,7 @@ class TestRedisResourceKwargs(ContainerResourceKwargs, total=False):
     multi_param_handle_callback: typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]
     data_volume: DataVolumeParameters | typing.Literal[True]
     concrete_vault_resource: TestVaultResource
+    python_builder_callback: typing.Callable[[TestRedisResource], None]
 
 class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString):
     """TestRedisResource resource."""
@@ -12603,7 +12626,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
     def on_connection_string_available(self, callback: typing.Callable[[ConnectionStringAvailableEvent], None]) -> typing.Self:
         """Subscribes to the ConnectionStringAvailable event."""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent",))
         result = self._client.invoke_capability(
             'Aspire.Hosting/onConnectionStringAvailable',
             rpc_args,
@@ -12744,7 +12767,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
     def with_multi_param_handle_callback(self, callback: typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]) -> typing.Self:
         """Tests multi-param callback destructuring"""
         rpc_args: dict[str, typing.Any] = {'builder': self._handle}
-        rpc_args['callback'] = self._client.register_callback(callback)
+        rpc_args['callback'] = self._client.register_callback(callback, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", "Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext"))
         result = self._client.invoke_capability(
             'Aspire.Hosting.CodeGeneration.Python.Tests/withMultiParamHandleCallback',
             rpc_args,
@@ -12777,6 +12800,17 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
         self._handle = self._wrap_builder(result)
         return self
 
+    def with_python_builder_callback(self, configure: typing.Callable[[TestRedisResource], None]) -> typing.Self:
+        """Configures a test resource through a resource builder callback."""
+        rpc_args: dict[str, typing.Any] = {'builder': self._handle}
+        rpc_args['configure'] = self._client.register_callback(configure, ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource",))
+        result = self._client.invoke_capability(
+            'Aspire.Hosting.CodeGeneration.Python.Tests/withPythonBuilderCallback',
+            rpc_args,
+        )
+        self._handle = self._wrap_builder(result)
+        return self
+
     def __init__(self, handle: Handle, client: AspireClient, **kwargs: typing.Unpack[TestRedisResourceKwargs]) -> None:
         if _connection_property := kwargs.pop("connection_property", None):
             if _validate_tuple_types(_connection_property, (str, str | ReferenceExpression)):
@@ -12789,7 +12823,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
         if _on_connection_string_available := kwargs.pop("on_connection_string_available", None):
             if _validate_type(_on_connection_string_available, typing.Callable[[ConnectionStringAvailableEvent], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ConnectionStringAvailableEvent], None], _on_connection_string_available))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[ConnectionStringAvailableEvent], None], _on_connection_string_available), ("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent",))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting/onConnectionStringAvailable', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'on_connection_string_available'. Expected: Callable[[ConnectionStringAvailableEvent], None]")
@@ -12843,7 +12877,7 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
         if _multi_param_handle_callback := kwargs.pop("multi_param_handle_callback", None):
             if _validate_type(_multi_param_handle_callback, typing.Callable[[TestCallbackContext, TestEnvironmentContext], None]):
                 rpc_args: dict[str, typing.Any] = {"builder": handle}
-                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext, TestEnvironmentContext], None], _multi_param_handle_callback))
+                rpc_args["callback"] = client.register_callback(typing.cast(typing.Callable[[TestCallbackContext, TestEnvironmentContext], None], _multi_param_handle_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", "Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext"))
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withMultiParamHandleCallback', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'multi_param_handle_callback'. Expected: Callable[[TestCallbackContext, TestEnvironmentContext], None]")
@@ -12865,6 +12899,13 @@ class TestRedisResource(ContainerResource, AbstractResourceWithConnectionString)
                 handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withConcreteVaultResource', rpc_args))
             else:
                 raise TypeError("Invalid type for option 'concrete_vault_resource'. Expected: TestVaultResource")
+        if _python_builder_callback := kwargs.pop("python_builder_callback", None):
+            if _validate_type(_python_builder_callback, typing.Callable[[TestRedisResource], None]):
+                rpc_args: dict[str, typing.Any] = {"builder": handle}
+                rpc_args["configure"] = client.register_callback(typing.cast(typing.Callable[[TestRedisResource], None], _python_builder_callback), ("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource",))
+                handle = self._wrap_builder(client.invoke_capability('Aspire.Hosting.CodeGeneration.Python.Tests/withPythonBuilderCallback', rpc_args))
+            else:
+                raise TypeError("Invalid type for option 'python_builder_callback'. Expected: Callable[[TestRedisResource], None]")
         super().__init__(handle, client, **kwargs)
 
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Redis/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Redis/Python/apphost.py
@@ -1,7 +1,11 @@
 # Aspire Python validation AppHost
 # Mirrors the top-level TypeScript playground surface with Python-style members.
 
-from aspire_app import RedisModules, create_builder
+from aspire_app import RedisCommanderResource, RedisModules, create_builder
+
+
+def configure_redis_commander(container: RedisCommanderResource) -> None:
+    container.with_host_port(port=8082)
 
 
 with create_builder() as builder:
@@ -24,7 +28,7 @@ with create_builder() as builder:
     new_password = builder.add_parameter("parameter")
     cache2.with_password(new_password)
     # withRedisCommander — with configureContainer callback exercising withHostPort
-    cache.with_redis_commander()
+    cache.with_redis_commander(configure_container=configure_redis_commander)
     # withRedisInsight — with configureContainer callback exercising withHostPort, withDataVolume, withDataBindMount
     cache.with_redis_insight()
     # ---- Property access on RedisResource (ExposeProperties = true) ----


### PR DESCRIPTION
## Description

Python callbacks exported as `Action<IResourceBuilder<T>>` received a raw `Handle` because .NET marshalled the callback argument with the generic builder ATS type ID while the generated Python wrapper registry used the concrete resource type ID. Calls such as `with_host_port` therefore failed at runtime.

Generated callback registrations now carry their concrete handle parameter type IDs. The Python runtime preserves exact runtime-type resolution and uses this metadata only as a fallback when the incoming type ID has no registered wrapper. This keeps other callback argument handling unchanged and does not alter TypeScript generation.

### User-facing usage

Typed integration callbacks can invoke exported wrapper methods:

```python
def configure_redis_commander(container: RedisCommanderResource) -> None:
    container.with_host_port(port=8082)

cache.with_redis_commander(configure_container=configure_redis_commander)
```

Regression coverage executes an exported `Action<IResourceBuilder<TestRedisResource>>` callback and verifies that the typed wrapper invokes another exported method. The Redis Python polyglot fixture also exercises `RedisCommanderResource.with_host_port`.

Validation:
- Python code generation tests: 25 passed
- TypeScript code generation tests: 128 passed
- Redis Python AppHost restored and generated SDK callback execution invoked `withRedisCommanderHostPort` with port 8082

Fixes: #19869

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No