### PR TITLE
Add dry-run organization-funded Copilot review workflow

### DIFF
--- a/.github/workflows/organization-funded-copilot-reviews.yml
+++ b/.github/workflows/organization-funded-copilot-reviews.yml
@@ -1,0 +1,169 @@
+# Bot-requested reviews are billed to the organization, unlike ruleset reviews.
+# See docs/ci/organization-funded-copilot-reviews.md before enabling writes.
+name: Organization-funded Copilot reviews
+
+on:
+  pull_request_target:
+    branches: [main, 'release/**']
+    # opened: a contributor creates a PR (including a draft); request its initial review.
+    # synchronize: commits are pushed or force-pushed to the PR branch; review the new head.
+    types: [opened, synchronize]
+  # Reconcile pushes made while a review was pending, and events coalesced by
+  # concurrency. Never consume PR artifacts or run a PR's workflow/code.
+  schedule:
+    - cron: '7,22,37,52 * * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+# Only one request-making run executes at a time, across all PRs, so a push
+# handler and the scheduled scan cannot both request a review for the same PR.
+# Runs submit requests without waiting for Copilot: reviews of different PRs
+# can still proceed concurrently after those requests are accepted.
+# Keep the active run, but GitHub may replace an older queued run with a newer
+# one. The scheduled scan catches any PR updates whose queued runs were replaced.
+concurrency:
+  group: organization-funded-copilot-reviews
+  cancel-in-progress: false
+
+jobs:
+  request-reviews:
+    if: >-
+      github.repository == 'microsoft/aspire' &&
+      vars.COPILOT_REVIEW_MODE != 'disabled' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      # Intentionally inline: this privileged workflow never checks out code.
+      - name: Reconcile Copilot reviews
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COPILOT_REVIEW_MODE: ${{ vars.COPILOT_REVIEW_MODE }}
+          COPILOT_REVIEW_PR_NUMBER: ${{ vars.COPILOT_REVIEW_PR_NUMBER }}
+        with:
+          github-token: ${{ github.token }}
+          # A timed-out POST may already have started a billable review.
+          retries: 0
+          script: |
+            const owner = 'microsoft';
+            const repo = 'aspire';
+            const reviewer = 'copilot-pull-request-reviewer[bot]';
+            const mode = process.env.COPILOT_REVIEW_MODE || 'dry-run';
+            if (!['disabled', 'dry-run', 'enabled'].includes(mode)) {
+              throw new Error('COPILOT_REVIEW_MODE must be disabled, dry-run, or enabled.');
+            }
+            if (context.repo.owner !== owner || context.repo.repo !== repo) {
+              throw new Error('This workflow only operates on microsoft/aspire.');
+            }
+            if (mode === 'disabled') {
+              core.info('Copilot review automation is disabled.');
+              return;
+            }
+            if (!['pull_request_target', 'schedule', 'workflow_dispatch'].includes(context.eventName) ||
+                (context.eventName === 'workflow_dispatch' && context.ref !== 'refs/heads/main')) {
+              throw new Error('Unsupported event or workflow dispatch ref.');
+            }
+
+            // Optional pilot scope: a positive decimal PR number, e.g. "12345".
+            // Reject whitespace, signs, and trailing text instead of parseInt's
+            // permissive truncation (e.g. "12345-untrusted" must not select a PR).
+            const pilotValue = process.env.COPILOT_REVIEW_PR_NUMBER || '';
+            const pilot = pilotValue === '' ? null : Number(pilotValue);
+            if (pilot !== null && (!/^[1-9][0-9]*$/.test(pilotValue) || !Number.isSafeInteger(pilot))) {
+              throw new Error('COPILOT_REVIEW_PR_NUMBER must be a positive decimal PR number.');
+            }
+            const rows = [];
+            function record(number, sha, decision) {
+              core.info(`PR #${number} (${sha}): ${decision}`);
+              rows.push([String(number), sha, decision]);
+            }
+            function isCopilot(user) {
+              return user?.type === 'Bot' && user.login === reviewer;
+            }
+            function validatePull(pull, number) {
+              if (pull.number !== number || pull.base?.repo?.full_name !== `${owner}/${repo}` ||
+                  !/^[a-f0-9]{40}$/.test(pull.head?.sha ?? '')) {
+                throw new Error(`Invalid repository, number, or head SHA for PR #${number}.`);
+              }
+              if (!Array.isArray(pull.requested_reviewers)) {
+                throw new Error(`Missing requested reviewers for PR #${number}.`);
+              }
+            }
+            function ineligibleReason(pull) {
+              if (pull.state !== 'open') {
+                return 'Skipped: PR is not open.';
+              }
+              if (pull.base.ref !== 'main' && !pull.base.ref.startsWith('release/')) {
+                return 'Skipped: target branch is outside main/release.';
+              }
+              return null;
+            }
+            async function reconcile(number) {
+              if (!Number.isSafeInteger(number) || number <= 0) {
+                throw new Error('Invalid PR number.');
+              }
+              if (pilot !== null && number !== pilot) {
+                record(number, '-', 'Skipped: outside pilot scope.');
+                return;
+              }
+              const args = { owner, repo, pull_number: number };
+              const { data: pull } = await github.rest.pulls.get(args);
+              validatePull(pull, number);
+              const sha = pull.head.sha;
+              const reason = ineligibleReason(pull);
+              if (reason) {
+                record(number, sha, reason);
+                return;
+              }
+              if (pull.requested_reviewers.some(isCopilot)) {
+                record(number, sha, 'Deferred: Copilot review is pending.');
+                return;
+              }
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { ...args, per_page: 100 });
+              // Dismissed reviews still consumed a review for this SHA. Human
+              // comments and reviews of an older head do not suppress new work.
+              if (reviews.some(review => isCopilot(review.user) &&
+                  review.commit_id === sha && review.state !== 'PENDING')) {
+                record(number, sha, 'Skipped: Copilot already reviewed this head.');
+                return;
+              }
+              // Re-fetch before writing: the PR may have changed while we read
+              // reviews. A later scheduled scan handles a changed head safely.
+              const { data: current } = await github.rest.pulls.get(args);
+              validatePull(current, number);
+              if (ineligibleReason(current) || current.head.sha !== sha ||
+                  current.base.ref !== pull.base.ref || current.requested_reviewers.some(isCopilot)) {
+                record(number, sha, 'Deferred: PR changed during reconciliation.');
+                return;
+              }
+              if (mode === 'dry-run') {
+                record(number, sha, 'Dry run: would request Copilot review.');
+                return;
+              }
+              await github.rest.pulls.requestReviewers({ ...args, reviewers: [reviewer] });
+              record(number, sha, 'Requested Copilot review as the Actions bot.');
+            }
+
+            if (context.eventName === 'pull_request_target') {
+              await reconcile(context.payload.pull_request?.number);
+            } else if (pilot !== null) {
+              await reconcile(pilot);
+            } else {
+              for await (const page of github.paginate.iterator(github.rest.pulls.list, {
+                owner, repo, state: 'open', sort: 'created', direction: 'asc', per_page: 100
+              })) {
+                for (const pull of page.data) {
+                  await reconcile(pull.number);
+                }
+              }
+            }
+            await core.summary
+              .addHeading(`Organization-funded Copilot reviews (${mode})`)
+              .addTable([
+                [{ data: 'PR', header: true }, { data: 'Head SHA', header: true }, { data: 'Decision', header: true }],
+                ...rows
+              ])
+              .write();

--- a/docs/ci/organization-funded-copilot-reviews.md
+++ b/docs/ci/organization-funded-copilot-reviews.md
@@ -1,0 +1,126 @@
+# Organization-funded Copilot reviews
+
+The `Organization-funded Copilot reviews` workflow requests Copilot code review
+(CCR) using the repository's `GITHUB_TOKEN`, not a contributor's personal token.
+It covers open PRs (including drafts) targeting `main` or `release/**`, including forks
+and bot-authored PRs. There is no author permission or license filter.
+
+**The default is dry-run. Merging this workflow does not enable billable review
+requests or change any GitHub rulesets.**
+
+## Controls
+
+Set repository variables under **Settings > Secrets and variables > Actions >
+Variables**. No follow-up PR is needed to change modes.
+
+| Variable | Value | Effect |
+| --- | --- | --- |
+| `COPILOT_REVIEW_MODE` | Unset or `dry-run` | Read metadata and report decisions; never request reviews. |
+| `COPILOT_REVIEW_MODE` | `enabled` | Request reviews using the Actions bot. |
+| `COPILOT_REVIEW_MODE` | `disabled` | Skip the job (kill switch). |
+| `COPILOT_REVIEW_PR_NUMBER` | Unset | Consider all eligible PRs, including PRs opened before rollout. |
+| `COPILOT_REVIEW_PR_NUMBER` | A positive PR number | Restrict both event-driven and scheduled processing to that PR for a pilot. |
+
+Invalid settings fail rather than enabling writes or broadening the pilot.
+Variables are read when a run starts. Disabling the workflow does not cancel an
+already-running job or a review already requested: cancel the active workflow
+run separately when stopping an incident.
+
+## Trigger and reconciliation behavior
+
+PR creation and new pushes trigger a metadata-only `pull_request_target` run,
+including for draft PRs. Reopening a PR or marking a draft ready does not trigger
+an additional run. Manual dispatch on `main` and a scheduled
+scan every 15 minutes reconcile open PRs. GitHub can delay scheduled runs.
+
+All runs share one concurrency group without canceling the active run. GitHub
+can replace pending runs; scheduled scanning recovers missed events. The scan
+also handles PR retargeting and pushes made while Copilot is still reviewing.
+Reopened PRs remain eligible for this scan, but reopening alone does not cause
+another review of an already-reviewed head. Maintainers can manually request a
+review when reopening a PR if one is needed immediately.
+Each PR's current state is fetched from the API, not trusted from an old event.
+Both open PR enumeration and review history are paginated.
+
+A pending Copilot request defers processing. Once it completes, the next scan
+requests a review if the current head SHA has not already been reviewed by
+Copilot. Reviews by humans do not count. A dismissed Copilot review still counts
+for that SHA. This is a review of the latest pushed head, not a separate review
+of every intermediate commit in a multi-commit push.
+
+The workflow re-fetches PR state immediately before requesting a review. GitHub
+does not provide a transaction or idempotency key tying a review request to a
+particular head SHA. A concurrent push or a review requested outside this
+workflow can still race the API call. Scheduled reconciliation repairs missed
+heads; it cannot guarantee exactly-once billing.
+
+API errors fail the run visibly. Review-request POSTs are not automatically
+retried because a timeout may occur after GitHub has accepted the request. A
+later scan reads pending requests and completed reviews before requesting again.
+A stuck pending request requires maintainer investigation; the workflow never
+removes someone else's review request to force a retry.
+
+## Security boundary
+
+- The privileged workflow does not check out source, execute PR code, load local
+  actions, install packages, or consume artifacts or caches.
+- The only action is a full-SHA-pinned `actions/github-script`. All logic is
+  inline so even loading policy code does not require checkout.
+- The only token permission is `pull-requests: write`. The job uses an ephemeral
+  GitHub-hosted runner with a ten-minute timeout. No App private key or PAT is
+  used.
+- Repository and reviewer identities are fixed. PR-controlled values are API
+  data, never interpolated into scripts or used as API URLs. Logs and summaries
+  include only validated PR numbers, SHAs, and fixed decision messages.
+- Runs outside `microsoft/aspire` are rejected. Manual dispatch must use `main`.
+  Protect `main` and allowed release branches and require trusted review of
+  workflow changes: `pull_request_target` executes the base branch's workflow.
+- This job only requests reviews. It does not approve, merge, push fixes, or run
+  suggestions. CCR's own runner/setup and secret configuration is a separate
+  security boundary that must be assessed before the pilot.
+
+Dry-run uses the same token permissions but never calls the write endpoint.
+The single-PR scope and kill switch are rollout controls, not a hard spending
+limit. Once enabled for everyone, contributors can generate organization-paid
+reviews by pushing changes. Configure organization budgets/alerts and monitor
+usage; reconsider cadence if this becomes expensive or is abused.
+
+## Billing and rollout
+
+[GitHub's CCR documentation](https://docs.github.com/en/copilot/concepts/agents/code-review#code-review-usage)
+attributes built-in automatic reviews to the author and explicitly states that
+bot-requested reviews are billed directly to the organization.
+[`GITHUB_TOKEN`](https://docs.github.com/en/actions/concepts/security/github_token)
+is an installation token, not the identity of the contributor triggering the
+workflow. GitHub documents
+[requesting the Copilot reviewer through REST](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review).
+These rules support this design, but actual execution and billing under
+Microsoft's policies must be confirmed before broad rollout.
+
+1. Merge in dry-run mode and inspect workflow decisions. No production billing
+   settings or automatic review rules are changed by this PR.
+2. Identify applicable repository and organization automatic CCR rules,
+   including "Review new pushes." Disable those paths before enabling writes,
+   or they can still create author-attributed or duplicate reviews.
+3. Set `COPILOT_REVIEW_PR_NUMBER` to an agreed pilot PR. Assess CCR's downstream
+   runner permissions and confirm organization funding/budget policies.
+4. Set `COPILOT_REVIEW_MODE=enabled`. Confirm that the Actions bot starts a
+   review, then push another commit and confirm a re-review, including a push
+   during an active review. Include an external contributor in the pilot.
+5. Have a billing administrator confirm organization attribution and no
+   contributor allowance consumption for these bot-requested reviews. An API
+   success or a posted review alone is not proof of billing attribution.
+6. Clear the pilot variable to cover all eligible open PRs. Keep human approval
+   requirements unchanged and monitor spend and failed workflow runs.
+
+If `GITHUB_TOKEN` cannot initiate CCR under organization policy, leave writes
+disabled until that failure is understood. An Aspire bot App installation token
+is a possible follow-up, scoped to this repository with Pull requests: write.
+Do not substitute a personal token, silently escalate permissions, or claim
+organization billing based only on the human who triggered a workflow run.
+
+Personal automatic-review settings and manual requests are outside this
+workflow's control and retain their own billing attribution. Actions usage for
+CCR's agentic capabilities is also separate from the AI credits for the review.
+Rollback is `COPILOT_REVIEW_MODE=disabled`; do not automatically restore
+author-attributed rulesets.

--- a/tests/Infrastructure.Tests/WorkflowScripts/OrganizationFundedCopilotReviewsTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/OrganizationFundedCopilotReviewsTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Infrastructure.Tests;
+
+public sealed class OrganizationFundedCopilotReviewsTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void WorkflowKeepsPrivilegedExecutionMetadataOnly()
+    {
+        var root = LoadWorkflow();
+        Assert.Empty(Mapping(root, "permissions").Children);
+        var triggers = Mapping(root, "on");
+        Assert.Equal(["pull_request_target", "schedule", "workflow_dispatch"], triggers.Children.Keys.Select(key => key.ToString()));
+        var pullRequestTrigger = Mapping(triggers, "pull_request_target");
+        Assert.Equal(["main", "release/**"], Sequence(pullRequestTrigger, "branches"));
+        Assert.Equal(["opened", "synchronize"], Sequence(pullRequestTrigger, "types"));
+        var schedule = Assert.IsType<YamlMappingNode>(Assert.Single(Assert.IsType<YamlSequenceNode>(triggers.Children[new YamlScalarNode("schedule")])));
+        Assert.Equal("7,22,37,52 * * * *", Scalar(schedule, "cron"));
+
+        var concurrency = Mapping(root, "concurrency");
+        Assert.Equal("organization-funded-copilot-reviews", Scalar(concurrency, "group"));
+        Assert.Equal("false", Scalar(concurrency, "cancel-in-progress"));
+        var jobs = Mapping(root, "jobs");
+        var job = Assert.IsType<YamlMappingNode>(Assert.Single(jobs.Children).Value);
+        Assert.Equal(
+            "github.repository == 'microsoft/aspire' && vars.COPILOT_REVIEW_MODE != 'disabled' && " +
+            "(github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')",
+            Scalar(job, "if"));
+        Assert.Equal("ubuntu-latest", Scalar(job, "runs-on"));
+        Assert.Equal("10", Scalar(job, "timeout-minutes"));
+        var permission = Assert.Single(Mapping(job, "permissions").Children);
+        Assert.Equal("pull-requests", permission.Key.ToString());
+        Assert.Equal("write", permission.Value.ToString());
+
+        var step = ScriptStep(root);
+        Assert.Equal(["name", "uses", "env", "with"], step.Children.Keys.Select(key => key.ToString()));
+        Assert.Matches("^actions/github-script@[a-f0-9]{40}$", Scalar(step, "uses"));
+        var environment = Mapping(step, "env");
+        Assert.Equal(["COPILOT_REVIEW_MODE", "COPILOT_REVIEW_PR_NUMBER"], environment.Children.Keys.Select(key => key.ToString()));
+        Assert.Equal("${{ vars.COPILOT_REVIEW_MODE }}", Scalar(environment, "COPILOT_REVIEW_MODE"));
+        Assert.Equal("${{ vars.COPILOT_REVIEW_PR_NUMBER }}", Scalar(environment, "COPILOT_REVIEW_PR_NUMBER"));
+        var options = Mapping(step, "with");
+        Assert.Equal(["github-token", "retries", "script"], options.Children.Keys.Select(key => key.ToString()));
+        Assert.Equal("${{ github.token }}", Scalar(options, "github-token"));
+        Assert.Equal("0", Scalar(options, "retries"));
+        Assert.Equal(-1, Scalar(options, "script").IndexOf("${{", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("default-dry-run")]
+    [InlineData("explicit-dry-run")]
+    [InlineData("disabled")]
+    [InlineData("invalid-mode")]
+    [InlineData("invalid-pilot")]
+    [InlineData("unsafe-pilot")]
+    [InlineData("pilot-other-pr")]
+    [InlineData("pilot-scheduled")]
+    [InlineData("external-author")]
+    [InlineData("bot-author")]
+    [InlineData("draft")]
+    [InlineData("draft-scheduled")]
+    [InlineData("closed")]
+    [InlineData("unsupported-branch")]
+    [InlineData("release-branch")]
+    [InlineData("pending")]
+    [InlineData("reviewed")]
+    [InlineData("dismissed")]
+    [InlineData("older-review")]
+    [InlineData("human-review")]
+    [InlineData("spoofed-reviewer")]
+    [InlineData("head-changed")]
+    [InlineData("closed-before-write")]
+    [InlineData("draft-before-write")]
+    [InlineData("retargeted-before-write")]
+    [InlineData("pending-before-write")]
+    [InlineData("metadata-injection")]
+    [InlineData("wrong-repository")]
+    [InlineData("wrong-pr-repository")]
+    [InlineData("wrong-number")]
+    [InlineData("invalid-number")]
+    [InlineData("invalid-sha")]
+    [InlineData("missing-reviewers")]
+    [InlineData("unsupported-event")]
+    [InlineData("untrusted-dispatch")]
+    [InlineData("manual-dispatch")]
+    [InlineData("api-read-error")]
+    [InlineData("api-history-error")]
+    [InlineData("api-write-error")]
+    [InlineData("pagination")]
+    [InlineData("push-during-review")]
+    [RequiresTools(["node"])]
+    public async Task ReconciliationHonorsPolicy(string scenario)
+    {
+        using var workspace = TemporaryWorkspace.Create(output);
+        var script = Scalar(Mapping(ScriptStep(LoadWorkflow()), "with"), "script");
+        var scriptPath = Path.Combine(workspace.Path, "review-script.js");
+        await File.WriteAllTextAsync(scriptPath, script);
+
+        using var node = new NodeCommand(output, nameof(OrganizationFundedCopilotReviewsTests))
+            .WithTimeout(TimeSpan.FromMinutes(1));
+        var result = await node.ExecuteScriptAsync(
+            Path.Combine(RepoRoot.Path, "tests", "Infrastructure.Tests", "WorkflowScripts", "organization-funded-copilot-reviews.harness.mjs"),
+            scriptPath,
+            scenario);
+
+        Assert.True(result.ExitCode == 0, result.Output);
+    }
+
+    private static YamlMappingNode LoadWorkflow()
+    {
+        using var reader = File.OpenText(Path.Combine(RepoRoot.Path, ".github", "workflows", "organization-funded-copilot-reviews.yml"));
+        var yaml = new YamlStream();
+        yaml.Load(reader);
+        return Assert.IsType<YamlMappingNode>(yaml.Documents[0].RootNode);
+    }
+
+    private static YamlMappingNode ScriptStep(YamlMappingNode root)
+    {
+        var job = Mapping(Mapping(root, "jobs"), "request-reviews");
+        return Assert.IsType<YamlMappingNode>(Assert.Single(Assert.IsType<YamlSequenceNode>(job.Children[new YamlScalarNode("steps")])));
+    }
+
+    private static YamlMappingNode Mapping(YamlMappingNode node, string key)
+        => Assert.IsType<YamlMappingNode>(node.Children[new YamlScalarNode(key)]);
+
+    private static string Scalar(YamlMappingNode node, string key)
+        => Assert.IsType<YamlScalarNode>(node.Children[new YamlScalarNode(key)]).Value!;
+
+    private static IEnumerable<string> Sequence(YamlMappingNode node, string key)
+        => Assert.IsType<YamlSequenceNode>(node.Children[new YamlScalarNode(key)]).Select(value => value.ToString());
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/organization-funded-copilot-reviews.harness.mjs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/organization-funded-copilot-reviews.harness.mjs
@@ -1,0 +1,311 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+// Infrastructure.Tests uses the runner's Node without a TypeScript toolchain.
+// Native ESM avoids requiring a loader or Node's newer type-stripping support.
+const source = readFileSync(process.argv[2], 'utf8');
+const scenario = process.argv[3];
+const reviewer = { login: 'copilot-pull-request-reviewer[bot]', type: 'Bot' };
+const head = 'a'.repeat(40);
+const previous = 'b'.repeat(40);
+const pull = {
+    number: 42,
+    state: 'open',
+    draft: false,
+    base: { ref: 'main', repo: { full_name: 'microsoft/aspire' } },
+    head: { sha: head, ref: 'feature', repo: { full_name: 'external/fork' } },
+    requested_reviewers: [],
+    user: { login: 'external-contributor', type: 'User' },
+    title: 'A contribution',
+    body: ''
+};
+const env = { COPILOT_REVIEW_MODE: 'enabled', COPILOT_REVIEW_PR_NUMBER: '' };
+const context = {
+    repo: { owner: 'microsoft', repo: 'aspire' },
+    eventName: 'pull_request_target',
+    ref: 'refs/heads/main',
+    payload: { pull_request: { number: 42 } }
+};
+let current;
+let reviewPages = [[]];
+let pullPages = [[42]];
+let expectedWrites = 0;
+let expectedDecision = '';
+let expectedError = '';
+let failEndpoint = '';
+const writes = [];
+const calls = [];
+const messages = [];
+const getCounts = new Map();
+
+switch (scenario) {
+    case 'default-dry-run':
+        env.COPILOT_REVIEW_MODE = '';
+        expectedDecision = 'Dry run: would request';
+        break;
+    case 'explicit-dry-run':
+        env.COPILOT_REVIEW_MODE = 'dry-run';
+        expectedDecision = 'Dry run: would request';
+        break;
+    case 'disabled':
+        env.COPILOT_REVIEW_MODE = 'disabled';
+        expectedDecision = 'automation is disabled';
+        break;
+    case 'invalid-mode':
+        env.COPILOT_REVIEW_MODE = 'enable';
+        expectedError = 'COPILOT_REVIEW_MODE must be';
+        break;
+    case 'invalid-pilot':
+    case 'unsafe-pilot':
+        env.COPILOT_REVIEW_PR_NUMBER = scenario === 'invalid-pilot' ? '42-untrusted' : '9007199254740992';
+        expectedError = 'COPILOT_REVIEW_PR_NUMBER must be';
+        break;
+    case 'pilot-other-pr':
+        env.COPILOT_REVIEW_PR_NUMBER = '43';
+        expectedDecision = 'outside pilot scope';
+        break;
+    case 'pilot-scheduled':
+        env.COPILOT_REVIEW_PR_NUMBER = '42';
+        context.eventName = 'schedule';
+        expectedWrites = 1;
+        break;
+    case 'external-author':
+    case 'bot-author':
+    case 'release-branch':
+    case 'metadata-injection':
+        if (scenario === 'bot-author') {
+            pull.user = { login: 'dependabot[bot]', type: 'Bot' };
+        }
+        if (scenario === 'release-branch') {
+            pull.base.ref = 'release/13.5';
+        }
+        if (scenario === 'metadata-injection') {
+            pull.title = pull.body = pull.head.ref = '${{ secrets.TOKEN }}"; throw new Error("injected"); //';
+            pull.user.login = '<script>alert(1)</script>';
+        }
+        expectedWrites = 1;
+        break;
+    case 'draft':
+    case 'draft-scheduled':
+        pull.draft = true;
+        if (scenario === 'draft-scheduled') {
+            context.eventName = 'schedule';
+        }
+        expectedWrites = 1;
+        break;
+    case 'draft-before-write':
+        current = structuredClone(pull);
+        current.draft = true;
+        expectedWrites = 1;
+        break;
+    case 'closed':
+        pull.state = 'closed';
+        expectedDecision = 'PR is not open';
+        break;
+    case 'unsupported-branch':
+        pull.base.ref = 'unprotected-branch';
+        expectedDecision = 'target branch is outside';
+        break;
+    case 'pending':
+        pull.requested_reviewers = [reviewer];
+        expectedDecision = 'review is pending';
+        break;
+    case 'reviewed':
+    case 'dismissed':
+        reviewPages = [[{ user: reviewer, commit_id: head, state: scenario === 'dismissed' ? 'DISMISSED' : 'COMMENTED' }]];
+        expectedDecision = 'already reviewed this head';
+        break;
+    case 'older-review':
+    case 'human-review':
+    case 'spoofed-reviewer':
+        reviewPages = [[{
+            user: scenario === 'older-review' ? reviewer : { login: scenario === 'human-review' ? 'maintainer' : reviewer.login, type: 'User' },
+            commit_id: scenario === 'older-review' ? previous : head,
+            state: 'COMMENTED'
+        }]];
+        expectedWrites = 1;
+        break;
+    case 'head-changed':
+    case 'closed-before-write':
+    case 'retargeted-before-write':
+    case 'pending-before-write':
+        current = structuredClone(pull);
+        if (scenario === 'head-changed') {
+            current.head.sha = previous;
+        } else if (scenario === 'closed-before-write') {
+            current.state = 'closed';
+        } else if (scenario === 'retargeted-before-write') {
+            current.base.ref = 'release/13.5';
+        } else {
+            current.requested_reviewers = [reviewer];
+        }
+        expectedDecision = 'changed during reconciliation';
+        break;
+    case 'wrong-repository':
+        context.repo.repo = 'fork';
+        expectedError = 'only operates on microsoft/aspire';
+        break;
+    case 'wrong-pr-repository':
+        pull.base.repo.full_name = 'external/fork';
+        expectedError = 'Invalid repository, number, or head SHA';
+        break;
+    case 'wrong-number':
+        pull.number = 43;
+        expectedError = 'Invalid repository, number, or head SHA';
+        break;
+    case 'invalid-number':
+        context.payload.pull_request.number = -1;
+        expectedError = 'Invalid PR number';
+        break;
+    case 'invalid-sha':
+        pull.head.sha = '<script>';
+        expectedError = 'Invalid repository, number, or head SHA';
+        break;
+    case 'missing-reviewers':
+        Reflect.deleteProperty(pull, 'requested_reviewers');
+        expectedError = 'Missing requested reviewers';
+        break;
+    case 'unsupported-event':
+        context.eventName = 'pull_request_review';
+        expectedError = 'Unsupported event';
+        break;
+    case 'untrusted-dispatch':
+        context.eventName = 'workflow_dispatch';
+        context.ref = 'refs/heads/untrusted';
+        expectedError = 'Unsupported event';
+        break;
+    case 'manual-dispatch':
+        context.eventName = 'workflow_dispatch';
+        expectedWrites = 1;
+        break;
+    case 'api-read-error':
+    case 'api-history-error':
+    case 'api-write-error':
+        failEndpoint = scenario === 'api-read-error' ? 'get' : scenario === 'api-history-error' ? 'listReviews' : 'requestReviewers';
+        expectedError = 'API unavailable';
+        break;
+    case 'pagination':
+        context.eventName = 'schedule';
+        pullPages = [[42], [43]];
+        // Only the second page contains the current-head review.
+        reviewPages = [[{ user: reviewer, commit_id: previous, state: 'COMMENTED' }], [{ user: reviewer, commit_id: head, state: 'COMMENTED' }]];
+        expectedDecision = 'already reviewed this head';
+        break;
+    case 'push-during-review':
+        pull.requested_reviewers = [reviewer];
+        expectedWrites = 1;
+        break;
+    default:
+        throw new Error(`Unknown scenario: ${scenario}`);
+}
+
+function request(endpoint, args) {
+    calls.push(endpoint);
+    assert.equal(args.owner, 'microsoft');
+    assert.equal(args.repo, 'aspire');
+    if (endpoint === failEndpoint) {
+        throw new Error('API unavailable');
+    }
+}
+
+const pulls = {
+    get: async (args) => {
+        request('get', args);
+        const number = args.pull_number;
+        const count = (getCounts.get(number) ?? 0) + 1;
+        getCounts.set(number, count);
+        const result = structuredClone(count > 1 && current ? current : pull);
+        if (scenario === 'pagination') {
+            result.number = number;
+        }
+        return { data: result };
+    },
+    listReviews: async (_args) => { throw new Error('Use paginated review history'); },
+    list: async (_args) => { throw new Error('Use paginated PR enumeration'); },
+    requestReviewers: async (args) => {
+        request('requestReviewers', args);
+        assert.equal(env.COPILOT_REVIEW_MODE, 'enabled');
+        assert.deepEqual(Array.from(args.reviewers), [reviewer.login]);
+        assert.equal(args.pull_number, 42);
+        writes.push(args);
+        pull.requested_reviewers = [reviewer];
+    }
+};
+const paginate = Object.assign(
+    async (endpoint, args) => {
+        assert.equal(endpoint, pulls.listReviews);
+        assert.equal(args.per_page, 100);
+        request('listReviews', args);
+        return reviewPages.flat();
+    },
+    {
+        iterator: async function* (endpoint, args) {
+            assert.equal(endpoint, pulls.list);
+            assert.equal(args.per_page, 100);
+            request('list', args);
+            for (const numbers of pullPages) {
+                yield { data: numbers.map(number => ({ number })) };
+            }
+        }
+    }
+);
+const summary = {
+    addHeading: (_heading) => summary,
+    addTable: (_rows) => summary,
+    write: async () => {}
+};
+async function execute() {
+    // Execute the exact YAML-extracted script with only mocked APIs and env.
+    // No production token, process object, or network implementation is exposed.
+    await runInNewContext(`(async () => { ${source}\n })()`, {
+        github: { rest: { pulls }, paginate },
+        core: { info: (message) => messages.push(message), summary },
+        context,
+        process: { env }
+    });
+}
+
+if (expectedError) {
+    await assert.rejects(execute, new RegExp(expectedError));
+} else {
+    await execute();
+    if (scenario === 'push-during-review') {
+        assert.equal(writes.length, 0);
+        // Completion on an older SHA clears the pending request. The scheduled
+        // pass must request the newer head exactly once, then defer while active.
+        pull.requested_reviewers = [];
+        reviewPages = [[{ user: reviewer, commit_id: previous, state: 'COMMENTED' }]];
+        context.eventName = 'schedule';
+        await execute();
+        await execute();
+        pull.requested_reviewers = [];
+        reviewPages[0].push({ user: reviewer, commit_id: head, state: 'COMMENTED' });
+        await execute();
+    }
+}
+assert.equal(writes.length, expectedWrites);
+if (expectedDecision) {
+    assert.ok(messages.some(message => message.includes(expectedDecision)), messages.join('\n'));
+}
+if (scenario === 'disabled' || scenario === 'pilot-other-pr' || scenario === 'invalid-pilot' ||
+    scenario === 'invalid-mode' || scenario === 'unsafe-pilot' || scenario === 'wrong-repository' ||
+    scenario === 'unsupported-event' || scenario === 'untrusted-dispatch' || scenario === 'invalid-number') {
+    assert.deepEqual(calls, []);
+}
+if (scenario === 'pilot-scheduled') {
+    assert.deepEqual(calls, ['get', 'listReviews', 'get', 'requestReviewers']);
+}
+if (scenario === 'pagination') {
+    assert.deepEqual([...getCounts.keys()], [42, 43]);
+}
+if (scenario === 'api-write-error') {
+    assert.equal(calls.filter(endpoint => endpoint === 'requestReviewers').length, 1);
+}
+if (scenario === 'metadata-injection') {
+    assert.equal(messages.some(message => message.includes('injected') || message.includes('<script>')), false);
+}
+console.log(`Passed: ${scenario}`);


### PR DESCRIPTION
## Description

Repository-configured automatic Copilot code reviews are attributed to PR authors, potentially consuming contributors' personal AI credits. GitHub documents that bot-requested reviews are instead billed directly to the organization. This adds a dry-run-first workflow to explore organization-funded reviews without excluding external contributors.

- Request reviews using `GITHUB_TOKEN` for all open PRs, including drafts and forks, targeting `main` or `release/**`.
- Trigger on PR creation and new pushes. A scheduled metadata-only scan catches updates made during pending reviews and events replaced in the concurrency queue.
- Skip pending requests and already-reviewed head SHAs. Serialize request-making runs while allowing the actual Copilot reviews to proceed concurrently.
- Default to dry-run, with repository-variable controls for enabling requests, disabling the workflow, and restricting rollout to one pilot PR.
- Document billing assumptions, security boundaries, operational limitations, and rollout steps.

**This PR does not enable billable review requests or change existing automatic CCR rules.** Before production rollout, disable applicable built-in automatic review rules and confirm in a controlled pilot that reviews complete and are attributed to the organization rather than the contributor.

GitHub references:
- [CCR usage and attribution](https://docs.github.com/en/copilot/concepts/agents/code-review#code-review-usage)
- [Requesting CCR through the REST API](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review)

### Security considerations

The request-making workflow uses trusted `pull_request_target` execution for PR events, default-branch scheduled execution, and manual dispatch restricted to `main`. It never checks out or executes PR code, consumes artifacts/caches, or interpolates PR metadata into executable script text. Its only action is the existing SHA-pinned `actions/github-script`, and its only token permission is `pull-requests: write`.

Security review is requested for the privileged event handling, token scope, and organization-funded usage model. CCR's downstream execution environment is a separate security boundary; billing confirmation and budget controls remain rollout prerequisites.

### Validation

The 42 focused `OrganizationFundedCopilotReviewsTests` cases pass. Coverage includes workflow structure and permissions, dry-run and pilot controls, drafts and external authors, duplicate suppression, pagination, concurrent state changes, pushes during pending reviews, malicious metadata, and API failures. No live billable reviews were requested.

Fixes # (issue)

cc @afscrome @DamianEdwards @maddymontaquila

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No