### PR TITLE
Reject numeric persistence mode values in dashboard configuration

### DIFF
--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -38,8 +38,9 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
         if (_configuration[DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] is { Length: > 0 } persistenceMode)
         {
-            if (Enum.TryParse<DashboardPersistenceMode>(persistenceMode, ignoreCase: true, out var parsedPersistenceMode) &&
-                Enum.IsDefined(parsedPersistenceMode))
+            if (!int.TryParse(persistenceMode, out _) &&
+    Enum.TryParse<DashboardPersistenceMode>(persistenceMode, ignoreCase: true, out var parsedPersistenceMode) &&
+    Enum.IsDefined(parsedPersistenceMode))
             {
                 options.Data.PersistenceMode = parsedPersistenceMode;
                 options.Data.PersistenceModeParseError = null;

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -39,8 +39,8 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
         if (_configuration[DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] is { Length: > 0 } persistenceMode)
         {
             if (!int.TryParse(persistenceMode, out _) &&
-    Enum.TryParse<DashboardPersistenceMode>(persistenceMode, ignoreCase: true, out var parsedPersistenceMode) &&
-    Enum.IsDefined(parsedPersistenceMode))
+               Enum.TryParse<DashboardPersistenceMode>(persistenceMode, ignoreCase: true, out var parsedPersistenceMode) &&
+               Enum.IsDefined(parsedPersistenceMode))
             {
                 options.Data.PersistenceMode = parsedPersistenceMode;
                 options.Data.PersistenceModeParseError = null;

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -90,6 +90,7 @@
       <GeneratorCommandLine>$(GeneratorCommandLine) @"$(ConfigurationSchemaGeneratorRspPath)"</GeneratorCommandLine>
     </PropertyGroup>
 
+
     <Exec Command="$(GeneratorCommandLine)" />
 
     <ItemGroup>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -90,6 +90,8 @@
       <GeneratorCommandLine>$(GeneratorCommandLine) @"$(ConfigurationSchemaGeneratorRspPath)"</GeneratorCommandLine>
     </PropertyGroup>
 
+
+
     <Exec Command="$(GeneratorCommandLine)" />
 
     <ItemGroup>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -90,7 +90,6 @@
       <GeneratorCommandLine>$(GeneratorCommandLine) @"$(ConfigurationSchemaGeneratorRspPath)"</GeneratorCommandLine>
     </PropertyGroup>
 
-
     <Exec Command="$(GeneratorCommandLine)" />
 
     <ItemGroup>

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -90,6 +90,26 @@ public sealed class DashboardOptionsTests
             result.FailureMessage);
     }
 
+    [Fact]
+    public void PostConfigure_NumericDashboardPersistenceMode_IsInvalid()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] = "1"
+            })
+            .Build();
+        var options = GetValidOptions();
+
+        new PostConfigureDashboardOptions(configuration).PostConfigure(null, options);
+        var result = new ValidateDashboardOptions().Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(
+            "Failed to parse dashboard persistence mode '1'. Possible values: None, Run, Resume.",
+            result.FailureMessage);
+    }
+
     #region Frontend options
 
     [Fact]


### PR DESCRIPTION
## Description

`PostConfigureDashboardOptions` uses `Enum.TryParse` followed by `Enum.IsDefined` to validate the `--persistence` value. `Enum.TryParse` accepts numeric strings that map to defined enum values, so `--persistence 1` silently succeeded and initialized the Dashboard in `Run` mode, even though only the named values `None`, `Run`, and `Resume` are documented as valid.

This adds a check to reject numeric input before attempting the enum parse, so numeric values are now correctly rejected with the existing parse-error message. Added a regression test covering this case.

Fixes #19781

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No