### PR TITLE
fix(dashboard): hide UTC timestamps option when Show timestamps is off

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -761,13 +761,16 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 Icon = new Icons.Regular.Size16.CalendarClock()
             });
 
-            _logsMenuItems.Add(new()
+            // UTC timestamps only apply when timestamps are shown.
+            if (_showTimestamp)
             {
-                OnClick = () => ToggleTimestampAsync(showTimestamp: _showTimestamp, isTimestampUtc: !_isTimestampUtc),
-                Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
-                Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
-                IsDisabled = !_showTimestamp
-            });
+                _logsMenuItems.Add(new()
+                {
+                    OnClick = () => ToggleTimestampAsync(showTimestamp: _showTimestamp, isTimestampUtc: !_isTimestampUtc),
+                    Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
+                    Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
+                });
+            }
 
             _logsMenuItems.Add(new()
             {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -1107,6 +1107,62 @@ public partial class ConsoleLogsTests : DashboardTestContext
         }
     }
 
+    [Fact]
+    public async Task UtcTimestampsMenuItem_HiddenWhenShowTimestampsDisabled_ShownWhenEnabled()
+    {
+        // Arrange
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: name => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var viewport = CreateViewport(isDesktop: true);
+        var cut = RenderConsoleLogsPage(viewport, "test-resource");
+
+        cut.WaitForState(() => cut.Instance.PageViewModel.SelectedResource?.Id?.InstanceId == "test-resource");
+
+        // Act: open settings menu while timestamps are off (default)
+        var settingsMenuButton = cut.Find("fluent-button[title='" + Resources.ConsoleLogs.ConsoleLogsSettings + "']");
+        settingsMenuButton.Click();
+
+        // Assert: UTC timestamps option is not present when Show timestamps is disabled
+        cut.WaitForAssertion(() =>
+        {
+            var settingsMenu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i =>
+                i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampShow ||
+                i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampHide));
+            Assert.DoesNotContain(settingsMenu.Instance.Items, i => i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc);
+        });
+
+        // Act: enable Show timestamps
+        var menu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i =>
+            i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampShow ||
+            i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampHide));
+        var showTimestampsItem = menu.Instance.Items.Single(i => i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampShow);
+        Assert.NotNull(showTimestampsItem.OnClick);
+        await cut.InvokeAsync(() => menu.Instance.OpenChanged.InvokeAsync(false));
+        await cut.InvokeAsync(showTimestampsItem.OnClick);
+        cut.Render();
+
+        // Re-open settings menu
+        cut.WaitForAssertion(() => Assert.False(menu.Instance.Open));
+        settingsMenuButton.Click();
+
+        // Assert: UTC timestamps option appears once timestamps are shown
+        cut.WaitForAssertion(() =>
+        {
+            var settingsMenu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i =>
+                i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampHide));
+            Assert.Contains(settingsMenu.Instance.Items, i => i.Text == Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc);
+        });
+    }
+
     private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null, IResourceRepository? resourceRepository = null)
     {
         FluentUISetupHelpers.SetupFluentDialogProvider(this);


### PR DESCRIPTION
## Summary
Hides the UTC timestamps menu item in the logs filter unless Show timestamps is enabled, matching expected UX.

Fixes #19019

## Test plan
- [x] Added UI coverage for hidden vs shown UTC menu item
- [ ] Manual dashboard check