### PR TITLE
Fix Escape handling for resource graph action menu

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -447,6 +447,15 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 });
             }
         }
+
+        [JSInvokable]
+        public async Task CloseResourceContextMenu()
+        {
+            await resources.InvokeAsync(async () =>
+            {
+                await resources.CloseContextMenuAsync(closeMenu: true);
+            });
+        }
     }
 
     internal IEnumerable<ResourceViewModel> GetFilteredResources()

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -617,7 +617,21 @@ class ResourceGraph {
     };
 
     cogMenuKeyDown = async (event) => {
-        if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
+        if (event.repeat) {
+            return;
+        }
+
+        // The cursor-positioned menu doesn't take focus, so Escape remains on the cog and must
+        // be forwarded to the Blazor close path that restores state and focus.
+        if (event.key === 'Escape' && this.openContextMenu) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            await this.resourcesInterop.invokeMethodAsync('CloseResourceContextMenu');
+            return;
+        }
+
+        if (event.key !== 'Enter' && event.key !== ' ') {
             return;
         }
 


### PR DESCRIPTION
## Description

The resource graph action menu stays focused on its cog trigger when opened, so pressing Escape never reaches the cursor-positioned menu and leaves it open with `aria-expanded="true"`.

This change forwards Escape from the focused cog through the existing Blazor menu-close lifecycle. The menu now closes, reports `aria-expanded="false"`, and restores focus to the cog consistently after either keyboard or mouse activation.

### User-facing usage

1. Open the dashboard Resources graph.
2. Focus or click a resource action cog to open its menu.
3. Press Escape to close the menu while retaining focus on the cog.

The existing `ResourceGraphCog_IsKeyboardAccessibleAndDoesNotDragNode` browser scenario covers this behavior. The flow was also verified against the DotnetProject AppHost using Chromium for both keyboard and mouse activation.

### Screenshots / Recordings


https://github.com/user-attachments/assets/7dd32492-c8cd-457a-86d1-33b5f7d64795



Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No