### PR TITLE
Hide UTC timestamps option when timestamps are disabled

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -761,13 +761,15 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 Icon = new Icons.Regular.Size16.CalendarClock()
             });
 
-            _logsMenuItems.Add(new()
+            if (_showTimestamp)
             {
-                OnClick = () => ToggleTimestampAsync(showTimestamp: _showTimestamp, isTimestampUtc: !_isTimestampUtc),
-                Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
-                Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
-                IsDisabled = !_showTimestamp
-            });
+                _logsMenuItems.Add(new()
+                {
+                    OnClick = () => ToggleTimestampAsync(showTimestamp: _showTimestamp, isTimestampUtc: !_isTimestampUtc),
+                    Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
+                    Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked()
+                });
+            }
 
             _logsMenuItems.Add(new()
             {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -140,6 +140,47 @@ public partial class ConsoleLogsTests
     }
 
     [Fact]
+    public async Task ConsoleLogs_TimestampDisabled_HidesUtcTimestampOption()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var terminalResource = CreateTerminalResource("test-resource", replicaIndex: 0, replicaCount: 1, state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [terminalResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "test-resource"));
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "test-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == terminalResource.Name);
+
+        // Switch to Console view so standard console log menu items are populated
+        await cut.InvokeAsync(() => instance.HandleViewChangedForTestAsync(nameof(ConsoleLogs.ConsoleLogsView.Console)));
+        cut.WaitForState(() => instance.ActiveViewForTest == ConsoleLogs.ConsoleLogsView.Console);
+
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.ConsoleLogs>>();
+        var utcText = loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)].Value;
+
+        // Timestamps are off by default: UTC timestamps option should be hidden
+        Assert.DoesNotContain(instance.LogsMenuItemsForTest, item => item.Text == utcText);
+    }
+
+    [Fact]
     public async Task TerminalResource_PausedConsoleLogs_DisplaysWarningOnTerminalView()
     {
         var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -140,47 +140,6 @@ public partial class ConsoleLogsTests
     }
 
     [Fact]
-    public async Task ConsoleLogs_TimestampDisabled_HidesUtcTimestampOption()
-    {
-        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
-        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
-        var terminalResource = CreateTerminalResource("test-resource", replicaIndex: 0, replicaCount: 1, state: KnownResourceState.Running);
-        var dashboardClient = new TestDashboardClient(
-            isEnabled: true,
-            consoleLogsChannelProvider: _ => consoleLogsChannel,
-            resourceChannelProvider: () => resourceChannel,
-            initialResources: [terminalResource]);
-
-        SetupConsoleLogsServices(dashboardClient);
-
-        var navigationManager = Services.GetRequiredService<NavigationManager>();
-        navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "test-resource"));
-
-        var dimensionManager = Services.GetRequiredService<DimensionManager>();
-        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
-        dimensionManager.InvokeOnViewportInformationChanged(viewport);
-
-        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
-        {
-            builder.Add(p => p.ResourceName, "test-resource");
-            builder.Add(p => p.ViewportInformation, viewport);
-        });
-
-        var instance = cut.Instance;
-        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == terminalResource.Name);
-
-        // Switch to Console view so standard console log menu items are populated
-        await cut.InvokeAsync(() => instance.HandleViewChangedForTestAsync(nameof(ConsoleLogs.ConsoleLogsView.Console)));
-        cut.WaitForState(() => instance.ActiveViewForTest == ConsoleLogs.ConsoleLogsView.Console);
-
-        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.ConsoleLogs>>();
-        var utcText = loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)].Value;
-
-        // Timestamps are off by default: UTC timestamps option should be hidden
-        Assert.DoesNotContain(instance.LogsMenuItemsForTest, item => item.Text == utcText);
-    }
-
-    [Fact]
     public async Task TerminalResource_PausedConsoleLogs_DisplaysWarningOnTerminalView()
     {
         var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -1107,6 +1107,50 @@ public partial class ConsoleLogsTests : DashboardTestContext
         }
     }
 
+    [Fact]
+    public async Task ConsoleLogs_TimestampVisibility_TogglesUtcTimestampOption()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var viewport = CreateViewport(isDesktop: true);
+        var cut = RenderConsoleLogsPage(viewport, testResource.Name);
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+        var showTimestampText = loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShow)].Value;
+        var hideTimestampText = loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampHide)].Value;
+        var utcText = loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)].Value;
+
+        // Timestamps are off by default: UTC timestamps option should be hidden
+        Assert.DoesNotContain(instance.LogsMenuItemsForTest, item => item.Text == utcText);
+
+        // Toggle "Show timestamps"
+        var showItem = Assert.Single(instance.LogsMenuItemsForTest, item => item.Text == showTimestampText);
+        Assert.NotNull(showItem.OnClick);
+        await cut.InvokeAsync(showItem.OnClick);
+
+        // UTC timestamps option should now be visible
+        Assert.Contains(instance.LogsMenuItemsForTest, item => item.Text == utcText);
+
+        // Toggle "Hide timestamps"
+        var hideItem = Assert.Single(instance.LogsMenuItemsForTest, item => item.Text == hideTimestampText);
+        Assert.NotNull(hideItem.OnClick);
+        await cut.InvokeAsync(hideItem.OnClick);
+
+        // UTC timestamps option should be hidden again
+        Assert.DoesNotContain(instance.LogsMenuItemsForTest, item => item.Text == utcText);
+    }
+
     private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null, IResourceRepository? resourceRepository = null)
     {
         FluentUISetupHelpers.SetupFluentDialogProvider(this);


### PR DESCRIPTION
## Description

On the Console Logs page, the options menu previously showed the `UTC timestamps` option as a disabled checkbox even when `Show timestamps` was turned off. This caused visual confusion (resembling a checkbox or broken glyph rather than an inactive setting).

This PR conditionally renders the `UTC timestamps` option only when `_showTimestamp` is `true`. When timestamps are turned off, the option is cleanly hidden from the menu.

Fixes #19019

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No