### PR TITLE
Measure PR age from ready-for-review time

### DIFF
--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -18,6 +18,7 @@ import {
   computeCommunityItems,
   isChecksFailing,
   isReviewDebt,
+  reviewAgeStartedAt,
   shouldHideFromSharedPullRequestLists,
   visibleCheckState,
 } from "./model.mjs";
@@ -96,6 +97,9 @@ query($owner:String!, $name:String!, $after:String) {
         baseRefName
         mergeable
         reviewDecision
+        readyForReviewEvents: timelineItems(last:1, itemTypes:[READY_FOR_REVIEW_EVENT]) {
+          nodes { ... on ReadyForReviewEvent { createdAt } }
+        }
         additions deletions changedFiles
         milestone { title }
         labels(first:15) { nodes { name } }
@@ -312,6 +316,7 @@ function normalizePr(repo, node, viewers, repoPrivate = false) {
     authorType,
     authorAvatarUrl: node.author?.avatarUrl ?? null,
     createdAt: node.createdAt,
+    readyForReviewAt: node.readyForReviewEvents?.nodes?.[0]?.createdAt ?? null,
     updatedAt: node.updatedAt,
     baseRef: node.baseRefName,
     milestone: node.milestone?.title ?? null,
@@ -488,7 +493,7 @@ function awaitingReview(pr) {
 // Oldest waits float to the top so nothing starves, with nudges for explicitly
 // requested reviewers and quick wins. Order is team-managed, not user-sortable.
 function reviewQueueScore(pr) {
-  const ageDays = (Date.now() - new Date(pr.createdAt).getTime()) / DAY_MS;
+  const ageDays = (Date.now() - new Date(reviewAgeStartedAt(pr)).getTime()) / DAY_MS;
   let s = Math.min(ageDays, 90);
   if (pr.requestedReviewers.length > 0) s += 20;
   if (isQuickWin(pr)) s += 12;

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { dayMs } from "./constants.mjs";
 import { capFocusKeepingDebt, loadDashboard } from "./github.mjs";
 
 const originalFetch = globalThis.fetch;
@@ -65,6 +66,38 @@ test("loadDashboard paginates open pull requests for each watched repo", async (
     dashboard.lanes.flatMap((lane) => lane.items).find((item) => item.pr.number === 1).pr.readyForReviewAt,
     "2026-07-01T09:30:00Z",
   );
+});
+
+test("loadDashboard ranks review-ready PRs by time waiting for review", async () => {
+  const oldDraft = prNode(1, new Date().toISOString(), isoAgo(dayMs));
+  oldDraft.createdAt = isoAgo(28 * dayMs);
+  oldDraft.author.login = "old-draft-author";
+
+  const longerWait = prNode(2, new Date().toISOString());
+  longerWait.createdAt = isoAgo(3 * dayMs);
+  longerWait.author.login = "longer-wait-author";
+
+  globalThis.fetch = async (_url, options = {}) => {
+    const body = JSON.parse(options.body);
+    if (body.query.includes("pullRequests")) {
+      return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: {
+        nodes: [oldDraft, longerWait],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      } } } });
+    }
+    throw new Error(`Unexpected query: ${body.query}`);
+  };
+
+  const dashboard = await loadDashboard({
+    accounts: [{ token: "token", login: "octo", repos: ["microsoft/aspire"] }],
+    mode: "review",
+    release: "9.5",
+    prefs: {},
+    dismissed: [],
+  });
+
+  const reviewQueue = dashboard.lanes.find((lane) => lane.id === "review-queue");
+  assert.deepEqual(reviewQueue.items.map((item) => item.pr.number), [2, 1]);
 });
 
 test("loadDashboard paginates open issues for each watched repo", async () => {
@@ -196,6 +229,10 @@ function page(after, firstNode, secondNode) {
   }
   assert.equal(after, "cursor-1");
   return { nodes: [secondNode], pageInfo: { hasNextPage: false, endCursor: null } };
+}
+
+function isoAgo(ms) {
+  return new Date(Date.now() - ms).toISOString();
 }
 
 function prNode(number, updatedAt, readyForReviewAt = null) {

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -39,9 +39,10 @@ test("loadDashboard paginates open pull requests for each watched repo", async (
     const body = JSON.parse(options.body);
     seenAfter.push(body.variables.after ?? null);
     if (body.query.includes("pullRequests")) {
+      assert.match(body.query, /readyForReviewEvents:\s*timelineItems\(last:1, itemTypes:\[READY_FOR_REVIEW_EVENT\]\)/);
       return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: page(
         body.variables.after,
-        prNode(1, "2026-07-01T10:00:00Z"),
+        prNode(1, "2026-07-01T10:00:00Z", "2026-07-01T09:30:00Z"),
         prNode(2, "2026-07-01T11:00:00Z"),
       ) } } });
     }
@@ -60,6 +61,10 @@ test("loadDashboard paginates open pull requests for each watched repo", async (
   assert.deepEqual(seenAfter, [null, "cursor-1"]);
   assert.equal(dashboard.counts.total, 2);
   assert.deepEqual(dashboard.lanes.flatMap((lane) => lane.items.map((item) => item.pr.number)).sort((a, b) => a - b), [1, 2]);
+  assert.equal(
+    dashboard.lanes.flatMap((lane) => lane.items).find((item) => item.pr.number === 1).pr.readyForReviewAt,
+    "2026-07-01T09:30:00Z",
+  );
 });
 
 test("loadDashboard paginates open issues for each watched repo", async () => {
@@ -193,7 +198,7 @@ function page(after, firstNode, secondNode) {
   return { nodes: [secondNode], pageInfo: { hasNextPage: false, endCursor: null } };
 }
 
-function prNode(number, updatedAt) {
+function prNode(number, updatedAt, readyForReviewAt = null) {
   return {
     number,
     title: `PR ${number}`,
@@ -206,6 +211,7 @@ function prNode(number, updatedAt) {
     baseRefName: "main",
     mergeable: "MERGEABLE",
     reviewDecision: null,
+    readyForReviewEvents: { nodes: readyForReviewAt ? [{ createdAt: readyForReviewAt }] : [] },
     additions: 1,
     deletions: 0,
     changedFiles: 1,

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -126,12 +126,15 @@ function isCommunityAuthor(author, authorType) {
 export function isCommunityPullRequest(pr) {
   return !pr.isMine && !pr.repoPrivate && isCommunityAuthor(pr.author, pr.authorType) && !isCommunityToolkitPullRequest(pr);
 }
+export function reviewAgeStartedAt(pr) {
+  return pr.readyForReviewAt ?? pr.createdAt;
+}
 export function isAgedOutCommunityPullRequest(pr) {
   return isCommunityPullRequest(pr) && ageMs(pr.updatedAt) > focusAgeLimitMs;
 }
 function isCommunityWaiting(pr) {
   return !pr.isMine && !pr.repoPrivate && isCommunityAuthor(pr.author, pr.authorType) && (
-    (pr.review.state === "waiting" && ageMs(pr.createdAt) >= communityWaitMs) ||
+    (pr.review.state === "waiting" && ageMs(reviewAgeStartedAt(pr)) >= communityWaitMs) ||
     (pr.review.state === "reviewed" && isIdle(pr))
   );
 }
@@ -357,7 +360,7 @@ function reviewSignal(pr, bucketLabel) {
     case "Docs": return "generated docs";
     case "Community Toolkit": return "CommunityToolkit/Aspire";
     case "Bots / automation": return "bot";
-    case "Community": return isCommunityWaiting(pr) ? `Community · waiting ${formatAge(pr.createdAt)}` : "community";
+    case "Community": return isCommunityWaiting(pr) ? `Community · waiting ${formatAge(reviewAgeStartedAt(pr))}` : "community";
     case agedOutCommunityBucketLabel: return agedOutCommunityBucketLabel;
     case "Quick wins": return reviewFootprint(pr);
     case "Needs review": return "No reviews";
@@ -465,9 +468,10 @@ export function createAttentionSignals(item) {
     signals.push(ageSignal);
   }
 
+  const reviewAgeAt = reviewAgeStartedAt(pullRequest);
   signals.push({
-    label: `open ${formatAge(pullRequest.createdAt)}`,
-    tone: Date.now() - new Date(pullRequest.createdAt).getTime() >= 7 * dayMs ? "warning" : "muted",
+    label: `open ${formatAge(reviewAgeAt)}`,
+    tone: ageMs(reviewAgeAt) >= 7 * dayMs ? "warning" : "muted",
   });
 
   if (progress && !prioritizeProgress) {
@@ -919,12 +923,12 @@ function pickScore(item) {
   if (st === "reviewed") score += 25;
   if (st === "approved") score += 5;
   if (isBotAuthor(item.pullRequest.author, item.pullRequest.authorType)) score -= 120;
-  return score + Math.min(3, Math.floor(ageMs(item.pullRequest.createdAt) / dayMs)) +
+  return score + Math.min(3, Math.floor(ageMs(reviewAgeStartedAt(item.pullRequest)) / dayMs)) +
     Math.min(1, Math.floor(ageMs(item.pullRequest.updatedAt) / dayMs));
 }
 
 function pickReason(pr) {
-  const signals = [`open ${formatAge(pr.createdAt)}`];
+  const signals = [`open ${formatAge(reviewAgeStartedAt(pr))}`];
   if (pr.review.approvalCount > 0) signals.push(formatCount(pr.review.approvalCount, "approval"));
   else if (pr.review.reviewerCount > 0) signals.push(`${formatCount(pr.review.reviewerCount, "reviewer")} · 0 approvals`);
   else signals.push("no reviews");

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { dayMs, personalPickActions, reviewDebtSignalLabel } from "./constants.mjs";
+import { dayMs, hourMs, personalPickActions, reviewDebtSignalLabel } from "./constants.mjs";
 import {
   actorIdentityKey,
   computeCommunityItems,
@@ -272,6 +272,27 @@ test("computeCommunityItems includes active external contributors and excludes t
   assert.equal(items[0].reason, "Community");
 });
 
+test("community wait signal starts when a draft becomes ready for review", () => {
+  const recentlyReady = makePr({
+    number: 24,
+    author: "recent-contributor",
+    createdAt: isoAgo(28 * dayMs),
+    readyForReviewAt: isoAgo(11 * hourMs),
+  });
+  const waiting = makePr({
+    number: 25,
+    author: "waiting-contributor",
+    createdAt: isoAgo(28 * dayMs),
+    readyForReviewAt: isoAgo(13 * hourMs),
+  });
+
+  const recentlyReadyAction = createAttentionSignals({ pullRequest: recentlyReady })[0];
+  const waitingAction = createAttentionSignals({ pullRequest: waiting })[0];
+
+  assert.deepEqual(recentlyReadyAction, { label: "community", tone: "accent" });
+  assert.deepEqual(waitingAction, { label: "community wait", tone: "warning" });
+});
+
 test("computeFocusExclusionItems explains why my own PRs are outside the focused queue", () => {
   const failing = makePr({ number: 30, author: "octo", isMine: true, checks: { state: "failure", failureCount: 1 } });
   const notMine = makePr({ number: 31, author: "davidfowl", isMine: false, checks: { state: "failure" } });
@@ -294,6 +315,26 @@ test("createForMeItems returns personal picks only when a login is supplied", ()
   const byNumber = new Map(picks.map((p) => [p.pullRequest.number, p]));
   assert.equal(byNumber.get(40)?.action, personalPickActions.reviewThis);
   assert.equal(byNumber.get(41)?.action, personalPickActions.finishThis);
+});
+
+test("createForMeItems ranks review requests by time waiting for review", () => {
+  const oldDraft = makePr({
+    number: 42,
+    author: "old-draft-author",
+    createdAt: isoAgo(28 * dayMs),
+    readyForReviewAt: isoAgo(dayMs),
+    review: { state: "waiting", reviewRequestedFromViewer: true },
+  });
+  const longerWait = makePr({
+    number: 43,
+    author: "longer-wait-author",
+    createdAt: isoAgo(3 * dayMs),
+    review: { state: "waiting", reviewRequestedFromViewer: true },
+  });
+
+  const picks = createForMeItems([oldDraft, longerWait], ["octo"]);
+
+  assert.deepEqual(picks.map((pick) => pick.pullRequest.number), [43, 42]);
 });
 
 test("createDeveloperPullRequestCounts attributes open PRs to core-team members and honors alias suffixes", () => {

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -70,6 +70,7 @@ function makePr(overrides = {}) {
     authorType: "User",
     authorAvatarUrl: null,
     createdAt: isoAgo(2 * dayMs),
+    readyForReviewAt: null,
     updatedAt: isoAgo(dayMs),
     baseRef: "main",
     milestone: null,
@@ -125,6 +126,22 @@ test("createAttentionBuckets only surfaces the My draft PRs bucket when a login 
 
   const withoutLogin = createAttentionBuckets([draft]);
   assert.equal(withoutLogin.find((b) => b.label === "My draft PRs"), undefined);
+});
+
+test("createAttentionSignals measures open age from the latest ready-for-review transition", () => {
+  const recentlyReady = makePr({
+    createdAt: isoAgo(28 * dayMs),
+    readyForReviewAt: isoAgo(2 * dayMs),
+  });
+  const alwaysReady = makePr({ createdAt: isoAgo(28 * dayMs) });
+
+  const recentlyReadyOpen = createAttentionSignals({ pullRequest: recentlyReady })
+    .find((signal) => signal.label.startsWith("open "));
+  const alwaysReadyOpen = createAttentionSignals({ pullRequest: alwaysReady })
+    .find((signal) => signal.label.startsWith("open "));
+
+  assert.deepEqual(recentlyReadyOpen, { label: "open 2d", tone: "muted" });
+  assert.deepEqual(alwaysReadyOpen, { label: "open 28d", tone: "warning" });
 });
 
 test("computeFocusItems keeps the highest-priority lane per PR and excludes CI-failing PRs", () => {


### PR DESCRIPTION
## Description

PR age indicators currently include time spent in draft, which makes a newly review-ready PR appear stale and can rank it ahead of PRs that have actually waited longer for review.

This change queries the latest GitHub `ReadyForReviewEvent` and uses that timestamp for the `open Nd` pill, review-queue ranking, community wait indicators, and personal-pick scoring. PRs that were never drafts continue to use their creation time.

### User-facing usage

A PR opened as a draft 28 days ago and marked ready for review 2 days ago now displays `open 2d` instead of `open 28d`.

Validation:

- All 172 Aspire Team App tests pass.
- The ready-for-review timeline query was verified against an open `microsoft/aspire` PR.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
