### PR TITLE
Disable npm audit for TypeScript AppHost installs

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -258,7 +258,10 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             InstallDependencies = new CommandSpec
             {
                 Command = "npm",
-                Args = ["install"]
+                // npm's automatic audit request is unrelated to installing the AppHost dependencies and
+                // can stall the entire Aspire command when the advisory service is unavailable.
+                // https://docs.npmjs.com/cli/v11/commands/npm-install#audit
+                Args = ["install", "--no-audit"]
             },
             PreExecute =
             [

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -251,11 +251,14 @@ public sealed class TypeScriptLanguageSupportTests(ITestOutputHelper outputHelpe
     public void GetRuntimeSpec_UsesAppHostSpecificTsConfig()
     {
         var runtimeSpec = _languageSupport.GetRuntimeSpec();
+        var installDependencies = Assert.IsType<CommandSpec>(runtimeSpec.InstallDependencies);
         var preExecute = Assert.Single(runtimeSpec.PreExecute!);
         var watchExecute = Assert.IsType<CommandSpec>(runtimeSpec.WatchExecute);
 
         Assert.Equal("NODE_EXTRA_CA_CERTS", _languageSupport.CertificateBundleEnvironmentVariable);
         Assert.Equal(_languageSupport.CertificateBundleEnvironmentVariable, runtimeSpec.CertificateBundleEnvironmentVariable);
+        Assert.Equal("npm", installDependencies.Command);
+        Assert.Equal(["install", "--no-audit"], installDependencies.Args);
         Assert.Equal("npx", preExecute.Command);
         Assert.Equal(new[] { "--no-install", "tsc", "--noEmit", "-p", "tsconfig.apphost.json" }, preExecute.Args);
         Assert.Equal(new[] { "--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);


### PR DESCRIPTION
## Description

TypeScript deployment tests can time out when npm's advisory service stalls because Aspire's automatic dependency installation enables npm audit by default. npm 10 first calls the bulk advisory endpoint and can fall back to the retired quick endpoint when that request fails, making an otherwise successful install depend on an unrelated service.

Run Aspire-managed TypeScript AppHost installs as `npm install --no-audit`. This preserves dependency installation while avoiding the advisory request during implicit CLI operations. Users can still run `npm audit` explicitly when they want a vulnerability report.

The TypeScript runtime-spec test now verifies the exact npm command.

Fixes: #19927

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No