### PR TITLE
[release/13.5] Mark Radius provider builders experimental

### DIFF
--- a/src/Aspire.Hosting.Radius/CloudProviders/AwsRadiusProviderBuilder.cs
+++ b/src/Aspire.Hosting.Radius/CloudProviders/AwsRadiusProviderBuilder.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.Radius.CloudProviders;
 
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Radius.CloudProviders;
 /// write wins) and the final value is hoisted into
 /// <see cref="AwsRadiusProviderConfig"/> by <c>WithAwsProvider</c>.
 /// </summary>
+[Experimental("ASPIRERADIUS003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 internal sealed class AwsRadiusProviderBuilder : IAwsRadiusProviderBuilder
 {
     private readonly ILogger _logger;

--- a/src/Aspire.Hosting.Radius/CloudProviders/AzureRadiusProviderBuilder.cs
+++ b/src/Aspire.Hosting.Radius/CloudProviders/AzureRadiusProviderBuilder.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.Radius.CloudProviders;
 
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Radius.CloudProviders;
 /// <see cref="AzureRadiusProviderConfig"/> by <c>WithAzureProvider</c> after
 /// the user callback returns.
 /// </summary>
+[Experimental("ASPIRERADIUS003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 internal sealed class AzureRadiusProviderBuilder : IAzureRadiusProviderBuilder
 {
     private readonly ILogger _logger;

--- a/src/Aspire.Hosting.Radius/CloudProviders/IAwsRadiusProviderBuilder.cs
+++ b/src/Aspire.Hosting.Radius/CloudProviders/IAwsRadiusProviderBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.Radius.CloudProviders;
 
@@ -10,6 +11,7 @@ namespace Aspire.Hosting.Radius.CloudProviders;
 /// selecting an AWS credential mode. Exactly one <c>With*</c> method must
 /// be called; a repeat call replaces the previous selection.
 /// </summary>
+[Experimental("ASPIRERADIUS003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IAwsRadiusProviderBuilder
 {
     /// <summary>

--- a/src/Aspire.Hosting.Radius/CloudProviders/IAzureRadiusProviderBuilder.cs
+++ b/src/Aspire.Hosting.Radius/CloudProviders/IAzureRadiusProviderBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.Radius.CloudProviders;
 
@@ -10,6 +11,7 @@ namespace Aspire.Hosting.Radius.CloudProviders;
 /// selecting an Azure credential mode. Exactly one <c>With*</c> method must
 /// be called; a repeat call replaces the previous selection.
 /// </summary>
+[Experimental("ASPIRERADIUS003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IAzureRadiusProviderBuilder
 {
     /// <summary>


### PR DESCRIPTION
## Description

Marks the Radius AWS and Azure cloud-provider callback interfaces with `Experimental("ASPIRERADIUS003")`, matching the `WithAwsProvider` and `WithAzureProvider` methods that expose them. This keeps consumers from referencing the callback contracts without acknowledging the same experimental stability boundary.

The internal provider builder implementations carry the same attribute so their implementation of the experimental contracts compiles without broad warning suppression.

This addresses the issue identified in the review of #19866: https://github.com/microsoft/aspire/pull/19866#discussion_r3916992948. Generated API baseline files are intentionally unchanged here; #19866 regenerates and pins the release surface separately.

Validation: all 207 tests in `Aspire.Hosting.Radius.Tests` pass.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
