### PR TITLE
Improve resource graph action discoverability

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -25,6 +25,20 @@
         {
             return @<FluentDivider />;
         }
+        else if (item.IsHeader)
+        {
+            // Non-interactive label identifying what the menu is for (e.g. the resource a graph
+            // context menu was opened on). role="presentation" keeps it out of the menu's item
+            // semantics (matching the FluentDivider above) so it isn't announced as a menu item
+            // or reached by keyboard navigation.
+            return @<div class="aspire-menu-header" role="presentation">
+                @if (item.Icon != null)
+                {
+                    <FluentIcon Value="@item.Icon" Width="16px" Class="aspire-menu-header-icon" />
+                }
+                <span class="aspire-menu-header-text" title="@item.Text">@item.Text</span>
+            </div>;
+        }
         else
         {
             var additionalMenuItemAttributes = new Dictionary<string, object>(item.AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -11,7 +11,8 @@
             OpenChanged="OnOpenChanged"
             Style="@Style"
             VerticalThreshold="@CalculatedVerticalThreshold"
-            HorizontalThreshold="200">
+            HorizontalThreshold="200"
+            aria-labelledby="@HeaderId">
     @foreach (var item in Items)
     {
         @RenderMenuItem(item)
@@ -31,8 +32,8 @@
             // context menu was opened on). role="presentation" keeps it out of the menu's item
             // semantics (matching the FluentDivider above) so it isn't announced as a menu item
             // or reached by keyboard navigation.
-            return @<div class="aspire-menu-header" role="presentation">
-                @if (item.Icon != null)
+            return @<div id="@item.Id" class="aspire-menu-header" role="presentation">
+                @if (item.Icon is not null)
                 {
                     <FluentIcon Value="@item.Icon" Width="16px" Class="aspire-menu-header-icon" />
                 }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -61,10 +61,15 @@ public partial class AspireMenu : FluentComponentBase
     [Inject]
     public required IMenuService MenuService { get; init; }
 
-    // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
+    // Each menu item is approximately 32px tall, while a header is 40px tall plus its 4px
+    // bottom margin. Include the full rendered height so cursor-positioned menus flip above
+    // the pointer before they would be clipped by the viewport.
     private const int EstimatedItemHeight = 32;
+    private const int EstimatedHeaderHeight = 44;
     private const int MenuVerticalPadding = 16;
-    private int CalculatedVerticalThreshold => VerticalThreshold ?? (Items.Count * EstimatedItemHeight + MenuVerticalPadding);
+    private int CalculatedVerticalThreshold => VerticalThreshold
+        ?? Items.Sum(item => item.IsHeader ? EstimatedHeaderHeight : EstimatedItemHeight) + MenuVerticalPadding;
+    private string? HeaderId => Items.FirstOrDefault(item => item.IsHeader)?.Id;
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
@@ -25,3 +25,33 @@ fluent-menu-item:focus-within > span[slot="end"] ::deep .aspire-menu-secondary-a
         visibility: visible;
     }
 }
+
+/* Match FluentUI's 32px menu-item icon track so the resource identity and actions share
+   one visual axis. Extra vertical space distinguishes the identity from a clickable item. */
+.aspire-menu-header {
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr);
+    align-items: center;
+    min-height: 40px;
+    margin: 0 4px 4px;
+    padding: 4px 8px 8px 0;
+    border-bottom: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-divider-rest);
+    color: var(--neutral-foreground-rest);
+    font-size: var(--type-ramp-base-font-size, 0.875rem);
+    font-weight: 600;
+    cursor: default;
+    user-select: none;
+}
+
+.aspire-menu-header ::deep .aspire-menu-header-icon {
+    grid-column: 1;
+    justify-self: center;
+}
+
+.aspire-menu-header-text {
+    grid-column: 2;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
@@ -32,6 +32,7 @@ fluent-menu-item:focus-within > span[slot="end"] ::deep .aspire-menu-secondary-a
     display: grid;
     grid-template-columns: 32px minmax(0, 1fr);
     align-items: center;
+    box-sizing: border-box;
     min-height: 40px;
     margin: 0 4px 4px;
     padding: 4px 8px 8px 0;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -391,7 +391,18 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
             _resourcesInteropReference = DotNetObjectReference.Create(new ResourcesInterop(this));
 
-            await _jsModule.InvokeVoidAsync("initializeResourcesGraph", _resourcesInteropReference);
+            // Static icons used by the graph that aren't tied to a specific resource. Converted to raw
+            // SVG path data here (the same way resource/state icons are) so the JS can render them.
+            var graphIcons = new
+            {
+                menu = new
+                {
+                    path = ResourceGraphMapper.GetIconPathData(new Icons.Regular.Size16.Settings()),
+                    tooltip = Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton)].Value
+                }
+            };
+
+            await _jsModule.InvokeVoidAsync("initializeResourcesGraph", _resourcesInteropReference, graphIcons);
             await UpdateResourceGraphResourcesAsync();
             await UpdateResourceGraphSelectedAsync();
         }
@@ -624,6 +635,17 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         if (_contextMenu is { } contextMenu)
         {
             _contextMenuItems.Clear();
+
+            // The graph context menu is cursor-positioned and detached from the node it targets, so
+            // without a label it's ambiguous which resource the actions apply to. Add a header row
+            // identifying the resource at the top of the menu.
+            _contextMenuItems.Add(new MenuButtonItem
+            {
+                IsHeader = true,
+                Text = ResourceViewModel.GetResourceName(resource, _resourceByName),
+                Icon = ResourceIconHelpers.GetIconForResource(IconResolver, resource, IconSize.Size16)
+            });
+
             ResourceMenuBuilder.AddMenuItems(
                 _contextMenuItems,
                 resource,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -398,7 +398,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 menu = new
                 {
                     path = ResourceGraphMapper.GetIconPathData(new Icons.Regular.Size16.Settings()),
-                    tooltip = Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton)].Value
+                    labelFormat = Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton)].Value
                 }
             };
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -127,6 +127,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private bool _contextMenuOpen;
     private readonly List<MenuButtonItem> _contextMenuItems = new();
     private TaskCompletionSource? _contextMenuClosedTcs;
+    private string? _contextMenuFocusElementId;
 
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
     private ColumnSortLabels _sortLabels = ColumnSortLabels.Default;
@@ -436,13 +437,13 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
 
         [JSInvokable]
-        public async Task ResourceContextMenu(string id, int screenWidth, int screenHeight, int clientX, int clientY)
+        public async Task ResourceContextMenu(string id, int screenWidth, int screenHeight, int clientX, int clientY, string? focusElementId)
         {
             if (resources._resourceByName.TryGetValue(id, out var resource))
             {
                 await resources.InvokeAsync(async () =>
                 {
-                    await resources.ShowContextMenuAsync(resource, screenWidth, screenHeight, clientX, clientY);
+                    await resources.ShowContextMenuAsync(resource, screenWidth, screenHeight, clientX, clientY, focusElementId);
                 });
             }
         }
@@ -627,13 +628,14 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         return false;
     }
 
-    private async Task ShowContextMenuAsync(ResourceViewModel resource, int screenWidth, int screenHeight, int clientX, int clientY)
+    private async Task ShowContextMenuAsync(ResourceViewModel resource, int screenWidth, int screenHeight, int clientX, int clientY, string? focusElementId)
     {
         // This is called when the browser requests to show the context menu for a resource.
         // The method doesn't complete until the context menu is closed so the browser can await
         // it and perform clean up when the context menu is closed.
         if (_contextMenu is { } contextMenu)
         {
+            _contextMenuFocusElementId = focusElementId;
             _contextMenuItems.Clear();
 
             // The graph context menu is cursor-positioned and detached from the node it targets, so
@@ -1036,6 +1038,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private async Task CloseContextMenuAsync(bool closeMenu)
     {
         _contextMenuOpen = false;
+        var focusElementId = _contextMenuFocusElementId;
+        _contextMenuFocusElementId = null;
 
         if (_contextMenu is { } menu)
         {
@@ -1043,6 +1047,13 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             {
                 await menu.CloseAsync();
             }
+        }
+
+        // Restore a keyboard-triggered menu to the graph cog before a selected menu item's
+        // callback can move focus to its destination (for example, the resource details view).
+        if (!string.IsNullOrEmpty(focusElementId))
+        {
+            await JS.InvokeVoidAsync("focusElement", focusElementId);
         }
 
         CompleteContextMenuClosed();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -652,7 +652,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 _contextMenuItems,
                 resource,
                 _resourceByName,
-                EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, focusElementId: null)),
+                EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, focusElementId)),
                 EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showViewDetails: true,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -269,8 +269,12 @@
     stroke-width: calc(var(--focus-stroke-width) * 1px);
 }
 
+::deep .resource-menu-cog[aria-expanded="true"] .resource-menu-cog-background {
+    stroke: transparent;
+}
+
 ::deep .resource-menu-cog-icon {
-    fill: var(--neutral-foreground-rest);
+    fill: var(--accent-fill-rest);
     pointer-events: none;
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -277,6 +277,10 @@
     outline: none;
 }
 
+::deep .resource-menu-cog:active {
+    outline: none;
+}
+
 ::deep .resource-menu-cog-icon {
     fill: var(--accent-fill-rest);
     pointer-events: none;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -246,6 +246,13 @@
     pointer-events: auto;
 }
 
+@media (hover: none) {
+    ::deep .resource-menu-cog {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
 ::deep .resource-menu-cog-background {
     fill: var(--neutral-fill-secondary-rest);
     stroke: var(--neutral-stroke-rest);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -254,7 +254,7 @@
 }
 
 ::deep .resource-menu-cog-background {
-    fill: var(--neutral-fill-secondary-rest);
+    fill: var(--fill-color);
     stroke: var(--neutral-stroke-rest);
     stroke-width: 1;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -273,6 +273,10 @@
     stroke: transparent;
 }
 
+::deep .resource-menu-cog[aria-expanded="true"]:focus-visible {
+    outline: none;
+}
+
 ::deep .resource-menu-cog-icon {
     fill: var(--accent-fill-rest);
     pointer-events: none;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -240,7 +240,8 @@
     transition: opacity 0.15s ease-in-out;
 }
 
-::deep .resource-group-hover .resource-menu-cog {
+::deep .resource-group-hover .resource-menu-cog,
+::deep .resource-menu-cog:focus {
     opacity: 1;
     pointer-events: auto;
 }
@@ -254,6 +255,11 @@
 ::deep .resource-menu-cog:hover .resource-menu-cog-background {
     fill: var(--neutral-fill-secondary-hover);
     stroke: var(--neutral-stroke-hover);
+}
+
+::deep .resource-menu-cog:focus-visible .resource-menu-cog-background {
+    stroke: var(--focus-stroke-outer);
+    stroke-width: calc(var(--focus-stroke-width) * 1px);
 }
 
 ::deep .resource-menu-cog-icon {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -230,6 +230,37 @@
     fill: var(--fill-color);
 }
 
+/* Context menu affordance (cog) shown on the lower-right of a node. Hidden until the node is
+   hovered so it doesn't clutter the graph, and non-interactive while hidden (pointer-events: none)
+   so the invisible element can't intercept clicks. */
+::deep .resource-menu-cog {
+    opacity: 0;
+    pointer-events: none;
+    cursor: pointer;
+    transition: opacity 0.15s ease-in-out;
+}
+
+::deep .resource-group-hover .resource-menu-cog {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+::deep .resource-menu-cog-background {
+    fill: var(--neutral-fill-secondary-rest);
+    stroke: var(--neutral-stroke-rest);
+    stroke-width: 1;
+}
+
+::deep .resource-menu-cog:hover .resource-menu-cog-background {
+    fill: var(--neutral-fill-secondary-hover);
+    stroke: var(--neutral-stroke-hover);
+}
+
+::deep .resource-menu-cog-icon {
+    fill: var(--neutral-foreground-rest);
+    pointer-events: none;
+}
+
 ::deep .resource-link {
     stroke: var(--neutral-stroke-rest);
     stroke-width: 1;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -273,7 +273,7 @@
     stroke: transparent;
 }
 
-::deep .resource-menu-cog[aria-expanded="true"]:focus-visible {
+::deep .resource-menu-cog[aria-expanded="true"] {
     outline: none;
 }
 

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -8,6 +8,12 @@ namespace Aspire.Dashboard.Model;
 public class MenuButtonItem
 {
     public bool IsDivider { get; set; }
+    /// <summary>
+    /// Whether the item is a non-interactive header used to label the menu (e.g. the resource
+    /// a context menu was opened for). Header items render <see cref="Text"/> and <see cref="Icon"/>
+    /// but ignore <see cref="OnClick"/> and are skipped by keyboard navigation.
+    /// </summary>
+    public bool IsHeader { get; set; }
     public List<MenuButtonItem>? NestedMenuItems { get; set; }
     public string? Text { get; set; }
     public string? Tooltip { get; set; }

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -474,6 +474,15 @@ namespace Aspire.Dashboard.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Resource actions.
+        /// </summary>
+        public static string ResourcesGraphResourceActionsButton {
+            get {
+                return ResourceManager.GetString("ResourcesGraphResourceActionsButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Zoom in.
         /// </summary>
         public static string ResourcesGraphZoomInButton {

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -474,7 +474,7 @@ namespace Aspire.Dashboard.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Resource actions.
+        ///   Looks up a localized string similar to Resource actions for {0}.
         /// </summary>
         public static string ResourcesGraphResourceActionsButton {
             get {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -306,6 +306,10 @@
   <data name="ResourcesGraphResetButton" xml:space="preserve">
     <value>Reset</value>
   </data>
+  <data name="ResourcesGraphResourceActionsButton" xml:space="preserve">
+    <value>Resource actions</value>
+    <comment>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</comment>
+  </data>
   <data name="ResourcesHideTypes" xml:space="preserve">
     <value>Hide resource types</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -307,8 +307,8 @@
     <value>Reset</value>
   </data>
   <data name="ResourcesGraphResourceActionsButton" xml:space="preserve">
-    <value>Resource actions</value>
-    <comment>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</comment>
+    <value>Resource actions for {0}</value>
+    <comment>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</comment>
   </data>
   <data name="ResourcesHideTypes" xml:space="preserve">
     <value>Hide resource types</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Resetovat</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Přiblížit</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Zurücksetzen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Vergrößern</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Restablecer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Acercar</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Réinitialiser</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Zoom avant</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Reimposta</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Ingrandisci</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -232,6 +232,11 @@
         <target state="translated">リセット</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">拡大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -232,6 +232,11 @@
         <target state="translated">초기화</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">확대</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Resetuj</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Powiększ</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Redefinir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Aumentar zoom</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Сбросить</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Увеличить</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -232,6 +232,11 @@
         <target state="translated">Sıfırla</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">Yakınlaştır</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -232,6 +232,11 @@
         <target state="translated">重置</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">放大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -232,6 +232,11 @@
         <target state="translated">重設</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResourceActionsButton">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+      </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>
         <target state="translated">放大</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -233,9 +233,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGraphResourceActionsButton">
-        <source>Resource actions</source>
-        <target state="new">Resource actions</target>
-        <note>Tooltip for the cog affordance on a graph resource node that opens the resource actions menu.</note>
+        <source>Resource actions for {0}</source>
+        <target state="new">Resource actions for {0}</target>
+        <note>Accessible label and tooltip for the cog affordance on a graph resource node that opens the resource actions menu. {0} is the resource display name.</note>
       </trans-unit>
       <trans-unit id="ResourcesGraphZoomInButton">
         <source>Zoom in</source>

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -459,7 +459,7 @@ class ResourceGraph {
 
             // Scale and center the icon inside the cog background, matching how resource icons are sized.
             cogIcon.each(function () {
-                const iconSize = 18;
+                const iconSize = 16;
                 const path = d3.select(this);
                 const bbox = this.getBBox();
                 const scale = iconSize / Math.max(bbox.width, bbox.height);

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -435,7 +435,7 @@ class ResourceGraph {
             .attr("transform", "translate(35,43)")
             .attr("role", "button")
             .attr("tabindex", 0)
-            .attr("aria-label", this.menuIcon ? this.menuIcon.tooltip : null)
+            .attr("aria-label", n => this.getResourceMenuLabel(n))
             // D3's drag handler is attached to the ancestor resource group. Stop drag-start
             // events here so an imprecise cog click can never move the resource node.
             .on('mousedown touchstart', event => event.stopPropagation())
@@ -447,7 +447,7 @@ class ResourceGraph {
             .attr("class", "resource-menu-cog-background");
         cogGroup
             .append("title")
-            .text(this.menuIcon ? this.menuIcon.tooltip : "");
+            .text(n => this.getResourceMenuLabel(n));
         if (this.menuIcon) {
             var cogIcon = cogGroup
                 .append("path")
@@ -473,6 +473,12 @@ class ResourceGraph {
         this.nodeElements = newNodes.merge(this.nodeElements);
 
         // Set resource values that change.
+        this.nodeElementsG
+            .selectAll(".resource-group")
+            .select(".resource-menu-cog")
+            .attr("aria-label", n => this.getResourceMenuLabel(n))
+            .select("title")
+            .text(n => this.getResourceMenuLabel(n));
         this.nodeElementsG
             .selectAll(".resource-group")
             .select(".resource-endpoint")
@@ -566,6 +572,10 @@ class ResourceGraph {
             return neighbors;
         },
             [node.id]);
+    }
+
+    getResourceMenuLabel(node) {
+        return this.menuIcon ? this.menuIcon.labelFormat.split('{0}').join(node.label) : "";
     }
 
     isNeighborLink(node, link) {

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -433,9 +433,13 @@ class ResourceGraph {
             .append("g")
             .attr("class", "resource-menu-cog")
             .attr("transform", "translate(35,43)")
+            .attr("role", "button")
+            .attr("tabindex", 0)
+            .attr("aria-label", this.menuIcon ? this.menuIcon.tooltip : null)
             // D3's drag handler is attached to the ancestor resource group. Stop drag-start
             // events here so an imprecise cog click can never move the resource node.
             .on('mousedown touchstart', event => event.stopPropagation())
+            .on('keydown', this.cogMenuKeyDown)
             .on('click', this.cogMenuClick);
         cogGroup
             .append("circle")
@@ -597,6 +601,22 @@ class ResourceGraph {
         event.stopPropagation();
 
         await this.openResourceContextMenu(data.id, event.clientX, event.clientY);
+    };
+
+    cogMenuKeyDown = async (event) => {
+        if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        var data = event.currentTarget.__data__;
+        var bounds = event.currentTarget.getBoundingClientRect();
+        await this.openResourceContextMenu(
+            data.id,
+            bounds.left + bounds.width / 2,
+            bounds.top + bounds.height / 2);
     };
 
     openResourceContextMenu = async (id, clientX, clientY) => {

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -436,6 +436,8 @@ class ResourceGraph {
             .attr("role", "button")
             .attr("tabindex", 0)
             .attr("aria-label", n => this.getResourceMenuLabel(n))
+            .attr("aria-haspopup", "menu")
+            .attr("aria-expanded", "false")
             // D3's drag handler is attached to the ancestor resource group. Stop drag-start
             // events here so an imprecise cog click can never move the resource node.
             .on('mousedown touchstart', event => event.stopPropagation())
@@ -610,7 +612,7 @@ class ResourceGraph {
         event.preventDefault();
         event.stopPropagation();
 
-        await this.openResourceContextMenu(data.id, event.clientX, event.clientY);
+        await this.openResourceContextMenu(data.id, event.clientX, event.clientY, event.currentTarget);
     };
 
     cogMenuKeyDown = async (event) => {
@@ -625,18 +627,21 @@ class ResourceGraph {
         var bounds = event.currentTarget.getBoundingClientRect();
         await this.openResourceContextMenu(
             data.id,
-            bounds.left + bounds.width / 2,
-            bounds.top + bounds.height / 2);
+            Math.round(bounds.left + bounds.width / 2),
+            Math.round(bounds.top + bounds.height / 2),
+            event.currentTarget);
     };
 
-    openResourceContextMenu = async (id, clientX, clientY) => {
+    openResourceContextMenu = async (id, clientX, clientY, trigger) => {
         this.openContextMenu = true;
+        trigger?.setAttribute("aria-expanded", "true");
 
         try {
             // Wait for method completion. It completes when the context menu is closed.
             await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', id, window.innerWidth, window.innerHeight, clientX, clientY);
         } finally {
             this.openContextMenu = false;
+            trigger?.setAttribute("aria-expanded", "false");
 
             // Unselect the node when the context menu is closed to reset mouseover state.
             this.updateNodeHighlights(null);

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -2,8 +2,8 @@ import './d3.v7.min.js'
 
 let resourceGraph = null;
 
-export function initializeResourcesGraph(resourcesInterop) {
-    resourceGraph = new ResourceGraph(resourcesInterop);
+export function initializeResourcesGraph(resourcesInterop, graphIcons) {
+    resourceGraph = new ResourceGraph(resourcesInterop, graphIcons);
     resourceGraph.resize();
 
     const observer = new ResizeObserver(function () {
@@ -28,10 +28,13 @@ export function updateResourcesGraphSelected(resourceName) {
 }
 
 class ResourceGraph {
-    constructor(resourcesInterop) {
+    constructor(resourcesInterop, graphIcons) {
         this.resources = [];
         this.resourcesInterop = resourcesInterop;
         this.openContextMenu = false;
+
+        // Static icon (SVG path + tooltip) shared by every node's context-menu affordance (cog).
+        this.menuIcon = graphIcons ? graphIcons.menu : null;
 
         this.nodes = [];
         this.links = [];
@@ -421,6 +424,45 @@ class ResourceGraph {
             .append("title")
             .text(n => n.label);
 
+        // Context menu affordance. A cog positioned on the circle rim directly below the status badge.
+        // The status badge sits at the top-right via "scale(1.6) translate(14,-34)" (center ~(35,-42)),
+        // so mirroring it vertically puts the cog at the bottom-right ~(35,43). Hidden until the node is
+        // hovered (see .resource-menu-cog CSS); it makes the node's interactivity discoverable by opening
+        // the same context menu as right-clicking the node.
+        var cogGroup = newNodesContainer
+            .append("g")
+            .attr("class", "resource-menu-cog")
+            .attr("transform", "translate(35,43)")
+            // D3's drag handler is attached to the ancestor resource group. Stop drag-start
+            // events here so an imprecise cog click can never move the resource node.
+            .on('mousedown touchstart', event => event.stopPropagation())
+            .on('click', this.cogMenuClick);
+        cogGroup
+            .append("circle")
+            .attr("r", 14)
+            .attr("class", "resource-menu-cog-background");
+        cogGroup
+            .append("title")
+            .text(this.menuIcon ? this.menuIcon.tooltip : "");
+        if (this.menuIcon) {
+            var cogIcon = cogGroup
+                .append("path")
+                .attr("class", "resource-menu-cog-icon")
+                .attr("d", this.menuIcon.path);
+
+            // Scale and center the icon inside the cog background, matching how resource icons are sized.
+            cogIcon.each(function () {
+                const iconSize = 18;
+                const path = d3.select(this);
+                const bbox = this.getBBox();
+                const scale = iconSize / Math.max(bbox.width, bbox.height);
+                const cx = bbox.x + bbox.width / 2;
+                const cy = bbox.y + bbox.height / 2;
+
+                path.attr("transform", `scale(${scale}) translate(${-cx},${-cy})`);
+            });
+        }
+
         newNodes.transition()
             .attr("opacity", 1);
 
@@ -542,11 +584,27 @@ class ResourceGraph {
         // Prevent default browser context menu.
         event.preventDefault();
 
+        await this.openResourceContextMenu(data.id, event.clientX, event.clientY);
+    };
+
+    cogMenuClick = async (event) => {
+        // currentTarget is the cog group the handler is attached to. Its datum is inherited from the
+        // node group (d3 propagates data to appended children).
+        var data = event.currentTarget.__data__;
+
+        // Stop the click from also reaching the node's click handler (which would select/deselect it).
+        event.preventDefault();
+        event.stopPropagation();
+
+        await this.openResourceContextMenu(data.id, event.clientX, event.clientY);
+    };
+
+    openResourceContextMenu = async (id, clientX, clientY) => {
         this.openContextMenu = true;
 
         try {
             // Wait for method completion. It completes when the context menu is closed.
-            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', data.id, window.innerWidth, window.innerHeight, event.clientX, event.clientY);
+            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', id, window.innerWidth, window.innerHeight, clientX, clientY);
         } finally {
             this.openContextMenu = false;
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -432,6 +432,7 @@ class ResourceGraph {
         var cogGroup = newNodesContainer
             .append("g")
             .attr("class", "resource-menu-cog")
+            .attr("id", n => `resource-menu-cog-${n.id}`)
             .attr("transform", "translate(35,43)")
             .attr("role", "button")
             .attr("tabindex", 0)
@@ -600,7 +601,7 @@ class ResourceGraph {
         // Prevent default browser context menu.
         event.preventDefault();
 
-        await this.openResourceContextMenu(data.id, event.clientX, event.clientY);
+        await this.openResourceContextMenu(data.id, event.clientX, event.clientY, null, null);
     };
 
     cogMenuClick = async (event) => {
@@ -612,7 +613,7 @@ class ResourceGraph {
         event.preventDefault();
         event.stopPropagation();
 
-        await this.openResourceContextMenu(data.id, event.clientX, event.clientY, event.currentTarget);
+        await this.openResourceContextMenu(data.id, event.clientX, event.clientY, event.currentTarget, null);
     };
 
     cogMenuKeyDown = async (event) => {
@@ -629,16 +630,17 @@ class ResourceGraph {
             data.id,
             Math.round(bounds.left + bounds.width / 2),
             Math.round(bounds.top + bounds.height / 2),
-            event.currentTarget);
+            event.currentTarget,
+            event.currentTarget.id);
     };
 
-    openResourceContextMenu = async (id, clientX, clientY, trigger) => {
+    openResourceContextMenu = async (id, clientX, clientY, trigger, focusElementId) => {
         this.openContextMenu = true;
         trigger?.setAttribute("aria-expanded", "true");
 
         try {
             // Wait for method completion. It completes when the context menu is closed.
-            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', id, window.innerWidth, window.innerHeight, clientX, clientY);
+            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', id, window.innerWidth, window.innerHeight, clientX, clientY, focusElementId);
         } finally {
             this.openContextMenu = false;
             trigger?.setAttribute("aria-expanded", "false");

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -86,6 +86,48 @@ public class AspireMenuTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task Header_LabelsMenuAndContributesToVerticalThreshold()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+
+        var header = new MenuButtonItem
+        {
+            Id = "resource-menu-header",
+            IsHeader = true,
+            Text = "Resource1",
+            Icon = new Icons.Regular.Size16.Info()
+        };
+        var menuHost = RenderComponent<AspireMenu>(builder =>
+        {
+            builder.Add(p => p.Anchor, "menu-anchor");
+            builder.Add(p => p.Anchored, false);
+            builder.Add(p => p.Open, true);
+            builder.Add(p => p.Items,
+            [
+                header,
+                new MenuButtonItem { Text = "View details" }
+            ]);
+        });
+
+        var menuElement = menuHost.Find("fluent-menu");
+        Assert.Equal(header.Id, menuElement.GetAttribute("aria-labelledby"));
+        Assert.Equal(header.Text, menuHost.Find($"#{header.Id}").TextContent.Trim());
+
+        // Two regular 32px items would fit below this pointer (15 + 80 <= 100), but replacing
+        // one with the 44px header requires the menu to flip above the pointer.
+        await menuHost.InvokeAsync(() => menuHost.Instance.OpenAsync(
+            screenWidth: 1920,
+            screenHeight: 100,
+            clientX: 10,
+            clientY: 15));
+
+        Assert.Contains("bottom: 85px", menuHost.Find("fluent-menu").GetAttribute("style"));
+    }
+
+    [Fact]
     public async Task RemoveAspireMenu_UnregistersFluentMenuFromMenuProvider()
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -302,6 +302,11 @@ public partial class ResourcesTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.True(cut.FindComponents<AspireMenu>().Single(m => !m.Instance.Anchored).Instance.Open));
 
         var contextMenu = cut.FindComponents<AspireMenu>().Single(m => !m.Instance.Anchored);
+        var headerItem = contextMenu.Instance.Items[0];
+        Assert.True(headerItem.IsHeader);
+        Assert.Equal("Resource1", headerItem.Text);
+        Assert.NotNull(headerItem.Icon);
+
         await cut.InvokeAsync(() => contextMenu.Instance.OpenChanged.InvokeAsync(false));
 
         await showContextMenuTask.WaitAsync(TimeSpan.FromSeconds(1));

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -296,7 +296,7 @@ public partial class ResourcesTests : DashboardTestContext
         Task? showContextMenuTask = null;
         await cut.InvokeAsync(() =>
         {
-            showContextMenuTask = (Task)showContextMenuAsync.Invoke(cut.Instance, [resource, 1024, 768, 20, 20])!;
+            showContextMenuTask = (Task)showContextMenuAsync.Invoke(cut.Instance, [resource, 1024, 768, 20, 20, null])!;
         });
         Assert.NotNull(showContextMenuTask);
         cut.WaitForAssertion(() => Assert.True(cut.FindComponents<AspireMenu>().Single(m => !m.Instance.Anchored).Instance.Open));

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -195,6 +195,26 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             await Assertions.Expect(menu).ToBeHiddenAsync();
             await Assertions.Expect(cog).ToHaveAttributeAsync("aria-expanded", "false");
             await Assertions.Expect(cog).ToBeFocusedAsync();
+
+            await page.Keyboard.PressAsync("Enter");
+            await page.GetByRole(
+                AriaRole.Menuitem,
+                new PageGetByRoleOptions
+                {
+                    Name = ControlsStrings.ActionViewDetailsText,
+                    Exact = true
+                }).ClickAsync();
+            await Assertions.Expect(page.Locator(".details-header-title")).ToHaveTextAsync("TestResource");
+
+            await page.GetByRole(
+                AriaRole.Button,
+                new PageGetByRoleOptions
+                {
+                    Name = ControlsStrings.SummaryDetailsViewCloseView,
+                    Exact = true
+                }).ClickAsync();
+            await Assertions.Expect(page.Locator(".details-header-title")).ToHaveCountAsync(0);
+            await Assertions.Expect(cog).ToBeFocusedAsync();
         });
     }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -151,6 +151,9 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
                 cogBounds.X + cogBounds.Width / 2,
                 cogBounds.Y + cogBounds.Height / 2);
             await page.Mouse.DownAsync();
+            Assert.Equal(
+                "none",
+                await cog.EvaluateAsync<string>("element => getComputedStyle(element).outlineStyle"));
             await page.Mouse.MoveAsync(
                 cogBounds.X + cogBounds.Width / 2 + 80,
                 cogBounds.Y + cogBounds.Height / 2 + 80,

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -190,6 +190,11 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             var headerBounds = await header.BoundingBoxAsync();
             Assert.NotNull(headerBounds);
             Assert.InRange(headerBounds.Height, 39, 41);
+
+            await page.Keyboard.PressAsync("Escape");
+            await Assertions.Expect(menu).ToBeHiddenAsync();
+            await Assertions.Expect(cog).ToHaveAttributeAsync("aria-expanded", "false");
+            await Assertions.Expect(cog).ToBeFocusedAsync();
         });
     }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -117,14 +117,27 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             await Assertions.Expect(node).ToBeVisibleAsync();
             await node.HoverAsync();
 
+            var resourceActionsLabel = string.Format(
+                Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton,
+                "TestResource");
+            var otherResourceActionsLabel = string.Format(
+                Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton,
+                "OtherResource");
             var cog = node.GetByRole(
                 AriaRole.Button,
                 new LocatorGetByRoleOptions
                 {
-                    Name = Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton,
+                    Name = resourceActionsLabel,
                     Exact = true
                 });
             await Assertions.Expect(cog).ToBeVisibleAsync();
+            await Assertions.Expect(page.GetByRole(
+                AriaRole.Button,
+                new PageGetByRoleOptions
+                {
+                    Name = otherResourceActionsLabel,
+                    Exact = true
+                })).ToHaveCountAsync(1);
 
             // Attempt a large drag from the cog. D3's drag behavior is attached to the ancestor
             // resource group, so this verifies the cog stops the initiating pointer event.
@@ -157,7 +170,11 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
                 AriaRole.Menu,
                 new PageGetByRoleOptions { Name = "TestResource", Exact = true });
             await Assertions.Expect(menu).ToBeVisibleAsync();
-            await Assertions.Expect(menu.Locator(".aspire-menu-header-text")).ToHaveTextAsync("TestResource");
+            var header = menu.Locator(".aspire-menu-header");
+            await Assertions.Expect(header.Locator(".aspire-menu-header-text")).ToHaveTextAsync("TestResource");
+            var headerBounds = await header.BoundingBoxAsync();
+            Assert.NotNull(headerBounds);
+            Assert.InRange(headerBounds.Height, 39, 41);
         });
     }
 
@@ -173,6 +190,10 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
                 [
                     new UrlViewModel("http", new Uri("about:blank#resource-url"), isInternal: false, isInactive: false, UrlDisplayPropertiesViewModel.Empty)
                 ]),
+            ModelTestHelpers.CreateResource(
+                resourceName: "OtherResource",
+                resourceType: KnownResourceTypes.Project,
+                state: KnownResourceState.Running),
             ModelTestHelpers.CreateResource(
                 resourceName: "HiddenResource",
                 resourceType: KnownResourceTypes.Container,

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -163,13 +163,28 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             Assert.InRange(Math.Abs(nodeBoundsAfter.Y - nodeBoundsBefore.Y), 0, 5);
             Assert.False((await node.GetAttributeAsync("class"))?.Split(' ').Contains("resource-group-selected"));
 
-            await cog.FocusAsync();
-            await page.Keyboard.PressAsync("Enter");
-
             var menu = page.GetByRole(
                 AriaRole.Menu,
                 new PageGetByRoleOptions { Name = "TestResource", Exact = true });
+            await Assertions.Expect(menu).ToBeHiddenAsync();
+
+            await node.HoverAsync();
+            await cog.ClickAsync();
             await Assertions.Expect(menu).ToBeVisibleAsync();
+            await Assertions.Expect(cog).ToHaveAttributeAsync("aria-expanded", "true");
+            Assert.False((await node.GetAttributeAsync("class"))?.Split(' ').Contains("resource-group-selected"));
+
+            await page.Keyboard.PressAsync("Escape");
+            await Assertions.Expect(menu).ToBeHiddenAsync();
+            await Assertions.Expect(cog).ToHaveAttributeAsync("aria-expanded", "false");
+
+            await node.HoverAsync();
+            await cog.FocusAsync();
+            await page.Keyboard.PressAsync("Enter");
+
+            await Assertions.Expect(menu).ToBeVisibleAsync();
+            await Assertions.Expect(cog).ToHaveAttributeAsync("aria-haspopup", "menu");
+            await Assertions.Expect(cog).ToHaveAttributeAsync("aria-expanded", "true");
             var header = menu.Locator(".aspire-menu-header");
             await Assertions.Expect(header.Locator(".aspire-menu-header-text")).ToHaveTextAsync("TestResource");
             var headerBounds = await header.BoundingBoxAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -104,6 +104,63 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
         });
     }
 
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task ResourceGraphCog_IsKeyboardAccessibleAndDoesNotDragNode()
+    {
+        await RunTestAsync(async page =>
+        {
+            await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
+            await page.Locator("#tab-Graph").ClickAsync();
+
+            var node = page.Locator(".resource-group[resource-name='TestResource']");
+            await Assertions.Expect(node).ToBeVisibleAsync();
+            await node.HoverAsync();
+
+            var cog = node.GetByRole(
+                AriaRole.Button,
+                new LocatorGetByRoleOptions
+                {
+                    Name = Dashboard.Resources.Resources.ResourcesGraphResourceActionsButton,
+                    Exact = true
+                });
+            await Assertions.Expect(cog).ToBeVisibleAsync();
+
+            // Attempt a large drag from the cog. D3's drag behavior is attached to the ancestor
+            // resource group, so this verifies the cog stops the initiating pointer event.
+            await page.WaitForTimeoutAsync(300);
+            var nodeBoundsBefore = await node.BoundingBoxAsync();
+            var cogBounds = await cog.BoundingBoxAsync();
+            Assert.NotNull(nodeBoundsBefore);
+            Assert.NotNull(cogBounds);
+
+            await page.Mouse.MoveAsync(
+                cogBounds.X + cogBounds.Width / 2,
+                cogBounds.Y + cogBounds.Height / 2);
+            await page.Mouse.DownAsync();
+            await page.Mouse.MoveAsync(
+                cogBounds.X + cogBounds.Width / 2 + 80,
+                cogBounds.Y + cogBounds.Height / 2 + 80,
+                new MouseMoveOptions { Steps = 5 });
+            await page.Mouse.UpAsync();
+
+            var nodeBoundsAfter = await node.BoundingBoxAsync();
+            Assert.NotNull(nodeBoundsAfter);
+            Assert.InRange(Math.Abs(nodeBoundsAfter.X - nodeBoundsBefore.X), 0, 5);
+            Assert.InRange(Math.Abs(nodeBoundsAfter.Y - nodeBoundsBefore.Y), 0, 5);
+            Assert.False((await node.GetAttributeAsync("class"))?.Split(' ').Contains("resource-group-selected"));
+
+            await cog.FocusAsync();
+            await page.Keyboard.PressAsync("Enter");
+
+            var menu = page.GetByRole(
+                AriaRole.Menu,
+                new PageGetByRoleOptions { Name = "TestResource", Exact = true });
+            await Assertions.Expect(menu).ToBeVisibleAsync();
+            await Assertions.Expect(menu.Locator(".aspire-menu-header-text")).ToHaveTextAsync("TestResource");
+        });
+    }
+
     public sealed class ResourcesDashboardServerFixture : DashboardServerFixture
     {
         protected override IReadOnlyList<ResourceViewModel> Resources =>


### PR DESCRIPTION
## Description

Resource actions in the dashboard Graph view were difficult to discover because nodes only exposed their context menu through right-click. The menu also did not identify which resource its actions targeted.

This change:

- Reveals a cog directly below a resource's status badge when the node is hovered.
- Opens the existing resource context menu when the cog is clicked.
- Prevents cog interactions from selecting or dragging the resource node.
- Adds a compact resource icon and name header to identify the context-menu target.

### User-facing usage

On **Resources > Graph**, hover a resource node and select the cog to open its actions. Right-clicking the node continues to open the same menu. The menu header identifies the selected resource.

### Screenshots / Recordings

![Resource Graph showing the hover cog and resource-labeled context menu](https://github.com/user-attachments/assets/f446538c-b9cb-4706-85c7-b84dfbc69823)

### Validation

- Built `src/Aspire.Dashboard/Aspire.Dashboard.csproj` and `tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj`.
- Ran 35 focused `ResourcesTests` and `AspireMenuTests` component tests.
- Added a Resources Playwright regression covering hover visibility, direct click and keyboard activation, per-resource accessible names, menu focus restoration, and drag prevention.
- Syntax-checked `app-resourcegraph.js`.
- Manually verified the Graph interaction with the `DotnetProject` playground AppHost.

Fixes #19892

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No