### PR TITLE
Register time API client for BlazorHosted prerendering

### DIFF
--- a/playground/BlazorHosted/BlazorHosted.Server/Program.cs
+++ b/playground/BlazorHosted/BlazorHosted.Server/Program.cs
@@ -44,6 +44,11 @@ builder.Services.AddHttpClient("weatherapi", client =>
     client.BaseAddress = new Uri("https+http://weatherapi");
 });
 
+builder.Services.AddHttpClient("timeapi", client =>
+{
+    client.BaseAddress = new Uri("https+http://timeapi");
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/tests/Aspire.Playground.Tests/BlazorWasmHostingTests.cs
+++ b/tests/Aspire.Playground.Tests/BlazorWasmHostingTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Playground.Tests;
 public class BlazorWasmHostingTests(ITestOutputHelper testOutput)
 {
     [Fact]
-    public async Task HostedBlazorWasm_ServesAppAndWeatherApi()
+    public async Task HostedBlazorWasm_ServesAppAndApis()
     {
         await using var app = await CreateAppAsync(typeof(Projects.BlazorHosted_AppHost));
 
@@ -27,6 +27,12 @@ public class BlazorWasmHostingTests(ITestOutputHelper testOutput)
         Assert.Equal(HttpStatusCode.OK, homeResponse.StatusCode);
         var homeContent = await homeResponse.Content.ReadAsStringAsync();
         Assert.Contains("blazor.web.js", homeContent);
+
+        var timeResponse = await blazorClient.GetAsync("/time");
+        Assert.Equal(HttpStatusCode.OK, timeResponse.StatusCode);
+        var timeContent = await timeResponse.Content.ReadAsStringAsync();
+        Assert.Contains("Server Time", timeContent);
+        Assert.Contains("Local Time:", timeContent);
 
         var configResponse = await blazorClient.GetAsync("/_blazor/_configuration");
         Assert.Equal(HttpStatusCode.OK, configResponse.StatusCode);


### PR DESCRIPTION
## Description

Registers the `timeapi` named `HttpClient` on the BlazorHosted server.

The Time page uses `IHttpClientFactory.CreateClient("timeapi")`. Because the component uses `InteractiveWebAssembly`, it can run during server prerendering before the WebAssembly client takes over. The WASM client already registers `timeapi`, but the server did not, so the initial prerender execution could enter the error path even though the later client-side execution succeeded.

This matches the existing `weatherapi` registration pattern already used by the sample.

<img width="1871" height="1152" alt="image" src="https://github.com/user-attachments/assets/36e763ef-9707-488c-b782-5e2016116583" />

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No