### PR TITLE
[Investigation] CI infrastructure failures — npm public-registry slowdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ You should evaluate whichever containers you chose to compose and automate with 
 ## License
 
 The code in this repo is licensed under the [MIT](LICENSE.TXT) license.
+

--- a/README.md
+++ b/README.md
@@ -111,4 +111,3 @@ You should evaluate whichever containers you chose to compose and automate with 
 ## License
 
 The code in this repo is licensed under the [MIT](LICENSE.TXT) license.
-

--- a/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting/TypeScript/apphost.mts
@@ -1081,3 +1081,4 @@ await container.withHttpCommand("/api/reset", "Reset", {
 
 const app = await builder.build();
 await app.run();
+


### PR DESCRIPTION
## Purpose

Whitespace-only commit to trigger CI so we can observe and diagnose current infrastructure failures.

**Not for merge.** Diagnostic vehicle only — no product code is changed.

## Conclusion

**This is an npm problem, not a NuGet problem.**

`npm install` against the public registry (`registry.npmjs.org`) has become drastically slow from CI runners — **~2m21s vs the normal ~4s** — so every Aspire path that shells out to `npm install` blows its 120s timeout. NuGet restore is healthy (1.1s in the same failing job) and there is **no evidence of a NuGet network-isolation lockdown**.

The decisive evidence is two `npm install` calls minutes apart inside the *same* CI container:

| Invocation | Registry | Duration |
|---|---|---|
| Docker global install (explicit `--registry`) | dnceng `dotnet-public-npm` mirror | **8s** ✅ |
| Guest AppHost install (default registry) | `registry.npmjs.org` | **2m21s** ⚠️ |
| Next guest install (default registry) | `registry.npmjs.org` | **killed at 120s**, exit 143 ❌ |

Generated apps are created outside the repo (`/tmp/...`), so they never inherit the repo's dnceng `.npmrc` and fall back to the public registry — which is why in-repo npm work (extension build, markdownlint) is unaffected while every generated TypeScript AppHost stalls.

Ruled out: NuGet isolation lockdown, an npm.js status-page incident (the only recent one was publish-only and resolved ~4h earlier), the Copilot agent firewall doc, and any repo regression in the window. `AzureSandboxes` is a separate, unrelated failure.

Full detail, log excerpts and the regression window are in the comments below, along with a correction on mitigation: the CLI **deliberately** pins the public registry (`NpmRunner.cs`, see #19370) because the private mirror 401s on unmirrored transitive dependencies — so redirecting to the mirror is not a safe fix.

## Verification

- Full deployment E2E run on `main`: [`33834532243`](https://github.com/microsoft/aspire/actions/runs/33834532243)
- This PR touches a TypeScript polyglot fixture so `job:polyglot` exercises the failing *TypeScript SDK Validation* job directly.
