### PR TITLE
Add configurable dev tunnel idle expiration

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -397,7 +397,7 @@ internal class DevTunnelCli
 
     private static string? GetExpirationArgument(DevTunnelOptions options)
         => options.ExpirationHours is { } expirationHours
-            ? expirationHours.ToString(CultureInfo.InvariantCulture) + "h"
+            ? expirationHours.ToString("0h", CultureInfo.InvariantCulture)
             : null;
 
     private static string? GetServiceUri(DevTunnelOptions options)

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -60,6 +60,7 @@ internal class DevTunnelCli
         return RunAsync(new ArgsBuilder(["create"])
             .AddIfNotNull(tunnelId)
             .AddIfNotNull("--description", options.Description)
+            .AddIfNotNull("--expiration", GetExpirationArgument(options))
             .AddIfNotNull("--service-uri", GetServiceUri(options))
             .AddIfTrue("--allow-anonymous", options.AllowAnonymous)
             .AddValues("--labels", options.Labels)
@@ -79,6 +80,7 @@ internal class DevTunnelCli
         options ??= new DevTunnelOptions();
         return RunAsync(new ArgsBuilder(["update", tunnelId])
             .AddIfNotNull("--description", options.Description)
+            .AddIfNotNull("--expiration", GetExpirationArgument(options))
             .AddValues("--add-labels", options.Labels)
             .Add("--json")
             .Add("--nologo")
@@ -215,7 +217,7 @@ internal class DevTunnelCli
         CancellationToken cancellationToken = default)
         => RunAsync(["port", "delete", tunnelId, "--port-number", portNumber.ToString(CultureInfo.InvariantCulture), "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
-    private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
+    protected virtual Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
         => RunAsync(args, outputWriter, errorWriter, useShellExecute: false, logger, cancellationToken);
 
     private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, bool useShellExecute = false, ILogger? logger = default, CancellationToken cancellationToken = default)
@@ -392,6 +394,11 @@ internal class DevTunnelCli
             }
         }
     }
+
+    private static string? GetExpirationArgument(DevTunnelOptions options)
+        => options.Expiration is { } expiration
+            ? (expiration.Ticks / TimeSpan.TicksPerHour).ToString(CultureInfo.InvariantCulture) + "h"
+            : null;
 
     private static string? GetServiceUri(DevTunnelOptions options)
     {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -396,8 +396,8 @@ internal class DevTunnelCli
     }
 
     private static string? GetExpirationArgument(DevTunnelOptions options)
-        => options.Expiration is { } expiration
-            ? (expiration.Ticks / TimeSpan.TicksPerHour).ToString(CultureInfo.InvariantCulture) + "h"
+        => options.ExpirationHours is { } expirationHours
+            ? expirationHours.ToString(CultureInfo.InvariantCulture) + "h"
             : null;
 
     private static string? GetServiceUri(DevTunnelOptions options)

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.DevTunnels;
 /// </summary>
 public sealed class DevTunnelOptions
 {
-    private TimeSpan? _expiration;
+    private int? _expirationHours;
 
     /// <summary>
     /// Optional description for the tunnel.
@@ -35,7 +35,7 @@ public sealed class DevTunnelOptions
     public DevTunnelRegion? Region { get; set; }
 
     /// <summary>
-    /// Gets or sets how long the tunnel can remain unused or unmodified before it expires.
+    /// Gets or sets how many hours the tunnel can remain unused or unmodified before it expires.
     /// </summary>
     /// <remarks>
     /// Specify a whole number of hours from one hour through 30 days, inclusive.
@@ -44,24 +44,18 @@ public sealed class DevTunnelOptions
     /// and existing tunnels retain their configured expiration period.
     /// This is an idle expiration period, not a maximum hosting duration or an access-token lifetime.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The value is outside the supported range or is not a whole number of hours.</exception>
-    public TimeSpan? Expiration
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside the supported range.</exception>
+    public int? ExpirationHours
     {
-        get => _expiration;
+        get => _expirationHours;
         set
         {
-            // The CLI accepts durations such as "4h" and "2d". Require whole hours so the
-            // requested period is representable without rounding.
-            // https://learn.microsoft.com/azure/developer/dev-tunnels/cli-commands#advanced-manage-dev-tunnels
-            if (value is { } expiration &&
-                (expiration < TimeSpan.FromHours(1) ||
-                 expiration > TimeSpan.FromDays(30) ||
-                 expiration.Ticks % TimeSpan.TicksPerHour != 0))
+            if (value is < 1 or > 30 * 24)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Tunnel expiration must be a whole number of hours from 1 hour through 30 days.");
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Tunnel expiration must be from 1 hour through 30 days.");
             }
 
-            _expiration = value;
+            _expirationHours = value;
         }
     }
 
@@ -85,7 +79,7 @@ public sealed class DevTunnelOptions
             _ => throw new ArgumentException("Invalid region specified", nameof(Region)),
         };
 
-    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Labels=[{string.Join(", ", Labels ?? [])}], Region={Region}, Expiration={Expiration} }}";
+    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Labels=[{string.Join(", ", Labels ?? [])}], Region={Region}, ExpirationHours={ExpirationHours} }}";
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
@@ -8,6 +8,8 @@ namespace Aspire.Hosting.DevTunnels;
 /// </summary>
 public sealed class DevTunnelOptions
 {
+    private TimeSpan? _expiration;
+
     /// <summary>
     /// Optional description for the tunnel.
     /// </summary>
@@ -32,6 +34,37 @@ public sealed class DevTunnelOptions
     /// </remarks>
     public DevTunnelRegion? Region { get; set; }
 
+    /// <summary>
+    /// Gets or sets how long the tunnel can remain unused or unmodified before it expires.
+    /// </summary>
+    /// <remarks>
+    /// Specify a whole number of hours from one hour through 30 days, inclusive.
+    /// The value applies when creating a tunnel and when updating an existing tunnel.
+    /// When <see langword="null"/>, no expiration override is sent: new tunnels use the service default
+    /// and existing tunnels retain their configured expiration period.
+    /// This is an idle expiration period, not a maximum hosting duration or an access-token lifetime.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside the supported range or is not a whole number of hours.</exception>
+    public TimeSpan? Expiration
+    {
+        get => _expiration;
+        set
+        {
+            // The CLI accepts durations such as "4h" and "2d". Require whole hours so the
+            // requested period is representable without rounding.
+            // https://learn.microsoft.com/azure/developer/dev-tunnels/cli-commands#advanced-manage-dev-tunnels
+            if (value is { } expiration &&
+                (expiration < TimeSpan.FromHours(1) ||
+                 expiration > TimeSpan.FromDays(30) ||
+                 expiration.Ticks % TimeSpan.TicksPerHour != 0))
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Tunnel expiration must be a whole number of hours from 1 hour through 30 days.");
+            }
+
+            _expiration = value;
+        }
+    }
+
     internal string RegionCode =>
         Region switch
         {
@@ -52,7 +85,7 @@ public sealed class DevTunnelOptions
             _ => throw new ArgumentException("Invalid region specified", nameof(Region)),
         };
 
-    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Labels=[{string.Join(", ", Labels ?? [])}], Region={Region} }}";
+    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Labels=[{string.Join(", ", Labels ?? [])}], Region={Region}, Expiration={Expiration} }}";
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -372,6 +372,34 @@ public static partial class DevTunnelsResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Configures how long the tunnel can remain unused or unmodified before it expires.
+    /// </summary>
+    /// <param name="tunnelBuilder">The resource builder.</param>
+    /// <param name="expiration">The idle expiration period, in whole hours from one hour through 30 days, inclusive.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// Applies to both new and existing tunnels. This does not limit hosting duration or access-token lifetime.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The <paramref name="tunnelBuilder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="expiration"/> is outside the supported range or is not a whole number of hours.</exception>
+    /// <example>
+    /// <code lang="csharp">
+    /// var tunnel = builder.AddDevTunnel("mytunnel")
+    ///     .WithExpiration(TimeSpan.FromDays(1))
+    ///     .WithReference(web);
+    /// </code>
+    /// </example>
+    [AspireExport]
+    public static IResourceBuilder<DevTunnelResource> WithExpiration(this IResourceBuilder<DevTunnelResource> tunnelBuilder, TimeSpan expiration)
+    {
+        ArgumentNullException.ThrowIfNull(tunnelBuilder);
+
+        tunnelBuilder.Resource.Options.Expiration = expiration;
+
+        return tunnelBuilder;
+    }
+
+    /// <summary>
     /// Gets the tunnel endpoint reference for the specified target resource and endpoint.
     /// </summary>
     /// <remarks>

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -375,26 +375,28 @@ public static partial class DevTunnelsResourceBuilderExtensions
     /// Configures how long the tunnel can remain unused or unmodified before it expires.
     /// </summary>
     /// <param name="tunnelBuilder">The resource builder.</param>
-    /// <param name="expiration">The idle expiration period, in whole hours from one hour through 30 days, inclusive.</param>
+    /// <param name="expirationHours">The idle expiration period, in whole hours from one hour through 30 days, inclusive.</param>
     /// <returns>The resource builder.</returns>
     /// <remarks>
     /// Applies to both new and existing tunnels. This does not limit hosting duration or access-token lifetime.
     /// </remarks>
     /// <exception cref="ArgumentNullException">The <paramref name="tunnelBuilder"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="expiration"/> is outside the supported range or is not a whole number of hours.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="expirationHours"/> is outside the supported range.</exception>
     /// <example>
     /// <code lang="csharp">
     /// var tunnel = builder.AddDevTunnel("mytunnel")
-    ///     .WithExpiration(TimeSpan.FromDays(1))
+    ///     .WithExpiration(24)
     ///     .WithReference(web);
     /// </code>
     /// </example>
     [AspireExport]
-    public static IResourceBuilder<DevTunnelResource> WithExpiration(this IResourceBuilder<DevTunnelResource> tunnelBuilder, TimeSpan expiration)
+    public static IResourceBuilder<DevTunnelResource> WithExpiration(this IResourceBuilder<DevTunnelResource> tunnelBuilder, int expirationHours)
     {
         ArgumentNullException.ThrowIfNull(tunnelBuilder);
+        ArgumentOutOfRangeException.ThrowIfLessThan(expirationHours, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(expirationHours, 30 * 24);
 
-        tunnelBuilder.Resource.Options.Expiration = expiration;
+        tunnelBuilder.Resource.Options.Expiration = TimeSpan.FromHours(expirationHours);
 
         return tunnelBuilder;
     }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -396,7 +396,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
         ArgumentOutOfRangeException.ThrowIfLessThan(expirationHours, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(expirationHours, 30 * 24);
 
-        tunnelBuilder.Resource.Options.Expiration = TimeSpan.FromHours(expirationHours);
+        tunnelBuilder.Resource.Options.ExpirationHours = expirationHours;
 
         return tunnelBuilder;
     }

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -142,7 +142,7 @@ Alternatively, set `Expiration` on `DevTunnelOptions` when calling `AddDevTunnel
 ```typescript
 const tunnel = await builder.addDevTunnel("mytunnel")
                     .withExpiration(24 * 60 * 60 * 1000)
-                    .withReference(web);
+                    .withTunnelReferenceAll(web, false);
 ```
 
 TypeScript durations are expressed in milliseconds. Expiration must be a whole number of hours,

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -123,6 +123,36 @@ var tunnel = builder.AddDevTunnel(name: "devtunnel", options: options)
              
 ```
 
+### Configure idle expiration
+
+Set an idle expiration period to clean up tunnels that are no longer used:
+
+**C#**
+
+```csharp
+var tunnel = builder.AddDevTunnel("mytunnel")
+                    .WithExpiration(TimeSpan.FromDays(1))
+                    .WithReference(web);
+```
+
+Alternatively, set `Expiration` on `DevTunnelOptions` when calling `AddDevTunnel`.
+
+**TypeScript**
+
+```typescript
+const tunnel = await builder.addDevTunnel("mytunnel")
+                    .withExpiration(24 * 60 * 60 * 1000)
+                    .withReference(web);
+```
+
+TypeScript durations are expressed in milliseconds. Expiration must be a whole number of hours,
+from one hour through 30 days, inclusive. Invalid values throw rather than being rounded.
+The setting applies to both new tunnels and existing tunnels reused by the AppHost.
+If omitted, new tunnels use the service default and existing tunnels keep their configured expiration period.
+
+This is the time a tunnel can remain unused or unmodified before it expires, not a limit on hosting
+duration or an access-token lifetime. See the [devtunnel CLI expiration documentation](https://learn.microsoft.com/azure/developer/dev-tunnels/cli-commands#advanced-manage-dev-tunnels).
+
 ### Multiple tunnels for different audiences
 
 ```csharp

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -135,7 +135,7 @@ var tunnel = builder.AddDevTunnel("mytunnel")
                     .WithReference(web);
 ```
 
-Alternatively, set `Expiration` on `DevTunnelOptions` when calling `AddDevTunnel`.
+Alternatively, set `ExpirationHours` on `DevTunnelOptions` when calling `AddDevTunnel`.
 
 **TypeScript**
 

--- a/src/Aspire.Hosting.DevTunnels/README.md
+++ b/src/Aspire.Hosting.DevTunnels/README.md
@@ -131,7 +131,7 @@ Set an idle expiration period to clean up tunnels that are no longer used:
 
 ```csharp
 var tunnel = builder.AddDevTunnel("mytunnel")
-                    .WithExpiration(TimeSpan.FromDays(1))
+                    .WithExpiration(24)
                     .WithReference(web);
 ```
 
@@ -141,12 +141,11 @@ Alternatively, set `Expiration` on `DevTunnelOptions` when calling `AddDevTunnel
 
 ```typescript
 const tunnel = await builder.addDevTunnel("mytunnel")
-                    .withExpiration(24 * 60 * 60 * 1000)
+                    .withExpiration(24)
                     .withTunnelReferenceAll(web, false);
 ```
 
-TypeScript durations are expressed in milliseconds. Expiration must be a whole number of hours,
-from one hour through 30 days, inclusive. Invalid values throw rather than being rounded.
+Expiration is expressed as a whole number of hours, from one hour through 30 days, inclusive.
 The setting applies to both new tunnels and existing tunnels reused by the AppHost.
 If omitted, new tunnels use the service default and existing tunnels keep their configured expiration period.
 

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Aspire.Hosting.DevTunnels.Tests.csproj
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Aspire.Hosting.DevTunnels.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)TestInteractionService.cs" Link="shared/TestInteractionService.cs" />
+    <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" Link="shared/TestModuleInitializer.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
@@ -57,19 +57,20 @@ public class DevTunnelExpirationTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void WithExpiration_ConfiguresOptions(bool polyglot)
+    [InlineData(false, 1)]
+    [InlineData(true, 24)]
+    [InlineData(false, 720)]
+    public void WithExpiration_ConfiguresOptions(bool polyglot, int hours)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var tunnel = polyglot
             ? builder.AddDevTunnelForPolyglot("tunnel")
             : builder.AddDevTunnel("tunnel");
 
-        var result = tunnel.WithExpiration(TimeSpan.FromDays(1));
+        var result = tunnel.WithExpiration(hours);
 
         Assert.Same(tunnel, result);
-        Assert.Equal(TimeSpan.FromDays(1), tunnel.Resource.Options.Expiration);
+        Assert.Equal(TimeSpan.FromHours(hours), tunnel.Resource.Options.Expiration);
     }
 
     [Fact]
@@ -77,19 +78,24 @@ public class DevTunnelExpirationTests
     {
         IResourceBuilder<DevTunnelResource> builder = null!;
 
-        var exception = Assert.Throws<ArgumentNullException>(() => builder.WithExpiration(TimeSpan.FromDays(1)));
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.WithExpiration(24));
 
         Assert.Equal("tunnelBuilder", exception.ParamName);
     }
 
-    [Fact]
-    public void WithExpiration_RejectsInvalidExpiration()
+    [Theory]
+    [InlineData(int.MinValue)]
+    [InlineData(0)]
+    [InlineData(721)]
+    [InlineData(int.MaxValue)]
+    public void WithExpiration_RejectsInvalidExpiration(int hours)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var tunnel = builder.AddDevTunnel("tunnel");
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => tunnel.WithExpiration(TimeSpan.FromMinutes(90)));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => tunnel.WithExpiration(hours));
 
+        Assert.Equal("expirationHours", exception.ParamName);
         Assert.Null(tunnel.Resource.Options.Expiration);
     }
 

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
@@ -11,49 +11,42 @@ namespace Aspire.Hosting.DevTunnels.Tests;
 public class DevTunnelExpirationTests
 {
     [Fact]
-    public void Expiration_DefaultsToNullAndCanBeCleared()
+    public void ExpirationHours_DefaultsToNullAndCanBeCleared()
     {
         var options = new DevTunnelOptions();
-        Assert.Null(options.Expiration);
+        Assert.Null(options.ExpirationHours);
 
-        options.Expiration = TimeSpan.FromDays(1);
-        options.Expiration = null;
+        options.ExpirationHours = 24;
+        options.ExpirationHours = null;
 
-        Assert.Null(options.Expiration);
+        Assert.Null(options.ExpirationHours);
     }
 
     [Theory]
     [InlineData(1)]
     [InlineData(25)]
     [InlineData(720)]
-    public void Expiration_AcceptsWholeHoursWithinRange(int hours)
+    public void ExpirationHours_AcceptsValuesWithinRange(int hours)
     {
-        var expiration = TimeSpan.FromHours(hours);
-        var options = new DevTunnelOptions { Expiration = expiration };
+        var options = new DevTunnelOptions { ExpirationHours = hours };
 
-        Assert.Equal(expiration, options.Expiration);
+        Assert.Equal(hours, options.ExpirationHours);
     }
 
     [Theory]
-    [InlineData(long.MinValue)]
-    [InlineData(-TimeSpan.TicksPerHour)]
+    [InlineData(int.MinValue)]
     [InlineData(0)]
-    [InlineData(TimeSpan.TicksPerHour - 1)]
-    [InlineData(TimeSpan.TicksPerHour + 1)]
-    [InlineData(TimeSpan.TicksPerHour + TimeSpan.TicksPerMinute)]
-    [InlineData(TimeSpan.TicksPerHour + TimeSpan.TicksPerHour / 2)]
-    [InlineData(30 * TimeSpan.TicksPerDay + 1)]
-    [InlineData(long.MaxValue)]
-    public void Expiration_RejectsInvalidValuesWithoutChangingOptions(long ticks)
+    [InlineData(721)]
+    [InlineData(int.MaxValue)]
+    public void ExpirationHours_RejectsInvalidValuesWithoutChangingOptions(int hours)
     {
-        var options = new DevTunnelOptions { Expiration = TimeSpan.FromDays(1) };
-        var expiration = TimeSpan.FromTicks(ticks);
+        var options = new DevTunnelOptions { ExpirationHours = 24 };
 
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Expiration = expiration);
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.ExpirationHours = hours);
 
         Assert.Equal("value", exception.ParamName);
-        Assert.Equal(expiration, exception.ActualValue);
-        Assert.Equal(TimeSpan.FromDays(1), options.Expiration);
+        Assert.Equal(hours, exception.ActualValue);
+        Assert.Equal(24, options.ExpirationHours);
     }
 
     [Theory]
@@ -70,7 +63,7 @@ public class DevTunnelExpirationTests
         var result = tunnel.WithExpiration(hours);
 
         Assert.Same(tunnel, result);
-        Assert.Equal(TimeSpan.FromHours(hours), tunnel.Resource.Options.Expiration);
+        Assert.Equal(hours, tunnel.Resource.Options.ExpirationHours);
     }
 
     [Fact]
@@ -96,7 +89,7 @@ public class DevTunnelExpirationTests
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => tunnel.WithExpiration(hours));
 
         Assert.Equal("expirationHours", exception.ParamName);
-        Assert.Null(tunnel.Resource.Options.Expiration);
+        Assert.Null(tunnel.Resource.Options.ExpirationHours);
     }
 
     [Theory]
@@ -112,7 +105,7 @@ public class DevTunnelExpirationTests
         cli.EnqueueUpdateResult(0);
         var options = new DevTunnelOptions
         {
-            Expiration = hours is { } value ? TimeSpan.FromHours(value) : null
+            ExpirationHours = hours
         };
 
         await cli.CreateTunnelAsync("mytunnel", options);
@@ -144,7 +137,7 @@ public class DevTunnelExpirationTests
             var cli = new TestDevTunnelCli();
             cli.EnqueueCreateResult(0);
             cli.EnqueueUpdateResult(0);
-            var options = new DevTunnelOptions { Expiration = TimeSpan.FromHours(25) };
+            var options = new DevTunnelOptions { ExpirationHours = 25 };
 
             await cli.CreateTunnelAsync("mytunnel", options);
             await cli.UpdateTunnelAsync("mytunnel", options);
@@ -170,7 +163,7 @@ public class DevTunnelExpirationTests
         var options = new DevTunnelOptions
         {
             Region = DevTunnelRegion.NorthEurope,
-            Expiration = hours is { } value ? TimeSpan.FromHours(value) : null
+            ExpirationHours = hours
         };
 
         var tunnel = await client.CreateTunnelAsync("mytunnel", options);
@@ -182,7 +175,7 @@ public class DevTunnelExpirationTests
     [Fact]
     public async Task ToLoggerString_IncludesExpiration()
     {
-        var options = new DevTunnelOptions { Expiration = TimeSpan.FromDays(1) };
+        var options = new DevTunnelOptions { ExpirationHours = 24 };
 
         await Verify(options.ToLoggerString());
     }

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelExpirationTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.DevTunnels.Tests;
+
+public class DevTunnelExpirationTests
+{
+    [Fact]
+    public void Expiration_DefaultsToNullAndCanBeCleared()
+    {
+        var options = new DevTunnelOptions();
+        Assert.Null(options.Expiration);
+
+        options.Expiration = TimeSpan.FromDays(1);
+        options.Expiration = null;
+
+        Assert.Null(options.Expiration);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(25)]
+    [InlineData(720)]
+    public void Expiration_AcceptsWholeHoursWithinRange(int hours)
+    {
+        var expiration = TimeSpan.FromHours(hours);
+        var options = new DevTunnelOptions { Expiration = expiration };
+
+        Assert.Equal(expiration, options.Expiration);
+    }
+
+    [Theory]
+    [InlineData(long.MinValue)]
+    [InlineData(-TimeSpan.TicksPerHour)]
+    [InlineData(0)]
+    [InlineData(TimeSpan.TicksPerHour - 1)]
+    [InlineData(TimeSpan.TicksPerHour + 1)]
+    [InlineData(TimeSpan.TicksPerHour + TimeSpan.TicksPerMinute)]
+    [InlineData(TimeSpan.TicksPerHour + TimeSpan.TicksPerHour / 2)]
+    [InlineData(30 * TimeSpan.TicksPerDay + 1)]
+    [InlineData(long.MaxValue)]
+    public void Expiration_RejectsInvalidValuesWithoutChangingOptions(long ticks)
+    {
+        var options = new DevTunnelOptions { Expiration = TimeSpan.FromDays(1) };
+        var expiration = TimeSpan.FromTicks(ticks);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Expiration = expiration);
+
+        Assert.Equal("value", exception.ParamName);
+        Assert.Equal(expiration, exception.ActualValue);
+        Assert.Equal(TimeSpan.FromDays(1), options.Expiration);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WithExpiration_ConfiguresOptions(bool polyglot)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var tunnel = polyglot
+            ? builder.AddDevTunnelForPolyglot("tunnel")
+            : builder.AddDevTunnel("tunnel");
+
+        var result = tunnel.WithExpiration(TimeSpan.FromDays(1));
+
+        Assert.Same(tunnel, result);
+        Assert.Equal(TimeSpan.FromDays(1), tunnel.Resource.Options.Expiration);
+    }
+
+    [Fact]
+    public void WithExpiration_RejectsNullBuilder()
+    {
+        IResourceBuilder<DevTunnelResource> builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.WithExpiration(TimeSpan.FromDays(1)));
+
+        Assert.Equal("tunnelBuilder", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithExpiration_RejectsInvalidExpiration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var tunnel = builder.AddDevTunnel("tunnel");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tunnel.WithExpiration(TimeSpan.FromMinutes(90)));
+
+        Assert.Null(tunnel.Resource.Options.Expiration);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    [InlineData(24)]
+    [InlineData(25)]
+    [InlineData(720)]
+    public async Task CreateAndUpdate_PassExpirationInHours(int? hours)
+    {
+        var cli = new TestDevTunnelCli();
+        cli.EnqueueCreateResult(0);
+        cli.EnqueueUpdateResult(0);
+        var options = new DevTunnelOptions
+        {
+            Expiration = hours is { } value ? TimeSpan.FromHours(value) : null
+        };
+
+        await cli.CreateTunnelAsync("mytunnel", options);
+        await cli.UpdateTunnelAsync("mytunnel", options);
+
+        await Verify(cli.Calls.Select(call => call.Arguments)).UseParameters(hours);
+    }
+
+    [Fact]
+    public async Task CreateAndUpdate_WithNullOptions_OmitExpiration()
+    {
+        var cli = new TestDevTunnelCli();
+        cli.EnqueueCreateResult(0);
+        cli.EnqueueUpdateResult(0);
+
+        await cli.CreateTunnelAsync("mytunnel");
+        await cli.UpdateTunnelAsync("mytunnel");
+
+        await Verify(cli.Calls.Select(call => call.Arguments));
+    }
+
+    [Fact]
+    public async Task CreateAndUpdate_FormatExpirationInvariantly()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ar-SA");
+            var cli = new TestDevTunnelCli();
+            cli.EnqueueCreateResult(0);
+            cli.EnqueueUpdateResult(0);
+            var options = new DevTunnelOptions { Expiration = TimeSpan.FromHours(25) };
+
+            await cli.CreateTunnelAsync("mytunnel", options);
+            await cli.UpdateTunnelAsync("mytunnel", options);
+
+            await Verify(cli.Calls.Select(call => call.Arguments));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(24)]
+    public async Task CreateTunnelAsync_WhenTunnelExists_PassesExpirationToUpdate(int? hours)
+    {
+        var cli = new TestDevTunnelCli();
+        cli.EnqueueCreateResult(DevTunnelCli.ResourceConflictsWithExistingExitCode);
+        cli.EnqueueUpdateResult(0, """{"tunnelId":"mytunnel.eun1"}""");
+        cli.EnqueueResetAccessResult(0, """{"accessControlEntries":[]}""");
+        var client = new DevTunnelCliClient(new ConfigurationBuilder().Build(), cli);
+        var options = new DevTunnelOptions
+        {
+            Region = DevTunnelRegion.NorthEurope,
+            Expiration = hours is { } value ? TimeSpan.FromHours(value) : null
+        };
+
+        var tunnel = await client.CreateTunnelAsync("mytunnel", options);
+
+        Assert.Equal("mytunnel.eun1", tunnel.TunnelId);
+        await Verify(cli.Calls).UseParameters(hours);
+    }
+
+    [Fact]
+    public async Task ToLoggerString_IncludesExpiration()
+    {
+        var options = new DevTunnelOptions { Expiration = TimeSpan.FromDays(1) };
+
+        await Verify(options.ToLoggerString());
+    }
+}

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_FormatExpirationInvariantly.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_FormatExpirationInvariantly.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --expiration,
+    25h,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --expiration,
+    25h,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=1.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=1.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --expiration,
+    1h,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --expiration,
+    1h,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=24.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=24.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --expiration,
+    24h,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --expiration,
+    24h,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=25.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=25.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --expiration,
+    25h,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --expiration,
+    25h,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=720.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=720.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --expiration,
+    720h,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --expiration,
+    720h,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=null.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_PassExpirationInHours_hours=null.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_WithNullOptions_OmitExpiration.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateAndUpdate_WithNullOptions_OmitExpiration.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  [
+    create,
+    mytunnel,
+    --json,
+    --nologo
+  ],
+  [
+    update,
+    mytunnel,
+    --json,
+    --nologo
+  ]
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateTunnelAsync_WhenTunnelExists_PassesExpirationToUpdate_hours=24.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateTunnelAsync_WhenTunnelExists_PassesExpirationToUpdate_hours=24.verified.txt
@@ -1,0 +1,39 @@
+﻿[
+  {
+    Method: CreateTunnelAsync,
+    TunnelId: mytunnel,
+    Arguments: [
+      create,
+      mytunnel,
+      --expiration,
+      24h,
+      --service-uri,
+      https://eun1.rel.tunnels.api.visualstudio.com,
+      --json,
+      --nologo
+    ]
+  },
+  {
+    Method: UpdateTunnelAsync,
+    TunnelId: mytunnel.eun1,
+    Arguments: [
+      update,
+      mytunnel.eun1,
+      --expiration,
+      24h,
+      --json,
+      --nologo
+    ]
+  },
+  {
+    Method: ResetAccessAsync,
+    TunnelId: mytunnel.eun1,
+    Arguments: [
+      access,
+      reset,
+      mytunnel.eun1,
+      --json,
+      --nologo
+    ]
+  }
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateTunnelAsync_WhenTunnelExists_PassesExpirationToUpdate_hours=null.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.CreateTunnelAsync_WhenTunnelExists_PassesExpirationToUpdate_hours=null.verified.txt
@@ -1,0 +1,35 @@
+﻿[
+  {
+    Method: CreateTunnelAsync,
+    TunnelId: mytunnel,
+    Arguments: [
+      create,
+      mytunnel,
+      --service-uri,
+      https://eun1.rel.tunnels.api.visualstudio.com,
+      --json,
+      --nologo
+    ]
+  },
+  {
+    Method: UpdateTunnelAsync,
+    TunnelId: mytunnel.eun1,
+    Arguments: [
+      update,
+      mytunnel.eun1,
+      --json,
+      --nologo
+    ]
+  },
+  {
+    Method: ResetAccessAsync,
+    TunnelId: mytunnel.eun1,
+    Arguments: [
+      access,
+      reset,
+      mytunnel.eun1,
+      --json,
+      --nologo
+    ]
+  }
+]

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.ToLoggerString_IncludesExpiration.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.ToLoggerString_IncludesExpiration.verified.txt
@@ -1,1 +1,1 @@
-﻿{ Description=, AllowAnonymous=False, Labels=[], Region=, Expiration=1.00:00:00 }
+﻿{ Description=, AllowAnonymous=False, Labels=[], Region=, ExpirationHours=24 }

--- a/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.ToLoggerString_IncludesExpiration.verified.txt
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/Snapshots/DevTunnelExpirationTests.ToLoggerString_IncludesExpiration.verified.txt
@@ -1,0 +1,1 @@
+﻿{ Description=, AllowAnonymous=False, Labels=[], Region=, Expiration=1.00:00:00 }

--- a/tests/Aspire.Hosting.DevTunnels.Tests/TestDevTunnelCli.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/TestDevTunnelCli.cs
@@ -10,6 +10,7 @@ internal sealed class TestDevTunnelCli : DevTunnelCli
 {
     private readonly ConcurrentQueue<TestDevTunnelCliResult> _createResults = new();
     private readonly ConcurrentQueue<TestDevTunnelCliResult> _updateResults = new();
+    private readonly ConcurrentQueue<TestDevTunnelCliResult> _resetAccessResults = new();
 
     public TestDevTunnelCli()
         : base("test-devtunnel")
@@ -24,28 +25,26 @@ internal sealed class TestDevTunnelCli : DevTunnelCli
     public void EnqueueUpdateResult(int exitCode, string? output = null, string? error = null)
         => _updateResults.Enqueue(new(exitCode, output, error));
 
-    public override Task<int> CreateTunnelAsync(
-        string? tunnelId = null,
-        DevTunnelOptions? options = null,
-        TextWriter? outputWriter = null,
-        TextWriter? errorWriter = null,
-        ILogger? logger = null,
-        CancellationToken cancellationToken = default)
-    {
-        Calls.Enqueue(new(nameof(CreateTunnelAsync), tunnelId));
-        return CompleteAsync(_createResults, outputWriter, errorWriter, cancellationToken);
-    }
+    public void EnqueueResetAccessResult(int exitCode, string? output = null, string? error = null)
+        => _resetAccessResults.Enqueue(new(exitCode, output, error));
 
-    public override Task<int> UpdateTunnelAsync(
-        string tunnelId,
-        DevTunnelOptions? options = null,
+    protected override Task<int> RunAsync(
+        string[] args,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
         ILogger? logger = null,
         CancellationToken cancellationToken = default)
     {
-        Calls.Enqueue(new(nameof(UpdateTunnelAsync), tunnelId));
-        return CompleteAsync(_updateResults, outputWriter, errorWriter, cancellationToken);
+        var (method, tunnelId, results) = args switch
+        {
+            ["create", ..] => (nameof(CreateTunnelAsync), args.Length > 1 && !args[1].StartsWith("--", StringComparison.Ordinal) ? args[1] : null, _createResults),
+            ["update", var id, ..] => (nameof(UpdateTunnelAsync), id, _updateResults),
+            ["access", "reset", var id, ..] => (nameof(ResetAccessAsync), id, _resetAccessResults),
+            _ => throw new InvalidOperationException($"Unexpected test devtunnel command: {string.Join(" ", args)}")
+        };
+
+        Calls.Enqueue(new(method, tunnelId, args));
+        return CompleteAsync(results, outputWriter, errorWriter, cancellationToken);
     }
 
     private static Task<int> CompleteAsync(
@@ -75,6 +74,6 @@ internal sealed class TestDevTunnelCli : DevTunnelCli
     }
 }
 
-internal sealed record TestDevTunnelCliCall(string Method, string? TunnelId);
+internal sealed record TestDevTunnelCliCall(string Method, string? TunnelId, string[] Arguments);
 
 internal sealed record TestDevTunnelCliResult(int ExitCode, string? Output, string? Error);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Go/apphost.go
@@ -66,7 +66,7 @@ func main() {
 	builder.AddDevTunnel("chained-tunnel").WithAnonymousAccess()
 
 	expiringTunnel := builder.AddDevTunnel("expiring-tunnel").
-		WithExpiration(24*60*60*1000).
+		WithExpiration(24).
 		WithTunnelReferenceAll(web, false)
 	if err = expiringTunnel.Err(); err != nil {
 		log.Fatalf(aspire.FormatError(err))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Go/apphost.go
@@ -65,6 +65,13 @@ func main() {
 
 	builder.AddDevTunnel("chained-tunnel").WithAnonymousAccess()
 
+	expiringTunnel := builder.AddDevTunnel("expiring-tunnel").
+		WithExpiration(24*60*60*1000).
+		WithTunnelReferenceAll(web, false)
+	if err = expiringTunnel.Err(); err != nil {
+		log.Fatalf(aspire.FormatError(err))
+	}
+
 	app, err := builder.Build()
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Java/AppHost.java
@@ -41,9 +41,9 @@ void main() throws Exception {
         // Test 10: Chained configuration
         builder.addDevTunnel("chained-tunnel")
             .withAnonymousAccess();
-        // Test 11: Idle expiration in milliseconds
+        // Test 11: Idle expiration in hours
         builder.addDevTunnel("expiring-tunnel")
-            .withExpiration(24 * 60 * 60 * 1000)
+            .withExpiration(24)
             .withTunnelReferenceAll(web, false);
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Java/AppHost.java
@@ -41,5 +41,9 @@ void main() throws Exception {
         // Test 10: Chained configuration
         builder.addDevTunnel("chained-tunnel")
             .withAnonymousAccess();
+        // Test 11: Idle expiration in milliseconds
+        builder.addDevTunnel("expiring-tunnel")
+            .withExpiration(24 * 60 * 60 * 1000)
+            .withTunnelReferenceAll(web, false);
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Python/apphost.py
@@ -37,4 +37,8 @@ with create_builder() as builder:
     tunnel5.with_tunnel_reference_anonymous(web5_endpoint, False)
     # Test 10: Chained configuration
     builder.add_dev_tunnel("resource")
+    # Test 11: Idle expiration in milliseconds
+    expiring_tunnel = builder.add_dev_tunnel("expiring-tunnel")
+    expiring_tunnel.with_expiration(24 * 60 * 60 * 1000)
+    expiring_tunnel.with_tunnel_reference_all(web, False)
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/Python/apphost.py
@@ -37,8 +37,8 @@ with create_builder() as builder:
     tunnel5.with_tunnel_reference_anonymous(web5_endpoint, False)
     # Test 10: Chained configuration
     builder.add_dev_tunnel("resource")
-    # Test 11: Idle expiration in milliseconds
+    # Test 11: Idle expiration in hours
     expiring_tunnel = builder.add_dev_tunnel("expiring-tunnel")
-    expiring_tunnel.with_expiration(24 * 60 * 60 * 1000)
+    expiring_tunnel.with_expiration(24)
     expiring_tunnel.with_tunnel_reference_all(web, False)
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/TypeScript/apphost.mts
@@ -56,9 +56,9 @@ await tunnel5.withTunnelReferenceAnonymous(web5Endpoint, true);
 await builder.addDevTunnel("chained-tunnel")
     .withAnonymousAccess();
 
-// Test 11: Idle expiration in milliseconds, as documented in the README
+// Test 11: Idle expiration in hours
 await builder.addDevTunnel("expiring-tunnel")
-    .withExpiration(24 * 60 * 60 * 1000)
+    .withExpiration(24)
     .withTunnelReferenceAll(web, false);
 
 await builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.DevTunnels/TypeScript/apphost.mts
@@ -56,4 +56,9 @@ await tunnel5.withTunnelReferenceAnonymous(web5Endpoint, true);
 await builder.addDevTunnel("chained-tunnel")
     .withAnonymousAccess();
 
+// Test 11: Idle expiration in milliseconds, as documented in the README
+await builder.addDevTunnel("expiring-tunnel")
+    .withExpiration(24 * 60 * 60 * 1000)
+    .withTunnelReferenceAll(web, false);
+
 await builder.build().run();


### PR DESCRIPTION
## Description

Expose the devtunnel CLI's idle expiration setting without changing the default expiration policy.

- Add nullable `DevTunnelOptions.ExpirationHours` and an exported `WithExpiration(int expirationHours)` fluent method for C# and polyglot AppHosts.
- Pass `--expiration` to both `create` and `update`, so existing tunnels reused by an AppHost receive the configured period too.
- Accept whole hours from 1 hour through 30 days, inclusive. Serialize invariantly as hours and reject values outside the supported range.
- Omit the argument when unset, preserving service defaults for new tunnels and the configured expiration period for existing tunnels.
- Include expiration in option logging and document C# and TypeScript usage.

```csharp
var tunnel = builder.AddDevTunnel("mytunnel")
    .WithExpiration(24)
    .WithReference(web);
```

This is idle expiration, not a maximum hosting duration or an access-token lifetime. The [devtunnel CLI reference](https://learn.microsoft.com/azure/developer/dev-tunnels/cli-commands#advanced-manage-dev-tunnels) documents the create/update option and supported range.

In Aspire with agents creating more and more work trees for inner-loop testing, I've found it very easy to hit the 10-tunnel limit for devspaces within 30 days. By exposing an optional and explicit expiration value that devtunnels support, setting that to something short is helpful at keeping things under 10 without trying to delete tunnels explicitly.

## Testing

All 71 tests in `Aspire.Hosting.DevTunnels.Tests` pass. Coverage includes default omission, create and update arguments, reuse after a create conflict, supported boundaries, invalid option values, culture-invariant formatting, and the fluent configuration method. CLI calls are captured by the shared test fake; no live tunnel operations are required.

Generated C# and ATS API release baselines are unchanged per repository policy.
