### PR TITLE
Fix deprecated Homebrew cask DSL usage

### DIFF
--- a/.github/workflows/homebrew-validate-release.yml
+++ b/.github/workflows/homebrew-validate-release.yml
@@ -1,7 +1,7 @@
 # Validate the Homebrew cask against a freshly-published Aspire release.
 #
 # Runs the full upstream-equivalent cask validation (`brew audit --cask
-# --online --signing` + a real `brew install`/`brew uninstall` cycle)
+# --online` + a real `brew install`/`brew uninstall` cycle)
 # against the cask file generated from the just-published release's
 # aspire-cli-osx-* archives. This is the same validation that used to
 # run as HomebrewValidateJob inside eng/pipelines/release-publish-nuget.yml.

--- a/.github/workflows/homebrew-validate-release.yml
+++ b/.github/workflows/homebrew-validate-release.yml
@@ -1,7 +1,8 @@
 # Validate the Homebrew cask against a freshly-published Aspire release.
 #
 # Runs the full upstream-equivalent cask validation (`brew audit --cask
-# --online` + a real `brew install`/`brew uninstall` cycle)
+# --online` + explicit binary notarization verification + a real
+# `brew install`/`brew uninstall` cycle)
 # against the cask file generated from the just-published release's
 # aspire-cli-osx-* archives. This is the same validation that used to
 # run as HomebrewValidateJob inside eng/pipelines/release-publish-nuget.yml.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,7 +33,7 @@ The Aspire release process uses these main automation components:
    - Normally dispatched automatically by the AzDO pipeline; it can also be run manually as a fallback after the GitHub release assets are live.
 5. **GitHub Actions workflow** (`.github/workflows/homebrew-validate-release.yml`)
    - Triggered when the release manager publishes the draft (i.e. `release: [published]`).
-   - Generates the Homebrew cask file from the just-published `aspire-cli-osx-*` assets and runs `brew audit --cask --online --signing` + a real `brew install`/`brew uninstall` cycle to catch problems before Homebrew/homebrew-cask's autobump PR is opened.
+   - Generates the Homebrew cask file from the just-published `aspire-cli-osx-*` assets and runs `brew audit --cask --online` + a real `brew install`/`brew uninstall` cycle to catch problems before Homebrew/homebrew-cask's autobump PR is opened.
 6. **GitHub Actions workflow** (`.github/workflows/extension-release.yml`)
    - Prepares a VS Code extension release PR.
    - Bumps `extension/package.json`.
@@ -233,7 +233,7 @@ This is a **manual** step performed by the release manager. The release is creat
 Publishing the draft fires the `release: [published]` event, which triggers:
 
 - [`release-update-support-mdx`](https://github.com/microsoft/aspire/actions/workflows/release-update-support-mdx.lock.yml): opens a draft PR on `microsoft/aspire.dev` to update the support mdx with the new release info.
-- [`homebrew-validate-release`](https://github.com/microsoft/aspire/actions/workflows/homebrew-validate-release.yml): runs `brew audit --cask --online --signing` + a real `brew install`/`brew uninstall` cycle against the cask generated from the just-published `aspire-cli-osx-*` assets.
+- [`homebrew-validate-release`](https://github.com/microsoft/aspire/actions/workflows/homebrew-validate-release.yml): runs `brew audit --cask --online` + a real `brew install`/`brew uninstall` cycle against the cask generated from the just-published `aspire-cli-osx-*` assets.
 
 If either downstream workflow fails, the release itself is fine — the release is published and immutable. Investigate the failure on the workflow run, fix the underlying issue, and rerun via `workflow_dispatch` against the published tag.
 
@@ -444,7 +444,7 @@ GitHub release-update-support-mdx.lock.yml (triggered on `release: published`)
 
 GitHub homebrew-validate-release.yml (triggered on `release: published`)
   -> generates aspire.rb from the just-published aspire-cli-osx-* assets
-  -> runs `brew audit --cask --online --signing` + brew install/uninstall
+  -> runs `brew audit --cask --online` + brew install/uninstall
 ```
 
 ## Related documentation

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,7 +33,7 @@ The Aspire release process uses these main automation components:
    - Normally dispatched automatically by the AzDO pipeline; it can also be run manually as a fallback after the GitHub release assets are live.
 5. **GitHub Actions workflow** (`.github/workflows/homebrew-validate-release.yml`)
    - Triggered when the release manager publishes the draft (i.e. `release: [published]`).
-   - Generates the Homebrew cask file from the just-published `aspire-cli-osx-*` assets and runs `brew audit --cask --online` + a real `brew install`/`brew uninstall` cycle to catch problems before Homebrew/homebrew-cask's autobump PR is opened.
+   - Generates the Homebrew cask file from the just-published `aspire-cli-osx-*` assets and runs `brew audit --cask --online` + explicit binary notarization verification + a real `brew install`/`brew uninstall` cycle to catch problems before Homebrew/homebrew-cask's autobump PR is opened.
 6. **GitHub Actions workflow** (`.github/workflows/extension-release.yml`)
    - Prepares a VS Code extension release PR.
    - Bumps `extension/package.json`.
@@ -233,7 +233,7 @@ This is a **manual** step performed by the release manager. The release is creat
 Publishing the draft fires the `release: [published]` event, which triggers:
 
 - [`release-update-support-mdx`](https://github.com/microsoft/aspire/actions/workflows/release-update-support-mdx.lock.yml): opens a draft PR on `microsoft/aspire.dev` to update the support mdx with the new release info.
-- [`homebrew-validate-release`](https://github.com/microsoft/aspire/actions/workflows/homebrew-validate-release.yml): runs `brew audit --cask --online` + a real `brew install`/`brew uninstall` cycle against the cask generated from the just-published `aspire-cli-osx-*` assets.
+- [`homebrew-validate-release`](https://github.com/microsoft/aspire/actions/workflows/homebrew-validate-release.yml): runs `brew audit --cask --online` + explicit binary notarization verification + a real `brew install`/`brew uninstall` cycle against the cask generated from the just-published `aspire-cli-osx-*` assets.
 
 If either downstream workflow fails, the release itself is fine — the release is published and immutable. Investigate the failure on the workflow run, fix the underlying issue, and rerun via `workflow_dispatch` against the published tag.
 
@@ -444,7 +444,7 @@ GitHub release-update-support-mdx.lock.yml (triggered on `release: published`)
 
 GitHub homebrew-validate-release.yml (triggered on `release: published`)
   -> generates aspire.rb from the just-published aspire-cli-osx-* assets
-  -> runs `brew audit --cask --online` + brew install/uninstall
+   -> runs `brew audit --cask --online` + binary notarization verification + brew install/uninstall
 ```
 
 ## Related documentation

--- a/eng/homebrew/README.md
+++ b/eng/homebrew/README.md
@@ -143,8 +143,8 @@ cask URL points at validation time:
 
 | Mode | Cask URL resolves? | Audit args | Used by |
 |---|---|---|---|
-| `LiveRelease` | Yes — points at a live GitHub release | `brew audit --cask --online --signing` + `brew install`/`brew uninstall` | `.github/workflows/homebrew-validate-release.yml`, on `release: [published]` after the human publishes the draft |
-| `LiveArchives` | Not yet — release for `v#{version}` hasn't been published | `brew audit --cask --no-signing` (no `--online`) | `azure-pipelines.yml` Homebrew Cask job; `.github/workflows/tests.yml`; `dogfood.sh` PR validation |
+| `LiveRelease` | Yes — points at a live GitHub release | `brew audit --cask --online` + `brew install`/`brew uninstall` | `.github/workflows/homebrew-validate-release.yml`, on `release: [published]` after the human publishes the draft |
+| `LiveArchives` | Not yet — release for `v#{version}` hasn't been published | `brew audit --cask` (no `--online`) | `azure-pipelines.yml` Homebrew Cask job; `.github/workflows/tests.yml`; `dogfood.sh` PR validation |
 
 Common to both modes:
 
@@ -160,8 +160,7 @@ audit methods (`audit_download`, `audit_signing`, `audit_rosetta`,
 release that doesn't exist yet at source-build time. Excluding them
 individually with `--except` is brittle — any new `--online`-gated audit
 method that touches the archive in a future brew release would silently
-start failing. `--no-signing` is also used because PR-build /
-source-build archives are unsigned CI artifacts.
+start failing.
 
 The price is that LiveArchives doesn't run the `--online`-only checks:
 github/gitlab repo probes, homepage redirect/404 detection, livecheck

--- a/eng/homebrew/README.md
+++ b/eng/homebrew/README.md
@@ -143,7 +143,7 @@ cask URL points at validation time:
 
 | Mode | Cask URL resolves? | Audit args | Used by |
 |---|---|---|---|
-| `LiveRelease` | Yes — points at a live GitHub release | `brew audit --cask --online` + `brew install`/`brew uninstall` | `.github/workflows/homebrew-validate-release.yml`, on `release: [published]` after the human publishes the draft |
+| `LiveRelease` | Yes — points at a live GitHub release | `brew audit --cask --online` + binary notarization verification + `brew install`/`brew uninstall` | `.github/workflows/homebrew-validate-release.yml`, on `release: [published]` after the human publishes the draft |
 | `LiveArchives` | Not yet — release for `v#{version}` hasn't been published | `brew audit --cask` (no `--online`) | `azure-pipelines.yml` Homebrew Cask job; `.github/workflows/tests.yml`; `dogfood.sh` PR validation |
 
 Common to both modes:

--- a/eng/homebrew/aspire.rb.template
+++ b/eng/homebrew/aspire.rb.template
@@ -5,8 +5,7 @@ cask "aspire" do
   sha256 arm:   "${SHA256_OSX_ARM64}",
          intel: "${SHA256_OSX_X64}"
 
-  url "https://github.com/microsoft/aspire/releases/download/v#{version}/aspire-cli-osx-#{arch}-#{version}.tar.gz",
-      verified: "github.com/microsoft/aspire/"
+  url "https://github.com/microsoft/aspire/releases/download/v#{version}/aspire-cli-osx-#{arch}-#{version}.tar.gz"
   name "Aspire CLI"
   desc "CLI for building observable, production-ready distributed applications"
   homepage "https://aspire.dev/"
@@ -31,8 +30,8 @@ cask "aspire" do
   # The sidecar tells the CLI which install channel placed this binary, so
   # behaviors like self-update can route through `brew` instead of overwriting
   # the cask payload. See docs/specs/install-routes.md.
-  postflight do
-    File.write("#{staged_path}/.aspire-install.json", %Q({"source":"brew"}\n))
+  postflight_steps do
+    write_file ".aspire-install.json", "{\"source\":\"brew\"}\n", base: :staged_path
   end
 
   # Empty by design. `~/.aspire/` is shared user state across all Aspire CLI

--- a/eng/homebrew/dogfood.sh
+++ b/eng/homebrew/dogfood.sh
@@ -134,13 +134,9 @@ local_url_prefix = ARGV[1]
 lines = File.readlines(cask_path, chomp: true)
 rewritten = []
 
-# The cask has a 2-line url stanza:
-#   url "https://github.com/microsoft/aspire/...",
-#       verified: "github.com/microsoft/aspire/"
-# For dogfood install, replace the url with a file:// path and drop the
-# trailing verified line. file:// URLs are exempt from `audit_missing_verified`
-# (brew's `file_url?` short-circuits the check), and dogfood.sh only runs
-# `brew install` — not `brew audit` — so audit_no_match never fires either.
+# For dogfood install, replace the release URL with a file:// path. The cask's
+# default URL verification behavior is sufficient for release downloads, and
+# file:// URLs do not require additional verification metadata.
 i = 0
 while i < lines.length
   line = lines[i]
@@ -148,9 +144,6 @@ while i < lines.length
   if stripped.start_with?('url "https://github.com/microsoft/aspire/releases/download/')
     rewritten << "  url \"#{local_url_prefix}/aspire-cli-osx-\#{arch}-\#{version}.tar.gz\""
     i += 1
-    if i < lines.length && lines[i].strip.start_with?('verified:')
-      i += 1
-    end
     next
   end
 

--- a/eng/homebrew/validate-cask-artifact.sh
+++ b/eng/homebrew/validate-cask-artifact.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 #
 # Validation modes:
 #   * LiveRelease  — Validates against the live GitHub release for the cask's
-#                    version. Runs the full `brew audit --cask --online
-#                    --signing` (the same gauntlet Homebrew/homebrew-cask's
-#                    per-cask CI runs for a bump PR) plus a real
+#                    version. Runs the full `brew audit --cask --online`
+#                    (the same gauntlet Homebrew/homebrew-cask's per-cask CI
+#                    runs for a bump PR) plus a real
 #                    `brew install`/`brew uninstall` cycle. Used by the
 #                    release pipeline after `PublishReleaseAssetsJob` has
 #                    uploaded the aspire-cli-osx-* archives to the GitHub
@@ -17,8 +17,8 @@ set -euo pipefail
 #   * LiveArchives — Validates against the cask file alone, without depending
 #                    on the cask URL resolving (the GitHub release for the
 #                    version-being-built doesn't exist yet at source-build
-#                    time). Runs `brew audit --cask --no-signing` — all
-#                    structural checks (style, syntax, naming, verified-vs-url
+#                    time). Runs `brew audit --cask` — all structural checks
+#                    (style, syntax, naming, verified-vs-url
 #                    consistency, version format, conflicts, depends_on
 #                    rules). Drops `--online` because several `audit_*`
 #                    methods (download, signing, rosetta, min_os) try to
@@ -160,9 +160,9 @@ echo "brew test-bot --only-tap-syntax succeeded."
 
 echo ""
 # Match the audit arg set that Homebrew/homebrew-cask CI runs for an existing
-# cask bump: `brew audit --cask --online --signing <cask>`. (`--new` is added
-# upstream only when the cask is being submitted for the first time, which is
-# a human-driven path not covered by this pipeline.)
+# cask bump: `brew audit --cask --online <cask>`. (`--new` is added upstream
+# only when the cask is being submitted for the first time, which is a
+# human-driven path not covered by this pipeline.)
 #
 # In LiveRelease mode `--online` is brew's depth flag that enables the
 # network-requiring audit methods on top of the structural ones: archive
@@ -177,9 +177,6 @@ echo ""
 # fetches the cask URL). Excluding them individually with `--except` is
 # brittle because any new `--online`-gated audit method that touches the
 # archive in a future brew release would silently start failing.
-# `--no-signing` is also used because PR-build / source-build archives are
-# unsigned/ad-hoc-signed CI artifacts, not notarized release assets — even
-# if we could fetch them, `audit_signing` would reject them.
 #
 # What we lose in LiveArchives by dropping `--online`:
 #   * github/gitlab repo probes (e.g. "is microsoft/aspire archived?")
@@ -188,9 +185,9 @@ echo ""
 # All of these run in LiveRelease in `homebrew-validate-release.yml` for every
 # released version, so a regression in any of them surfaces there.
 echo "Auditing cask via local tap..."
-audit_args=(--cask --online --signing)
+audit_args=(--cask --online)
 if [[ "$VALIDATION_MODE" == "LiveArchives" ]]; then
-  audit_args=(--cask --no-signing)
+  audit_args=(--cask)
 fi
 audit_args+=("$TAP_NAME/$CASK_NAME")
 audit_command="brew audit ${audit_args[*]}"

--- a/eng/homebrew/validate-cask-artifact.sh
+++ b/eng/homebrew/validate-cask-artifact.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # Validation modes:
 #   * LiveRelease  — Validates against the live GitHub release for the cask's
 #                    version. Runs the full `brew audit --cask --online`
-#                    (the same gauntlet Homebrew/homebrew-cask's per-cask CI
-#                    runs for a bump PR) plus a real
+#                    plus explicit binary notarization verification (matching
+#                    Homebrew/homebrew-cask's signing audit) and a real
 #                    `brew install`/`brew uninstall` cycle. Used by the
 #                    release pipeline after `PublishReleaseAssetsJob` has
 #                    uploaded the aspire-cli-osx-* archives to the GitHub
@@ -228,6 +228,24 @@ if [[ "$VALIDATION_MODE" == "LiveRelease" ]]; then
     brew info --cask "$test_cask_ref" || true
     exit 1
   fi
+
+  cask_version="$(awk -F'"' '/^[[:space:]]*version[[:space:]]+"/ { print $2; exit }' "$CASK_FILE")"
+  installed_binary="$(brew --prefix)/Caskroom/$CASK_NAME/$cask_version/aspire"
+  if [[ ! -f "$installed_binary" ]]; then
+    echo "Error: installed Aspire binary not found at $installed_binary." >&2
+    exit 1
+  fi
+
+  if ! command -v codesign >/dev/null 2>&1; then
+    echo "Error: codesign is required for LiveRelease binary notarization validation." >&2
+    exit 1
+  fi
+
+  # Homebrew no longer exposes --signing for `brew audit`. Because this cask
+  # is installed from a temporary third-party tap, audit_signing does not run
+  # automatically as it does for homebrew/cask. Preserve that release gate by
+  # applying the same notarization requirement directly to the installed binary.
+  codesign --verify -R=notarized --check-notarization "$installed_binary"
 
   echo "  Path: $(command -v aspire)"
   aspire_version="$(aspire --version 2>&1)"

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
@@ -614,6 +614,9 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
 
         Assert.NotEqual(0, result.ExitCode);
         var brewLog = await File.ReadAllTextAsync(Path.Combine(env.TempDirectory, "brew.log"));
+        Assert.Contains("audit --cask --online local/aspire/aspire", brewLog);
+        Assert.DoesNotContain("--signing", brewLog);
+        Assert.DoesNotContain("--no-signing", brewLog);
         Assert.Contains("uninstall --cask local/aspire-test/aspire", brewLog);
     }
 
@@ -642,22 +645,26 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
         var cask = await File.ReadAllTextAsync(Path.Combine(outputDir, "aspire.rb"));
         Assert.Contains("version \"13.3.0\"", cask);
         Assert.Contains("https://github.com/microsoft/aspire/releases/download/v#{version}/aspire-cli-osx-#{arch}-#{version}.tar.gz", cask);
-        Assert.Contains("verified: \"github.com/microsoft/aspire/\"", cask);
+        Assert.DoesNotContain("verified:", cask);
+        Assert.Contains("postflight_steps do", cask);
+        Assert.Contains("write_file \".aspire-install.json\", \"{\\\"source\\\":\\\"brew\\\"}\\n\", base: :staged_path", cask);
         Assert.Contains((await GetSha256HexAsync(Path.Combine(archiveRoot, "aspire-cli-osx-arm64-13.3.0.tar.gz"))).ToLowerInvariant(), cask);
         Assert.Contains((await GetSha256HexAsync(Path.Combine(archiveRoot, "aspire-cli-osx-x64-13.3.0.tar.gz"))).ToLowerInvariant(), cask);
         Assert.DoesNotContain("${", cask);
         Assert.True(File.Exists(Path.Combine(outputDir, "dogfood.sh")));
 
-        // LiveArchives mode must drop `--online` and add `--no-signing` to `brew audit`,
-        // because the cask URL points at a github.com/microsoft/aspire release that does
+        // LiveArchives mode must drop `--online` from `brew audit`, because the cask URL
+        // points at a github.com/microsoft/aspire release that does
         // not exist yet at source-build time. See the `audit_args` block in
         // eng/homebrew/validate-cask-artifact.sh for the full rationale; this assertion
         // locks the contract so a regression in the mode selection surfaces here rather
         // than silently failing (or worse, silently succeeding) in the source-build
         // prepare stage.
         var brewLog = await File.ReadAllTextAsync(Path.Combine(env.TempDirectory, "brew.log"));
-        Assert.Contains("audit --cask --no-signing local/aspire/aspire", brewLog);
+        Assert.Contains("audit --cask local/aspire/aspire", brewLog);
         Assert.DoesNotContain("audit --cask --online", brewLog);
+        Assert.DoesNotContain("--signing", brewLog);
+        Assert.DoesNotContain("--no-signing", brewLog);
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
@@ -106,12 +106,13 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
         return (manifestDir, archiveRoot);
     }
 
-    private static async Task<string> CreateMockHomebrewBinAsync(TestEnvironment env, int aspireExitCode)
+    private static async Task<string> CreateMockHomebrewBinAsync(TestEnvironment env, int aspireExitCode, int codesignExitCode = 0)
     {
         var mockBinDir = Path.Combine(env.TempDirectory, "mock-homebrew-bin");
         var brewRepository = Path.Combine(env.TempDirectory, "brew-repository");
         var brewPrefix = Path.Combine(env.TempDirectory, "brew-prefix");
         var brewLog = Path.Combine(env.TempDirectory, "brew.log");
+        var codesignLog = Path.Combine(env.TempDirectory, "codesign.log");
 
         Directory.CreateDirectory(mockBinDir);
         Directory.CreateDirectory(brewRepository);
@@ -130,6 +131,8 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
             exit {{aspireExitCode}}
             ASPIRE
               chmod +x "{{mockBinDir}}/aspire"
+                            mkdir -p "{{brewPrefix}}/Caskroom/aspire/13.3.0"
+                            cp "{{mockBinDir}}/aspire" "{{brewPrefix}}/Caskroom/aspire/13.3.0/aspire"
             }
 
             case "${1:-}" in
@@ -179,6 +182,7 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
                 ;;
               uninstall)
                 rm -f "{{mockBinDir}}/aspire"
+                                rm -rf "{{brewPrefix}}/Caskroom/aspire"
                 exit 0
                 ;;
               untap)
@@ -198,6 +202,14 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
             exit 0
             """);
         FileHelper.MakeExecutable(curlPath);
+
+        var codesignPath = Path.Combine(mockBinDir, "codesign");
+        await File.WriteAllTextAsync(codesignPath, $$"""
+            #!/usr/bin/env bash
+            echo "$*" >> "{{codesignLog}}"
+            exit {{codesignExitCode}}
+            """);
+        FileHelper.MakeExecutable(codesignPath);
 
         return mockBinDir;
     }
@@ -617,6 +629,35 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
         Assert.Contains("audit --cask --online local/aspire/aspire", brewLog);
         Assert.DoesNotContain("--signing", brewLog);
         Assert.DoesNotContain("--no-signing", brewLog);
+        Assert.Contains("uninstall --cask local/aspire-test/aspire", brewLog);
+        var codesignLog = await File.ReadAllTextAsync(Path.Combine(env.TempDirectory, "codesign.log"));
+        Assert.Contains("--verify -R=notarized --check-notarization", codesignLog);
+        Assert.Contains("Caskroom/aspire/13.3.0/aspire", codesignLog);
+    }
+
+    [Fact]
+    [RequiresTools(["ruby"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "Bash script tests require bash shell")]
+    public async Task Bash_PrepareHomebrewCask_FailedSigningValidation_UninstallsCask()
+    {
+        using var env = new TestEnvironment();
+        var archiveRoot = Path.Combine(env.TempDirectory, "archives");
+        await CreateFakeHomebrewArchivesAsync(archiveRoot);
+        var mockBinDir = await CreateMockHomebrewBinAsync(env, aspireExitCode: 0, codesignExitCode: 42);
+        using var cmd = new ScriptToolCommand("eng/homebrew/prepare-cask-artifact.sh", env, _testOutput);
+        cmd.WithEnvironmentVariable("PATH", $"{mockBinDir}{Path.PathSeparator}/usr/bin:/bin:/usr/sbin:/sbin");
+
+        var result = await cmd.ExecuteAsync(
+            "--version", "13.3.0",
+            "--channel", "stable",
+            "--archive-root", archiveRoot,
+            "--output-dir", Path.Combine(env.TempDirectory, "homebrew-output"),
+            "--validation-mode", "LiveRelease");
+
+        Assert.NotEqual(0, result.ExitCode);
+        var codesignLog = await File.ReadAllTextAsync(Path.Combine(env.TempDirectory, "codesign.log"));
+        Assert.Contains("--verify -R=notarized --check-notarization", codesignLog);
+        var brewLog = await File.ReadAllTextAsync(Path.Combine(env.TempDirectory, "brew.log"));
         Assert.Contains("uninstall --cask local/aspire-test/aspire", brewLog);
     }
 


### PR DESCRIPTION
## Description

Homebrew 6.x reports deprecation warnings for the Aspire cask because it uses the legacy `verified:` URL parameter and `postflight` stanza. This updates the generated cask template to use Homebrew's default URL verification behavior and `postflight_steps`/`write_file`, so `brew update` and cask validation no longer emit those warnings.

The Homebrew validation scripts, workflow documentation, and regression tests are updated to use the current `brew audit` arguments without the removed `--signing` and `--no-signing` flags. Dogfood URL rewriting remains compatible with the updated one-line URL stanza.

Validation completed:

- `brew style --cask` passed.
- `brew test-bot --only-tap-syntax` passed.
- `brew audit --cask` passed against the generated cask.
- Targeted Homebrew acquisition tests passed.
- Shell syntax and `git diff --check` passed.

Fixes # (issue)

## Notes

Output from terminal 

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the microsoft/homebrew-aspire tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/microsoft/homebrew-aspire/Casks/a/aspire.rb:8

Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the microsoft/homebrew-aspire tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/microsoft/homebrew-aspire/Casks/a/aspire.rb:24
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
