### PR TITLE
Honor selected launch profile in bundled dotnet run

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -1553,7 +1553,11 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
             KillOnParentExit = true,
             GracefulShutdownSignaler = _gracefulShutdownSignaler,
             ShutdownService = _shutdownService,
-            LaunchProfile = context.LaunchProfile,
+            // The bundled AppHost run hook delegates dotnet run to aspire run. The SDK passes
+            // its selected profile through DOTNET_LAUNCH_PROFILE rather than a CLI argument.
+            // Preserve that selection for both direct launch and the dotnet run fallback,
+            // while allowing an explicit Aspire CLI option to take precedence.
+            LaunchProfile = context.LaunchProfile ?? GetEffectiveEnvironmentValue(env, "DOTNET_LAUNCH_PROFILE"),
             ExtensionAppHostLaunchCompletedAsync = deferBuildCompletion
                 ? () =>
                 {

--- a/tests/Aspire.Cli.EndToEnd.Tests/LaunchProfileTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LaunchProfileTests.cs
@@ -15,8 +15,10 @@ namespace Aspire.Cli.EndToEnd.Tests;
 public sealed class LaunchProfileTests(ITestOutputHelper output)
 {
     [CaptureWorkspaceOnFailure]
-    [Fact]
-    public async Task RunStartsAppHostWithSelectedLaunchProfile()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunStartsAppHostWithSelectedLaunchProfile(bool useDotNetRun)
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -50,7 +52,7 @@ public sealed class LaunchProfileTests(ITestOutputHelper output)
             $$"""
             File.WriteAllText(
                 {{JsonSerializer.Serialize(containerProfileOutputPath)}},
-                $"{Environment.GetEnvironmentVariable("SELECTED_PROFILE")}|{Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")}|{string.Join("|", args)}");
+                $"{Environment.GetEnvironmentVariable("SELECTED_PROFILE")}|{Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE")}|{string.Join("|", args)}|{Environment.GetEnvironmentVariable("ASPNETCORE_URLS")}");
 
             var builder = DistributedApplication.CreateBuilder(args);
 
@@ -73,9 +75,11 @@ public sealed class LaunchProfileTests(ITestOutputHelper output)
                 },
                 "E2E": {
                   "commandName": "Project",
+                  "applicationUrl": "http://127.0.0.1:0",
                   "commandLineArgs": "--profile-argument selected-profile",
                   "environmentVariables": {
-                    "SELECTED_PROFILE": "selected-profile"
+                    "SELECTED_PROFILE": "selected-profile",
+                    "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
                   }
                 }
               }
@@ -83,7 +87,12 @@ public sealed class LaunchProfileTests(ITestOutputHelper output)
             """);
 
         await auto.RunCommandAsync("cd LaunchProfile.AppHost", counter);
-        await auto.TypeAsync(CliE2EAutomatorHelpers.GetAspireRunCommand("--launch-profile E2E"));
+        // Exercise the SDK's bundle delegation as well as an explicit Aspire CLI option.
+        // dotnet run passes the selected profile to the CLI through its environment.
+        var runCommand = useDotNetRun
+            ? $"ASPIRE_CLI_START_TIMEOUT={CliE2EAutomatorHelpers.AspireRunStartupBudgetSeconds} dotnet run --launch-profile E2E /p:AspireUseCliBundle=true"
+            : CliE2EAutomatorHelpers.GetAspireRunCommand("--launch-profile E2E");
+        await auto.TypeAsync(runCommand);
         await auto.EnterAsync();
 
         await auto.WaitUntilAsync(
@@ -95,6 +104,6 @@ public sealed class LaunchProfileTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter);
 
         Assert.True(File.Exists(profileOutputPath), $"Expected AppHost to write selected profile details to: {profileOutputPath}");
-        Assert.Equal("selected-profile|E2E|--profile-argument|selected-profile", File.ReadAllText(profileOutputPath));
+        Assert.Equal("selected-profile|E2E|--profile-argument|selected-profile|http://127.0.0.1:0", File.ReadAllText(profileOutputPath));
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -1174,8 +1174,80 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         Assert.Equal(125, exitCode);
     }
 
-    [Fact]
-    public async Task RunAsync_ProjectAppHostMissingSelectedLaunchProfileFallsBackWithoutSelectingDefault()
+    [Theory]
+    [InlineData(null, null, "http", "http")]
+    [InlineData(null, "http", "https", "http")]
+    [InlineData("https", null, "http", "https")]
+    [InlineData(null, null, null, "https")]
+    [InlineData(null, null, "", "https")]
+    public async Task RunAsync_ProjectAppHostDirectLaunchHonorsLaunchProfileEnvironment(
+        string? explicitProfile, string? contextProfile, string? inheritedProfile, string expectedProfile)
+    {
+        var appHostFile = CreateProjectAppHost();
+        var appHostCommand = CreateBuiltAppHostCommand("AppHost");
+        Directory.CreateDirectory(Path.Combine(appHostFile.DirectoryName!, "Properties"));
+        File.WriteAllText(Path.Combine(appHostFile.DirectoryName!, "Properties", "launchSettings.json"), """
+            {
+              "profiles": {
+                "https": {
+                  "commandName": "Project",
+                  "applicationUrl": "https://localhost:15000",
+                  "environmentVariables": { "SELECTED_PROFILE": "https" }
+                },
+                "http": {
+                  "commandName": "Project",
+                  "applicationUrl": "http://localhost:16000",
+                  "environmentVariables": { "SELECTED_PROFILE": "http" }
+                }
+              }
+            }
+            """);
+
+        var runner = new TestDotNetCliRunner
+        {
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) => (0, CreateAppHostInfoJson(runCommand: appHostCommand.FullName)),
+            RunAsyncCallback = (_, _, _, _, _, _, _, _, _) => throw new InvalidOperationException("A Project launch profile should use direct launch."),
+            RunAppHostCommandAsyncCallback = (_, command, _, args, env, _, _, _) =>
+            {
+                Assert.Equal(appHostCommand.FullName, command);
+                Assert.Equal(["--custom", "value"], args);
+                Assert.NotNull(env);
+                Assert.Equal(expectedProfile, env["DOTNET_LAUNCH_PROFILE"]);
+                Assert.Equal(expectedProfile, env["SELECTED_PROFILE"]);
+                Assert.Equal(expectedProfile == "http" ? "http://localhost:16000" : "https://localhost:15000", env[KnownAspNetCoreConfigNames.Urls]);
+                return Task.FromResult(125);
+            }
+        };
+        // dotnet run sets DOTNET_LAUNCH_PROFILE on the Aspire CLI process when the bundle
+        // hook delegates the launch. Keep that inherited state isolated from the test process.
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["DOTNET_LAUNCH_PROFILE"] = inheritedProfile
+        });
+        var project = CreateDotNetAppHostProject(runner, environment: environment);
+        var contextEnvironment = new Dictionary<string, string>();
+        if (contextProfile is not null)
+        {
+            contextEnvironment["DOTNET_LAUNCH_PROFILE"] = contextProfile;
+        }
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            LaunchProfile = explicitProfile,
+            NoBuild = true,
+            UnmatchedTokens = ["--custom", "value"],
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = contextEnvironment
+        }, CancellationToken.None);
+
+        Assert.Equal(125, exitCode);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunAsync_ProjectAppHostMissingSelectedLaunchProfileFallsBackWithoutSelectingDefault(bool inheritedProfile)
     {
         var appHostFile = CreateProjectAppHost();
         var appHostCommand = CreateBuiltAppHostCommand("AppHost");
@@ -1199,7 +1271,11 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) => (0, CreateAppHostInfoJson(runCommand: appHostCommand.FullName)),
             RunAppHostCommandAsyncCallback = (_, _, _, _, _, _, _, _) => throw new InvalidOperationException("direct launch should not substitute the default profile.")
         };
-        var project = CreateDotNetAppHostProject(runner);
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["DOTNET_LAUNCH_PROFILE"] = inheritedProfile ? "missing" : null
+        });
+        var project = CreateDotNetAppHostProject(runner, environment: environment);
 
         runner.RunAsyncCallback = (_, watch, noBuild, noRestore, args, env, _, options, _) =>
         {
@@ -1216,7 +1292,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         var exitCode = await project.RunAsync(new AppHostProjectContext
         {
             AppHostFile = appHostFile,
-            LaunchProfile = "missing",
+            LaunchProfile = inheritedProfile ? null : "missing",
             NoBuild = false,
             NoRestore = false,
             WorkingDirectory = _workspace.WorkspaceRoot,


### PR DESCRIPTION
## Description

With CLI bundles enabled, `dotnet run --launch-profile http` delegates to `aspire run`. The .NET SDK passes the selected profile through `DOTNET_LAUNCH_PROFILE`, but the Aspire launcher ignored it and selected the first profile again.

Use the effective `DOTNET_LAUNCH_PROFILE` value when no explicit Aspire launch-profile option is provided. This preserves the selection for both direct AppHost launch and the fallback to `dotnet run`; an explicit `--launch-profile` still takes precedence.

Fixes #19867

## Validation

- Reproduced three failing regression cases before the fix: inherited selection, context environment selection, and a missing inherited profile silently falling back to the default.
- AppHost launcher unit tests: 154 passed, 1 skipped because the local filesystem is case-insensitive.
- Full build and package generation: passed with no warnings or errors.
- Both `LaunchProfileTests` end-to-end cases passed in Linux ARM64 Docker containers using a locally built CLI bundle. They run `aspire run --launch-profile E2E` and `dotnet run --launch-profile E2E /p:AspireUseCliBundle=true`, asserting the profile name, environment, application URL, and arguments observed by the running AppHost.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
