### PR TITLE
Increment patch version from 3 to 4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- This repo version -->
     <MajorVersion>13</MajorVersion>
     <MinorVersion>5</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <PatchVersion>4</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
     <DefaultTargetFramework>net8.0</DefaultTargetFramework>


### PR DESCRIPTION
## Description

Increment the `release/13.5` patch version to 13.5.4 now that 13.5.3 has shipped.

Keeping the release branch on the published 13.5.3 version causes PR builds such as `13.5.3-pr.*` to sort below the stable release. CLI end-to-end tests then detect 13.5.3 as an update and block on the interactive self-update prompt. Using the next unshipped servicing version restores the expected version ordering for backport CI.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
