### PR TITLE
Fix explicit dashboard run options not overriding inherited environment values

### DIFF
--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -119,8 +119,14 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Build args from typed options. These are added before unmatched tokens
         // so that raw pass-through arguments (unmatched tokens) take precedence.
         var unmatchedTokens = parseResult.UnmatchedTokens;
-        var allowAnonymous = parseResult.GetValue(s_allowAnonymousOption);
         AddOptionArgs(parseResult, dashboardArgs, unmatchedTokens, _environment);
+
+        // Resolve the effective anonymous-access setting using the same precedence
+        // (forwarded arg, then unmatched token, then environment) that determines what
+        // actually reaches the child process, so credential generation below stays
+        // consistent with what AddOptionArgs just decided to forward.
+        var allowAnonymousValue = ResolveSettingValue(dashboardArgs, unmatchedTokens, _environment, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
+        var allowAnonymous = allowAnonymousValue is not null && bool.TryParse(allowAnonymousValue, out var parsedAllowAnonymous) && parsedAllowAnonymous;
 
         // Set a browser token for frontend auth unless anonymous access is enabled.
         // Tokens and keys are passed via environment variables (not command-line args)
@@ -133,7 +139,7 @@ internal sealed class DashboardRunCommand : BaseCommand
             ["Logging__LogLevel__Default"] = LogLevel.Debug.ToString()
         };
         layoutLease?.AddEnvironment(environmentVariables);
-        if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, _environment, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
+        if (!allowAnonymous)
         {
             if (!ConfigSettingHasValue(unmatchedTokens, _environment, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName))
             {

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -120,6 +120,7 @@ internal sealed class DashboardRunCommand : BaseCommand
         // so that raw pass-through arguments (unmatched tokens) take precedence.
         var unmatchedTokens = parseResult.UnmatchedTokens;
         AddOptionArgs(parseResult, dashboardArgs, unmatchedTokens, _environment);
+        dashboardArgs.AddRange(unmatchedTokens);
 
         // Resolve the effective anonymous-access setting using the same precedence
         // (forwarded arg, then unmatched token, then environment) that determines what
@@ -160,8 +161,6 @@ internal sealed class DashboardRunCommand : BaseCommand
                 }
             }
         }
-
-        dashboardArgs.AddRange(unmatchedTokens);
 
         // Resolve URLs for the summary display.
         var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, _environment, browserToken);

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -302,41 +302,35 @@ internal sealed class DashboardRunCommand : BaseCommand
     /// </summary>
     internal static string? ResolveSettingValue(List<string> args, IReadOnlyList<string> unmatchedTokens, IEnvironment environment, string key)
     {
-        // First check --KEY=value in args (last-wins).
-        var result = ResolveArgValue(args, key);
-        if (result is not null)
-        {
-            return result;
-        }
+        var combined = new List<string>(args);
+        combined.AddRange(unmatchedTokens); // safe even if args already contains these — last-wins is idempotent under duplication
 
-        // Check unmatched tokens for space-separated form: --KEY value
+        string? result = null;
+        var equalsPrefix = $"--{key}=";
         var bareKey = $"--{key}";
-        for (var i = 0; i < unmatchedTokens.Count; i++)
+        for (var i = 0; i < combined.Count; i++)
         {
-            if (unmatchedTokens[i].Equals(bareKey, StringComparison.OrdinalIgnoreCase) && i + 1 < unmatchedTokens.Count)
+            var arg = combined[i];
+            if (arg.StartsWith(equalsPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                return unmatchedTokens[i + 1];
+                result = arg[equalsPrefix.Length..];
+            }
+            else if (arg.Equals(bareKey, StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < combined.Count && !combined[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    result = combined[i + 1];
+                    i++;
+                }
+                else
+                {
+                    result = "true";
+                }
             }
         }
 
         // Fall back to environment variable.
-        return environment.GetEnvironmentVariable(key);
-    }
-
-    internal static string? ResolveArgValue(List<string> args, string key)
-    {
-        // Scan for --KEY=value (last-wins).
-        string? result = null;
-        var prefix = $"--{key}=";
-        foreach (var arg in args)
-        {
-            if (arg.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            {
-                result = arg.Substring(prefix.Length);
-            }
-        }
-
-        return result;
+        return result ?? environment.GetEnvironmentVariable(key);
     }
 
     internal sealed record DashboardInfo(string DashboardUrl, string OtlpGrpcUrl, string OtlpHttpUrl);

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -201,12 +201,14 @@ internal sealed class DashboardRunCommand : BaseCommand
     private static void AddStringOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
         IEnvironment environment, Option<string?> option, string envVarName, string? defaultValue)
     {
-        if (ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
+        var explicitResult = parseResult.GetResult(option);
+
+        if (explicitResult is null && ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
         {
             return;
         }
 
-        var value = parseResult.GetResult(option) is not null
+        var value = explicitResult is not null
             ? parseResult.GetValue(option)
             : defaultValue;
 
@@ -219,18 +221,18 @@ internal sealed class DashboardRunCommand : BaseCommand
     private static void AddBoolOptionArg(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens,
         IEnvironment environment, Option<bool> option, string envVarName, bool? defaultValue = null)
     {
-        if (ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
+        var result = parseResult.GetResult(option);
+        var isExplicit = result is not null && !result.Implicit;
+        if (!isExplicit && ConfigSettingHasValue(unmatchedTokens, environment, envVarName))
         {
             return;
         }
-
-        var result = parseResult.GetResult(option);
 
         // When the user explicitly specified the option, use their value.
         // When a defaultValue is provided and the user did not specify the option, use the default.
         // Without a defaultValue, skip when the result comes from the option's default value rather
         // than explicit user input, to avoid always emitting e.g. "--ALLOW_ANONYMOUS=false".
-        if (result is not null && !result.Implicit)
+        if (isExplicit)
         {
             var value = parseResult.GetValue(option);
             args.Add($"--{envVarName}={value.ToString().ToLowerInvariant()}");

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -311,6 +311,59 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_ExplicitAllowAnonymousFalse_OverridesEnvironmentValue()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var environment = CreateEnvironment(new Dictionary<string, string?>
+        {
+            ["ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS"] = "true"
+        });
+
+        string[]? capturedArgs = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace, environment: environment);
+        executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run --allow-anonymous false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedArgs);
+        Assert.Contains("--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=false", capturedArgs);
+    }
+
+    [Fact]
+    public async Task DashboardRunCommand_ExplicitAllowAnonymousFalse_OverridesEnvironment_StillGeneratesCredentials()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var environment = CreateEnvironment(new Dictionary<string, string?>
+        {
+            ["ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS"] = "true"
+        });
+
+        IDictionary<string, string>? capturedEnv = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace, environment: environment);
+        executionFactory.AssertionCallback = (_, env, _, _) => { capturedEnv = env; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run --allow-anonymous false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedEnv);
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__FRONTEND__BROWSERTOKEN"));
+        Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__FRONTEND__BROWSERTOKEN"]));
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__API__PRIMARYAPIKEY"));
+        Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__API__PRIMARYAPIKEY"]));
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_WithoutAllowAnonymous_SetsBrowserTokenEnvVar()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -389,6 +389,32 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_TypedTrueThenSpaceSeparatedUnmatchedFalse_StillGeneratesCredentials()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        string[]? capturedArgs = null;
+        IDictionary<string, string>? capturedEnv = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
+        executionFactory.AssertionCallback = (args, env, _, _) => { capturedArgs = args; capturedEnv = env; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run --allow-anonymous --ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedEnv);
+        // The later space-separated unmatched token makes the effective value false,
+        // so the dashboard runs secured — credentials MUST be generated or it's unreachable.
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__FRONTEND__BROWSERTOKEN"));
+        Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__FRONTEND__BROWSERTOKEN"]));
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__API__PRIMARYAPIKEY"));
+        Assert.False(string.IsNullOrEmpty(capturedEnv["DASHBOARD__API__PRIMARYAPIKEY"]));
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_WithoutAllowAnonymous_SetsBrowserTokenEnvVar()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -364,6 +364,31 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_ConflictingTypedAndUnmatchedAllowAnonymous_UnmatchedTokenWins()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        string[]? capturedArgs = null;
+        IDictionary<string, string>? capturedEnv = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
+        executionFactory.AssertionCallback = (args, env, _, _) => { capturedArgs = args; capturedEnv = env; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run --allow-anonymous --ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedArgs);
+        Assert.Equal(
+            "--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=false",
+            capturedArgs.Last(a => a.StartsWith("--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=", StringComparison.Ordinal)));
+        Assert.NotNull(capturedEnv);
+        Assert.True(capturedEnv.ContainsKey("DASHBOARD__FRONTEND__BROWSERTOKEN"));
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_WithoutAllowAnonymous_SetsBrowserTokenEnvVar()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -260,6 +260,57 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_ExplicitPersistenceOption_OverridesEnvironmentValue()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var environment = CreateEnvironment(new Dictionary<string, string?>
+        {
+            ["ASPIRE_DASHBOARD_PERSISTENCE_MODE"] = "Run"
+        });
+
+        string[]? capturedArgs = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace, environment: environment);
+        executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run --persistence None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedArgs);
+        Assert.Contains("--ASPIRE_DASHBOARD_PERSISTENCE_MODE=None", capturedArgs);
+        Assert.DoesNotContain("--ASPIRE_DASHBOARD_PERSISTENCE_MODE=Run", capturedArgs);
+    }
+
+    [Fact]
+    public async Task DashboardRunCommand_NoExplicitOption_UsesEnvironmentValue()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var environment = CreateEnvironment(new Dictionary<string, string?>
+        {
+            ["ASPIRE_DASHBOARD_APPLICATION_NAME"] = "EnvApp"
+        });
+
+        string[]? capturedArgs = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace, environment: environment);
+        executionFactory.AssertionCallback = (args, _, _, _) => { capturedArgs = args; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedArgs);
+        Assert.DoesNotContain(capturedArgs, arg => arg.StartsWith("--ASPIRE_DASHBOARD_APPLICATION_NAME=", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_WithoutAllowAnonymous_SetsBrowserTokenEnvVar()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -625,7 +676,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     private (IServiceCollection Services, string ManagedPath, TestProcessExecutionFactory ExecutionFactory) CreateServicesWithLayout(
         TemporaryWorkspace workspace,
         TestInteractionService? interactionService = null,
-        TestBundleService? bundleService = null)
+        TestBundleService? bundleService = null,
+        IEnvironment? environment = null)
     {
         var layoutDir = Path.Combine(workspace.WorkspaceRoot.FullName, "layout");
         var managedDir = Path.Combine(layoutDir, "managed");
@@ -654,6 +706,10 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             if (interactionService is not null)
             {
                 options.InteractionServiceFactory = _ => interactionService;
+            }
+            if (environment is not null)
+            {
+                options.EnvironmentFactory = _ => environment;
             }
         });
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -91,6 +91,7 @@ internal static class CliTestHelper
         // Populate feature flag configuration in in-memory collection.
         options.ConfigurationCallback += config =>
         {
+
             foreach (var featureFlag in options.EnabledFeatures)
             {
                 config[$"{KnownFeatures.FeaturePrefix}:{featureFlag}"] = "true";
@@ -704,6 +705,7 @@ internal sealed class CliServiceCollectionTestOptions
     // Layout discovery - returns null by default (no bundle layout), causing SDK mode fallback
     public Func<IServiceProvider, ILayoutDiscovery> LayoutDiscoveryFactory { get; set; } = _ => new NullLayoutDiscovery();
     public Func<IServiceProvider, IEnvironment> EnvironmentFactory { get; set; } = _ => new TestEnvironment();
+
     // Bundle service - returns no-op implementation by default (no embedded bundle)
     public Func<IServiceProvider, IBundleService> BundleServiceFactory { get; set; } = _ => new NullBundleService();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -4,23 +4,30 @@
 using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Agents;
-using Aspire.Cli.Agents.Hooks;
 using Aspire.Cli.Agents.AspireSkills;
+using Aspire.Cli.Agents.Hooks;
 using Aspire.Cli.Agents.Playwright;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Caching;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Commands.Sdk;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Diagnostics;
 using Aspire.Cli.Documentation.ApiDocs;
+using Aspire.Cli.Documentation.Docs;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Git;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Mcp;
-using Aspire.Cli.Documentation.Docs;
+using Aspire.Cli.Migrations;
+using Aspire.Cli.Npm;
 using Aspire.Cli.NuGet;
+using Aspire.Cli.Packaging;
 using Aspire.Cli.Processes;
+using Aspire.Cli.Profiling;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Secrets;
@@ -28,6 +35,8 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Utils;
+using Aspire.Cli.Utils.EnvironmentChecker;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,15 +45,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
-using Aspire.Cli.Configuration;
-using Aspire.Cli.Migrations;
-using Aspire.Cli.Utils;
-using Aspire.Cli.Utils.EnvironmentChecker;
-using Aspire.Cli.Packaging;
-using Aspire.Cli.Caching;
-using Aspire.Cli.Diagnostics;
-using Aspire.Cli.Npm;
-using Aspire.Cli.Profiling;
 
 namespace Aspire.Cli.Tests.Utils;
 
@@ -89,7 +89,8 @@ internal static class CliTestHelper
         var configurationValues = new Dictionary<string, string?>();
 
         // Populate feature flag configuration in in-memory collection.
-        options.ConfigurationCallback += config => {
+        options.ConfigurationCallback += config =>
+        {
             foreach (var featureFlag in options.EnabledFeatures)
             {
                 config[$"{KnownFeatures.FeaturePrefix}:{featureFlag}"] = "true";
@@ -221,7 +222,7 @@ internal static class CliTestHelper
         // IdentityChannelReader for AspireVersionCheck (doctor) — uses the same
         // pattern as production wiring in Program.cs.
         services.AddSingleton<IIdentityChannelReader>(_ => new IdentityChannelReader(typeof(Program).Assembly));
-        services.AddSingleton<IEnvironment, TestEnvironment>();
+        services.AddSingleton(options.EnvironmentFactory);
         services.AddSingleton<ProfileCaptureState>();
         services.AddSingleton<ProfileCaptureService>();
 
@@ -702,7 +703,7 @@ internal sealed class CliServiceCollectionTestOptions
 
     // Layout discovery - returns null by default (no bundle layout), causing SDK mode fallback
     public Func<IServiceProvider, ILayoutDiscovery> LayoutDiscoveryFactory { get; set; } = _ => new NullLayoutDiscovery();
-
+    public Func<IServiceProvider, IEnvironment> EnvironmentFactory { get; set; } = _ => new TestEnvironment();
     // Bundle service - returns no-op implementation by default (no embedded bundle)
     public Func<IServiceProvider, IBundleService> BundleServiceFactory { get; set; } = _ => new NullBundleService();
 


### PR DESCRIPTION
## Description

`DashboardRunCommand.AddStringOptionArg` and `AddBoolOptionArg` checked whether an environment variable already had a value before checking if the user explicitly supplied a CLI option. If the environment variable existed, the method returned early and never forwarded the explicit `--persistence` or `--application-name` flag, so the inherited environment value always won — even when the user explicitly passed a different value on the command line.

Both methods now check for an explicit CLI option first and only fall back to the environment-check early return when no explicit option was supplied, so explicit CLI options correctly take precedence.

Added test coverage for both the override case (explicit option beats environment value) and the existing correct fallback case (environment value is still used when no explicit option is given).

Fixes #19779

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No