### PR TITLE
Document release branch version bumps

### DIFF
--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -33,6 +33,7 @@ When Aspire snaps a release branch (e.g., `release/13.3`), bug fixes that meet t
   ```
 
 - Shiproom requires the four headed sections (**Customer Impact**, **Testing**, **Risk**, **Regression?**) to be filled in before the backport can be approved/merged.
+- The target branch's `eng/Versions.props` must identify the next unshipped servicing release. After stable `X.Y.Z` is published, increment `PatchVersion` to `Z+1` in a dedicated PR before accepting more backports. Otherwise `X.Y.Z-pr.*` builds sort below stable `X.Y.Z` and can fail update-related CI.
 
 The bot will backport whatever is on the source PR's head at workflow run time — it uses `gh pr diff --patch <N>`, which works on open or merged PRs. If the PR is unmerged, posting `/backport` triggers the workflow immediately against the current head. Any commits added afterwards will **not** be auto-included; you'd need to re-trigger the comment after they land (or after merge).
 
@@ -86,6 +87,15 @@ Check:
   ```
 
   If the call fails with 404, surface a clear error: "The target branch `<target-branch>` doesn't exist. Common typo, or the branch hasn't been cut yet."
+- Confirm that the target branch is not still configured for an already-published stable version:
+
+  ```powershell
+  git fetch origin <target-branch>
+  git show "origin/<target-branch>:eng/Versions.props"
+  gh release list --repo microsoft/aspire --limit 20 --json tagName,isPrerelease,publishedAt
+  ```
+
+  Read `MajorVersion`, `MinorVersion`, and `PatchVersion` from `eng/Versions.props` and compare `X.Y.Z` with the newest published non-prerelease tag for the same `X.Y` line. If they are equal, stop before triggering the backport and explain that the release branch must first increment `PatchVersion` in a dedicated PR. Do not put the version bump in an individual backport PR.
 
 ### 2. Decide whether to trigger the backport
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -81,7 +81,10 @@ Before starting a release:
    - The build must include native CLI NuGet packages, `microsoft-aspire-cli*.tgz` npm tarballs from the native archive jobs, matching `.tgz.sig` detached signature sidecars, and the Windows, Linux, and macOS npm install validation summaries.
    - If publishing the VS Code extension, the build must include the `aspire-vscode-extension` artifact with exactly one `.vsix`, matching `.manifest`, and matching `.signature.p7s`.
    - If publishing the VS Code extension as a Marketplace pre-release, the build that runs automatically on merge will not work because it packages a stable VSIX; manually queue the `microsoft-aspire` source build on the merge commit with `Package VS Code Extension as Pre-Release=true` so the produced VSIX is marked as pre-release before signing.
-2. **Release branch**: Ensure the release branch exists, for example `release/9.2`.
+2. **Release branch and version**: Ensure the release branch exists, for example `release/9.2`, and that `eng/Versions.props` identifies the next unshipped release.
+   - Before the first stable `X.Y.0` release, the branch remains on `X.Y.0`.
+   - Immediately after publishing stable `X.Y.Z`, merge a dedicated PR that increments `PatchVersion` to `Z+1` before accepting more backports.
+   - Do not leave the branch on a published version. A PR build such as `X.Y.Z-pr.*` has lower SemVer precedence than stable `X.Y.Z`, which can make release-branch CI and CLI update scenarios incorrectly treat the published release as an available update.
 3. **Permissions and approvals**:
    - Access to run Azure DevOps pipelines with the publishing pool.
    - Permission to use the NuGet.org service connection.
@@ -225,6 +228,7 @@ This is a **manual** step performed by the release manager. The release is creat
 3. Uncheck **Set as a pre-release** if it is checked but this is a stable release (or check it for a preview release).
 4. Click **Publish release**.
 5. **Now merge the baseline version PR.** With the release published, its `eng/nix/versions.json` asset URLs resolve, so merging it updates `PackageValidationBaselineVersion` and the Nix manifest on `main` without breaking the flake.
+6. For a stable release, open and merge a dedicated PR against the release branch that increments `PatchVersion` in `eng/Versions.props`. Complete this before accepting more backports so subsequent PR builds use the next unshipped servicing version.
 
 Publishing the draft fires the `release: [published]` event, which triggers:
 


### PR DESCRIPTION
## Description

Document that each release branch must identify the next unshipped servicing version after a stable release is published.

The release process now calls for an immediate, dedicated `PatchVersion` bump after publishing. The backport skill also checks the target branch against published stable tags and stops before creating a backport when the branch still points at an already-published version. This prevents release PR builds from sorting below stable and blocking update-related CI on self-update prompts.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
