### PR TITLE
Resolve IPV4Host from the allocated address when TargetHost is customized

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -438,8 +438,15 @@ public enum EndpointProperty
     /// </summary>
     Host,
     /// <summary>
-    /// The IPv4 address of the endpoint.
+    /// The address of the endpoint, preferring an IP literal over a host name that may resolve to more than one address.
     /// </summary>
+    /// <remarks>
+    /// An endpoint bound to localhost - the default, a <c>*.localhost</c> TLD, a wildcard address, or a machine name -
+    /// resolves to <c>127.0.0.1</c> rather than <c>localhost</c>, so that consumers which cannot use a host name are not
+    /// handed a name that may resolve to <c>::1</c>. An endpoint whose <see cref="EndpointAnnotation.TargetHost"/> names
+    /// one specific address resolves to the address the orchestrator allocated, which may be IPv6, for example
+    /// <c>[::1]</c>.
+    /// </remarks>
     IPV4Host,
     /// <summary>
     /// The port of the endpoint.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using Aspire.Hosting.Dcp;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -221,6 +222,11 @@ public sealed class EndpointReference : IExpressionValue, IManifestExpressionPro
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
+    // The endpoint annotation, or null when the endpoint is not defined on the resource. Unlike
+    // EndpointAnnotation this never throws, so callers that only want to inspect the endpoint can do so
+    // without turning a missing endpoint into an exception.
+    internal EndpointAnnotation? EndpointAnnotationOrDefault => GetEndpointAnnotation();
+
     private EndpointAnnotation? GetEndpointAnnotation()
     {
         if (_endpointAnnotation is not null)
@@ -364,10 +370,30 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
         {
             EndpointProperty.Scheme => new(Endpoint.Scheme),
             EndpointProperty.TlsEnabled => Endpoint.TlsEnabled ? bool.TrueString : bool.FalseString,
-            EndpointProperty.IPV4Host when networkContext == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
+            EndpointProperty.IPV4Host when networkContext == KnownNetworkIdentifiers.LocalhostNetwork && BindsToLocalhost() => "127.0.0.1",
             EndpointProperty.TargetPort when Endpoint.TargetPort is int port => new(port.ToString(CultureInfo.InvariantCulture)),
             _ => await ResolveValueWithAllocatedAddress().ConfigureAwait(false)
         };
+
+        // IPV4Host exists so that consumers which cannot use a hostname (SQL Server, the Azure emulators) get an
+        // IPv4 literal rather than "localhost", which may resolve to ::1. That substitution is only correct while the
+        // endpoint address is "localhost" - the default, a *.localhost TLD, a wildcard bind, or an arbitrary machine
+        // name, all of which NormalizeTargetHost maps to localhost. When TargetHost names one specific address
+        // instead ("[::1]", a LAN address), the endpoint is not reachable on 127.0.0.1, so fall through and use the
+        // address the orchestrator allocated, the same value EndpointProperty.Host resolves to.
+        bool BindsToLocalhost()
+        {
+            // A null annotation means the endpoint is not defined. Keep answering immediately rather than letting
+            // the fall-through path surface the missing-endpoint exception for a property that never needed it.
+            var targetHost = Endpoint.EndpointAnnotationOrDefault?.TargetHost;
+            if (targetHost is null)
+            {
+                return true;
+            }
+
+            var (address, _) = DcpModelUtilities.NormalizeTargetHost(targetHost);
+            return string.Equals(address, KnownHostNames.Localhost, StringComparison.OrdinalIgnoreCase);
+        }
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -128,6 +128,48 @@ public class EndpointReferenceTests
     }
 
     [Fact]
+    public async Task GetValueAsync_IPV4Host_WithCustomTargetHost_UsesAllocatedAddress()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "tcp", name: "tcp")
+        {
+            TargetHost = "[::1]"
+        };
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var ipv4Expr = endpointRef.Property(EndpointProperty.IPV4Host);
+
+        // A customized TargetHost means the endpoint is not on 127.0.0.1, so the value has to wait for the
+        // address the orchestrator actually allocated instead of answering with the loopback literal.
+        var getValueTask = ipv4Expr.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "[::1]", 1433);
+
+        var ipv4 = await getValueTask;
+        Assert.Equal("[::1]", ipv4);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_IPV4Host_WithLocalhostTldTargetHost_ReturnsImmediately()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http")
+        {
+            TargetHost = "myapp.dev.localhost"
+        };
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var ipv4Expr = endpointRef.Property(EndpointProperty.IPV4Host);
+
+        // A *.localhost name resolves to the caller's own loopback, so the literal is still correct here.
+        var ipv4 = await ipv4Expr.GetValueAsync(CancellationToken.None);
+        Assert.Equal("127.0.0.1", ipv4);
+    }
+
+    [Fact]
     public async Task GetValueAsync_TargetPort_WithStaticPort_ReturnsImmediately()
     {
         var resource = new TestResource("test");


### PR DESCRIPTION
Fixes #19972

## Problem

`EndpointProperty.IPV4Host` returned the literal `"127.0.0.1"` for any endpoint resolved in the localhost network context, without ever consulting the endpoint's configured or allocated address:

```csharp
EndpointProperty.IPV4Host when networkContext == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
```

So `WithEndpoint("tcp", e => { e.TargetHost = "[::1]"; e.IsProxied = false; })` changes the DCP port binding and the allocated endpoint, but every `IPV4Host` consumer stays pointed at `127.0.0.1`. The most visible casualty is `SqlServerServerResource`, whose connection string is built from `IPV4Host` (`src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs:50`) — the `sql_check` health check and the `AddDatabase` creation step both fail with "connection refused" because nothing is listening on `127.0.0.1:1433`. The issue reports the same `127.0.0.1` data source for all eight `TargetHost` variants tried.

## Fix

The loopback literal is only the correct answer while the endpoint address is `localhost`. `DcpModelUtilities.NormalizeTargetHost` already encodes exactly that distinction, so the shortcut is now gated on it:

| `TargetHost` | Normalized | `IPV4Host` |
| --- | --- | --- |
| (default) `localhost` | `localhost` | `127.0.0.1` — unchanged |
| `myapp.dev.localhost` | `localhost` | `127.0.0.1` — unchanged |
| `0.0.0.0` / `[::]` | `localhost` | `127.0.0.1` — unchanged |
| `machine-name` | `localhost` | `127.0.0.1` — unchanged |
| `[::1]` | `[::1]` | allocated address |
| `10.0.0.1` | `10.0.0.1` | allocated address |

Wildcard binds and arbitrary machine names keep the literal, since their allocated address is `localhost` and substituting it would defeat the purpose of `IPV4Host` (avoiding a name that may resolve to `::1`). Only a `TargetHost` naming one specific address falls through to `ResolveValueWithAllocatedAddress()`, resolving to the same value `EndpointProperty.Host` returns.

Two details worth a reviewer's eye:

- The guard reads the annotation through a new internal `EndpointReference.EndpointAnnotationOrDefault`, which returns null instead of throwing, so an undefined endpoint still answers immediately rather than turning this property into a missing-endpoint exception.
- It reaches from `ApplicationModel` into `Aspire.Hosting.Dcp` for `NormalizeTargetHost`. Reusing it keeps one source of truth for the wildcard and machine-name mapping; happy to move that helper somewhere more neutral if you'd prefer.

An endpoint with a customized `TargetHost` now waits for allocation instead of answering synchronously. That matches `EndpointProperty.Host`, and the default path still returns immediately.

## Tests

Added to `tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs`:

- `GetValueAsync_IPV4Host_WithCustomTargetHost_UsesAllocatedAddress` — `TargetHost = "[::1]"` does not complete before allocation and resolves to `[::1]`. Verified this fails on the unpatched source.
- `GetValueAsync_IPV4Host_WithLocalhostTldTargetHost_ReturnsImmediately` — a `*.localhost` TLD still returns `127.0.0.1` immediately.

`EndpointReferenceTests`, `ExpressionResolverTests` (98 tests) and `Dcp.DcpExecutorTests` (277) pass. `Aspire.Hosting.SqlServer.Tests`: 56 pass, 9 fail because no Docker daemon is available on this machine.

The end-to-end SQL Server scenario from the issue needs a container runtime and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpvU2U6aPPWcG4XdPGLVNk