### PR TITLE
Improve XML comments for CustomResourceSnapshot.HealthReports property

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -88,6 +88,7 @@ public sealed record CustomResourceSnapshot
     /// <remarks>
     /// May be zero or more. If there are no health reports, the resource is considered healthy
     /// so long as no heath checks are registered for the resource.
+    /// Use <see cref="CustomResourceSnapshotExtensions.WithHealthReports"/> to modify.
     /// </remarks>
     public ImmutableArray<HealthReportSnapshot> HealthReports
     {


### PR DESCRIPTION
Hint for CustomResourceSnapshot.HealthReports property updating mechanism.

## Description

HealthReports appears to be `internal init` without clear mechanism on how to update, but there is this extension that is only discoverable by browsing sources

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [n] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [n] No
