### PR TITLE
Add "Manage" links from Redis to Redis Commander/Insight

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -245,6 +245,8 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 8081, name: "http")
                                       .ExcludeFromManifest();
 
+            AddManagementLinks(resourceBuilder, "http", "Manage (Commander)");
+
             builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, async (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
@@ -392,10 +394,38 @@ public static class RedisBuilderExtensions
                 resourceBuilder.WithEndpoint("http", ep => ep.UriScheme = "https");
             });
 
+            AddManagementLinks(resourceBuilder, "http", "Manage (Insights)");
+
             configureContainer?.Invoke(resourceBuilder);
 
             return builder;
         }
+    }
+
+    /// <summary>
+    /// Hides <paramref name="resourceBuilder"/> and adds a "Manage" URL pointing at its <paramref name="endpointName"/>
+    /// endpoint to every <see cref="RedisResource"/> in the app.
+    /// </summary>
+    private static void AddManagementLinks<T>(IResourceBuilder<T> resourceBuilder, string endpointName, string displayText)
+        where T : IResourceWithEndpoints
+    {
+        resourceBuilder.WithHidden();
+
+        var endpoint = resourceBuilder.GetEndpoint(endpointName);
+        resourceBuilder.ApplicationBuilder.OnBeforeStart((@event, ct) =>
+        {
+            foreach (var redisResource in @event.Model.Resources.OfType<RedisResource>())
+            {
+                redisResource.Annotations.Add(new ResourceUrlAnnotation
+                {
+                    Url = "/",
+                    DisplayText = displayText,
+                    Endpoint = endpoint
+                });
+            }
+
+            return Task.CompletedTask;
+        });
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -858,14 +858,56 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             return;
         }
 
-        if (endpoint.Metadata.OwnerReferences is null)
+        if (endpoint.Metadata.OwnerReferences is not null)
+        {
+            foreach (var ownerReference in endpoint.Metadata.OwnerReferences)
+            {
+                await TryRefreshResource(ownerReference.Kind, ownerReference.Name).ConfigureAwait(false);
+            }
+        }
+
+        // A resource can display a URL for an endpoint owned by a different resource (see
+        // ResourceUrlAnnotation.Endpoint and the cross-resource URL handling in ResourceSnapshotBuilder.GetUrls).
+        // The refresh above only covers the endpoint's owning resource, so resources that merely reference the
+        // endpoint would otherwise never learn that it became active/inactive and their URL would get stuck.
+        await RefreshResourcesReferencingEndpoint(endpoint).ConfigureAwait(false);
+    }
+
+    private async Task RefreshResourcesReferencingEndpoint(Endpoint endpoint)
+    {
+        if (endpoint.Spec.ServiceName is not { } serviceName ||
+            !_resourceState.ServicesMap.TryGetValue(serviceName, out var service) ||
+            service.AppModelResourceName is not { } endpointOwnerResourceName ||
+            service.EndpointName is not { } endpointName)
         {
             return;
         }
 
-        foreach (var ownerReference in endpoint.Metadata.OwnerReferences)
+        foreach (var (resourceName, resource) in _resourceState.ApplicationModel)
         {
-            await TryRefreshResource(ownerReference.Kind, ownerReference.Name).ConfigureAwait(false);
+            if (StringComparers.ResourceName.Equals(resourceName, endpointOwnerResourceName))
+            {
+                // The owning resource was already refreshed above.
+                continue;
+            }
+
+            if (!resource.TryGetUrls(out var urls) ||
+                !urls.Any(u => u.Endpoint is { } e &&
+                    StringComparers.ResourceName.Equals(e.Resource.Name, endpointOwnerResourceName) &&
+                    string.Equals(e.EndpointName, endpointName, StringComparisons.EndpointAnnotationName)))
+            {
+                continue;
+            }
+
+            foreach (var appResource in _resourceState.AppResources)
+            {
+                if (appResource is IResourceReference reference &&
+                    reference is not ServiceWithModelResource &&
+                    StringComparers.ResourceName.Equals(reference.ModelResource.Name, resourceName))
+                {
+                    await TryRefreshResource(appResource.DcpResourceKind, appResource.DcpResourceName).ConfigureAwait(false);
+                }
+            }
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -875,8 +875,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     private async Task RefreshResourcesReferencingEndpoint(Endpoint endpoint)
     {
-        if (endpoint.Spec.ServiceName is not { } serviceName ||
-            !_resourceState.ServicesMap.TryGetValue(serviceName, out var service) ||
+        // Resolved from AppResources rather than ServicesMap: AppResources is built synchronously from the app
+        // model before the resource watcher starts, so it can't race against the separate Service watch loop
+        // that populates ServicesMap.
+        var service = endpoint.Spec.ServiceName is { } serviceName
+            ? _resourceState.AppResources.OfType<ServiceWithModelResource>().Select(s => s.Service).FirstOrDefault(s => s.Metadata.Name == serviceName)
+            : null;
+
+        if (service is null ||
             service.AppModelResourceName is not { } endpointOwnerResourceName ||
             service.EndpointName is not { } endpointName)
         {

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
@@ -264,6 +265,76 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var redisinsight = builder.Resources.Single(r => r.Name.Equals("redisinsight"));
 
         Assert.NotNull(redisinsight);
+    }
+
+    [Fact]
+    public void WithRedisCommanderHidesTheCommanderResource()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddRedis("myredis").WithRedisCommander();
+
+        var commander = Assert.Single(builder.Resources.OfType<RedisCommanderResource>());
+        var hidden = Assert.Single(commander.Annotations.OfType<HiddenAnnotation>());
+        Assert.Equal(HiddenBehavior.Always, hidden.Behavior);
+    }
+
+    [Fact]
+    public void WithRedisInsightHidesTheInsightResource()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddRedis("myredis").WithRedisInsight();
+
+        var insight = Assert.Single(builder.Resources.OfType<RedisInsightResource>());
+        var hidden = Assert.Single(insight.Annotations.OfType<HiddenAnnotation>());
+        Assert.Equal(HiddenBehavior.Always, hidden.Behavior);
+    }
+
+    [Fact]
+    public async Task WithRedisInsightAddsManagementLinkToEveryRedisResourceInTheApp()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        var redis1 = builder.AddRedis("myredis1").WithRedisInsight();
+        var redis2 = builder.AddRedis("myredis2");
+
+        using var app = builder.Build();
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var insight = Assert.Single(model.Resources.OfType<RedisInsightResource>());
+
+        await eventing.PublishAsync(new BeforeStartEvent(app.Services, model));
+
+        foreach (var redis in new[] { redis1.Resource, redis2.Resource })
+        {
+            var managementUrl = Assert.Single(redis.Annotations.OfType<ResourceUrlAnnotation>(), u => u.DisplayText == "Manage (Insights)");
+            Assert.Equal(insight.Name, managementUrl.Endpoint?.Resource.Name);
+            Assert.Equal("http", managementUrl.Endpoint?.EndpointName);
+            Assert.Equal("/", managementUrl.Url);
+        }
+    }
+
+    [Fact]
+    public async Task WithRedisCommanderAddsManagementLinkToEveryRedisResourceInTheApp()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+        var redis1 = builder.AddRedis("myredis1").WithRedisCommander();
+        var redis2 = builder.AddRedis("myredis2").WithRedisCommander();
+        // redis3 never calls WithRedisCommander() itself, but Commander manages every Redis resource in the app.
+        var redis3 = builder.AddRedis("myredis3");
+
+        using var app = builder.Build();
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var commander = Assert.Single(model.Resources.OfType<RedisCommanderResource>());
+
+        await eventing.PublishAsync(new BeforeStartEvent(app.Services, model));
+
+        foreach (var redis in new[] { redis1.Resource, redis2.Resource, redis3.Resource })
+        {
+            var managementUrl = Assert.Single(redis.Annotations.OfType<ResourceUrlAnnotation>(), u => u.DisplayText == "Manage (Commander)");
+            Assert.Equal(commander.Name, managementUrl.Endpoint?.Resource.Name);
+            Assert.Equal("http", managementUrl.Endpoint?.EndpointName);
+            Assert.Equal("/", managementUrl.Url);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -97,6 +97,96 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresFeature(TestFeature.ContainerRuntime)]
+    public async Task VerifyRedisCommanderManagementLinkCoversEveryRedisResourceItManages()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        IResourceBuilder<RedisCommanderResource>? commanderBuilder = null;
+        var redis1 = builder.AddRedis("redis1").WithRedisCommander(c => commanderBuilder = c);
+        var redis2 = builder.AddRedis("redis2");
+        Assert.NotNull(commanderBuilder);
+
+        using var app = builder.Build();
+
+        await app.StartAsync(cts.Token);
+
+        foreach (var redis in new[] { redis1, redis2 })
+        {
+            var redisEvent = await app.ResourceNotifications.WaitForResourceAsync(
+                redis.Resource.Name,
+                e => e.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "Manage (Commander)") is { IsInactive: false },
+                cts.Token);
+
+            var managementUrl = redisEvent.Snapshot.Urls.First(u => u.DisplayProperties.DisplayName == "Manage (Commander)");
+            Assert.Equal("http", managementUrl.Name);
+
+            Assert.Equal(managementUrl.Url, managementUrl.Url);
+        }
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
+    public async Task VerifyRedisCommanderManagementLinkTracksCommanderLifecycleAndCommanderIsHidden()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
+
+        IResourceBuilder<RedisCommanderResource>? commanderBuilder = null;
+        var redis = builder.AddRedis("redis").WithRedisCommander(c =>
+        {
+            c.WithExplicitStart();
+            commanderBuilder = c;
+        });
+        Assert.NotNull(commanderBuilder);
+
+        using var app = builder.Build();
+
+        await app.StartAsync(cts.Token);
+
+        var redisEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            redis.Resource.Name,
+            e => e.Snapshot.State == KnownResourceStates.Running,
+            cts.Token);
+
+        var managementUrl = redisEvent.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "Manage (Commander)");
+        Assert.NotNull(managementUrl);
+        Assert.True(managementUrl.IsInactive);
+
+        var startResult = await app.ResourceCommands.ExecuteCommandAsync(commanderBuilder.Resource, KnownResourceCommands.StartCommand);
+        Assert.True(startResult.Success, startResult.Message);
+
+        var commanderEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            commanderBuilder.Resource.Name,
+            e => e.Snapshot.State == KnownResourceStates.Running,
+            cts.Token);
+        Assert.True(commanderEvent.Snapshot.IsHidden);
+
+        redisEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            redis.Resource.Name,
+            e => e.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "Manage (Commander)") is { IsInactive: false },
+            cts.Token);
+
+        // The link must be a real, absolute, clickable URL, not the "/" placeholder some AppHost code paths use
+        // before the standard URL pipeline resolves it against the endpoint's allocated address.
+        managementUrl = redisEvent.Snapshot.Urls.First(u => u.DisplayProperties.DisplayName == "Manage (Commander)");
+        Assert.True(Uri.TryCreate(managementUrl.Url, UriKind.Absolute, out _), $"Expected an absolute URL but got '{managementUrl.Url}'.");
+
+        var stopResult = await app.ResourceCommands.ExecuteCommandAsync(commanderBuilder.Resource, KnownResourceCommands.StopCommand);
+        Assert.True(stopResult.Success, stopResult.Message);
+
+        await app.ResourceNotifications.WaitForResourceAsync(
+            redis.Resource.Name,
+            e => e.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "Manage (Commander)") is { IsInactive: true },
+            cts.Token);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -99,7 +99,6 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisCommanderManagementLinkCoversEveryRedisResourceItManages()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
 
         IResourceBuilder<RedisCommanderResource>? commanderBuilder = null;
@@ -109,7 +108,14 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync(cts.Token);
+        // Startup gets its own timeout budget, separate from the verification waits below, so slow container
+        // startup under CI contention can't eat into the time available for those waits.
+        using (var startCts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
+        {
+            await app.StartAsync(startCts.Token);
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
 
         var commanderEvent = await app.ResourceNotifications.WaitForResourceAsync(
             commanderBuilder.Resource.Name,
@@ -136,7 +142,6 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisCommanderManagementLinkTracksCommanderLifecycleAndCommanderIsHidden()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
 
         IResourceBuilder<RedisCommanderResource>? commanderBuilder = null;
@@ -149,7 +154,14 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync(cts.Token);
+        // Startup gets its own timeout budget, separate from the verification waits below, so slow container
+        // startup under CI contention can't eat into the time available for those waits.
+        using (var startCts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
+        {
+            await app.StartAsync(startCts.Token);
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
 
         var redisEvent = await app.ResourceNotifications.WaitForResourceAsync(
             redis.Resource.Name,

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -111,6 +111,12 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
         await app.StartAsync(cts.Token);
 
+        var commanderEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            commanderBuilder.Resource.Name,
+            e => e.Snapshot.State == KnownResourceStates.Running,
+            cts.Token);
+        var commanderEndpointUri = new Uri(commanderEvent.Snapshot.Urls.First(u => u.Name == "http").Url);
+
         foreach (var redis in new[] { redis1, redis2 })
         {
             var redisEvent = await app.ResourceNotifications.WaitForResourceAsync(
@@ -120,8 +126,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
             var managementUrl = redisEvent.Snapshot.Urls.First(u => u.DisplayProperties.DisplayName == "Manage (Commander)");
             Assert.Equal("http", managementUrl.Name);
-
-            Assert.Equal(managementUrl.Url, managementUrl.Url);
+            Assert.Equal(commanderEndpointUri, new Uri(managementUrl.Url));
         }
 
         await app.StopAsync();

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -987,6 +987,64 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         Assert.False(crossResourceUrl.IsInactive);
     }
 
+    [Fact]
+    public async Task WithUrlFromAnotherResourcesEndpointTracksThatResourcesRunningState()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        // Resource A has the endpoint. It starts explicitly so the test can control exactly when it becomes active.
+        var resourceA = builder.AddProject<Projects.ServiceA>("resourcea")
+            .WithHttpEndpoint(name: "api")
+            .WithExplicitStart();
+
+        // Resource B gets a URL that references resource A's endpoint via the object model.
+        var resourceB = builder.AddProject<Projects.ServiceA>("resourceb")
+            .WithUrls(c =>
+            {
+                c.Urls.Add(new()
+                {
+                    DisplayText = "API Docs",
+                    Url = "/",
+                    Endpoint = resourceA.Resource.GetEndpoint("api")
+                });
+            });
+
+        await using var app = await builder.BuildAsync();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await app.StartAsync();
+
+        // Resource B comes up before resource A is started, so its cross-resource URL should be present but inactive.
+        var resourceEvent = await rns.WaitForResourceAsync(
+            resourceB.Resource.Name,
+            e => e.Snapshot.State == KnownResourceStates.Running,
+            default).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+
+        var crossResourceUrl = resourceEvent.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "API Docs");
+        Assert.NotNull(crossResourceUrl);
+        Assert.True(crossResourceUrl.IsInactive);
+
+        // Start resource A. Resource B never changes state itself, but its cross-resource URL should become active.
+        var startResult = await app.ResourceCommands.ExecuteCommandAsync(resourceA.Resource, KnownResourceCommands.StartCommand).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(startResult.Success, startResult.Message);
+
+        resourceEvent = await rns.WaitForResourceAsync(
+            resourceB.Resource.Name,
+            e => e.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "API Docs") is { IsInactive: false },
+            default).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+
+        // Stop resource A again. Resource B's URL should go back to inactive, without resource B itself restarting.
+        var stopResult = await app.ResourceCommands.ExecuteCommandAsync(resourceA.Resource, KnownResourceCommands.StopCommand).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(stopResult.Success, stopResult.Message);
+
+        resourceEvent = await rns.WaitForResourceAsync(
+            resourceB.Resource.Name,
+            e => e.Snapshot.Urls.FirstOrDefault(u => u.DisplayProperties.DisplayName == "API Docs") is { IsInactive: true },
+            default).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+
+        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
+    }
+
     private sealed class CustomResource(string name) : Resource(name), IResourceWithEndpoints
     {
 


### PR DESCRIPTION
## Summary

With that fixed, `WithRedisCommander()`/`WithRedisInsight()` now hide the tool container and add a "Manage" URL back onto every Redis resource in the app (not just the one the method happened to be called on, since the tool manages all of them). The link is registered once via the app-wide `BeforeStartEvent`, early enough for Aspire's standard URL-processing pipeline to resolve it against the tool's allocated endpoint.  Fixes #11603.

Also Fixes Underlying DCP bug behind #14061 -  `DcpResourceWatcher` only refreshed a resource's own snapshot when *its* endpoint changed, so a resource displaying a cross-resource URL (via `ResourceUrlAnnotation.Endpoint`) never had its `IsInactive` flag updated when the *referenced* resource's endpoint activated/deactivated — the URL got stuck. `RefreshResourcesReferencingEndpoint` now finds and refreshes any resource holding such a reference.

<img width="1258" height="361" alt="image" src="https://github.com/user-attachments/assets/3a27d69f-ef30-44de-be35-8e51dc6760fb" />

For now, only applying this against Redis Insights/Commander.  Assuming this works out, I'd like to expand this pattern to other management resources.  (phpmyadmin, dbgate etc.)

## Validation

- Verified live against the Redis playground dashboard: the "Manage (Commander)"/"Manage (Insights)" links render as real, absolute, clickable URLs on the `redis` resource, and clicking through opens a working, already-connected tool instance.
- New regression test (`WithUrlsTests.cs`) reproduces the stuck cross-resource URL bug and confirms the DCP fix.
- Unit tests (`AddRedisTests.cs`) cover: every Redis resource in the app gets the link (not just ones that called `WithRedisCommander`/`WithRedisInsight` directly), and the tool resource is hidden.
- Real-container functional tests (`RedisFunctionalTests.cs`) cover: link tracks the tool's start/stop lifecycle, `WithExplicitStart` combinations, and a single shared tool instance linking correctly from multiple Redis resources.
- Full existing `RedisFunctionalTests`/`DcpExecutorTests`/`WithUrlsTests` suites pass with no regressions.

## Test plan

- [x] `dotnet test` — `Aspire.Hosting.Tests` (`WithUrlsTests`, `DcpExecutorTests`, `DistributedApplicationTests`)
- [x] `dotnet test` — `Aspire.Hosting.Redis.Tests` (`AddRedisTests`, `RedisFunctionalTests`)
- [x] Manual verification against the Redis playground dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)