### PR TITLE
Remove dead Playwright scanner applicators

### DIFF
--- a/src/Aspire.Cli/Agents/AgentEnvironmentScanContext.cs
+++ b/src/Aspire.Cli/Agents/AgentEnvironmentScanContext.cs
@@ -9,7 +9,6 @@ namespace Aspire.Cli.Agents;
 internal sealed class AgentEnvironmentScanContext
 {
     private readonly List<AgentEnvironmentApplicator> _applicators = [];
-    private readonly HashSet<string> _skillBaseDirectories = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<AgentClientKind> _detectedClients = [];
 
     /// <summary>
@@ -25,12 +24,6 @@ internal sealed class AgentEnvironmentScanContext
     public required DirectoryInfo RepositoryRoot { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether a Playwright CLI applicator has been added.
-    /// This is used to ensure only one applicator for Playwright is added across all scanners.
-    /// </summary>
-    public bool PlaywrightApplicatorAdded { get; set; }
-
-    /// <summary>
     /// Adds an applicator to the collection of detected agent environments.
     /// </summary>
     /// <param name="applicator">The applicator to add.</param>
@@ -44,21 +37,6 @@ internal sealed class AgentEnvironmentScanContext
     /// Gets the collection of detected applicators.
     /// </summary>
     public IReadOnlyList<AgentEnvironmentApplicator> Applicators => _applicators;
-
-    /// <summary>
-    /// Registers a skill base directory for an agent environment (e.g., ".claude/skills", ".github/skills").
-    /// These directories are used to mirror skill files across all detected agent environments.
-    /// </summary>
-    /// <param name="relativeSkillBaseDir">The relative path to the skill base directory from the repository root.</param>
-    public void AddSkillBaseDirectory(string relativeSkillBaseDir)
-    {
-        _skillBaseDirectories.Add(relativeSkillBaseDir);
-    }
-
-    /// <summary>
-    /// Gets the registered skill base directories for all detected agent environments.
-    /// </summary>
-    public IReadOnlyCollection<string> SkillBaseDirectories => _skillBaseDirectories;
 
     /// <summary>
     /// Records that an agent client was detected as present in the environment. Used to scope

--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
@@ -17,10 +16,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
     private const string ClaudeCodeFolderName = ".claude";
     private const string McpConfigFileName = ".mcp.json";
     private const string AspireServerName = "aspire";
-    private static readonly string s_skillBaseDirectory = Path.Combine(".claude", "skills");
-
     private readonly IClaudeCodeCliRunner _claudeCodeCliRunner;
-    private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly CliExecutionContext _executionContext;
     private readonly ILogger<ClaudeCodeAgentEnvironmentScanner> _logger;
 
@@ -28,17 +24,14 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
     /// Initializes a new instance of <see cref="ClaudeCodeAgentEnvironmentScanner"/>.
     /// </summary>
     /// <param name="claudeCodeCliRunner">The Claude Code CLI runner for checking if Claude Code is installed.</param>
-    /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="executionContext">The CLI execution context for accessing environment variables and settings.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public ClaudeCodeAgentEnvironmentScanner(IClaudeCodeCliRunner claudeCodeCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, ILogger<ClaudeCodeAgentEnvironmentScanner> logger)
+    public ClaudeCodeAgentEnvironmentScanner(IClaudeCodeCliRunner claudeCodeCliRunner, CliExecutionContext executionContext, ILogger<ClaudeCodeAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(claudeCodeCliRunner);
-        ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(logger);
         _claudeCodeCliRunner = claudeCodeCliRunner;
-        _playwrightCliInstaller = playwrightCliInstaller;
         _executionContext = executionContext;
         _logger = logger;
     }
@@ -73,9 +66,6 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
             {
                 _logger.LogDebug("Aspire MCP server is already configured");
             }
-
-            // Register Playwright CLI installation applicator
-            CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
         }
         else
         {
@@ -99,9 +89,6 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
                 {
                     _logger.LogDebug("Aspire MCP server is already configured");
                 }
-
-                // Register Playwright CLI installation applicator
-                CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
             }
             else
             {

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Agents.Playwright;
-
 namespace Aspire.Cli.Agents;
 
 /// <summary>
@@ -29,36 +27,6 @@ internal static class CommonAgentApplicators
     /// The name of the dotnet-inspect skill.
     /// </summary>
     internal const string DotnetInspectSkillName = "dotnet-inspect";
-
-    /// <summary>
-    /// Adds a single Playwright CLI installation applicator if not already added.
-    /// Called by scanners that detect an environment supporting Playwright.
-    /// The applicator uses <see cref="PlaywrightCliInstaller"/> to securely install the CLI and generate skill files.
-    /// </summary>
-    /// <param name="context">The scan context.</param>
-    /// <param name="installer">The Playwright CLI installer that handles secure installation.</param>
-    /// <param name="skillBaseDirectory">The relative path to the skill base directory for this agent environment (e.g., ".claude/skills", ".github/skills").</param>
-    public static void AddPlaywrightCliApplicator(
-        AgentEnvironmentScanContext context,
-        PlaywrightCliInstaller installer,
-        string skillBaseDirectory)
-    {
-        // Register the skill base directory so skill files can be mirrored to all environments
-        context.AddSkillBaseDirectory(skillBaseDirectory);
-
-        // Only add the Playwright applicator prompt once across all environments
-        if (context.PlaywrightApplicatorAdded)
-        {
-            return;
-        }
-
-        context.PlaywrightApplicatorAdded = true;
-        context.AddApplicator(new AgentEnvironmentApplicator(
-            "Install Playwright CLI (Recommended for browser automation)",
-            ct => installer.InstallAsync(context.RepositoryRoot.FullName, context.SkillBaseDirectories.ToHashSet(StringComparer.OrdinalIgnoreCase), ct),
-            promptGroup: McpInitPromptGroup.Tools,
-            priority: 1));
-    }
 
     /// <summary>
     /// Gets the content for the dotnet-inspect skill file.

--- a/src/Aspire.Cli/Agents/Copilot/CopilotAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/Copilot/CopilotAgentEnvironmentScanner.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
@@ -16,11 +15,8 @@ internal sealed class CopilotAgentEnvironmentScanner : IAgentEnvironmentScanner
 {
     private const string McpConfigFileName = "mcp-config.json";
     private const string AspireServerName = "aspire";
-    private static readonly string s_skillBaseDirectory = Path.Combine(".github", "skills");
-
     private readonly ICopilotCliRunner _copilotCliRunner;
     private readonly ICopilotAppInstallationDetector _copilotAppInstallationDetector;
-    private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly CliExecutionContext _executionContext;
     private readonly IEnvironment _environment;
     private readonly ILogger<CopilotAgentEnvironmentScanner> _logger;
@@ -30,27 +26,23 @@ internal sealed class CopilotAgentEnvironmentScanner : IAgentEnvironmentScanner
     /// </summary>
     /// <param name="copilotCliRunner">The Copilot CLI runner for checking if Copilot CLI is installed.</param>
     /// <param name="copilotAppInstallationDetector">The detector for checking if the Copilot App is installed.</param>
-    /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="executionContext">The CLI execution context for accessing environment variables and settings.</param>
     /// <param name="environment">The environment abstraction for reading environment variables.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
     public CopilotAgentEnvironmentScanner(
         ICopilotCliRunner copilotCliRunner,
         ICopilotAppInstallationDetector copilotAppInstallationDetector,
-        PlaywrightCliInstaller playwrightCliInstaller,
         CliExecutionContext executionContext,
         IEnvironment environment,
         ILogger<CopilotAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(copilotCliRunner);
         ArgumentNullException.ThrowIfNull(copilotAppInstallationDetector);
-        ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(environment);
         ArgumentNullException.ThrowIfNull(logger);
         _copilotCliRunner = copilotCliRunner;
         _copilotAppInstallationDetector = copilotAppInstallationDetector;
-        _playwrightCliInstaller = playwrightCliInstaller;
         _executionContext = executionContext;
         _environment = environment;
         _logger = logger;
@@ -117,8 +109,6 @@ internal sealed class CopilotAgentEnvironmentScanner : IAgentEnvironmentScanner
         {
             _logger.LogDebug("Aspire MCP server is already configured in GitHub Copilot");
         }
-
-        CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
@@ -16,25 +15,19 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
 {
     private const string OpenCodeConfigFileName = "opencode.jsonc";
     private const string AspireServerName = "aspire";
-    private static readonly string s_skillBaseDirectory = Path.Combine(".opencode", "skill");
-
     private readonly IOpenCodeCliRunner _openCodeCliRunner;
-    private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly ILogger<OpenCodeAgentEnvironmentScanner> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="OpenCodeAgentEnvironmentScanner"/>.
     /// </summary>
     /// <param name="openCodeCliRunner">The OpenCode CLI runner for checking if OpenCode is installed.</param>
-    /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public OpenCodeAgentEnvironmentScanner(IOpenCodeCliRunner openCodeCliRunner, PlaywrightCliInstaller playwrightCliInstaller, ILogger<OpenCodeAgentEnvironmentScanner> logger)
+    public OpenCodeAgentEnvironmentScanner(IOpenCodeCliRunner openCodeCliRunner, ILogger<OpenCodeAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(openCodeCliRunner);
-        ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(logger);
         _openCodeCliRunner = openCodeCliRunner;
-        _playwrightCliInstaller = playwrightCliInstaller;
         _logger = logger;
     }
 
@@ -67,9 +60,6 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
             {
                 _logger.LogDebug("Aspire MCP server is already configured");
             }
-
-            // Register Playwright CLI installation applicator
-            CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
         }
         else
         {
@@ -86,9 +76,6 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
                 // OpenCode is installed - offer to create config
                 _logger.LogDebug("Adding OpenCode applicator to create new opencode.jsonc at: {ConfigDirectory}", configDirectory.FullName);
                 context.AddApplicator(CreateApplicator(configDirectory));
-
-                // Register Playwright CLI installation applicator
-                CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
             }
             else
             {

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
@@ -17,10 +16,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     private const string VsCodeFolderName = ".vscode";
     private const string McpConfigFileName = "mcp.json";
     private const string AspireServerName = "aspire";
-    private static readonly string s_skillBaseDirectory = Path.Combine(".github", "skills");
-
     private readonly IVsCodeCliRunner _vsCodeCliRunner;
-    private readonly PlaywrightCliInstaller _playwrightCliInstaller;
     private readonly CliExecutionContext _executionContext;
     private readonly IEnvironment _environment;
     private readonly ILogger<VsCodeAgentEnvironmentScanner> _logger;
@@ -29,19 +25,16 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     /// Initializes a new instance of <see cref="VsCodeAgentEnvironmentScanner"/>.
     /// </summary>
     /// <param name="vsCodeCliRunner">The VS Code CLI runner for checking if VS Code is installed.</param>
-    /// <param name="playwrightCliInstaller">The Playwright CLI installer for secure installation.</param>
     /// <param name="executionContext">The CLI execution context for accessing environment variables and settings.</param>
     /// <param name="environment">The environment abstraction for reading environment variables.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public VsCodeAgentEnvironmentScanner(IVsCodeCliRunner vsCodeCliRunner, PlaywrightCliInstaller playwrightCliInstaller, CliExecutionContext executionContext, IEnvironment environment, ILogger<VsCodeAgentEnvironmentScanner> logger)
+    public VsCodeAgentEnvironmentScanner(IVsCodeCliRunner vsCodeCliRunner, CliExecutionContext executionContext, IEnvironment environment, ILogger<VsCodeAgentEnvironmentScanner> logger)
     {
         ArgumentNullException.ThrowIfNull(vsCodeCliRunner);
-        ArgumentNullException.ThrowIfNull(playwrightCliInstaller);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(environment);
         ArgumentNullException.ThrowIfNull(logger);
         _vsCodeCliRunner = vsCodeCliRunner;
-        _playwrightCliInstaller = playwrightCliInstaller;
         _executionContext = executionContext;
         _environment = environment;
         _logger = logger;
@@ -73,9 +66,6 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
             {
                 _logger.LogDebug("Aspire MCP server is already configured in .vscode/mcp.json");
             }
-
-            // Register Playwright CLI installation applicator
-            CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
         }
         else if (await IsVsCodeAvailableAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -88,9 +78,6 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
             var targetVsCodeFolder = new DirectoryInfo(Path.Combine(context.RepositoryRoot.FullName, VsCodeFolderName));
             _logger.LogDebug("Adding VS Code applicator for new .vscode folder at: {VsCodeFolder}", targetVsCodeFolder.FullName);
             context.AddApplicator(CreateAspireApplicator(targetVsCodeFolder));
-
-            // Register Playwright CLI installation applicator
-            CommonAgentApplicators.AddPlaywrightCliApplicator(context, _playwrightCliInstaller, s_skillBaseDirectory);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -353,8 +353,6 @@ internal sealed class AgentInitCommand : BaseCommand
 
         foreach (var location in selectedLocations)
         {
-            context.AddSkillBaseDirectory(location.RelativeSkillDirectory);
-
             foreach (var skill in selectedSkills)
             {
                 // Playwright CLI is installed via PlaywrightCliInstaller, not as a static skill file

--- a/tests/Aspire.Cli.Tests/Agents/AgentEnvironmentDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/AgentEnvironmentDetectorTests.cs
@@ -96,23 +96,6 @@ public class AgentEnvironmentDetectorTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, applicators.Length);
     }
 
-    [Fact]
-    public async Task DetectAsync_WithConfigurePlaywrightTrue_PassesContextToScanner()
-    {
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var scanner = new TestAgentEnvironmentScanner();
-        var detector = new AgentEnvironmentDetector([scanner]);
-        var context = new AgentEnvironmentScanContext
-        {
-            WorkingDirectory = workspace.WorkspaceRoot,
-            RepositoryRoot = workspace.WorkspaceRoot,
-        };
-
-        var applicators = await detector.DetectAsync(context, CancellationToken.None).DefaultTimeout();
-
-        Assert.True(scanner.WasScanned);
-    }
-
     private sealed class TestAgentEnvironmentScanner : IAgentEnvironmentScanner
     {
         public bool WasScanned { get; private set; }

--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Configuration;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.ClaudeCode;
-using Aspire.Cli.Agents.Playwright;
-using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
@@ -27,14 +24,15 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
         // The scan should succeed (HasServerConfigured catches JsonException)
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.ClaudeCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         // Applying should throw with a descriptive message
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -55,13 +53,14 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.ClaudeCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
@@ -81,13 +80,14 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.ClaudeCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
@@ -113,17 +113,6 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
             workingDirectory,
             debugMode: false,
             homeDirectory: workingDirectory);
-    }
-
-    private static PlaywrightCliInstaller CreatePlaywrightCliInstaller()
-    {
-        return new PlaywrightCliInstaller(
-            new FakeNpmRunner(),
-            new FakeNpmProvenanceChecker(),
-            new FakePlaywrightCliRunner(),
-            new TestInteractionService(),
-            new ConfigurationBuilder().Build(),
-            NullLogger<PlaywrightCliInstaller>.Instance);
     }
 
     private sealed class FakeClaudeCodeCliRunner(SemVersion? version) : IClaudeCodeCliRunner

--- a/tests/Aspire.Cli.Tests/Agents/CopilotAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotAgentEnvironmentScannerTests.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Configuration;
 using System.Globalization;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.Copilot;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
 
@@ -24,14 +21,14 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("GitHub Copilot"));
+        Assert.Equal([AgentClientKind.CopilotCli], context.DetectedClients);
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("GitHub Copilot", applicator.Description);
     }
 
     [Fact]
@@ -45,13 +42,11 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         // Create a scanner that writes to a known test location
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
         
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
         var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
         
         await aspireApplicator.ApplyAsync(CancellationToken.None).DefaultTimeout();
@@ -101,7 +96,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         {
             ["COPILOT_HOME"] = copilotHome.FullName,
         });
-        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(new SemVersion(1, 0, 0)), new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), CreateExecutionContext(workspace.WorkspaceRoot), environment, NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(new SemVersion(1, 0, 0)), new FakeCopilotAppInstallationDetector(), CreateExecutionContext(workspace.WorkspaceRoot), environment, NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -133,7 +128,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -152,7 +147,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ScanAsync_WhenAspireAlreadyConfigured_ReturnsPlaywrightCliApplicatorOnly()
+    public async Task ScanAsync_WhenAspireAlreadyConfigured_DetectsClientWithoutApplicators()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var copilotFolder = workspace.CreateDirectory(".copilot");
@@ -173,14 +168,13 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Only the Playwright CLI applicator should be offered (Aspire MCP is configured, all skill files are up to date)
-        Assert.Single(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("Playwright CLI"));
+        Assert.Equal([AgentClientKind.CopilotCli], context.DetectedClients);
+        Assert.Empty(context.Applicators);
     }
 
     [Fact]
@@ -190,37 +184,37 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var copilotCliRunner = new FakeCopilotCliRunner(null); // Return null to verify it's not called
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
         var vsCodeEnvironment = new TestEnvironment(new Dictionary<string, string?> { ["TERM_PROGRAM"] = "vscode" });
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, vsCodeEnvironment, NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, vsCodeEnvironment, NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("GitHub Copilot"));
+        Assert.Equal([AgentClientKind.CopilotCli], context.DetectedClients);
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("GitHub Copilot", applicator.Description);
         Assert.False(copilotCliRunner.WasCalled); // Verify GetVersionAsync was not called
     }
 
     [Fact]
-    public async Task ScanAsync_WhenOnlyCopilotAppIsInstalled_DetectsAppAndReturnsSharedApplicators()
+    public async Task ScanAsync_WhenOnlyCopilotAppIsInstalled_DetectsAppAndReturnsMcpApplicator()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var copilotCliRunner = new FakeCopilotCliRunner(null);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector("AI_AGENT"), CreatePlaywrightCliInstaller(), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector("AI_AGENT"), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal([AgentClientKind.CopilotApp], context.DetectedClients);
-        Assert.Contains(context.Applicators, applicator => applicator.Description.Contains("Aspire MCP"));
-        Assert.Contains(context.Applicators, applicator => applicator.Description.Contains("Playwright CLI"));
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", applicator.Description);
     }
 
     [Fact]
-    public async Task ScanAsync_WhenCopilotAppAndCliAreInstalled_DetectsBothAndReturnsSharedApplicatorsOnce()
+    public async Task ScanAsync_WhenCopilotAppAndCliAreInstalled_DetectsBothAndReturnsMcpApplicatorOnce()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(new SemVersion(1, 0, 0)), new FakeCopilotAppInstallationDetector("AI_AGENT"), CreatePlaywrightCliInstaller(), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(new SemVersion(1, 0, 0)), new FakeCopilotAppInstallationDetector("AI_AGENT"), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -228,15 +222,15 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             [AgentClientKind.CopilotCli, AgentClientKind.CopilotApp],
             context.DetectedClients.OrderBy(static client => client));
-        Assert.Single(context.Applicators, applicator => applicator.Description.Contains("Aspire MCP"));
-        Assert.Single(context.Applicators, applicator => applicator.Description.Contains("Playwright CLI"));
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", applicator.Description);
     }
 
     [Fact]
     public async Task ScanAsync_WhenNeitherCopilotClientIsInstalled_DoesNotReturnApplicators()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(null), new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(new FakeCopilotCliRunner(null), new FakeCopilotAppInstallationDetector(), CreateExecutionContext(workspace.WorkspaceRoot), new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -275,7 +269,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -303,7 +297,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -327,7 +321,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(mcpConfigPath, originalContent);
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -355,7 +349,7 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
+        var scanner = new CopilotAgentEnvironmentScanner(copilotCliRunner, new FakeCopilotAppInstallationDetector(), executionContext, new TestEnvironment(), NullLogger<CopilotAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -387,14 +381,4 @@ public class CopilotAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         }
     }
 
-    private static PlaywrightCliInstaller CreatePlaywrightCliInstaller()
-    {
-        return new PlaywrightCliInstaller(
-            new FakeNpmRunner(),
-            new FakeNpmProvenanceChecker(),
-            new FakePlaywrightCliRunner(),
-            new TestInteractionService(),
-            new ConfigurationBuilder().Build(),
-            NullLogger<PlaywrightCliInstaller>.Instance);
-    }
 }

--- a/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Configuration;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.OpenCode;
-using Aspire.Cli.Agents.Playwright;
-using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
 
@@ -24,14 +21,15 @@ public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper
         await File.WriteAllTextAsync(configPath, "{ invalid json content");
 
         var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
-        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, CreatePlaywrightCliInstaller(), NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
         // The scan should succeed (HasServerConfigured catches JsonException)
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.OpenCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         // Applying should throw with a descriptive message
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -50,13 +48,14 @@ public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper
         await File.WriteAllTextAsync(configPath, "");
 
         var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
-        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, CreatePlaywrightCliInstaller(), NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.OpenCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
@@ -74,13 +73,14 @@ public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper
         await File.WriteAllTextAsync(configPath, originalContent);
 
         var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
-        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, CreatePlaywrightCliInstaller(), NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        Assert.NotEmpty(context.Applicators);
-        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+        Assert.Equal([AgentClientKind.OpenCode], context.DetectedClients);
+        var aspireApplicator = Assert.Single(context.Applicators);
+        Assert.Contains("Aspire MCP", aspireApplicator.Description);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
@@ -98,17 +98,6 @@ public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper
             WorkingDirectory = workingDirectory,
             RepositoryRoot = workingDirectory
         };
-    }
-
-    private static PlaywrightCliInstaller CreatePlaywrightCliInstaller()
-    {
-        return new PlaywrightCliInstaller(
-            new FakeNpmRunner(),
-            new FakeNpmProvenanceChecker(),
-            new FakePlaywrightCliRunner(),
-            new TestInteractionService(),
-            new ConfigurationBuilder().Build(),
-            NullLogger<PlaywrightCliInstaller>.Instance);
     }
 
     private sealed class FakeOpenCodeCliRunner(SemVersion? version) : IOpenCodeCliRunner

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Configuration;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Agents;
-using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Agents.VsCode;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
 
@@ -23,14 +20,14 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodeFolder = workspace.CreateDirectory(".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("VS Code"));
+        Assert.Equal([AgentClientKind.VsCode], context.DetectedClients);
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("VS Code", applicator.Description);
     }
 
     [Fact]
@@ -41,14 +38,14 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var childDir = workspace.CreateDirectory("subdir");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(childDir);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(childDir, workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("VS Code"));
+        Assert.Equal([AgentClientKind.VsCode], context.DetectedClients);
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("VS Code", applicator.Description);
     }
 
     [Fact]
@@ -59,7 +56,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         // Repository root is the workspace root, so search should stop there
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(childDir);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(childDir, workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -73,14 +70,14 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var vsCodeCliRunner = new FakeVsCodeCliRunner(new SemVersion(1, 85, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
-        Assert.Contains(context.Applicators, a => a.Description.Contains("VS Code"));
+        Assert.Equal([AgentClientKind.VsCode], context.DetectedClients);
+        var applicator = Assert.Single(context.Applicators);
+        Assert.Contains("VS Code", applicator.Description);
     }
 
     [Fact]
@@ -89,7 +86,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         // This test assumes no VSCODE_* environment variables are set
@@ -107,7 +104,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         
         // First, make the scanner find a parent .vscode folder to get an applicator
         var parentVsCode = workspace.CreateDirectory(".vscode");
@@ -115,8 +112,6 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
         
-        // Scanner adds applicators for: Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
         var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
         
         // Apply the configuration
@@ -134,7 +129,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         var vsCodeFolder = workspace.CreateDirectory(".vscode");
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -190,7 +185,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -231,13 +226,11 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
         
-        // Should return applicators for Aspire MCP, Playwright CLI, and agent instructions
-        Assert.NotEmpty(context.Applicators);
         var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
         
         await aspireApplicator.ApplyAsync(CancellationToken.None).DefaultTimeout();
@@ -256,22 +249,6 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ScanAsync_AddsPlaywrightCliApplicator()
-    {
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var vsCodeFolder = workspace.CreateDirectory(".vscode");
-        var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
-        var context = CreateScanContext(workspace.WorkspaceRoot);
-
-        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
-
-        // Should have a Playwright CLI installation applicator
-        Assert.Contains(context.Applicators, a => a.Description.Contains("Playwright CLI"));
-    }
-
-    [Fact]
     public async Task ApplyAsync_WithMalformedMcpJson_ThrowsInvalidOperationException()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -283,7 +260,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -311,7 +288,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -337,7 +314,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
 
         var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, CreatePlaywrightCliInstaller(), executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, new TestEnvironment(), NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
         var context = CreateScanContext(workspace.WorkspaceRoot);
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
@@ -359,17 +336,6 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
     private sealed class FakeVsCodeCliRunner(SemVersion? version) : IVsCodeCliRunner
     {
         public Task<SemVersion?> GetVersionAsync(VsCodeRunOptions options, CancellationToken cancellationToken) => Task.FromResult(version);
-    }
-
-    private static PlaywrightCliInstaller CreatePlaywrightCliInstaller()
-    {
-        return new PlaywrightCliInstaller(
-            new FakeNpmRunner(),
-            new FakeNpmProvenanceChecker(),
-            new FakePlaywrightCliRunner(),
-            new TestInteractionService(),
-            new ConfigurationBuilder().Build(),
-            NullLogger<PlaywrightCliInstaller>.Instance);
     }
 
     private static AgentEnvironmentScanContext CreateScanContext(


### PR DESCRIPTION
## Description

Removes scanner-side Playwright CLI applicator plumbing that no longer has a consumer.

PR #14837 (commit `43dced33bb5f980c88438dce20208b28c6fe2584`) added scanner-created `toolApplicators` to `promptChoices` and executed the selected applicators. PR #15022 (commit `db249e43a943b083c2946aea735befeb4251ac3d`, March 24, 2026) made Playwright CLI a first-class `SkillDefinition.PlaywrightCli` choice installed directly through `PlaywrightCliInstaller.InstallAsync`. That change removed `toolApplicators` from the prompt and execution path but left scanner registration behind, so scanner-created Playwright applicators have been collected but unconsumed since then.

This cleanup removes that unreachable applicator, its scan-context state, and the installer dependencies from the Claude Code, Copilot, OpenCode, and VS Code scanners. Scanner tests now assert their live responsibilities: client detection and Aspire MCP applicators. The direct Playwright selection, installation, and selected-location mirroring path in `AgentInitCommand` remains unchanged.

Validation:

- Focused `Aspire.Cli.Tests` scanner, AgentInit, and Playwright installer tests
- `Aspire.Cli.Tests.csproj` build

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
