### PR TITLE
Add a simple single-member MongoDB replica set path

### DIFF
--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -81,7 +81,8 @@ public static class MongoDBBuilderExtensions
                 name: healthCheckKey,
                 clientFactory: sp => client ??= new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable")),
                 // NOTE: Without a database as the target of the healthcheck, the healthcheck runs a `listDatabases` command against the Mongo server. This is problematic in cases where the Mongo server is a replica set secondary node, because during the phase in which the replica set is being initialized, the secondary node will return an error when `listDatabases` is called. To avoid this, we specify a database to use for the healthcheck. The healthcheck will then run a `ping` command against the specified database instead of `listDatabases`, which works even on a secondary node during replica set initialization.
-                databaseNameFactory: _ => mongoServerResource.Databases.Values.FirstOrDefault(defaultValue: MongoDBServerResource.DefaultAuthenticationDatabase)
+                databaseNameFactory: _ => mongoServerResource.Databases.Values.FirstOrDefault(defaultValue: MongoDBServerResource.DefaultAuthenticationDatabase),
+                singleMemberReplicaSetFactory: _ => mongoServerResource.TryGetLastAnnotation<MongoDBSingleMemberReplicaSetAnnotation>(out var replicaSet) ? replicaSet : null
             );
 
         var mongoBuilder = builder
@@ -369,32 +370,85 @@ public static class MongoDBBuilderExtensions
     }
 
     /// <summary>
-    /// Annotates a MongoDB server resource as a member of a replica set with the specified name. This will configure the necessary command line arguments on the MongoDB container to initialize it as a member of the replica set.
+    /// Configures and initializes the MongoDB server as a single-member replica set for local development.
     /// </summary>
     /// <remarks>
-    /// This method will normally be called by the replica set resource builder when you add a MongoDB server resource as a member of the replica set using <see cref="MongoDBReplicaSetBuilderExtensions.WithMember(IResourceBuilder{MongoDBReplicaSetResource}, IResourceBuilder{MongoDBServerResource})"/>. It can also be called directly if you are looking for lower-level control.
+    /// <para>
+    /// Enables transactions and change streams without changing database resources or references. The server becomes
+    /// healthy only after initialization and primary election. Connections use the server's normal endpoint directly;
+    /// a developer certificate, topology discovery, and fixed host ports are not required.
+    /// </para>
+    /// <para>
+    /// A key file is generated for authentication unless <see cref="WithKeyFile"/> was called first.
+    /// Existing single-member data is reused without reconfiguration. Keep the set name and credentials unchanged when
+    /// reusing a data volume. Publishing and deploying this configuration are not supported.
+    /// </para>
+    /// <para>
+    /// Unlike the previous low-level behavior of this experimental method, this method initializes the set.
+    /// For multiple members, use <see cref="MongoDBReplicaSetBuilderExtensions.AddMongoDBReplicaSet"/> and
+    /// <see cref="MongoDBReplicaSetBuilderExtensions.WithMember"/> instead, without calling this method on the members.
+    /// </para>
     /// </remarks>
     /// <param name="builder">The MongoDB server resource builder.</param>
-    /// <param name="name">The name of the replica set the server is a member of.</param>
+    /// <param name="name">The replica set name. Defaults to the resource name, or the name previously configured by this method.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
+    /// <exception cref="ArgumentNullException">The builder is null.</exception>
+    /// <exception cref="ArgumentException">The name is empty or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">The server is configured for a different set or for advanced membership.</exception>
+    /// <exception cref="NotSupportedException">The application is running in publish mode.</exception>
+    /// <example>
+    /// <code lang="csharp">
+    /// var mongo = builder.AddMongoDB("mongo").WithReplicaSet();
+    /// var database = mongo.AddDatabase("orders");
+    /// builder.AddProject&lt;Projects.Api&gt;("api").WithReference(database).WaitFor(database);
+    /// </code>
+    /// </example>
     [AspireExport]
     [Experimental("ASPIREMONGODB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    public static IResourceBuilder<MongoDBServerResource> WithReplicaSet(this IResourceBuilder<MongoDBServerResource> builder, string name)
+    public static IResourceBuilder<MongoDBServerResource> WithReplicaSet(this IResourceBuilder<MongoDBServerResource> builder, string? name = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentException.ThrowIfNullOrEmpty(name);
+        name ??= builder.Resource.ReplicaSetName ?? builder.Resource.Name;
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ThrowIfPublishMode(builder.ApplicationBuilder, nameof(WithReplicaSet));
 
-        // NOTE: `mongod` refuses to start when `--replSet` is given more than once, so calling this twice has to either be
-        // a no-op or an error rather than appending a second option.
         if (builder.Resource.ReplicaSetName is { } existingName)
         {
-            return string.Equals(existingName, name, StringComparisons.ResourceName)
+            if (!builder.Resource.HasAnnotationOfType<MongoDBSingleMemberReplicaSetAnnotation>())
+            {
+                throw new InvalidOperationException($"The MongoDB server resource '{builder.Resource.Name}' belongs to the advanced replica set '{existingName}'. Configure it with WithMember instead of WithReplicaSet.");
+            }
+
+            return string.Equals(existingName, name, StringComparison.Ordinal)
                 ? builder
                 : throw new InvalidOperationException($"The MongoDB server resource '{builder.Resource.Name}' is already configured as a member of the replica set '{existingName}' and cannot also be a member of '{name}'.");
         }
 
+        if (!builder.Resource.HasAnnotationOfType<MongoDBServerKeyFileAnnotation>())
+        {
+            builder.WithKeyFile(CreateReplicaSetKeyFile(builder.ApplicationBuilder, builder.Resource.Name));
+        }
+
+        var annotation = new MongoDBSingleMemberReplicaSetAnnotation(name);
+        return ConfigureReplicaSetMember(builder, name)
+            .WithAnnotation(annotation)
+            .OnInitializeResource((resource, evt, ct) => MongoDBSingleMemberReplicaSet.InitializeAsync(resource, annotation, evt, ct));
+    }
+
+    internal static ParameterResource CreateReplicaSetKeyFile(IDistributedApplicationBuilder builder, string name) =>
+        ParameterResourceBuilderExtensions.CreateGeneratedParameter(builder, $"{name}-keyfile-content", secret: true,
+            new GenerateParameterDefault
+            {
+                // MongoDB key files require 6-1024 base64 characters:
+                // https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set-with-keyfile-access-control/#create-a-keyfile
+                MinLength = 512,
+                Special = false,
+            });
+
+    // Only configures mongod. The single-member initializer and the advanced facade own their respective initialization.
+    internal static IResourceBuilder<MongoDBServerResource> ConfigureReplicaSetMember(IResourceBuilder<MongoDBServerResource> builder, string name)
+    {
         builder.Resource.ReplicaSetName = name;
         return builder
             .WithAnnotation(new MongoDBServerReplicaSetAnnotation(name))
@@ -677,6 +731,7 @@ internal static class MyMongoDbHealthCheckBuilderExtensions
 
     public static IHealthChecksBuilder AddMyMongoDb(
         this IHealthChecksBuilder builder,
+        Func<IServiceProvider, MongoDBSingleMemberReplicaSetAnnotation?> singleMemberReplicaSetFactory,
         Func<IServiceProvider, IMongoClient>? clientFactory = default,
         Func<IServiceProvider, string>? databaseNameFactory = default,
         string? name = default,
@@ -686,18 +741,18 @@ internal static class MyMongoDbHealthCheckBuilderExtensions
     {
         return builder.Add(new HealthCheckRegistration(
             name ?? NAME,
-            sp => Factory(sp, clientFactory, databaseNameFactory),
+            sp => Factory(sp, clientFactory, databaseNameFactory, singleMemberReplicaSetFactory),
             failureStatus,
             tags,
             timeout));
 
-        static MyMongoDbHealthCheck Factory(IServiceProvider sp, Func<IServiceProvider, IMongoClient>? clientFactory, Func<IServiceProvider, string>? databaseNameFactory)
+        static MyMongoDbHealthCheck Factory(IServiceProvider sp, Func<IServiceProvider, IMongoClient>? clientFactory, Func<IServiceProvider, string>? databaseNameFactory, Func<IServiceProvider, MongoDBSingleMemberReplicaSetAnnotation?> singleMemberReplicaSetFactory)
         {
             // The user might have registered a factory for MongoClient type, but not for the abstraction (IMongoClient).
             // That is why we try to resolve MongoClient first.
             IMongoClient client = clientFactory?.Invoke(sp) ?? sp.GetService<MongoClient>() ?? sp.GetRequiredService<IMongoClient>();
             string? databaseName = databaseNameFactory?.Invoke(sp);
-            return new(client, databaseName);
+            return new(client, databaseName, singleMemberReplicaSetFactory(sp));
         }
     }
 }
@@ -715,11 +770,13 @@ internal class MyMongoDbHealthCheck : IHealthCheck
     private static readonly Lazy<BsonDocumentCommand<BsonDocument>> s_command = new(() => new(BsonDocument.Parse("{ping:1}")));
     private readonly IMongoClient _client;
     private readonly string? _specifiedDatabase;
+    private readonly MongoDBSingleMemberReplicaSetAnnotation? _singleMemberReplicaSet;
 
-    public MyMongoDbHealthCheck(IMongoClient client, string? databaseName = default)
+    public MyMongoDbHealthCheck(IMongoClient client, string? databaseName, MongoDBSingleMemberReplicaSetAnnotation? singleMemberReplicaSet)
     {
         _client = client;
         _specifiedDatabase = databaseName;
+        _singleMemberReplicaSet = singleMemberReplicaSet;
     }
 
     /// <inheritdoc />
@@ -727,6 +784,22 @@ internal class MyMongoDbHealthCheck : IHealthCheck
     {
         try
         {
+            if (_singleMemberReplicaSet is { } replicaSet)
+            {
+                if (replicaSet.InitializationError is { } error)
+                {
+                    return HealthCheckResult.Unhealthy(error);
+                }
+
+                var status = await _client.GetDatabase(MongoDBServerResource.DefaultAuthenticationDatabase)
+                    .RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetStatus", 1), ReadPreference.Nearest, cancellationToken)
+                    .ConfigureAwait(false);
+
+                return MongoDBSingleMemberReplicaSet.IsPrimary(status, replicaSet.Name)
+                    ? HealthCheckResult.Healthy()
+                    : HealthCheckResult.Unhealthy($"MongoDB replica set '{replicaSet.Name}' is not a writable single-member primary.");
+            }
+
             if (!string.IsNullOrEmpty(_specifiedDatabase))
             {
                 // some users can't list all databases depending on database privileges, with

--- a/src/Aspire.Hosting.MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBServerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.MongoDB;
 
 #pragma warning disable ASPIREMONGODB001
 
@@ -165,8 +166,13 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
             builder.AppendLiteral(PasswordParameter is not null ? "&" : "?");
             // NOTE: This is necessary when connecting to a single node that happens to be part of the replica set. Otherwise, the driver will attempt to discover other nodes in the replica set, and this would most notably fail upon attempting to `rs.initialize` since the replica set is not fully initialized at that point.
             builder.AppendLiteral("directConnection=true");
-            // NOTE: The default read preference is "primary", which means that even though we have set `directConnection` to `true`, any read operation run against individual nodes (which is what this connection string should enable, including for complex healthchecks, for example) would be rejected by the server. The way to resolve that is to set the read preference to either `secondaryPreferred`, which we do here for that reason. See https://www.mongodb.com/docs/manual/core/read-preference-use-cases/#indications-to-use-non-primary-read-preference
-            builder.AppendLiteral("&readPreference=secondaryPreferred");
+            if (!this.HasAnnotationOfType<MongoDBSingleMemberReplicaSetAnnotation>())
+            {
+                // Advanced members can be secondaries. The simple single-member path keeps the default primary
+                // preference, which transactions require.
+                // https://www.mongodb.com/docs/manual/core/read-preference-use-cases/#indications-to-use-non-primary-read-preference
+                builder.AppendLiteral("&readPreference=secondaryPreferred");
+            }
         }
 
         // NOTE: TLS is turned on lazily (at `BeforeStartEvent` time, once a certificate is known to be available for this

--- a/src/Aspire.Hosting.MongoDB/MongoDBSingleMemberReplicaSet.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBSingleMemberReplicaSet.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+#pragma warning disable ASPIREMONGODB001
+
+namespace Aspire.Hosting.MongoDB;
+
+internal sealed class MongoDBSingleMemberReplicaSetAnnotation(string name) : IResourceAnnotation
+{
+    public string Name { get; } = name;
+
+    // Initialization and health polling run concurrently. Null means initialization and election succeeded.
+    public volatile string? InitializationError = "The single-member replica set has not been initialized.";
+}
+
+internal static class MongoDBSingleMemberReplicaSet
+{
+    internal static async Task InitializeAsync(
+        MongoDBServerResource resource,
+        MongoDBSingleMemberReplicaSetAnnotation annotation,
+        InitializeResourceEvent evt,
+        CancellationToken cancellationToken)
+    {
+        using var stopping = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, evt.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping);
+
+        try
+        {
+            var wasRunning = false;
+            // InitializeResourceEvent is dispatched non-blocking, so waiting for Running does not block container
+            // startup. ResourceReadyEvent would deadlock: primary election is a prerequisite for this resource's health.
+            // Observe start transitions too, so restarting a failed or recreated container retries initialization.
+            await foreach (var update in evt.Notifications.WatchAsync(stopping.Token).ConfigureAwait(false))
+            {
+                if (update.Resource != resource)
+                {
+                    continue;
+                }
+
+                var isRunning = update.Snapshot.State?.Text == KnownResourceStates.Running;
+                if (isRunning && !wasRunning)
+                {
+                    annotation.InitializationError = "Waiting for single-member replica set initialization and primary election.";
+                    using var timeout = CancellationTokenSource.CreateLinkedTokenSource(stopping.Token);
+                    timeout.CancelAfter(TimeSpan.FromSeconds(90));
+
+                    try
+                    {
+                        var connectionString = await resource.ConnectionStringExpression.GetValueAsync(timeout.Token).ConfigureAwait(false)
+                            ?? throw new DistributedApplicationException($"The connection string for MongoDB resource '{resource.Name}' is unavailable.");
+                        var settings = MongoClientSettings.FromConnectionString(connectionString);
+                        settings.ServerSelectionTimeout = TimeSpan.FromSeconds(2);
+                        settings.ConnectTimeout = TimeSpan.FromSeconds(2);
+                        using var client = new MongoClient(settings);
+                        var database = client.GetDatabase(MongoDBServerResource.DefaultAuthenticationDatabase);
+
+                        // Loopback is stable across container and AppHost restarts, including random host-port changes.
+                        // Clients use directConnection=true and never try to discover or connect to this internal address.
+                        var host = $"localhost:{resource.PrimaryEndpoint.TargetPort}";
+                        await InitializeAndWaitForPrimaryAsync(database, annotation.Name, host, timeout.Token).ConfigureAwait(false);
+                        annotation.InitializationError = null;
+                        evt.Logger.LogInformation("MongoDB resource '{ResourceName}' is the primary of single-member replica set '{ReplicaSetName}'.", resource.Name, annotation.Name);
+                    }
+                    catch (OperationCanceledException) when (!stopping.IsCancellationRequested)
+                    {
+                        annotation.InitializationError = $"MongoDB resource '{resource.Name}' did not initialize replica set '{annotation.Name}' and elect a primary within 90 seconds. Check the container logs, credentials, and existing data volume, then restart the resource.";
+                        evt.Logger.LogError("{Message}", annotation.InitializationError);
+                    }
+                    catch (Exception ex) when (ex is MongoException or TimeoutException or DistributedApplicationException)
+                    {
+                        annotation.InitializationError = $"MongoDB resource '{resource.Name}' could not initialize replica set '{annotation.Name}'. Check the container logs and ensure the data volume belongs to this single-member set and uses the configured credentials.";
+                        evt.Logger.LogError(ex, "{Message}", annotation.InitializationError);
+                    }
+                }
+
+                wasRunning = isRunning;
+            }
+        }
+        catch (OperationCanceledException) when (stopping.IsCancellationRequested)
+        {
+            // AppHost shutdown cancels both the notification watch and any in-flight MongoDB command.
+        }
+    }
+
+    internal static async Task InitializeAndWaitForPrimaryAsync(IMongoDatabase database, string name, string host, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                BsonDocument config;
+                try
+                {
+                    var result = await database.RunCommandAsync<BsonDocument>(
+                        new BsonDocument("replSetGetConfig", 1), ReadPreference.Nearest, cancellationToken).ConfigureAwait(false);
+                    config = result["config"].AsBsonDocument;
+                }
+                catch (MongoCommandException ex) when (ex.CodeName == "NotYetInitialized")
+                {
+                    // The official image creates the authenticated root user using a temporary standalone mongod.
+                    // Initiation must target the final server, not an init script against that temporary process.
+                    // https://github.com/docker-library/mongo/blob/master/docker-entrypoint.sh
+                    await database.RunCommandAsync<BsonDocument>(
+                        new BsonDocument("replSetInitiate", new BsonDocument
+                        {
+                            ["_id"] = name,
+                            ["members"] = new BsonArray { new BsonDocument { ["_id"] = 0, ["host"] = host } },
+                        }), ReadPreference.Nearest, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                ValidateConfiguration(config, name, host);
+                var status = await database.RunCommandAsync<BsonDocument>(
+                    new BsonDocument("replSetGetStatus", 1), ReadPreference.Nearest, cancellationToken).ConfigureAwait(false);
+                if (IsPrimary(status, name))
+                {
+                    return;
+                }
+            }
+            catch (MongoCommandException ex) when (ex.CodeName == "AlreadyInitialized")
+            {
+                // Another initializer won the race. Read and validate its configuration; never force a reconfiguration.
+            }
+            catch (Exception ex) when (ex is MongoConnectionException or TimeoutException)
+            {
+                // Running means the container started, not that mongod is already accepting authenticated commands.
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal static void ValidateConfiguration(BsonDocument config, string name, string host)
+    {
+        // replSetGetConfig returns { config: { _id: "mongo", members: [{ _id: 0, host: "localhost:27017", ... }], ... } }.
+        // Ignore server-populated defaults but refuse to rewrite existing identities, addresses, or multi-member data.
+        if (config["_id"].AsString != name ||
+            config["members"].AsBsonArray is not { Count: 1 } members ||
+            members[0]["host"].AsString != host)
+        {
+            throw new DistributedApplicationException($"The existing MongoDB replica set configuration does not match single-member set '{name}' at '{host}'. Use its original configuration and data volume; automatic migration or reconfiguration is not supported.");
+        }
+    }
+
+    internal static bool IsPrimary(BsonDocument status, string name) =>
+        status["set"].AsString == name && status["myState"].AsInt32 == 1 && status["members"].AsBsonArray.Count == 1;
+}

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -14,29 +14,89 @@ aspire add Aspire.Hosting.MongoDB
 
 ## Usage example
 
-In the AppHost, add a MongoDB resource and reference it from another resource with either C# or TypeScript:
+Then, in the AppHost, add a MongoDB server with a single-member replica set for local transactions and change streams. Add a database and reference it using the normal resource APIs:
+
+> **Experimental:** Replica set, keyfile, and TLS configuration APIs are marked `ASPIREMONGODB001` and may change. C# AppHosts must explicitly opt in by suppressing this diagnostic where these APIs are used.
 
 **C#**
 
 ```csharp
-var db = builder.AddMongoDB("mongodb").AddDatabase("mydb");
+#pragma warning disable ASPIREMONGODB001
+var mongodb = builder.AddMongoDB("mongodb").WithReplicaSet();
+#pragma warning restore ASPIREMONGODB001
+var db = mongodb.AddDatabase("mydb");
 
-var myService = builder.AddProject<Projects.MyService>()
-                       .WithReference(db);
+var myService = builder.AddProject<Projects.MyService>("myservice")
+                       .WithReference(db)
+                       .WaitFor(db);
 ```
 
 **TypeScript**
 
 ```typescript
-const db = await builder.addMongoDB("mongodb").addDatabase("mydb");
+const mongodb = await builder.addMongoDB("mongodb").withReplicaSet();
+const db = await mongodb.addDatabase("mydb");
 
 const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
-                       .withReference(db);
+    .withReference(db)
+    .waitFor(db);
 ```
 
-### Replica set
+Omit `WithReplicaSet()` / `withReplicaSet()` when a standalone server is sufficient.
 
-A replica set groups several MongoDB servers into one logical resource, which is what enables transactions and change streams. Reference the replica set rather than any individual member:
+### Single-member replica set
+
+`WithReplicaSet()` configures **and initializes** a single-member replica set on the same `MongoDBServerResource`; it is no longer just a low-level `mongod` option. No separate replica set resource is needed. `AddDatabase`, `WithReference`, and `WaitFor` continue to work with the server or its databases. Initialization runs during the resource lifecycle, not in health checks. Readiness waits for initialization and primary election, so consumers can use transactions and change streams after `WaitFor`.
+
+The optional set name defaults to the server's Aspire resource name. To choose a different name:
+
+**C#**
+
+```csharp
+var mongodb = builder.AddMongoDB("mongodb").WithReplicaSet("app-rs");
+```
+
+**TypeScript**
+
+```typescript
+const mongodb = await builder.addMongoDB("mongodb").withReplicaSet({ name: "app-rs" });
+```
+
+Repeating the same configuration is a no-op; a conflicting name throws. Omitting the name on a later call preserves the previously configured name.
+
+Consumer connection strings use the server's normal endpoint with `directConnection=true` and the driver's default primary read preference. This path does not use topology discovery, split-horizon addresses, or fixed host ports. It preserves normal automatic TLS behavior but does not require a developer certificate or insecure TLS flags.
+
+#### Keyfiles and persistence
+
+MongoDB requires a keyfile when authentication and replication are enabled, even with one member. `WithReplicaSet()` generates a secret keyfile if none is configured. To supply your own keyfile content, pass a secret parameter to `WithKeyFile` **before** calling `WithReplicaSet`:
+
+**C#**
+
+```csharp
+var keyfile = builder.AddParameter("mongo-keyfile", secret: true);
+var mongodb = builder.AddMongoDB("mongodb")
+    .WithKeyFile(keyfile.Resource)
+    .WithReplicaSet();
+```
+
+**TypeScript**
+
+```typescript
+const keyfile = await builder.addParameter("mongo-keyfile", { secret: true });
+const mongodb = await builder.addMongoDB("mongodb")
+    .withKeyFile(keyfile)
+    .withReplicaSet();
+```
+
+The parameter supplies the file's **contents**, not a host file path. Contents must satisfy [MongoDB's keyfile requirements](https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set-with-keyfile-access-control/#create-a-keyfile). The file is mounted inside the container at `/etc/rs.key` by default with restricted permissions. It authenticates replica set members and does not replace the username and password used by applications. Supplying a different keyfile after `WithReplicaSet()` conflicts with the generated keyfile and throws; repeating the same explicit keyfile parameter and container path is a no-op.
+
+Use `WithDataVolume()` or `WithDataBindMount()` to persist data. MongoDB only applies initial credentials to an empty data directory, so keep the configured credentials and replica set identity unchanged when reusing data. With the default set name, renaming the Aspire resource also changes the set identity. Existing compatible single-member data is reused without forced reconfiguration; mismatched set names, member addresses, or multi-member data are rejected. Preserve the original configuration or deliberately start with an empty development volume rather than expecting automatic migration.
+
+### Advanced multi-member experiments
+
+`AddMongoDBReplicaSet(...).WithMember(...)` is a separate experimental path for **local multi-member replication experiments**, not a production-ready deployment model. Use it when exploring replication or elections across multiple containers, not merely to enable transactions or change streams. Production topology and deployment projection require separate support.
+
+Create plain MongoDB servers and let `WithMember` configure their shared replication settings. Do **not** call `WithReplicaSet` on these servers: a single-member set configured that way cannot be adopted by the advanced API, and `WithMember` rejects it even if the set names match.
 
 **C#**
 
@@ -50,7 +110,7 @@ var replicaSet = builder.AddMongoDBReplicaSet("rs0")
                         .WithMember(mongo2)
                         .WithMember(mongo3);
 
-var myService = builder.AddProject<Projects.MyService>()
+var myService = builder.AddProject<Projects.MyService>("myservice")
                        .WithReference(replicaSet)
                        .WaitFor(replicaSet);
 ```
@@ -72,11 +132,13 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
     .waitFor(replicaSet);
 ```
 
-A single member is enough if all you need is transactions and change streams rather than redundancy. A replica set holds at most 50 members, the first seven of which vote in elections; the rest join as non-voting members that still carry a full copy of the data.
+Reference and wait for the advanced replica set resource, rather than an individual member. A replica set holds at most 50 members, the first seven of which vote in elections; the rest join as non-voting members that still carry a full copy of the data.
 
-> **Replica sets only work when running locally.** The set is initialized by the app host itself, and nothing performs that step during a deployment, so `AddMongoDBReplicaSet` throws when the app host runs in publish mode. The same applies to `WithReplicaSet`, `WithKeyFile` and the TLS configuration methods. An application that uses a replica set therefore cannot be published or deployed yet.
+Members share credentials and a keyfile owned by the advanced replica set. Pass a username or password to `AddMongoDBReplicaSet`, not to individual members; conflicting credentials or member-specific keyfiles are rejected. Existing volumes retain their original credentials, so use matching credential parameters or intentionally start with empty development volumes. This does not migrate an existing single-member set into the advanced topology.
 
-Members share one set of credentials, which the replica set owns. Pass a user name or password to `AddMongoDBReplicaSet` rather than to the individual members; passing different ones to a member is rejected. Note that MongoDB only applies the initial credentials to an empty data directory, so a server that already has a data volume from a previous run as a standalone server keeps the credentials that volume was created with. Adding such a server to a replica set means starting from an empty volume, or passing that server's existing password parameter to `AddMongoDBReplicaSet` so that both agree.
+### Publish limitation
+
+**Both replica set paths are supported only for local runs.** `WithReplicaSet` and `AddMongoDBReplicaSet` reject publish mode as unsupported, rather than being silently excluded or becoming no-ops. `WithKeyFile` and the TLS configuration methods also reject publish mode. Applications using these configurations cannot be published or deployed yet; production deployment projection is separate work.
 
 ## TLS
 
@@ -84,7 +146,9 @@ A MongoDB server serves TLS whenever an HTTPS/TLS certificate is available for i
 
 The developer certificate is issued for `localhost`, so a consumer running on the host validates it without any further configuration. A consumer running in a container is a different matter: it reaches the server by its resource name on the container network, which is not a name the certificate carries, so its TLS handshake fails host name validation. Until certificates covering container network names are available, a containerized consumer of a TLS-enabled MongoDB server has to be configured to relax host name validation.
 
-Opting the server out of TLS with `WithoutHttpsCertificate()` is the other way around this, but only for a standalone server. Replica set members have to serve TLS, because the split-horizon addressing that advertises host-reachable addresses to outside clients keys off the SNI of the incoming connection, and a member without TLS fails initialization with an explicit error. A containerized consumer of a replica set therefore has to relax host name validation.
+`WithoutHttpsCertificate()` can opt out of TLS for either a standalone server or the simple `WithReplicaSet()` path. The single-member path does not require TLS and does not automatically enable `WithTlsAllowInvalidCertificates()`. When TLS is available, consumers still need to trust the certificate and connect using a hostname it covers.
+
+Only the advanced `AddMongoDBReplicaSet(...).WithMember(...)` path requires TLS for split-horizon addressing: host-reachable addresses are selected using the incoming connection's SNI, and a member without TLS fails initialization. Its current member configuration relaxes peer certificate validation, and containerized clients need certificates covering container network names or development-only hostname-validation relaxation. These limitations are another reason to keep this path for local experiments.
 
 ## Connection Properties
 
@@ -104,6 +168,8 @@ The MongoDB server resource exposes the following connection properties:
 | `AuthenticationMechanism` | The authentication mechanism (available when a password parameter is configured) |
 | `Uri` | The connection URI, with the format `mongodb://{Username}:{Password}@{Host}:{Port}/?authSource={AuthenticationDatabase}&authMechanism={AuthenticationMechanism}` |
 
+With `WithReplicaSet()`, this remains a server resource with a single `Host` and `Port`; its URI adds `directConnection=true` and keeps the default primary read preference. TLS adds `tls=true` when enabled.
+
 ### MongoDB database
 
 The MongoDB database resource combines the server properties above and adds the following connection property:
@@ -112,9 +178,9 @@ The MongoDB database resource combines the server properties above and adds the 
 |---------------|-------------|
 | `DatabaseName` | The MongoDB database name |
 
-### MongoDB replica set
+### Advanced MongoDB replica set
 
-The MongoDB replica set resource exposes the following connection properties. It has no single `Host` and `Port`, because clients discover the members through the seed list carried in the `Uri`:
+The resource returned by `AddMongoDBReplicaSet` exposes the following connection properties. Unlike the server configured with `WithReplicaSet`, it has no single `Host` and `Port`, because clients discover the members through the seed list carried in the `Uri`:
 
 | Property Name | Description |
 |---------------|-------------|

--- a/src/Aspire.Hosting.MongoDB/README.md
+++ b/src/Aspire.Hosting.MongoDB/README.md
@@ -53,7 +53,9 @@ The optional set name defaults to the server's Aspire resource name. To choose a
 **C#**
 
 ```csharp
+#pragma warning disable ASPIREMONGODB001
 var mongodb = builder.AddMongoDB("mongodb").WithReplicaSet("app-rs");
+#pragma warning restore ASPIREMONGODB001
 ```
 
 **TypeScript**
@@ -74,9 +76,11 @@ MongoDB requires a keyfile when authentication and replication are enabled, even
 
 ```csharp
 var keyfile = builder.AddParameter("mongo-keyfile", secret: true);
+#pragma warning disable ASPIREMONGODB001
 var mongodb = builder.AddMongoDB("mongodb")
     .WithKeyFile(keyfile.Resource)
     .WithReplicaSet();
+#pragma warning restore ASPIREMONGODB001
 ```
 
 **TypeScript**
@@ -105,6 +109,7 @@ var mongo1 = builder.AddMongoDB("mongo-1");
 var mongo2 = builder.AddMongoDB("mongo-2");
 var mongo3 = builder.AddMongoDB("mongo-3");
 
+#pragma warning disable ASPIREMONGODB001
 var replicaSet = builder.AddMongoDBReplicaSet("rs0")
                         .WithMember(mongo1)
                         .WithMember(mongo2)
@@ -113,6 +118,7 @@ var replicaSet = builder.AddMongoDBReplicaSet("rs0")
 var myService = builder.AddProject<Projects.MyService>("myservice")
                        .WithReference(replicaSet)
                        .WaitFor(replicaSet);
+#pragma warning restore ASPIREMONGODB001
 ```
 
 **TypeScript**

--- a/src/Aspire.Hosting.MongoDB/ReplicaSet/MongoDBReplicaSetBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/ReplicaSet/MongoDBReplicaSetBuilderExtensions.cs
@@ -399,6 +399,7 @@ public static class MongoDBReplicaSetBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(member);
+        MongoDBBuilderExtensions.ThrowIfPublishMode(builder.ApplicationBuilder, nameof(WithMember));
 
         if (member.Resource.HasAnnotationOfType<MongoDBSingleMemberReplicaSetAnnotation>())
         {

--- a/src/Aspire.Hosting.MongoDB/ReplicaSet/MongoDBReplicaSetBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/ReplicaSet/MongoDBReplicaSetBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.MongoDB;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
@@ -74,16 +75,7 @@ public static class MongoDBReplicaSetBuilderExtensions
 
         var rsResource = new MongoDBReplicaSetResource(
             name: name,
-            keyFile: ParameterResourceBuilderExtensions.CreateGeneratedParameter(
-                builder,
-                $"{name}-keyfile-content",
-                secret: true,
-                new GenerateParameterDefault
-                {
-                    MinLength = 512, // NOTE: MongoDB requires the key file content to be between 6 and 1024 characters — see https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set-with-keyfile-access-control/#create-a-keyfile
-                    Special = false,
-                }
-            ),
+            keyFile: MongoDBBuilderExtensions.CreateReplicaSetKeyFile(builder, name),
             sharedUserName: userName?.Resource,
             sharedPassword: password?.Resource
                 ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password", special: false)
@@ -393,7 +385,7 @@ public static class MongoDBReplicaSetBuilderExtensions
     /// <remarks>
     /// Internally calls the following methods on the member's builder:
     /// <list type="number">
-    /// <item> <description><see cref="MongoDBBuilderExtensions.WithReplicaSet(IResourceBuilder{MongoDBServerResource}, string)"/> to set the replica set name on the member resource and configure it accordingly. </description></item>
+    /// <item> <description>Configures the member's replica set name and command-line arguments without initializing a separate single-member set. Do not call <see cref="MongoDBBuilderExtensions.WithReplicaSet"/> on these members. </description></item>
     /// <item> <description><see cref="MongoDBBuilderExtensions.WithKeyFile(IResourceBuilder{MongoDBServerResource}, IExpressionValue, string)"/> to set the key file parameter on the member resource, which is required for internal authentication between replica set members. </description></item>
     /// <item> <description><see cref="MongoDBBuilderExtensions.WithTlsAllowInvalidCertificates(IResourceBuilder{MongoDBServerResource})"/> because members authenticate to each other with the same certificate they serve to clients, which does not carry a <c>clientAuth</c> extended key usage. </description></item>
     /// <item> <description><see cref="ResourceBuilderExtensions.WithHttpsDeveloperCertificate{TResource}(IResourceBuilder{TResource}, IResourceBuilder{ParameterResource}?)"/>, unless the member already has certificate configuration of its own. TLS is required for members of a replica set, because the split-horizon member hostname advertisement performed by the server operates on top of SNI. </description></item>
@@ -407,6 +399,11 @@ public static class MongoDBReplicaSetBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(member);
+
+        if (member.Resource.HasAnnotationOfType<MongoDBSingleMemberReplicaSetAnnotation>())
+        {
+            throw new InvalidOperationException($"The MongoDB server resource '{member.Resource.Name}' is configured as a single-member replica set. Remove WithReplicaSet before adding it to the advanced replica set '{builder.Resource.Name}'. Migrating existing single-member data to an advanced replica set is not supported.");
+        }
 
         if (builder.Resource.Members.Count() >= MaxMembers)
         {
@@ -454,7 +451,7 @@ public static class MongoDBReplicaSetBuilderExtensions
                 $"The MongoDB server resource '{member.Resource.Name}' was given an explicit password that differs from the one of the replica set '{builder.Resource.Name}'. Members of a replica set share a single set of credentials: pass the password to '{nameof(AddMongoDBReplicaSet)}' instead of to the individual members.");
         }
 
-        member.WithReplicaSet(builder.Resource.Name);
+        MongoDBBuilderExtensions.ConfigureReplicaSetMember(member, builder.Resource.Name);
 
         // NOTE: A member that already carries the replica set's shared key file keeps it exactly as it is, mounted wherever
         // the caller put it. Configuring it again would only be a no-op when the path happened to match the default too,

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDBPublicApiTests.cs
@@ -315,19 +315,15 @@ public class MongoDBPublicApiTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void WithReplicaSetShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    [InlineData("")]
+    [InlineData(" ")]
+    public void WithReplicaSetShouldThrowWhenNameIsEmptyOrWhitespace(string name)
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         var mongo = builder.AddMongoDB("mongo1");
-        var name = isNull ? null! : string.Empty;
-
         var action = () => mongo.WithReplicaSet(name);
 
-        var exception = isNull
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
+        var exception = Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
 

--- a/tests/Aspire.Hosting.MongoDB.Tests/ReplicaSet/AddMongoDBReplicaSetTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/ReplicaSet/AddMongoDBReplicaSetTests.cs
@@ -164,6 +164,31 @@ public class AddMongoDBReplicaSetTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void WithMemberThrowsBeforeMutatingInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var keyFile = builder.AddParameter("keyfile", "sharedkey", secret: true);
+        var password = builder.AddParameter("password", "sharedpassword", secret: true);
+        // The public constructor bypasses AddMongoDBReplicaSet's publish guard.
+        var rs = builder.AddResource(new MongoDBReplicaSetResource("rs0", keyFile.Resource, null, password.Resource));
+        var member = builder.AddMongoDB("mongo1");
+        var memberAnnotations = member.Resource.Annotations.ToArray();
+        var replicaSetAnnotations = rs.Resource.Annotations.ToArray();
+        var memberPassword = member.Resource.PasswordParameter;
+        var resources = builder.Resources.ToArray();
+
+        Assert.Throws<NotSupportedException>(() => rs.WithMember(member));
+
+        Assert.Null(member.Resource.ReplicaSetName);
+        Assert.Equal(memberAnnotations, member.Resource.Annotations);
+        Assert.Equal(replicaSetAnnotations, rs.Resource.Annotations);
+        Assert.Null(member.Resource.UserNameParameter);
+        Assert.Same(memberPassword, member.Resource.PasswordParameter);
+        Assert.True(member.Resource.PasswordParameterWasGenerated);
+        Assert.Equal(resources, builder.Resources);
+    }
+
+    [Fact]
     public void WithMemberOptsTheMemberInToTheDeveloperCertificate()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetFunctionalTests.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Dcp;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+#pragma warning disable ASPIRECERTIFICATES001
+#pragma warning disable ASPIREMONGODB001
+
+namespace Aspire.Hosting.MongoDB.Tests;
+
+public class SingleMemberReplicaSetFunctionalTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
+    public Task TransactionsAndChangeStreamsWorkWithoutADeveloperCertificate() => VerifyFeaturesAsync(useTls: false);
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.DevCert)]
+    public Task TransactionsAndChangeStreamsWorkWithTls() => VerifyFeaturesAsync(useTls: true);
+
+    private async Task VerifyFeaturesAsync(bool useTls)
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        if (!useTls)
+        {
+            builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
+                [], supportsContainerTrust: true, trustCertificate: true, tlsTerminate: false));
+        }
+
+        var mongo = builder.AddMongoDB("mongo").WithReplicaSet();
+        if (useTls)
+        {
+            mongo.WithHttpsDeveloperCertificate();
+        }
+
+        var database = mongo.AddDatabase("orders");
+        using var app = builder.Build();
+        using var startup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        await app.StartAsync(startup.Token);
+        using var ready = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(database.Resource.Name, ready.Token);
+        Assert.Equal(useTls, mongo.Resource.TlsEnabled);
+
+        using var operations = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var serverClient = new MongoClient(await mongo.Resource.ConnectionStringExpression.GetValueAsync(operations.Token));
+        using var databaseClient = new MongoClient(await database.Resource.ConnectionStringExpression.GetValueAsync(operations.Token));
+        await VerifyTransactionsAndChangeStreamsAsync(serverClient.GetDatabase("serverdb"), operations.Token);
+        await VerifyTransactionsAndChangeStreamsAsync(databaseClient.GetDatabase("orders"), operations.Token);
+        await app.StopAsync();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
+    public async Task InitializationDoesNotWaitForHealthAndWaitForGatesContainerClients(bool waitForDatabase)
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        var gate = new TaskCompletionSource<HealthCheckResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        builder.Services.AddHealthChecks().AddCheck("held", () =>
+            gate.Task.IsCompletedSuccessfully ? gate.Task.Result : HealthCheckResult.Unhealthy("Held until the test releases readiness."));
+        var mongo = builder.AddMongoDB("mongo").WithoutHttpsCertificate().WithReplicaSet().WithHealthCheck("held");
+        var database = mongo.AddDatabase("orders");
+
+        // This is a real container consumer of the normal database reference. Its address is translated to the
+        // container network, not the host's random proxy port, and it must be able to commit immediately after WaitFor.
+        var consumer = builder.AddContainer("consumer", MongoDBContainerImageTags.Image, MongoDBContainerImageTags.Tag)
+            .WithImageRegistry(MongoDBContainerImageTags.Registry)
+            .WithEntrypoint("mongosh")
+            .WithReference(database)
+            .WithArgs("--quiet", "--nodb", "--eval", """
+                const connection = new Mongo(process.env.ConnectionStrings__orders);
+                const session = connection.startSession();
+                session.startTransaction();
+                session.getDatabase("orders").items.insertOne({ _id: 1, name: "container" });
+                session.commitTransaction();
+                session.endSession();
+                """);
+        if (waitForDatabase)
+        {
+            consumer.WaitFor(database);
+        }
+        else
+        {
+            consumer.WaitFor(mongo);
+        }
+
+        using var app = builder.Build();
+        using var startup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        var pendingStart = app.StartAsync(startup.Token);
+        using var ready = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await app.ResourceNotifications.WaitForResourceAsync(mongo.Resource.Name,
+            update => update.Snapshot.HealthReports.Any(r => r.Name == "mongo_check" && r.Status == HealthStatus.Healthy), ready.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(consumer.Resource.Name, KnownResourceStates.Waiting, ready.Token);
+
+        gate.SetResult(HealthCheckResult.Healthy());
+        await pendingStart;
+        var completed = await app.ResourceNotifications.WaitForResourceAsync(consumer.Resource.Name,
+            update => update.Snapshot.State?.Text == KnownResourceStates.Exited, ready.Token);
+        Assert.Equal(0, completed.Snapshot.ExitCode);
+
+        using var client = new MongoClient(await database.Resource.ConnectionStringExpression.GetValueAsync(ready.Token));
+        var item = await client.GetDatabase("orders").GetCollection<BsonDocument>("items").Find(new BsonDocument("_id", 1)).SingleAsync(ready.Token);
+        Assert.Equal("container", item["name"].AsString);
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public async Task DataAndReplicaSetIdentitySurviveNewAppHostsAndPorts()
+    {
+        using var builder1 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        var mongo1 = builder1.AddMongoDB("mongo").WithoutHttpsCertificate().WithReplicaSet("orders-rs");
+        var volumeName = VolumeNameGenerator.Generate(mongo1, nameof(DataAndReplicaSetIdentitySurviveNewAppHostsAndPorts));
+        DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
+        mongo1.WithDataVolume(volumeName);
+
+        string password;
+        BsonDocument originalConfig;
+        int originalPort;
+        try
+        {
+            using (var app = builder1.Build())
+            {
+                using var startup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+                await app.StartAsync(startup.Token);
+                using var ready = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                var running = await app.ResourceNotifications.WaitForResourceHealthyAsync(mongo1.Resource.Name, ready.Token);
+                password = (await mongo1.Resource.PasswordParameter!.GetValueAsync(ready.Token))!;
+                originalPort = mongo1.Resource.PrimaryEndpoint.Port;
+                using var client = new MongoClient(await mongo1.Resource.ConnectionStringExpression.GetValueAsync(ready.Token));
+                await VerifyTransactionsAndChangeStreamsAsync(client.GetDatabase("orders"), ready.Token);
+                originalConfig = await client.GetDatabase("admin").RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetConfig", 1), cancellationToken: ready.Token);
+
+                using var restart = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                var orchestrator = app.Services.GetRequiredService<ApplicationOrchestratorProxy>();
+                await orchestrator.StopResourceAsync(running.ResourceId, restart.Token);
+                await app.ResourceNotifications.WaitForResourceAsync(mongo1.Resource.Name, KnownResourceStates.Exited, restart.Token);
+                await orchestrator.StartResourceAsync(running.ResourceId, restart.Token);
+                await app.ResourceNotifications.WaitForResourceAsync(mongo1.Resource.Name, KnownResourceStates.Running, restart.Token);
+                await app.ResourceNotifications.WaitForResourceHealthyAsync(mongo1.Resource.Name, restart.Token);
+                await VerifyTransactionsAndChangeStreamsAsync(client.GetDatabase("aftercontainerrestart"), restart.Token);
+                await app.StopAsync();
+            }
+
+            using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+            var mongo2 = builder2.AddMongoDB("mongo", password: builder2.AddParameter("password", password, secret: true))
+                .WithoutHttpsCertificate().WithReplicaSet("orders-rs").WithDataVolume(volumeName);
+            using var app2 = builder2.Build();
+            using var secondStartup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+            await app2.StartAsync(secondStartup.Token);
+            using var secondReady = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            await app2.ResourceNotifications.WaitForResourceHealthyAsync(mongo2.Resource.Name, secondReady.Token);
+            testOutputHelper.WriteLine($"Host ports across AppHost runs: {originalPort}, {mongo2.Resource.PrimaryEndpoint.Port}");
+
+            using var secondClient = new MongoClient(await mongo2.Resource.ConnectionStringExpression.GetValueAsync(secondReady.Token));
+            var currentConfig = await secondClient.GetDatabase("admin").RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetConfig", 1), cancellationToken: secondReady.Token);
+            // Elections advance the term without changing the configuration version or replicaSetId.
+            Assert.True(currentConfig["config"]["term"].ToInt64() >= originalConfig["config"]["term"].ToInt64());
+            originalConfig["config"].AsBsonDocument.Remove("term");
+            currentConfig["config"].AsBsonDocument.Remove("term");
+            Assert.Equal(originalConfig["config"], currentConfig["config"]);
+            var item = await secondClient.GetDatabase("orders").GetCollection<BsonDocument>("items").Find(new BsonDocument("_id", 1)).SingleAsync(secondReady.Token);
+            Assert.Equal("committed", item["name"].AsString);
+            await VerifyTransactionsAndChangeStreamsAsync(secondClient.GetDatabase("afterrestart"), secondReady.Token);
+            await app2.StopAsync();
+        }
+        finally
+        {
+            DockerUtils.AttemptDeleteDockerVolume(volumeName);
+        }
+    }
+
+    private static async Task VerifyTransactionsAndChangeStreamsAsync(IMongoDatabase database, CancellationToken cancellationToken)
+    {
+        await database.CreateCollectionAsync("items", cancellationToken: cancellationToken);
+        var collection = database.GetCollection<BsonDocument>("items");
+        using var changes = await collection.WatchAsync(new ChangeStreamOptions { MaxAwaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+        using var session = await database.Client.StartSessionAsync(cancellationToken: cancellationToken);
+        session.StartTransaction();
+        await collection.InsertOneAsync(session, new BsonDocument { ["_id"] = 1, ["name"] = "committed" }, cancellationToken: cancellationToken);
+        await session.CommitTransactionAsync(cancellationToken);
+
+        var item = await collection.Find(new BsonDocument("_id", 1)).SingleAsync(cancellationToken);
+        Assert.Equal("committed", item["name"].AsString);
+        while (await changes.MoveNextAsync(cancellationToken))
+        {
+            if (changes.Current.FirstOrDefault() is { } change)
+            {
+                Assert.Equal(ChangeStreamOperationType.Insert, change.OperationType);
+                Assert.Equal(item, change.FullDocument);
+                return;
+            }
+        }
+
+        Assert.Fail("The committed transaction did not produce a change stream event.");
+    }
+}

--- a/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetFunctionalTests.cs
@@ -140,6 +140,7 @@ public class SingleMemberReplicaSetFunctionalTests(ITestOutputHelper testOutputH
                 using var client = new MongoClient(await mongo1.Resource.ConnectionStringExpression.GetValueAsync(ready.Token));
                 await VerifyTransactionsAndChangeStreamsAsync(client.GetDatabase("orders"), ready.Token);
                 originalConfig = await client.GetDatabase("admin").RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetConfig", 1), cancellationToken: ready.Token);
+                Assert.Equal("localhost:27017", Assert.Single(originalConfig["config"]["members"].AsBsonArray)["host"].AsString);
 
                 using var restart = new CancellationTokenSource(TimeSpan.FromMinutes(2));
                 var orchestrator = app.Services.GetRequiredService<ApplicationOrchestratorProxy>();
@@ -149,30 +150,36 @@ public class SingleMemberReplicaSetFunctionalTests(ITestOutputHelper testOutputH
                 await app.ResourceNotifications.WaitForResourceAsync(mongo1.Resource.Name, KnownResourceStates.Running, restart.Token);
                 await app.ResourceNotifications.WaitForResourceHealthyAsync(mongo1.Resource.Name, restart.Token);
                 await VerifyTransactionsAndChangeStreamsAsync(client.GetDatabase("aftercontainerrestart"), restart.Token);
+
+                // Stop mongod to release the data volume, but keep this AppHost and its endpoint proxy alive.
+                // Holding the first port guarantees that the second AppHost gets a different random host port.
+                using var stop = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                await orchestrator.StopResourceAsync(running.ResourceId, stop.Token);
+                await app.ResourceNotifications.WaitForResourceAsync(mongo1.Resource.Name, KnownResourceStates.Exited, stop.Token);
+
+                using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+                var mongo2 = builder2.AddMongoDB("mongo", password: builder2.AddParameter("password", password, secret: true))
+                    .WithoutHttpsCertificate().WithReplicaSet("orders-rs").WithDataVolume(volumeName);
+                using var app2 = builder2.Build();
+                using var secondStartup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+                await app2.StartAsync(secondStartup.Token);
+                using var secondReady = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                await app2.ResourceNotifications.WaitForResourceHealthyAsync(mongo2.Resource.Name, secondReady.Token);
+                Assert.Equal(2, new[] { originalPort, mongo2.Resource.PrimaryEndpoint.Port }.Distinct().Count());
+
+                using var secondClient = new MongoClient(await mongo2.Resource.ConnectionStringExpression.GetValueAsync(secondReady.Token));
+                var currentConfig = await secondClient.GetDatabase("admin").RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetConfig", 1), cancellationToken: secondReady.Token);
+                // Elections advance the term without changing the configuration version or replicaSetId.
+                Assert.True(currentConfig["config"]["term"].ToInt64() >= originalConfig["config"]["term"].ToInt64());
+                originalConfig["config"].AsBsonDocument.Remove("term");
+                currentConfig["config"].AsBsonDocument.Remove("term");
+                Assert.Equal(originalConfig["config"], currentConfig["config"]);
+                var item = await secondClient.GetDatabase("orders").GetCollection<BsonDocument>("items").Find(new BsonDocument("_id", 1)).SingleAsync(secondReady.Token);
+                Assert.Equal("committed", item["name"].AsString);
+                await VerifyTransactionsAndChangeStreamsAsync(secondClient.GetDatabase("afterrestart"), secondReady.Token);
+                await app2.StopAsync();
                 await app.StopAsync();
             }
-
-            using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var mongo2 = builder2.AddMongoDB("mongo", password: builder2.AddParameter("password", password, secret: true))
-                .WithoutHttpsCertificate().WithReplicaSet("orders-rs").WithDataVolume(volumeName);
-            using var app2 = builder2.Build();
-            using var secondStartup = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-            await app2.StartAsync(secondStartup.Token);
-            using var secondReady = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-            await app2.ResourceNotifications.WaitForResourceHealthyAsync(mongo2.Resource.Name, secondReady.Token);
-            testOutputHelper.WriteLine($"Host ports across AppHost runs: {originalPort}, {mongo2.Resource.PrimaryEndpoint.Port}");
-
-            using var secondClient = new MongoClient(await mongo2.Resource.ConnectionStringExpression.GetValueAsync(secondReady.Token));
-            var currentConfig = await secondClient.GetDatabase("admin").RunCommandAsync<BsonDocument>(new BsonDocument("replSetGetConfig", 1), cancellationToken: secondReady.Token);
-            // Elections advance the term without changing the configuration version or replicaSetId.
-            Assert.True(currentConfig["config"]["term"].ToInt64() >= originalConfig["config"]["term"].ToInt64());
-            originalConfig["config"].AsBsonDocument.Remove("term");
-            currentConfig["config"].AsBsonDocument.Remove("term");
-            Assert.Equal(originalConfig["config"], currentConfig["config"]);
-            var item = await secondClient.GetDatabase("orders").GetCollection<BsonDocument>("items").Find(new BsonDocument("_id", 1)).SingleAsync(secondReady.Token);
-            Assert.Equal("committed", item["name"].AsString);
-            await VerifyTransactionsAndChangeStreamsAsync(secondClient.GetDatabase("afterrestart"), secondReady.Token);
-            await app2.StopAsync();
         }
         finally
         {

--- a/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/SingleMemberReplicaSetTests.cs
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+#pragma warning disable ASPIRECERTIFICATES001
+#pragma warning disable ASPIREMONGODB001
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
+namespace Aspire.Hosting.MongoDB.Tests;
+
+public class SingleMemberReplicaSetTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task WithReplicaSetKeepsTheServerAndDatabaseModel()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var mongo = builder.AddMongoDB("mongo");
+        var password = mongo.Resource.PasswordParameter;
+        var database = mongo.AddDatabase("orders");
+
+        Assert.Same(mongo, mongo.WithReplicaSet().WithReplicaSet("mongo").WithReplicaSet());
+        Assert.Equal("mongo", mongo.Resource.ReplicaSetName);
+        Assert.Same(password, mongo.Resource.PasswordParameter);
+        Assert.Same(mongo.Resource, database.Resource.Parent);
+        Assert.Equal(["mongo", "orders"], builder.Resources.Where(r => r is not ParameterResource).Select(r => r.Name));
+        Assert.Equal(["--keyFile", "/etc/rs.key", "--bind_ip_all", "--replSet", "mongo"],
+            await ArgumentEvaluator.GetArgumentListAsync(mongo.Resource));
+        var endpoint = Assert.Single(mongo.Resource.Annotations.OfType<EndpointAnnotation>());
+        Assert.Null(endpoint.Port);
+        Assert.Equal(27017, endpoint.TargetPort);
+        Assert.True(endpoint.IsProxied);
+        Assert.Single(mongo.Resource.Annotations.OfType<MongoDBSingleMemberReplicaSetAnnotation>());
+        Assert.True(Assert.IsType<ParameterResource>(
+            Assert.Single(mongo.Resource.Annotations.OfType<MongoDBServerKeyFileAnnotation>()).Value).Secret);
+    }
+
+    [Fact]
+    public async Task WithReplicaSetHonorsAnExplicitKeyFileAndSetName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var key = builder.AddParameter("key", "sharedkey", secret: true);
+        var mongo = builder.AddMongoDB("mongo").WithKeyFile(key.Resource, "/etc/custom.key").WithReplicaSet("rs0").WithReplicaSet();
+
+        Assert.Equal("rs0", mongo.Resource.ReplicaSetName);
+        Assert.Same(key.Resource, Assert.Single(mongo.Resource.Annotations.OfType<MongoDBServerKeyFileAnnotation>()).Value);
+        Assert.Equal(["--keyFile", "/etc/custom.key", "--bind_ip_all", "--replSet", "rs0"],
+            await ArgumentEvaluator.GetArgumentListAsync(mongo.Resource));
+        Assert.Equal(["key"], builder.Resources.OfType<ParameterResource>().Select(r => r.Name));
+    }
+
+    [Fact]
+    public void ReplicaSetNamesAreCaseSensitive()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var mongo = builder.AddMongoDB("mongo").WithReplicaSet("rs0");
+        var annotations = mongo.Resource.Annotations.ToArray();
+
+        Assert.Throws<InvalidOperationException>(() => mongo.WithReplicaSet("RS0"));
+        Assert.Equal(annotations, mongo.Resource.Annotations);
+        Assert.Equal("rs0", mongo.Resource.ReplicaSetName);
+    }
+
+    [Theory]
+    [InlineData("rs0")]
+    [InlineData("advanced")]
+    public void AdvancedSetCannotAdoptASingleMember(string name)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var mongo = builder.AddMongoDB("mongo").WithReplicaSet("rs0");
+        var advanced = builder.AddMongoDBReplicaSet(name);
+        var annotations = mongo.Resource.Annotations.ToArray();
+        var password = mongo.Resource.PasswordParameter;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => advanced.WithMember(mongo));
+        Assert.Contains("Remove WithReplicaSet", exception.Message);
+        Assert.Equal(annotations, mongo.Resource.Annotations);
+        Assert.Same(password, mongo.Resource.PasswordParameter);
+        Assert.Empty(advanced.Resource.Members);
+    }
+
+    [Fact]
+    public void SingleMemberCannotInitializeAnAdvancedMember()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var mongo = builder.AddMongoDB("mongo");
+        var advanced = builder.AddMongoDBReplicaSet("advanced").WithMember(mongo);
+        var annotations = mongo.Resource.Annotations.ToArray();
+
+        Assert.Throws<InvalidOperationException>(() => mongo.WithReplicaSet());
+        Assert.Equal(annotations, mongo.Resource.Annotations);
+        Assert.Same(mongo.Resource, Assert.Single(advanced.Resource.Members));
+    }
+
+    [Fact]
+    public void DefaultReplicaSetThrowsBeforeMutatingInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var mongo = builder.AddMongoDB("mongo");
+        var annotations = mongo.Resource.Annotations.ToArray();
+        var resources = builder.Resources.ToArray();
+
+        Assert.Throws<NotSupportedException>(() => mongo.WithReplicaSet());
+        Assert.Equal(annotations, mongo.Resource.Annotations);
+        Assert.Equal(resources, builder.Resources);
+    }
+
+    [Fact]
+    public async Task SingleMemberWithoutDeveloperCertificateKeepsSecureAuthenticationAndDirectPrimaryConnections()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
+            [], supportsContainerTrust: true, trustCertificate: true, tlsTerminate: false));
+        var password = builder.AddParameter("password", "p@ssword", secret: true);
+        var mongo = builder.AddMongoDB("mongo", password: password).WithReplicaSet()
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 43210));
+        var database = mongo.AddDatabase("orders");
+
+        using var app = builder.Build();
+        await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+
+        Assert.False(mongo.Resource.TlsEnabled);
+        Assert.False(mongo.Resource.TlsAllowInvalidCertificates);
+        Assert.Equal(["--keyFile", "/etc/rs.key", "--bind_ip_all", "--replSet", "mongo"],
+            await ArgumentEvaluator.GetArgumentListAsync(mongo.Resource));
+
+        foreach (IResourceWithConnectionString resource in new IResourceWithConnectionString[] { mongo.Resource, database.Resource })
+        {
+            var connectionString = await resource.GetConnectionStringAsync();
+            var url = new MongoUrl(connectionString);
+            Assert.True(url.DirectConnection);
+            Assert.Equal(ReadPreference.Primary, MongoClientSettings.FromUrl(url).ReadPreference);
+            Assert.Equal("admin", url.Username);
+            Assert.Equal("p@ssword", url.Password);
+            Assert.Equal("localhost:43210", url.Server.ToString());
+            Assert.Equal(resource == database.Resource ? "orders" : null, url.DatabaseName);
+            Assert.Equal(connectionString, await resource.GetConnectionProperties().Single(p => p.Key == "Uri").Value.GetValueAsync(default));
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("A resource-specific initialization failure.")]
+    public async Task HealthIsUnhealthyBeforeInitializationOrAfterFailure(string? error)
+    {
+        using var client = new MongoClient();
+        var annotation = new MongoDBSingleMemberReplicaSetAnnotation("mongo");
+        if (error is not null)
+        {
+            annotation.InitializationError = error;
+        }
+
+        var check = new MyMongoDbHealthCheck(client, "admin", annotation);
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Equal(error ?? "The single-member replica set has not been initialized.", result.Description);
+    }
+
+    [Fact]
+    public void ExistingSingleMemberConfigurationIsNotMutated()
+    {
+        var config = BsonDocument.Parse("""{ "_id": "mongo", "version": 7, "members": [{ "_id": 0, "host": "localhost:27017", "priority": 1 }], "settings": { "heartbeatIntervalMillis": 2000 } }""");
+        var original = config.DeepClone();
+
+        MongoDBSingleMemberReplicaSet.ValidateConfiguration(config, "mongo", "localhost:27017");
+
+        Assert.Equal(original, config);
+    }
+
+    [Theory]
+    [InlineData("""{ "_id": "other", "members": [{ "host": "localhost:27017" }] }""")]
+    [InlineData("""{ "_id": "mongo", "members": [{ "host": "old-host:27017" }] }""")]
+    [InlineData("""{ "_id": "mongo", "members": [{ "host": "localhost:27017" }, { "host": "other:27017" }] }""")]
+    public void IncompatibleDataIsRejectedWithoutReconfiguration(string json)
+    {
+        var config = BsonDocument.Parse(json);
+        var original = config.DeepClone();
+
+        var exception = Assert.Throws<DistributedApplicationException>(() =>
+            MongoDBSingleMemberReplicaSet.ValidateConfiguration(config, "mongo", "localhost:27017"));
+
+        Assert.Contains("automatic migration or reconfiguration is not supported", exception.Message);
+        Assert.Equal(original, config);
+    }
+
+    [Theory]
+    [InlineData("mongo", 1, 1, true)]
+    [InlineData("mongo", 2, 1, false)]
+    [InlineData("other", 1, 1, false)]
+    [InlineData("mongo", 1, 2, false)]
+    public void ReadinessRequiresTheSingleMemberPrimary(string name, int state, int memberCount, bool expected)
+    {
+        var status = new BsonDocument
+        {
+            ["set"] = name,
+            ["myState"] = state,
+            ["members"] = new BsonArray(Enumerable.Range(0, memberCount).Select(id => new BsonDocument("_id", id))),
+        };
+
+        Assert.Equal(expected, MongoDBSingleMemberReplicaSet.IsPrimary(status, "mongo"));
+    }
+
+    [Fact]
+    public async Task InitializationHonorsCancellationBeforeSendingCommands()
+    {
+        using var client = new MongoClient();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            MongoDBSingleMemberReplicaSet.InitializeAndWaitForPrimaryAsync(client.GetDatabase("admin"), "mongo", "localhost:27017", cancellation.Token));
+    }
+}

--- a/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Go/apphost.go
@@ -53,14 +53,26 @@ func main() {
 	// Test 11: Test WithBindIpAll
 	builder.AddMongoDB("mongo-bind-all").WithBindIpAll()
 
-	// Test 12: Test WithReplicaSet with WithKeyFile, WithTlsMode and WithTlsAllowInvalidCertificates
-	keyFileParam := builder.AddParameter("rs-keyfile", &aspire.AddParameterOptions{Secret: aspire.BoolPtr(true), Value: aspire.StringPtr("my-secret-key")})
-	mongoRsMember := builder.AddMongoDB("mongo-rs-member").WithReplicaSet("rs0").WithKeyFile(keyFileParam, &aspire.WithKeyFileOptions{KeyFilePath: aspire.StringPtr("/etc/rs.key")}).WithTlsMode().WithTlsAllowInvalidCertificates()
-	if err = mongoRsMember.Err(); err != nil {
-		log.Fatalf(aspire.FormatError(err))
+	// Test 12: Initialize a single-member replica set with the resource name and a generated keyfile.
+	singleDB := builder.AddMongoDB("mongo-single").WithReplicaSet().AddDatabase("single-db")
+	if err = singleDB.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
 	}
 
-	// Test 13: Test AddMongoDBReplicaSet with WithMember
+	// Test 13: Initialize a single-member replica set with an explicit set name.
+	namedSingleDB := builder.AddMongoDB("mongo-single-named").WithReplicaSet(&aspire.WithReplicaSetOptions{Name: aspire.StringPtr("app-rs")}).AddDatabase("single-named-db")
+	if err = namedSingleDB.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	// Test 14: Supply a keyfile before initialization; TLS options are separate export coverage, not prerequisites.
+	keyFileParam := builder.AddParameter("rs-keyfile", &aspire.AddParameterOptions{Secret: aspire.BoolPtr(true), Value: aspire.StringPtr("bW9uZ29kYmtleWZpbGUxMjM0")})
+	mongoConfigured := builder.AddMongoDB("mongo-rs-configured").WithKeyFile(keyFileParam, &aspire.WithKeyFileOptions{KeyFilePath: aspire.StringPtr("/etc/rs.key")}).WithReplicaSet(&aspire.WithReplicaSetOptions{Name: aspire.StringPtr("configured-rs")}).WithTlsMode().WithTlsAllowInvalidCertificates()
+	if err = mongoConfigured.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	// Test 15: Advanced local multi-member experiments use plain servers, not WithReplicaSet single-member sets.
 	// NOTE: The members are not given a key file of their own here. WithMember gives them the replica set's shared one,
 	// and a member carrying a different key file is rejected.
 	mongo1 := builder.AddMongoDB("mongo-rs-1")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Java/AppHost.java
@@ -37,14 +37,22 @@ void main() throws Exception {
         // Test 11: Test withBindIpAll
         builder.addMongoDB("mongo-bind-all")
             .withBindIpAll();
-        // Test 12: Test withReplicaSet with withKeyFile, withTlsMode and withTlsAllowInvalidCertificates
-        var keyFileParam = builder.addParameter("rs-keyfile", new AddParameterOptions().secret(true).value("my-secret-key"));
-        builder.addMongoDB("mongo-rs-member")
-            .withReplicaSet("rs0")
+        // Test 12: Initialize a single-member replica set with the resource name and a generated keyfile.
+        builder.addMongoDB("mongo-single")
+            .withReplicaSet()
+            .addDatabase("single-db");
+        // Test 13: Initialize a single-member replica set with an explicit set name.
+        builder.addMongoDB("mongo-single-named")
+            .withReplicaSet("app-rs")
+            .addDatabase("single-named-db");
+        // Test 14: Supply a keyfile before initialization; TLS options are separate export coverage, not prerequisites.
+        var keyFileParam = builder.addParameter("rs-keyfile", new AddParameterOptions().secret(true).value("bW9uZ29kYmtleWZpbGUxMjM0"));
+        builder.addMongoDB("mongo-rs-configured")
             .withKeyFile(keyFileParam, "/etc/rs.key")
+            .withReplicaSet("configured-rs")
             .withTlsMode()
             .withTlsAllowInvalidCertificates();
-        // Test 13: Test addMongoDBReplicaSet with withMember
+        // Test 15: Advanced local multi-member experiments use plain servers, not withReplicaSet single-member sets.
         // NOTE: The members are not given a key file of their own here. withMember gives them the replica set's shared one,
         // and a member carrying a different key file is rejected.
         var mongo1 = builder.addMongoDB("mongo-rs-1");

--- a/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/Python/apphost.py
@@ -34,10 +34,14 @@ with create_builder() as builder:
     mongo_chained.add_database("analytics-db", database_name="analytics")
     # Test 11: Test with_bind_ip_all
     builder.add_mongo_db("mongo-bind-all").with_bind_ip_all()
-    # Test 12: Test with_replica_set with with_key_file, with_tls_mode and with_tls_allow_invalid_certificates
-    key_file_param = builder.add_parameter("rs-keyfile", secret=True, value="my-secret-key")
-    builder.add_mongo_db("mongo-rs-member").with_replica_set("rs0").with_key_file(key_file_param, key_file_path="/etc/rs.key").with_tls_mode().with_tls_allow_invalid_certificates()
-    # Test 13: Test add_mongo_db_replica_set with with_member
+    # Test 12: Initialize a single-member replica set with the resource name and a generated keyfile.
+    builder.add_mongo_db("mongo-single").with_replica_set().add_database("single-db")
+    # Test 13: Initialize a single-member replica set with an explicit set name.
+    builder.add_mongo_db("mongo-single-named").with_replica_set(name="app-rs").add_database("single-named-db")
+    # Test 14: Supply a keyfile before initialization; TLS options are separate export coverage, not prerequisites.
+    key_file_param = builder.add_parameter("rs-keyfile", secret=True, value="bW9uZ29kYmtleWZpbGUxMjM0")
+    builder.add_mongo_db("mongo-rs-configured").with_key_file(key_file_param, key_file_path="/etc/rs.key").with_replica_set(name="configured-rs").with_tls_mode().with_tls_allow_invalid_certificates()
+    # Test 15: Advanced local multi-member experiments use plain servers, not with_replica_set single-member sets.
     # NOTE: The members are not given a key file of their own here. with_member gives them the replica set's shared one,
     # and a member carrying a different key file is rejected.
     mongo1 = builder.add_mongo_db("mongo-rs-1")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.MongoDB/TypeScript/apphost.mts
@@ -51,15 +51,25 @@ await mongoChained.addDatabase("analytics-db", { databaseName: "analytics" });
 await builder.addMongoDB("mongo-bind-all")
     .withBindIpAll();
 
-// Test 12: Test withReplicaSet with KeyFile and TLS configuration
-const keyFileParam = await builder.addParameter("rs-keyfile", { secret: true, value: "my-secret-key" });
-await builder.addMongoDB("mongo-rs-member")
-    .withReplicaSet("rs0")
+// Test 12: Initialize a single-member replica set with the resource name and a generated keyfile.
+await builder.addMongoDB("mongo-single")
+    .withReplicaSet()
+    .addDatabase("single-db");
+
+// Test 13: Initialize a single-member replica set with an explicit set name.
+await builder.addMongoDB("mongo-single-named")
+    .withReplicaSet({ name: "app-rs" })
+    .addDatabase("single-named-db");
+
+// Test 14: Supply a keyfile before initialization; TLS options are separate export coverage, not prerequisites.
+const keyFileParam = await builder.addParameter("rs-keyfile", { secret: true, value: "bW9uZ29kYmtleWZpbGUxMjM0" });
+await builder.addMongoDB("mongo-rs-configured")
     .withKeyFile(keyFileParam, { keyFilePath: "/etc/rs.key" })
+    .withReplicaSet({ name: "configured-rs" })
     .withTlsMode()
     .withTlsAllowInvalidCertificates();
 
-// Test 13: Test AddMongoDBReplicaSet with WithMember
+// Test 15: Advanced local multi-member experiments use plain servers, not withReplicaSet single-member sets.
 // NOTE: The members are not given a key file of their own here. withMember gives them the replica set's shared one,
 // and a member carrying a different key file is rejected.
 const mongo1 = await builder.addMongoDB("mongo-rs-1");


### PR DESCRIPTION
## Description

Transactions and change streams need replica-set mode, but enabling them locally should not require a separate logical replica-set resource or split-horizon TLS configuration. This follow-up to #18196 adds an initialized single-member path directly on `MongoDBServerResource`, addressing the simple inner-loop scenario discussed in #5238.

### User-facing usage: before and after

#### Before: a separate logical replica-set resource

The advanced API can already use one physical member, but still introduces a separate logical resource and its TLS/split-horizon requirements. Consumers reference and wait for that replica-set resource. This is unnecessary complexity when the goal is only local transactions and change streams.

C#:

```csharp
var mongodb = builder.AddMongoDB("mongodb");
#pragma warning disable ASPIREMONGODB001
var replicaSet = builder.AddMongoDBReplicaSet("rs0")
    .WithMember(mongodb);
#pragma warning restore ASPIREMONGODB001

builder.AddProject<Projects.MyService>("myservice")
    .WithReference(replicaSet)
    .WaitFor(replicaSet);
```

TypeScript:

```typescript
const mongodb = await builder.addMongoDB("mongodb");
const replicaSet = await builder.addMongoDBReplicaSet("rs0")
    .withMember(mongodb);

await builder.addNodeApp("myService", "../my-service", "server.js")
    .withReference(replicaSet)
    .waitFor(replicaSet);
```

#### After: opt in on the existing MongoDB server

Add `WithReplicaSet()` to the normal server configuration. Keep using ordinary `AddDatabase`, `WithReference(db)`, and `WaitFor(db)` calls; no logical replica-set resource is needed. Initialization and primary readiness are handled automatically, without requiring TLS or fixed host ports.

C#:

```csharp
#pragma warning disable ASPIREMONGODB001
var mongodb = builder.AddMongoDB("mongodb").WithReplicaSet();
#pragma warning restore ASPIREMONGODB001
var db = mongodb.AddDatabase("mydb");

builder.AddProject<Projects.MyService>("myservice")
    .WithReference(db)
    .WaitFor(db);
```

TypeScript:

```typescript
const mongodb = await builder.addMongoDB("mongodb").withReplicaSet();
const db = await mongodb.addDatabase("mydb");

await builder.addNodeApp("myService", "../my-service", "server.js")
    .withReference(db)
    .waitFor(db);
```

The before example remains supported for advanced replication/topology experiments. This PR provides a simpler path for the single-member scenario; it does not remove the advanced API or require multiple containers in the old path.

### Implementation

The optional set name defaults to the resource name. Initialization runs in the resource lifecycle with cancellation and a 90-second deadline; health checks remain observational and require a writable single-member primary. Clients use the normal endpoint with `directConnection=true` and primary read preference, so random ports and normal server/database references work without topology discovery or mandatory TLS.

Compatible persisted data is reused without forced reconfiguration. Repeated matching configuration is idempotent; conflicting names and mixing simple initialization with advanced membership fail before mutation. Advanced multi-member APIs remain separate and experimental, and both paths explicitly reject unsupported publishing. Plain MongoDB and automatic TLS behavior are preserved. README examples and all four MongoDB polyglot fixtures are updated. No new dependencies.

### API compatibility

**There are no breaking changes to the non-experimental API surface shipped in Aspire 13.5.** Existing stable APIs are preserved, and this PR adds no obsoletions. Existing standalone MongoDB usage does not need to change.

The public API contract changes are limited to the experimental replica-set APIs introduced by #18196 after 13.5. These APIs remain marked `ASPIREMONGODB001`:

- `WithReplicaSet(name)` now configures and initializes a single-member set. The name is optional, enabling `WithReplicaSet()`; existing explicit-name calls retain the same CLR method signature.
- For advanced multi-member usage, call `AddMongoDBReplicaSet(...).WithMember(...)` with plain MongoDB resources, without first calling `WithReplicaSet()` on those members. The advanced API handles their configuration and initialization separately.

These are revisions to experimental functionality, not changes to the stable 13.5 compatibility contract.

### Security considerations

The new path performs authenticated replica-set administration and generates a secret keyfile when none is supplied, reusing the existing container-file mounting and owner-read-only permissions. Authentication remains enabled, and the simple path does not enable invalid-certificate flags. An explicit keyfile must be configured before `WithReplicaSet`. Review should confirm the initialization authorization and secret-file handling; a formal threat model/security review has not been performed.

### Validation

- 142 model/public API tests passed.
- Five new functional cases passed: transactions/change streams without a developer certificate and with TLS; real container clients gated by `WaitFor(server)` and `WaitFor(database)`; and persistence across container restarts and new AppHosts.
- Existing plain MongoDB and advanced replica-set functional regressions passed.
- All four SDK restores and TypeScript, Go, Java, and Python compile/type checks passed. Full polyglot runtime orchestration was not run. An auxiliary Go test/vet run encountered pre-existing nonconstant `log.Fatalf` format calls; newly added/modified error branches use `log.Fatal`.

Container results used Docker Hub's native arm64 `mongo:8.3`: the CI mirror's amd64 image exits with `Illegal instruction` on this arm64 host. The temporary test-registry override was reverted and is not part of this PR.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No