### PR TITLE
[experiment] Simplify exported-surface test routing

### DIFF
--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -195,20 +195,11 @@ path_rules:
     reason: vitest over generated TS SDK; ts-starter is a narrow sub-path of Aspire.Cli, not the whole project
   - paths:
       - src/**/*.tscompat.suppression.txt
+      - src/Aspire.Hosting*/api/*.ats.txt
       - tools/TypeScriptApiCompat/**
       - .github/workflows/typescript-api-compat.yml
     targets: [job:typescript-api-compat]
-    reason: checked-in suppression baselines are not compiled items (Layer 1 blind); Hosting/Cli production projects are in affected_project_rules
-  # A checked-in *.ats.txt baseline changes EXACTLY when an integration's [AspireExport] surface
-  # changes -- the same surface the per-language polyglot playground scripts regenerate and compile
-  # (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). So an exported-surface
-  # change must run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate+compile in every
-  # language), even when the author has not also touched the tests/PolyglotAppHosts fixtures. The baseline
-  # is not a compiled item, so Layer 1 is blind to it and these targets must be enumerated here.
-  - paths:
-      - src/Aspire.Hosting*/api/*.ats.txt
-    targets: [job:typescript-api-compat, job:polyglot]
-    reason: an integration's *.ats.txt baseline tracks its exported ATS surface; the polyglot playground regenerates+compiles that surface per language, so a baseline change must run polyglot too
+    reason: checked-in suppression and exported-surface baselines are not compiled items (Layer 1 blind); Hosting/Cli production projects are in affected_project_rules
   - paths:
       - extension/**
       - .vscode/launch.json

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -502,6 +502,15 @@ public sealed class TestTriggerMapTests
         Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
     }
 
+    [Fact]
+    public void ExportedSurfaceBaselineSelectsAtLeastOneTarget()
+    {
+        var result = SelectWithRealMap("src/Aspire.Hosting.Redis/api/Aspire.Hosting.Redis.ats.txt");
+        var selectedTargets = result.TestProjects.Select(name => $"test:{name}").Concat(result.Jobs);
+
+        Assert.NotEmpty(selectedTargets);
+    }
+
     [Theory]
     [InlineData(".gitattributes")]
     [InlineData("eng/scripts/gha-testreport.ps1")]


### PR DESCRIPTION
Validation-only draft for exercising repository-local code-review guidance. This change is intentionally isolated and will not be merged.
