### PR TITLE
Allow skipping main.bicep generation in AzurePublishingContext

### DIFF
--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -47,7 +47,7 @@ public sealed class AzurePublishingContext(
     };
 
     /// <summary>
-    /// Gets or sets a value indicating whether generation of the root main.bicep template is skipped.
+    /// Gets or sets a value indicating whether writing the root main.bicep file is skipped.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -60,11 +60,11 @@ public sealed class AzurePublishingContext(
     /// <para>
     /// When set to <see langword="true"/>, <see cref="WriteModelAsync"/> still writes every per-resource
     /// Bicep module and populates <see cref="ParameterLookup"/> and <see cref="OutputLookup"/> against
-    /// <see cref="MainInfrastructure"/>, but <see cref="MainInfrastructure"/> is never built, compiled,
-    /// or written to disk. The default is <see langword="false"/>.
+    /// <see cref="MainInfrastructure"/>. <see cref="MainInfrastructure"/> remains available in memory, but
+    /// it is never built, compiled, or written to disk. The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
-    public bool SkipMainBicepGeneration { get; set; }
+    public bool SkipWritingMainBicepFile { get; set; }
 
     /// <summary>
     /// Gets a dictionary that maps parameter resources to provisioning parameters.
@@ -559,12 +559,12 @@ public sealed class AzurePublishingContext(
     /// <returns>A task that represents the asynchronous save operation.</returns>
     private async Task SaveToDiskAsync(string outputDirectoryPath)
     {
-        if (SkipMainBicepGeneration)
+        if (SkipWritingMainBicepFile)
         {
-            // Building the root is skipped entirely rather than compiled and discarded, because a model that
+            // The root is not even built, rather than compiled and then discarded, because a model that
             // only the individual modules support (such as a tenant-scoped module without a location parameter)
             // makes compiling the root throw.
-            logger.LogDebug("Skipping generation of {BicepName}.bicep because {PropertyName} is set.", MainInfrastructure.BicepName, nameof(SkipMainBicepGeneration));
+            logger.LogDebug("Skipping writing {BicepName}.bicep because {PropertyName} is set.", MainInfrastructure.BicepName, nameof(SkipWritingMainBicepFile));
             return;
         }
 

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -52,10 +52,10 @@ public sealed class AzurePublishingContext(
     /// <remarks>
     /// <para>
     /// Callers of this class might not need main.bicep. A publisher that deploys each resource module
-    /// directly from its own deployment manifest never consumes the root template, and compiling it can
-    /// even fail for models the individual modules handle correctly. For example, the generated root always
-    /// passes <c>location</c> to each module, but a tenant-scoped module does not declare a <c>location</c>
-    /// parameter, so compiling the root fails with <c>BCP037</c>.
+    /// directly from its own deployment manifest never consumes the root template. Although Azure.Provisioning
+    /// can emit that template, a later Bicep compilation can fail for models the individual modules handle
+    /// correctly. For example, the generated root always passes <c>location</c> to each module, but a
+    /// tenant-scoped module does not declare a <c>location</c> parameter, resulting in <c>BCP037</c>.
     /// </para>
     /// <para>
     /// When set to <see langword="true"/>, <see cref="WriteModelAsync"/> still writes every per-resource

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -47,7 +47,7 @@ public sealed class AzurePublishingContext(
     };
 
     /// <summary>
-    /// Gets or sets a value indicating whether writing the root main.bicep file is skipped.
+    /// Gets or sets a value indicating whether the root main.bicep file is excluded from the published output.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -64,7 +64,7 @@ public sealed class AzurePublishingContext(
     /// it is never built, compiled, or written to disk. The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
-    public bool SkipWritingMainBicepFile { get; set; }
+    public bool ExcludeMainBicepFile { get; set; }
 
     /// <summary>
     /// Gets a dictionary that maps parameter resources to provisioning parameters.
@@ -559,12 +559,12 @@ public sealed class AzurePublishingContext(
     /// <returns>A task that represents the asynchronous save operation.</returns>
     private async Task SaveToDiskAsync(string outputDirectoryPath)
     {
-        if (SkipWritingMainBicepFile)
+        if (ExcludeMainBicepFile)
         {
             // The root is not even built, rather than compiled and then discarded, because a model that
             // only the individual modules support (such as a tenant-scoped module without a location parameter)
             // makes compiling the root throw.
-            logger.LogDebug("Skipping writing {BicepName}.bicep because {PropertyName} is set.", MainInfrastructure.BicepName, nameof(SkipWritingMainBicepFile));
+            logger.LogDebug("Excluding {BicepName}.bicep from the output because {PropertyName} is set.", MainInfrastructure.BicepName, nameof(ExcludeMainBicepFile));
             return;
         }
 

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -47,6 +47,26 @@ public sealed class AzurePublishingContext(
     };
 
     /// <summary>
+    /// Gets or sets a value indicating whether generation of the root main.bicep template is skipped.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Callers of this class might not need main.bicep. A publisher that deploys each resource module
+    /// directly from its own deployment manifest never consumes the root template, and compiling it can
+    /// even fail for models the individual modules handle correctly. For example, the generated root always
+    /// passes <c>location</c> to each module, but a tenant-scoped module does not declare a <c>location</c>
+    /// parameter, so compiling the root fails with <c>BCP037</c>.
+    /// </para>
+    /// <para>
+    /// When set to <see langword="true"/>, <see cref="WriteModelAsync"/> still writes every per-resource
+    /// Bicep module and populates <see cref="ParameterLookup"/> and <see cref="OutputLookup"/> against
+    /// <see cref="MainInfrastructure"/>, but <see cref="MainInfrastructure"/> is never built, compiled,
+    /// or written to disk. The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    public bool SkipMainBicepGeneration { get; set; }
+
+    /// <summary>
     /// Gets a dictionary that maps parameter resources to provisioning parameters.
     /// </summary>
     /// <remarks>
@@ -539,6 +559,15 @@ public sealed class AzurePublishingContext(
     /// <returns>A task that represents the asynchronous save operation.</returns>
     private async Task SaveToDiskAsync(string outputDirectoryPath)
     {
+        if (SkipMainBicepGeneration)
+        {
+            // Building the root is skipped entirely rather than compiled and discarded, because a model that
+            // only the individual modules support (such as a tenant-scoped module without a location parameter)
+            // makes compiling the root throw.
+            logger.LogDebug("Skipping generation of {BicepName}.bicep because {PropertyName} is set.", MainInfrastructure.BicepName, nameof(SkipMainBicepGeneration));
+            return;
+        }
+
         var plan = MainInfrastructure.Build(provisioningOptions.ProvisioningBuildOptions);
         var compiledBicep = plan.Compile().First();
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -250,7 +250,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task AzurePublishingContext_SkipWritingMainBicepFile_WritesModulesWithoutMainBicep()
+    public async Task AzurePublishingContext_ExcludeMainBicepFile_WritesModulesWithoutMainBicep()
     {
         using var workspace = TemporaryWorkspace.Create(output);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
@@ -267,7 +267,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
         var outputPath = Path.Combine(workspace.Path, "skip-main");
         var context = await CreatePublishingContextAsync(app, outputPath);
-        context.SkipWritingMainBicepFile = true;
+        context.ExcludeMainBicepFile = true;
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();
@@ -302,7 +302,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         var outputPath = Path.Combine(workspace.Path, "write-main");
         var context = await CreatePublishingContextAsync(app, outputPath);
 
-        Assert.False(context.SkipWritingMainBicepFile);
+        Assert.False(context.ExcludeMainBicepFile);
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -250,7 +250,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task AzurePublishingContext_SkipMainBicepGeneration_WritesModulesWithoutMainBicep()
+    public async Task AzurePublishingContext_SkipWritingMainBicepFile_WritesModulesWithoutMainBicep()
     {
         using var workspace = TemporaryWorkspace.Create(output);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
@@ -267,7 +267,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
         var outputPath = Path.Combine(workspace.Path, "skip-main");
         var context = await CreatePublishingContextAsync(app, outputPath);
-        context.SkipMainBicepGeneration = true;
+        context.SkipWritingMainBicepFile = true;
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();
@@ -302,7 +302,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         var outputPath = Path.Combine(workspace.Path, "write-main");
         var context = await CreatePublishingContextAsync(app, outputPath);
 
-        Assert.False(context.SkipMainBicepGeneration);
+        Assert.False(context.SkipWritingMainBicepFile);
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -256,16 +256,11 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
 
         builder.AddAzureEnvironment();
-        builder.AddBicepTemplateString("mod",
-            """
-            param location string
-
-            output value string = 'mod'
-            """);
+        AddTenantScopedModuleWithoutLocation(builder);
 
         using var app = builder.Build();
 
-        var outputPath = Path.Combine(workspace.Path, "skip-main");
+        var outputPath = Path.Combine(workspace.Path, "exclude-main");
         var context = await CreatePublishingContextAsync(app, outputPath);
         context.ExcludeMainBicepFile = true;
 
@@ -290,12 +285,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
 
         builder.AddAzureEnvironment();
-        builder.AddBicepTemplateString("mod",
-            """
-            param location string
-
-            output value string = 'mod'
-            """);
+        AddTenantScopedModuleWithoutLocation(builder);
 
         using var app = builder.Build();
 
@@ -309,8 +299,32 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
         await context.WriteModelAsync(model, environment, CancellationToken.None);
 
-        Assert.True(File.Exists(Path.Combine(outputPath, "main.bicep")));
         Assert.True(File.Exists(Path.Combine(outputPath, "mod", "mod.bicep")));
+
+        // The default root is written, and it passes `location` to the tenant-scoped module even though
+        // that module declares no such parameter. This is the shape that fails a real `bicep build` with
+        // BCP037 and motivates ExcludeMainBicepFile. Azure.Provisioning emits the text without running the
+        // Bicep compiler, so the invalid template is only observable in the generated content here.
+        var mainBicep = await File.ReadAllTextAsync(Path.Combine(outputPath, "main.bicep"));
+        Assert.Contains("scope: tenant()", mainBicep);
+        Assert.Contains("location: location", mainBicep);
+    }
+
+    /// <summary>
+    /// Adds the module shape that motivates <see cref="AzurePublishingContext.ExcludeMainBicepFile"/>: a
+    /// tenant-scoped module that declares no <c>location</c> parameter, which the generated root passes
+    /// <c>location</c> to regardless.
+    /// </summary>
+    private static void AddTenantScopedModuleWithoutLocation(IDistributedApplicationBuilder builder)
+    {
+        var module = builder.AddBicepTemplateString("mod",
+            """
+            targetScope = 'tenant'
+
+            output value string = 'mod'
+            """);
+
+        module.Resource.Scope = AzureBicepResourceScope.CreateForTenant();
     }
 
     private async Task<AzurePublishingContext> CreatePublishingContextAsync(DistributedApplication app, string outputPath)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning;
 using Azure.Provisioning.Storage;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -243,6 +247,79 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         var mainBicep = File.ReadAllText(Path.Combine(workspace.Path, "main.bicep"));
 
         await Verify(mainBicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AzurePublishingContext_SkipMainBicepGeneration_WritesModulesWithoutMainBicep()
+    {
+        using var workspace = TemporaryWorkspace.Create(output);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        builder.AddAzureEnvironment();
+        builder.AddBicepTemplateString("mod",
+            """
+            param location string
+
+            output value string = 'mod'
+            """);
+
+        using var app = builder.Build();
+
+        var outputPath = Path.Combine(workspace.Path, "skip-main");
+        var context = await CreatePublishingContextAsync(app, outputPath);
+        context.SkipMainBicepGeneration = true;
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();
+
+        await context.WriteModelAsync(model, environment, CancellationToken.None);
+
+        Assert.False(File.Exists(Path.Combine(outputPath, "main.bicep")));
+        Assert.True(File.Exists(Path.Combine(outputPath, "mod", "mod.bicep")));
+
+        // The lookups are still populated so callers can resolve parameters and outputs
+        // even though the root template was never compiled.
+        Assert.Contains(environment.Location, context.ParameterLookup.Keys);
+        Assert.Contains(environment.ResourceGroupName, context.ParameterLookup.Keys);
+    }
+
+    [Fact]
+    public async Task AzurePublishingContext_WritesMainBicepByDefault()
+    {
+        using var workspace = TemporaryWorkspace.Create(output);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        builder.AddAzureEnvironment();
+        builder.AddBicepTemplateString("mod",
+            """
+            param location string
+
+            output value string = 'mod'
+            """);
+
+        using var app = builder.Build();
+
+        var outputPath = Path.Combine(workspace.Path, "write-main");
+        var context = await CreatePublishingContextAsync(app, outputPath);
+
+        Assert.False(context.SkipMainBicepGeneration);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var environment = model.Resources.OfType<AzureEnvironmentResource>().Single();
+
+        await context.WriteModelAsync(model, environment, CancellationToken.None);
+
+        Assert.True(File.Exists(Path.Combine(outputPath, "main.bicep")));
+        Assert.True(File.Exists(Path.Combine(outputPath, "mod", "mod.bicep")));
+    }
+
+    private async Task<AzurePublishingContext> CreatePublishingContextAsync(DistributedApplication app, string outputPath)
+    {
+        var provisioningOptions = app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>().Value;
+        var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<AzurePublishingContext>();
+        var step = await new TestPipelineActivityReporter(output).CreateStepAsync("Publishing Azure resources");
+
+        return new AzurePublishingContext(outputPath, provisioningOptions, app.Services, logger, step);
     }
 
     private sealed class TestProject : IProjectMetadata


### PR DESCRIPTION
## Description

Callers of `AzurePublishingContext` might not need the root `main.bicep`. A publisher that deploys each resource module directly from its own deployment manifest never consumes the root template, and today it is always built, compiled, and written.

Worse, compiling the root can fail for models the individual modules handle correctly: the generated root always passes `location` to each module, but a tenant-scoped module does not declare a `location` parameter, so compiling the root throws `BCP037: The property "location" is not allowed on objects of type "params"`. Consumers currently work around this by deleting the file after publish or filtering it out by path.

This adds an opt-out:

```csharp
public sealed class AzurePublishingContext
{
+    public bool ExcludeMainBicepFile { get; set; }
}
```

When `true`, `WriteModelAsync` still writes every per-resource Bicep module and populates `ParameterLookup` / `OutputLookup` against `MainInfrastructure`. `MainInfrastructure` remains available in memory, but it is never built, compiled, or written to disk — skipping before `Build()` rather than compiling and discarding, so models that cannot compile the root still publish successfully.

The default is `false`, so existing output is unchanged.

The name matches the exclusion vocabulary already used in `WriteAzureArtifactsOutputAsync`, which filters resources with `IsExcludedFromPublish()`, and the model-level `ExcludeFromManifest()` API — same mental model of leaving something out of the published output.

Fixes #19913

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No

## Testing

Two tests added to `AzureEnvironmentResourceTests`, both passing along with the rest of the class (11/11):

- `AzurePublishingContext_ExcludeMainBicepFile_WritesModulesWithoutMainBicep` — asserts `main.bicep` is absent, the per-resource module is still written, and `ParameterLookup` is still populated.
- `AzurePublishingContext_WritesMainBicepByDefault` — guards the default (`false`) behavior.

`ExcludeMainBicepFile` is new public API on an `[Experimental("ASPIREAZURE001")]` type and still needs API review.