### PR TITLE
Preserve pnpm workspace settings for TypeScript AppHosts

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -2070,7 +2070,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             if (TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(_resolvedLanguage))
             {
                 var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, _environment, _logger);
-                runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
+                runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain, directory);
             }
             else if (JavaAppHostToolchainResolver.IsJavaLanguage(_resolvedLanguage))
             {

--- a/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
+++ b/src/Aspire.Cli/Projects/TypeScriptAppHostToolchainResolver.cs
@@ -29,6 +29,7 @@ internal static class TypeScriptAppHostToolchainResolver
     private const string YarnConfigFileName = ".yarnrc.yml";
     private const string PackageLockFileName = "package-lock.json";
     private const string PnpmLockFileName = "pnpm-lock.yaml";
+    private const string PnpmWorkspaceFileName = "pnpm-workspace.yaml";
     private const string DenoLockFileName = "deno.lock";
     private const string DenoJsonFileName = "deno.json";
     private const string DenoJsoncFileName = "deno.jsonc";
@@ -155,7 +156,7 @@ internal static class TypeScriptAppHostToolchainResolver
         };
     }
 
-    public static RuntimeSpec ApplyToRuntimeSpec(RuntimeSpec baseRuntimeSpec, TypeScriptAppHostToolchain toolchain)
+    public static RuntimeSpec ApplyToRuntimeSpec(RuntimeSpec baseRuntimeSpec, TypeScriptAppHostToolchain toolchain, DirectoryInfo appHostDirectory)
     {
         if (toolchain == TypeScriptAppHostToolchain.Npm)
         {
@@ -171,7 +172,7 @@ internal static class TypeScriptAppHostToolchainResolver
             CodeGenLanguage = baseRuntimeSpec.CodeGenLanguage,
             DetectionPatterns = baseRuntimeSpec.DetectionPatterns,
             Initialize = baseRuntimeSpec.Initialize,
-            InstallDependencies = CreateInstallCommand(toolchain),
+            InstallDependencies = CreateInstallCommand(toolchain, appHostDirectory),
             PreExecute = CreatePreExecuteCommands(toolchain, tsConfigFileName),
             Execute = CreateExecuteCommand(toolchain, tsConfigFileName),
             WatchExecute = CreateWatchCommand(toolchain, tsConfigFileName),
@@ -189,13 +190,14 @@ internal static class TypeScriptAppHostToolchainResolver
         };
     }
 
-    private static CommandSpec CreateInstallCommand(TypeScriptAppHostToolchain toolchain)
+    private static CommandSpec CreateInstallCommand(TypeScriptAppHostToolchain toolchain, DirectoryInfo appHostDirectory)
     {
-        // pnpm resolves a parent pnpm-workspace.yaml when install runs in a nested package.
-        // The generated brownfield AppHost intentionally lives outside the user's workspace
-        // package graph, so install only that package instead of requiring edits to the
-        // user's workspace file. See https://pnpm.io/workspaces.
-        string[] args = toolchain == TypeScriptAppHostToolchain.Pnpm
+        // A generated brownfield AppHost is intentionally outside its parent's package graph, so
+        // isolate that install. When the AppHost owns the workspace file, pnpm must honor it because
+        // it contains workspace settings such as catalogs and build-script approvals.
+        // See https://pnpm.io/workspaces.
+        string[] args = toolchain == TypeScriptAppHostToolchain.Pnpm &&
+            !File.Exists(Path.Combine(appHostDirectory.FullName, PnpmWorkspaceFileName))
             ? ["install", "--ignore-workspace"]
             : ["install"];
 

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -22,6 +22,7 @@ namespace Aspire.Cli.Scaffolding;
 internal sealed class ScaffoldingService : IScaffoldingService
 {
     private const string PackageJsonFileName = "package.json";
+    private const string YarnLockFileName = "yarn.lock";
     private const string VsCodeSettingsFileName = ".vscode/settings.json";
     private const string JavaScriptHostingPackageName = "Aspire.Hosting.JavaScript";
     internal const string BrownfieldTypeScriptAppHostDirectoryName = "aspire-apphost";
@@ -216,6 +217,8 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
         if (IsNestedBrownfieldTypeScriptAppHost(directory, scaffoldDirectory, language))
         {
+            var toolchain = TypeScriptAppHostToolchainResolver.Resolve(scaffoldDirectory, _environment, _logger);
+            EnsureNestedBrownfieldTypeScriptToolchainFiles(scaffoldDirectory, toolchain);
             await AddRootTypeScriptAppHostScriptsAsync(directory, scaffoldDirectory, cancellationToken);
         }
 
@@ -288,6 +291,23 @@ internal sealed class ScaffoldingService : IScaffoldingService
                rootDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
                scaffoldDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
                StringComparison.Ordinal);
+
+    internal static void EnsureNestedBrownfieldTypeScriptToolchainFiles(DirectoryInfo appHostDirectory, TypeScriptAppHostToolchain toolchain)
+    {
+        if (toolchain != TypeScriptAppHostToolchain.Yarn)
+        {
+            return;
+        }
+
+        // Yarn 2+ rejects a nested package that is not listed in its parent's workspace. An empty
+        // lockfile establishes the generated AppHost as an independent project without changing
+        // the user's workspace package graph. See https://yarnpkg.com/features/workspaces.
+        var yarnLockPath = Path.Combine(appHostDirectory.FullName, YarnLockFileName);
+        if (!File.Exists(yarnLockPath))
+        {
+            File.WriteAllText(yarnLockPath, string.Empty);
+        }
+    }
 
     private async Task AddRootTypeScriptAppHostScriptsAsync(DirectoryInfo rootDirectory, DirectoryInfo appHostDirectory, CancellationToken cancellationToken)
     {
@@ -426,7 +446,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
         if (TypeScriptAppHostToolchainResolver.IsTypeScriptLanguage(language))
         {
             var toolchain = TypeScriptAppHostToolchainResolver.Resolve(directory, _environment, _logger);
-            runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain);
+            runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(runtimeSpec, toolchain, directory);
         }
 
         var runtime = new GuestRuntime(runtimeSpec, _logger, PathLookupHelper.FindFullPathFromPath, _environment, _profilingTelemetry);

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -22,10 +22,17 @@ namespace Aspire.Cli.Scaffolding;
 internal sealed class ScaffoldingService : IScaffoldingService
 {
     private const string PackageJsonFileName = "package.json";
+    private const string PnpmWorkspaceFileName = "pnpm-workspace.yaml";
     private const string YarnLockFileName = "yarn.lock";
     private const string VsCodeSettingsFileName = ".vscode/settings.json";
     private const string JavaScriptHostingPackageName = "Aspire.Hosting.JavaScript";
     internal const string BrownfieldTypeScriptAppHostDirectoryName = "aspire-apphost";
+
+    private const string NestedPnpmWorkspaceContent = """
+        allowBuilds:
+          esbuild: true
+
+        """;
 
     private static readonly JsonSerializerOptions s_scaffoldJsonSerializerOptions = new()
     {
@@ -294,18 +301,29 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
     internal static void EnsureNestedBrownfieldTypeScriptToolchainFiles(DirectoryInfo appHostDirectory, TypeScriptAppHostToolchain toolchain)
     {
-        if (toolchain != TypeScriptAppHostToolchain.Yarn)
+        switch (toolchain)
         {
-            return;
+            case TypeScriptAppHostToolchain.Yarn:
+                // Yarn 2+ rejects a nested package that is not listed in its parent's workspace. An empty
+                // lockfile establishes the generated AppHost as an independent project without changing
+                // the user's workspace package graph. See https://yarnpkg.com/features/workspaces.
+                EnsureFileExists(appHostDirectory, YarnLockFileName, string.Empty);
+                break;
+            case TypeScriptAppHostToolchain.Pnpm:
+                // pnpm 11 fails installs with unreviewed dependency build scripts. The generated AppHost
+                // owns tsx, whose esbuild dependency requires a postinstall, so approve only that reviewed
+                // package in the isolated AppHost. See https://pnpm.io/settings/build#allowbuilds.
+                EnsureFileExists(appHostDirectory, PnpmWorkspaceFileName, NestedPnpmWorkspaceContent);
+                break;
         }
+    }
 
-        // Yarn 2+ rejects a nested package that is not listed in its parent's workspace. An empty
-        // lockfile establishes the generated AppHost as an independent project without changing
-        // the user's workspace package graph. See https://yarnpkg.com/features/workspaces.
-        var yarnLockPath = Path.Combine(appHostDirectory.FullName, YarnLockFileName);
-        if (!File.Exists(yarnLockPath))
+    private static void EnsureFileExists(DirectoryInfo directory, string fileName, string content)
+    {
+        var filePath = Path.Combine(directory.FullName, fileName);
+        if (!File.Exists(filePath))
         {
-            File.WriteAllText(yarnLockPath, string.Empty);
+            File.WriteAllText(filePath, content);
         }
     }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
@@ -132,7 +132,7 @@ internal static class TypeScriptAppHostToolchainTestHelpers
         {
             "bun" => "bun@1.2.0",
             "yarn" => "yarn@4.14.1",
-            "pnpm" => "pnpm@10.0.0",
+            "pnpm" => "pnpm@11.5.2",
             "npm" => "npm@10.0.0",
             "deno" => "deno@2.9.0",
             _ => throw new ArgumentOutOfRangeException(nameof(toolchain), toolchain, "Unsupported TypeScript AppHost toolchain.")

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -109,14 +109,33 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
             await builder.build().run();
             """;
-
         File.WriteAllText(appHostPath, newContent);
+
+        string? expectedPnpmWorkspaceContent = null;
+        var pnpmWorkspacePath = Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-workspace.yaml");
+        if (toolchain == "pnpm")
+        {
+            expectedPnpmWorkspaceContent = """
+                allowBuilds:
+                  esbuild: true
+                  protobufjs: true
+                packages:
+                  - viteapp
+
+                """;
+            File.WriteAllText(pnpmWorkspacePath, expectedPnpmWorkspaceContent);
+        }
 
         // Step 6: Restore and type-check with the configured package manager before running.
         await auto.TypeAsync("aspire restore");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("SDK code restored successfully", timeout: TimeSpan.FromMinutes(3));
         await auto.WaitForSuccessPromptAsync(counter);
+
+        if (expectedPnpmWorkspaceContent is not null)
+        {
+            Assert.Equal(expectedPnpmWorkspaceContent, File.ReadAllText(pnpmWorkspacePath));
+        }
 
         var appHostLockFilePath = Path.Combine(
             workspace.WorkspaceRoot.FullName,
@@ -154,6 +173,11 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         // Step 8: Stop the apphost
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await auto.WaitForSuccessPromptAsync(counter);
+
+        if (expectedPnpmWorkspaceContent is not null)
+        {
+            Assert.Equal(expectedPnpmWorkspaceContent, File.ReadAllText(pnpmWorkspacePath));
+        }
     }
 
     [Fact]
@@ -391,8 +415,11 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.WaitForAnyPromptAsync(counter);
     }
 
-    [Fact]
-    public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoInWorkspaceSubdirectory()
+    [Theory]
+    [InlineData("npm")]
+    [InlineData("yarn")]
+    [CaptureWorkspaceOnFailure]
+    public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoInWorkspaceSubdirectory(string toolchain)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -406,7 +433,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         // CLI's baked channel + ambient NuGet feeds.
         var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, mountDockerSocket: true, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, mountDockerSocket: true, workspace: workspace);
         string? originalDevScript = null;
         string? originalBuildScript = null;
         string? originalPreviewScript = null;
@@ -445,6 +472,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         // Capture original package.json scripts and tsconfig before aspire init
         var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "packages", "brownfield");
+        TypeScriptAppHostToolchainTestHelpers.SetPackageManager(projectRoot, toolchain, cleanInstallState: true);
         var packageJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectRoot, "package.json")))!.AsObject();
         var scripts = packageJson["scripts"]!.AsObject();
         originalDevScript = scripts["dev"]?.GetValue<string>();
@@ -483,8 +511,9 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         Assert.Equal(originalBuildScript, scripts["build"]?.GetValue<string>());
         Assert.Equal(originalPreviewScript, scripts["preview"]?.GetValue<string>());
         Assert.Equal("custom-apphost-start", scripts["aspire:start"]?.GetValue<string>());
-        Assert.Equal("npm --prefix aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
-        Assert.Equal("npm --prefix aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
+        var directoryOption = toolchain == "yarn" ? "--cwd" : "--prefix";
+        Assert.Equal($"{toolchain} {directoryOption} aspire-apphost run aspire:build", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal($"{toolchain} {directoryOption} aspire-apphost run aspire:dev", scripts["aspire:dev"]?.GetValue<string>());
         Assert.Equal(originalPackageType, packageJson["type"]?.GetValue<string>());
         Assert.False(scripts.ContainsKey("start"));
         var rootDependencies = packageJson["dependencies"]?.AsObject();
@@ -514,6 +543,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         Assert.NotNull(appHostDevDependencies["tsx"]);
         Assert.NotNull(appHostDevDependencies["typescript"]);
         Assert.True(File.Exists(Path.Combine(appHostDirectory, "tsconfig.apphost.json")));
+        Assert.True(File.Exists(Path.Combine(appHostDirectory, TypeScriptAppHostToolchainTestHelpers.GetLockFileName(toolchain))));
 
         // Verify Aspire.Hosting.JavaScript was pre-added in config
         var configPath = Path.Combine(projectRoot, "aspire.config.json");

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -415,6 +415,90 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.WaitForAnyPromptAsync(counter);
     }
 
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task InitTypeScriptAppHost_CreatesIsolatedPnpmWorkspaceInBrownfieldRepo()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, strategy,
+            ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);
+        var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, variant: CliE2ETestHelpers.DockerfileVariant.Polyglot, mountDockerSocket: true, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        var expectedRootPnpmWorkspaceContent = """
+            packages:
+              - packages/*
+            allowBuilds:
+              esbuild: true
+              protobufjs: true
+
+            """;
+        var rootPnpmWorkspacePath = Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-workspace.yaml");
+        File.WriteAllText(rootPnpmWorkspacePath, expectedRootPnpmWorkspaceContent);
+        File.WriteAllText(
+            Path.Combine(workspace.WorkspaceRoot.FullName, "package.json"),
+            """
+            {
+              "name": "workspace-root",
+              "private": true
+            }
+            """);
+
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "packages", "brownfield");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(
+            Path.Combine(projectRoot, "package.json"),
+            """
+            {
+              "name": "brownfield",
+              "private": true,
+              "type": "module",
+              "packageManager": "pnpm@11.5.2"
+            }
+            """);
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(projectRoot, localChannel.SdkVersion);
+        }
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.EnablePolyglotSupportAsync(counter);
+        await auto.RunCommandAsync("cd packages/brownfield", counter);
+
+        await auto.TypeAsync($"aspire init --language typescript --non-interactive{channelArgument}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created aspire-apphost/apphost.mts", timeout: TimeSpan.FromMinutes(3));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        var appHostDirectory = Path.Combine(projectRoot, "aspire-apphost");
+        Assert.Equal(expectedRootPnpmWorkspaceContent, File.ReadAllText(rootPnpmWorkspacePath));
+        Assert.Equal(
+            """
+            allowBuilds:
+              esbuild: true
+
+            """,
+            File.ReadAllText(Path.Combine(appHostDirectory, "pnpm-workspace.yaml")));
+        Assert.True(File.Exists(Path.Combine(appHostDirectory, "pnpm-lock.yaml")));
+
+        await auto.TypeAsync("aspire run");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Press CTRL+C to stop the AppHost and exit.", timeout: TimeSpan.FromMinutes(3));
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        Assert.Equal(expectedRootPnpmWorkspaceContent, File.ReadAllText(rootPnpmWorkspacePath));
+    }
+
     [Theory]
     [InlineData("npm")]
     [InlineData("yarn")]

--- a/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/TypeScriptAppHostToolchainResolverTests.cs
@@ -348,9 +348,10 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     [Fact]
     public void ApplyToRuntimeSpec_WhenBunSelected_UsesBunCommandsAndPreservesExtensionLaunch()
     {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var baseRuntimeSpec = CreateBaseRuntimeSpec();
 
-        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Bun);
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Bun, workspace.WorkspaceRoot);
 
         Assert.Equal("TypeScript (Bun)", runtimeSpec.DisplayName);
         Assert.NotNull(runtimeSpec.InstallDependencies);
@@ -382,9 +383,10 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     [Fact]
     public void ApplyToRuntimeSpec_WhenYarnSelected_UsesYarnExecCommands()
     {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var baseRuntimeSpec = CreateBaseRuntimeSpec();
 
-        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Yarn);
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Yarn, workspace.WorkspaceRoot);
 
         var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         Assert.Equal("yarn", preExecute.Command);
@@ -396,11 +398,12 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
-    public void ApplyToRuntimeSpec_WhenPnpmSelected_UsesPnpmTypeCheckCommands()
+    public void ApplyToRuntimeSpec_WhenPnpmSelectedOutsideWorkspace_UsesIsolatedInstallAndPnpmTypeCheckCommands()
     {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var baseRuntimeSpec = CreateBaseRuntimeSpec();
 
-        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Pnpm);
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Pnpm, workspace.WorkspaceRoot);
 
         var installDependencies = Assert.IsType<CommandSpec>(runtimeSpec.InstallDependencies);
         Assert.Equal("pnpm", installDependencies.Command);
@@ -415,11 +418,26 @@ public sealed class TypeScriptAppHostToolchainResolverTests(ITestOutputHelper ou
     }
 
     [Fact]
-    public void ApplyToRuntimeSpec_WhenDenoSelected_UsesDenoRunCommands()
+    public void ApplyToRuntimeSpec_WhenPnpmSelectedAtWorkspaceRoot_UsesWorkspaceInstall()
     {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, "pnpm-workspace.yaml"), "packages: []");
         var baseRuntimeSpec = CreateBaseRuntimeSpec();
 
-        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Deno);
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Pnpm, workspace.WorkspaceRoot);
+
+        var installDependencies = Assert.IsType<CommandSpec>(runtimeSpec.InstallDependencies);
+        Assert.Equal("pnpm", installDependencies.Command);
+        Assert.Equal(["install"], installDependencies.Args);
+    }
+
+    [Fact]
+    public void ApplyToRuntimeSpec_WhenDenoSelected_UsesDenoRunCommands()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var baseRuntimeSpec = CreateBaseRuntimeSpec();
+
+        var runtimeSpec = TypeScriptAppHostToolchainResolver.ApplyToRuntimeSpec(baseRuntimeSpec, TypeScriptAppHostToolchain.Deno, workspace.WorkspaceRoot);
 
         Assert.Equal("TypeScript (Deno)", runtimeSpec.DisplayName);
         Assert.Equal("deno", runtimeSpec.InstallDependencies?.Command);

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -125,6 +125,53 @@ public class ScaffoldingServiceTests
     }
 
     [Fact]
+    public void EnsureNestedBrownfieldTypeScriptToolchainFiles_WhenPnpmSelected_CreatesWorkspaceFile()
+    {
+        var appHostDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            ScaffoldingService.EnsureNestedBrownfieldTypeScriptToolchainFiles(
+                appHostDirectory,
+                TypeScriptAppHostToolchain.Pnpm);
+
+            Assert.Equal(
+                """
+                allowBuilds:
+                  esbuild: true
+
+                """,
+                File.ReadAllText(Path.Combine(appHostDirectory.FullName, "pnpm-workspace.yaml")));
+        }
+        finally
+        {
+            appHostDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnsureNestedBrownfieldTypeScriptToolchainFiles_WhenPnpmWorkspaceExists_PreservesContent()
+    {
+        var appHostDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var pnpmWorkspacePath = Path.Combine(appHostDirectory.FullName, "pnpm-workspace.yaml");
+            File.WriteAllText(pnpmWorkspacePath, "allowBuilds:\n  custom-package: true\n");
+
+            ScaffoldingService.EnsureNestedBrownfieldTypeScriptToolchainFiles(
+                appHostDirectory,
+                TypeScriptAppHostToolchain.Pnpm);
+
+            Assert.Equal("allowBuilds:\n  custom-package: true\n", File.ReadAllText(pnpmWorkspacePath));
+        }
+        finally
+        {
+            appHostDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void SerializePackageJson_PreservesTrailingNewLine_WhenOriginalHadOne()
     {
         var packageJson = JsonNode.Parse("""{ "scripts": { "aspire:start": "npm --prefix aspire-apphost run aspire:start" } }""")!.AsObject();

--- a/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/ScaffoldingServiceTests.cs
@@ -84,6 +84,47 @@ public class ScaffoldingServiceTests
     }
 
     [Fact]
+    public void EnsureNestedBrownfieldTypeScriptToolchainFiles_WhenYarnSelected_CreatesLockFile()
+    {
+        var appHostDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            ScaffoldingService.EnsureNestedBrownfieldTypeScriptToolchainFiles(
+                appHostDirectory,
+                TypeScriptAppHostToolchain.Yarn);
+
+            Assert.Equal(string.Empty, File.ReadAllText(Path.Combine(appHostDirectory.FullName, "yarn.lock")));
+        }
+        finally
+        {
+            appHostDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnsureNestedBrownfieldTypeScriptToolchainFiles_WhenYarnLockExists_PreservesContent()
+    {
+        var appHostDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var yarnLockPath = Path.Combine(appHostDirectory.FullName, "yarn.lock");
+            File.WriteAllText(yarnLockPath, "# existing lockfile");
+
+            ScaffoldingService.EnsureNestedBrownfieldTypeScriptToolchainFiles(
+                appHostDirectory,
+                TypeScriptAppHostToolchain.Yarn);
+
+            Assert.Equal("# existing lockfile", File.ReadAllText(yarnLockPath));
+        }
+        finally
+        {
+            appHostDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void SerializePackageJson_PreservesTrailingNewLine_WhenOriginalHadOne()
     {
         var packageJson = JsonNode.Parse("""{ "scripts": { "aspire:start": "npm --prefix aspire-apphost run aspire:start" } }""")!.AsObject();


### PR DESCRIPTION
## Description

TypeScript AppHosts at a pnpm workspace root currently install with `--ignore-workspace`. With pnpm 11, that can rewrite the user's `pnpm-workspace.yaml`, reset approved `allowBuilds` entries, ignore catalogs, and fail `aspire restore` or `aspire run`.

This change makes pnpm installation layout-aware: AppHosts that own `pnpm-workspace.yaml` use a normal workspace install, while Aspire-generated nested brownfield AppHosts retain the isolated install behavior. It also creates a local `yarn.lock` boundary for generated Yarn brownfield AppHosts so Yarn 4 treats them as independent projects instead of rejecting them as unlisted workspace members.

### User-facing behavior

Existing pnpm workspace configuration is preserved across:

```bash
aspire restore
aspire run
```

The TypeScript CLI E2E matrix now exercises pnpm 11 workspace approvals and Yarn 4 brownfield initialization. Targeted CLI unit tests and all seven affected E2E scenarios pass.

Fixes: #18012

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No