### PR TITLE
fix(ci): stop benchmark-only changes from running all tests

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -129,14 +129,53 @@ Flag concrete selection gaps:
 - Route Layer 2 inputs to their precise consumer, to `ALL` for broad impact, or
   explicitly outside the selector. Do not allow `ignore` or prefilter entries
   to hide a real PR-CI consumer.
+- Inspect runtime-only package and fixture consumption in E2E tests, including
+  `aspire add`, generated AppHost package sets, package filters, templates, and
+  workspace copies. If a PR adds or removes one of these consumers, require the
+  corresponding exact `affected_project_rules` or `path_rules` entry to change
+  in the same PR.
+- Inspect changes to `QuarantinedTest`, `ActiveIssue`, and `OuterloopTest` on
+  runtime-consuming E2E scenarios. Regular-PR targets must include only
+  consumers eligible for regular PR CI; require the exact map edge and focused
+  regression coverage to change when eligibility changes.
+- Project-name patterns are globs, not regular expressions. For expensive or
+  class-sharded selector-gated targets, flag family globs that include projects
+  the target does not exercise. Use a family glob only when every current and
+  future matching project should select the target; otherwise keep an audited
+  exact consumer list. For smaller unsharded jobs, accept safe broad routing
+  when an exhaustive consumer list would add fragility for little CI savings.
+  Do not expand or refine advisory targets that gate no PR jobs in an unrelated
+  PR focused on PR-gated work; audit them when their workflow or routing is
+  intentionally in scope.
+- For a dedicated package-input directory in `path_rules`, prefer one stable
+  directory glob when enumerating individual files or RIDs would let a new
+  input silently miss its consumers. Accept cross-RID over-selection when that
+  is the explicit resilience tradeoff, and do not flag that over-selection as a
+  routing defect. Require focused exclusions only when a split has material
+  savings and can be maintained safely.
+- Keep each trigger-map `reason` concise: it should state what the rule covers
+  or why the target consumes the input. Request more detail only for a
+  non-obvious relationship or constraint. Do not turn `reason` into PR prose,
+  repeat the full rule, or preserve investigation history there. The `targets`
+  field owns the target list, so do not request those names again in `reason`.
+  Accept a category-level description; do not require the reason to explain
+  every target or make the rule self-contained. Selection-design rationale,
+  such as why paths are split or broadened, belongs in the PR or maintenance
+  documentation.
 - Require `run_*` wiring for gated `job:` targets, advisory classification for
   targets outside the regular PR matrix or job gates, and routing from reusable
   workflow implementations to the jobs they implement.
 
 Selector behavior changes must keep the action, workflow gates, tool, map,
 tests, and canonical documentation synchronized. Require real-map tests for
-curated routing changes and focused synthetic-map tests for engine or CLI
-behavior. See `docs/ci/test-trigger-map.md` for the complete contract.
+curated routing changes: a representative positive per distinct routing
+boundary, focused negatives for deliberately excluded consumers, and a
+structural assertion for consumer lists duplicated across rule types. Do not
+request an acceptance case per consumer; instead audit the complete curated
+list against the consuming workflow. Treat a widened or relaxed negative
+expectation as a finding until the workflow's artifacts and execution lane
+justify it. Require focused synthetic-map tests for engine or CLI behavior.
+See `docs/ci/test-trigger-map.md` for the complete contract.
 
 ### Test Coverage Review
 

--- a/.agents/skills/test-management/SKILL.md
+++ b/.agents/skills/test-management/SKILL.md
@@ -56,6 +56,15 @@ grep -r "public.*void.*TestMethodName\|public.*async.*Task.*TestMethodName" test
 
 Once located, determine the fully-qualified name (Namespace.Type.Method) by examining the file structure.
 
+Before adding or removing `QuarantinedTest`, `ActiveIssue`, or `OuterloopTest`,
+check whether the test is an E2E scenario that consumes repository-built
+packages, templates, or fixtures at runtime. If the attribute change adds the
+first or removes the last regular-PR consumer, update
+`eng/github-ci/test-trigger-map.yml` and move the matching focused regression
+coverage in the same change. Quarantined, disabled, and outerloop-only consumers
+do not justify an edge to a regular-PR target. `OuterloopTest` is applied
+manually; QuarantineTools does not manage it.
+
 ### 3. Run QuarantineTools for Each Test
 
 For **quarantining/disabling** tests, run QuarantineTools once per test:
@@ -304,6 +313,7 @@ After completing the task, provide a summary:
 - **Issue URLs are mandatory** - never quarantine/disable without a URL
 - **Fully-qualified names required** - QuarantineTools needs Namespace.Type.Method format
 - **Conditional attributes require manual editing** - QuarantineTools adds basic attributes only
+- **Audit runtime-only E2E routing** - scheduling-attribute changes can add or remove a regular-PR consumer
 - **No placeholder values** - use actual issue numbers and test names
 
 ## Repository-Specific Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ needs to change if the diff:
 * Adds or changes a CI job, reusable workflow, or `run_*` selection gate.
 * Adds or changes a script, configuration file, or other loose input consumed by
   CI or tests but not represented by an MSBuild project reference.
+* Adds, removes, or changes a runtime-only dependency on a repository-built
+  package, template, or fixture. Examples include packages loaded by `aspire
+  add`, generated AppHosts, package filters in E2E tests, and files copied into
+  an E2E workspace.
+* Adds, removes, or conditionally changes `QuarantinedTest`, `ActiveIssue`, or
+  `OuterloopTest` on an E2E scenario with runtime-only dependencies.
 
 Do not request manual mappings for files evaluated by projects in the
 `Aspire.slnx`-rooted ProjectGraph; Layer 1 owns them. For Layer 2 blind spots,
@@ -54,9 +60,54 @@ dedicated workflows and paths with no PR-CI consumer. A gated job implemented by
 a reusable workflow must route changes to that workflow file to the job target
 and keep its `run_*` output wiring consistent.
 
+For runtime-only consumers that ProjectGraph cannot see, require an
+`affected_project_rules` entry for each actual non-matrix project consumer and
+a `path_rules` entry for loose inputs. Project-name patterns use globs, not
+regular expressions. For expensive or class-sharded targets, prefer exact
+project names; use a family glob only when every current and future matching
+project should run that target. When a PR changes the packages or fixtures an
+E2E scenario consumes, add or remove the corresponding trigger-map entry in the
+same PR.
+
+For a dedicated package-input directory in `path_rules`, prefer one stable
+directory glob when enumerating individual files or RIDs would let a new input
+silently miss its consumers. Split by RID only when the savings justify that
+maintenance risk and focused coverage guards every deliberate exclusion. Do
+not flag intentional cross-RID over-selection when the rule records this
+resilience tradeoff.
+
+Keep each trigger-map `reason` concise: state what the rule covers or why the
+target consumes the input. Add detail only for a non-obvious relationship or
+constraint. Do not use `reason` to narrate the PR, duplicate the full rule, or
+record investigation history. The `targets` field is the source of truth for
+the target list; do not enumerate those target names again in `reason`. A
+category-level description is sufficient; the reason does not need to explain
+every target or make the rule self-contained. Keep discussion of alternative
+rule shapes or why a glob was split or broadened in the PR or maintenance
+documentation.
+
+Apply that precision to expensive or class-sharded selector-gated work. For
+smaller unsharded jobs, prefer safe broad routing when an exhaustive consumer
+list would add fragility for little CI savings. Do not expand or refine advisory
+targets that gate no PR jobs in an unrelated PR focused on PR-gated work; audit
+them when their workflow or routing is intentionally in scope.
+
+Match runtime-only edges to the target's execution lane. A regular-PR target is
+justified only by scenarios that run in regular PR CI; quarantined, disabled,
+and outerloop-only consumers do not qualify. When a scheduling attribute moves
+a scenario into or out of regular PR CI, update the exact trigger-map edge and
+focused regression coverage in the same PR.
+
 Selector behavior changes should include focused coverage in
-`tests/Infrastructure.Tests/TestTriggerMap/`. See
-`docs/ci/test-trigger-map.md` for the map vocabulary and maintenance guidance.
+`tests/Infrastructure.Tests/TestTriggerMap/`. Audit the complete curated
+consumer and path lists whenever a PR changes routing or runtime consumption;
+tests are regression guards, not a second copy of that audit. Cover each
+distinct heavy-target routing boundary with a representative positive, record
+deliberate exclusions in focused negative cases, and add a structural assertion
+when the same consumer list is intentionally duplicated across rule types.
+Treat a relaxed negative expectation as a signal to verify the consuming
+workflow's artifacts and execution lane. See `docs/ci/test-trigger-map.md` for
+the map vocabulary and maintenance guidance.
 
 ### API Files and Public API Surface
 

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -9,6 +9,22 @@ The machine-readable form lives at
 the rollout plan are in
 [`test-trigger-selector-design.md`](./test-trigger-selector-design.md).
 
+To inspect the authoritative computed result for a local change set, run
+`SelectTests` with `--explain` and either `--changed-files` or `--from`:
+
+```bash
+dotnet run --project tools/SelectTests -- --changed-files changed-files.txt --explain
+```
+
+The output is produced by the same selector used in CI and includes the selected
+projects, jobs, causes, unattributed files, and fallback status. Do not infer a
+target set by reading the YAML; use this command (or the CI artifact) instead.
+`--skip-layer1` is useful for focused Layer 2 tests, but is not an authoritative
+PR result because it omits the MSBuild dependency graph.
+The output is the real computed selection; without `--enforce`, audit mode only
+means that CI continues to run the full matrix while reporting what would have
+been selected.
+
 ## Two layers
 
 Selective CI is split by **who can know a dependency**:

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -47,7 +47,7 @@ paths.
 | `conventions` | `<name>`-capture pattern → target template, emitted only if the derived test exists (existence guard). Additive. Covers a test's own folder and the Hosting/Components integration dirs as a backstop for non-MSBuild files the graph cannot attribute. |
 | `ignore` | globs Layer 2 accounts for with **no** target, so they do not trip the run-all fallback. Link-compiled `src/Shared` / `tests/Shared` / `Components/Common` files are attributed by Layer 1; the curated entries cover only paths that still need an explicit exemption. See [test-trigger-selector-design.md](./test-trigger-selector-design.md) §Layer 2. |
 | `path_rules` | a path glob set → a target set (`test:` / `job:` / a group / `ALL`). The single general path matcher: catch-all-to-`ALL`, convention misses, non-.NET job loose-file triggers, and loose-file reads all live here under comment headers |
-| `affected_project_rules` | an affected **production** project, matched by project-name glob against Layer 1's affected set, → a target set. Matched against production names **only** — affected matrix test projects are excluded, so a test-only change cannot fire production jobs via a glob like `Aspire.Hosting*`. Follows the graph's transitive closure |
+| `affected_project_rules` | an affected **non-matrix** project, matched by project-name glob against Layer 1's affected set, → a target set. Matrix test projects are excluded because Layer 1 already selects them directly; non-matrix support projects can still match broad globs. Follows the graph's transitive closure |
 | `derived_targets` | "if any of these tests is selected, also run these jobs/tests" — a *test-set* relationship, not a file edge |
 | `groups` | named, reusable bundles of `test:`/`job:` targets that expand recursively |
 
@@ -177,17 +177,31 @@ Highlights:
   **both** `job:typescript-api-compat` (baseline diff) and `job:polyglot`,
   because the polyglot playground regenerates and compiles that exported surface
   in every language.
-- **loose-file deps** — `eng/clipack/**`, `eng/winget/**`, `eng/homebrew/**`,
+- **loose-file deps** — `eng/clipack/**`, `eng/dashboardpack/**`,
+  `eng/dcppack/**`, `eng/winget/**`, `eng/homebrew/**`,
   `src/Aspire.ProjectTemplates/**`, `playground/**`, `.github/workflows/**`,
-  and `eng/Bundle.proj`.
+  `eng/Bundle.proj`, and `tools/CreateLayout/**`. Runtime consumers are
+  additive: CLI and extension E2E execute the CLI archive and its Dashboard/DCP
+  payloads, CLI E2E restores the built `Aspire.ProjectTemplates` package,
+  Templates.Tests generates AppHosts that consume the Linux and Windows
+  Dashboard/DCP packages, extension E2E copies `playground/JavaSpringBoot/**`,
+  and the repository-root `.gitignore` controls whether that Java AppHost is
+  discoverable. The `.gitignore` invariant is covered by a focused
+  `Infrastructure.Tests` guard instead of the expensive extension E2E matrix.
+  Dedicated package-input directories use broad `/**` rules when enumerating
+  files or RIDs would let a newly added input silently miss its consumers.
 
 ### Project rules (`affected_project_rules`)
 
-An affected **production** project → a target set, matched by project-**name**
+An affected **non-matrix** project → a target set, matched by project-**name**
 glob against Layer 1's affected set. Matrix test projects are handled by the
-Layer 1 intersection.
+Layer 1 intersection and excluded here. Non-matrix test-support projects can
+still match broad globs. Narrow those matches for expensive or class-sharded
+gated targets; broader no-miss matching can be appropriate for smaller
+unsharded jobs when maintaining an exhaustive allowlist would be more fragile
+than the harmless over-selection.
 
-This is keyed by project identity rather than literal production-project path
+This is keyed by project identity rather than literal project-path
 globs, so it follows the graph's transitive closure and survives project
 directory moves. It is additive and inert when Layer 1 is explicitly skipped
 with `--skip-layer1`; the loose-file `path_rules` still cover those triggers.
@@ -198,6 +212,48 @@ Project name means the `.csproj` base name, which is what Layer 1 emits.
 - projects: [Aspire.Hosting*, Aspire.Cli]
   targets: [job:typescript-api-compat]
 ```
+
+ProjectGraph cannot see a test or job that restores repository-built packages
+at runtime instead of referencing their projects. For expensive or
+class-sharded selector-gated work, represent those edges with exact production
+project names in `affected_project_rules`. Keep the list to packages the target
+actually exercises; do not replace it with a broad family glob merely because
+the target consumes some members of that family.
+
+Do not expand or refine advisory targets that gate no PR jobs in an unrelated
+PR focused on PR-gated work. Audit them when their workflow or routing is
+intentionally in scope.
+
+"Actually exercises" is relative to the target's execution lane. A regular-PR
+target includes only consumers that run in regular PR CI; quarantined, disabled,
+and outerloop-only scenarios do not justify an edge to that target. Adding or
+removing `QuarantinedTest`, `ActiveIssue`, or `OuterloopTest` on a runtime
+consumer requires auditing the exact map edge and updating focused regression
+coverage when eligibility changes.
+
+This distinction is especially important for class-sharded E2E targets. The
+[issue #19879 audit](https://github.com/microsoft/aspire/issues/19879) found
+that broad Hosting routing created 772 unnecessary extension E2E jobs and
+about 3,388 aggregate runner-minutes across 24 runs. A full CLI E2E selection
+created 87–88 class jobs and consumed 398–440 aggregate runner-minutes across
+four measured runs, plus its Docker image build. Representative CI runs are
+[33596440076](https://github.com/microsoft/aspire/actions/runs/33596440076)
+and
+[33414997820](https://github.com/microsoft/aspire/actions/runs/33414997820).
+
+Audit the complete curated consumer and path lists against the consuming
+workflow whenever routing or runtime consumption changes. Do not duplicate the
+whole list in a test: it cannot detect a consumer missing from both copies and
+encourages mechanically accepting over-selection. Tests are regression guards
+for distinct routing boundaries:
+
+- add a representative positive for each new or narrowed edge;
+- record deliberately excluded consumers in focused negative cases; and
+- add a structural assertion when the same consumer list is intentionally
+  duplicated across `path_rules` and `affected_project_rules`.
+
+Treat a widened or relaxed negative expectation as a reason to re-check which
+artifacts the workflow downloads and which lanes execute it.
 
 ### Derived targets (`derived_targets`)
 
@@ -257,16 +313,25 @@ it.
      target to schedule; record why in the adjacent YAML comment;
    - add a top-level skip pattern only when the path cannot affect main CI, or a
      dedicated workflow fully validates it; preserve any `keep_routed` carve-out;
-   - use `affected_project_rules` only when an affected production project
+   - use `affected_project_rules` only when an affected non-matrix project
      implies work beyond the graph-selected tests, and `derived_targets` only
-     when selecting one test inherently requires another target.
+     when selecting one test inherently requires another target;
+   - keep `reason` to a short description of what the rule covers or why the
+     target consumes the input. Add detail only for a non-obvious relationship
+     or constraint. The `targets` field is the source of truth for the target
+     list; do not repeat those names in `reason` or use it for PR narrative or
+     investigation history. A category-level description is sufficient; the
+     reason does not need to explain every target or make the rule
+     self-contained. Keep discussion of alternative rule shapes or why a glob
+     was split or broadened in the PR or maintenance documentation.
 4. **Wire jobs end to end.** A selector-gated `job:` target needs a matching
    `run_*` output in `tests.yml`, a gate that consumes that output, and a route
    from any reusable workflow that implements the job. Targets outside those PR
    gates must remain advisory rather than appearing as PR-runnable work.
-5. **Add a regression that would catch both under- and over-selection.**
-   - curated routing changes use the real map in `TestTriggerMapTests.cs` and
-     compare the complete selected target sets;
+5. **Add focused regressions for the routing boundary.**
+   - curated routing changes use the real map with a representative positive
+     and focused negatives for deliberate exclusions;
+   - intentionally duplicated consumer lists get a structural equality check;
    - selector-engine behavior uses focused synthetic maps in
      `SelectTestsAcceptanceTests.cs`;
    - CLI rendering and side-channel behavior belongs in

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -63,7 +63,7 @@ paths.
 | `conventions` | `<name>`-capture pattern → target template, emitted only if the derived test exists (existence guard). Additive. Covers a test's own folder and the Hosting/Components integration dirs as a backstop for non-MSBuild files the graph cannot attribute. |
 | `ignore` | globs Layer 2 accounts for with **no** target, so they do not trip the run-all fallback. Link-compiled `src/Shared` / `tests/Shared` / `Components/Common` files are attributed by Layer 1; the curated entries cover only paths that still need an explicit exemption. See [test-trigger-selector-design.md](./test-trigger-selector-design.md) §Layer 2. |
 | `path_rules` | a path glob set → a target set (`test:` / `job:` / a group / `ALL`). The single general path matcher: catch-all-to-`ALL`, convention misses, non-.NET job loose-file triggers, and loose-file reads all live here under comment headers |
-| `affected_project_rules` | an affected **non-matrix** project, matched by project-name glob against Layer 1's affected set, → a target set. Matrix test projects are excluded because Layer 1 already selects them directly; non-matrix support projects can still match broad globs. Follows the graph's transitive closure |
+| `affected_project_rules` | an affected **production/non-test** project, matched by project-name glob against Layer 1's affected set, → a target set. Every project under `tests/` is excluded because test projects are selected through the Layer 1 intersection or explicit test rules. Follows the graph's transitive closure |
 | `derived_targets` | "if any of these tests is selected, also run these jobs/tests" — a *test-set* relationship, not a file edge |
 | `groups` | named, reusable bundles of `test:`/`job:` targets that expand recursively |
 
@@ -209,13 +209,15 @@ Highlights:
 
 ### Project rules (`affected_project_rules`)
 
-An affected **non-matrix** project → a target set, matched by project-**name**
-glob against Layer 1's affected set. Matrix test projects are handled by the
-Layer 1 intersection and excluded here. Non-matrix test-support projects can
-still match broad globs. Narrow those matches for expensive or class-sharded
-gated targets; broader no-miss matching can be appropriate for smaller
-unsharded jobs when maintaining an exhaustive allowlist would be more fragile
-than the harmless over-selection.
+An affected **production/non-test** project → a target set, matched by
+project-**name** glob against Layer 1's affected set. Every project under
+`tests/`, including non-matrix fixtures and support projects, is excluded here.
+Test projects are selected through the Layer 1 intersection or explicit test
+rules; these rules describe dependencies from production projects to additional
+selector-gated jobs. Narrow those matches for expensive or class-sharded gated
+targets; broader no-miss matching can be appropriate for smaller unsharded jobs
+when maintaining an exhaustive allowlist would be more fragile than harmless
+over-selection.
 
 This is keyed by project identity rather than literal project-path
 globs, so it follows the graph's transitive closure and survives project

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -189,12 +189,13 @@ Highlights:
 - **non-.NET job loose triggers** — only the paths the project graph cannot
   attribute, such as `tests/PolyglotAppHosts/**`, checked-in
   `*.tscompat.suppression.txt` baselines, `tools/TypeScriptApiCompat/**`, and
- `extension/**`. Checked-in `*.ats.txt` baselines under `src/**/api/**` are
+ `extension/**`. Checked-in `*.ats.txt` baselines under the project `api/`
+ directories are
  generated artifacts dropped by the prefilter (see below) when they are the
  only changed files, so no dedicated rule routes them here. Hosting integration
- source changes additionally route to `job:polyglot` because those exports are
- consumed by the per-language AppHost fixtures.
-- **loose-file deps** — `eng/clipack/**`, `eng/winget/**`, `eng/homebrew/**`,
+ projects with polyglot fixtures are listed in `affected_project_rules`.
+- **loose-file deps** — `eng/clipack/**`, `eng/dashboardpack/**`,
+  `eng/dcppack/**`, `eng/winget/**`, `eng/homebrew/**`,
   `src/Aspire.ProjectTemplates/**`, `playground/**`, `.github/workflows/**`,
   `eng/Bundle.proj`, and `tools/CreateLayout/**`. Runtime consumers are
   additive: CLI and extension E2E execute the CLI archive and its Dashboard/DCP

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -187,14 +187,14 @@ Highlights:
   `src/Aspire.Hosting.Integration.Analyzers/**` →
   `test:Aspire.Hosting.Analyzers.Tests`.
 - **non-.NET job loose triggers** — only the paths the project graph cannot
-  attribute, such as `tests/PolyglotAppHosts/**`, checked-in `*.ats.txt` /
+  attribute, such as `tests/PolyglotAppHosts/**`, checked-in
   `*.tscompat.suppression.txt` baselines, `tools/TypeScriptApiCompat/**`, and
-  `extension/**`. A `src/Aspire.Hosting*/api/*.ats.txt` baseline fans out to
-  **both** `job:typescript-api-compat` (baseline diff) and `job:polyglot`,
-  because the polyglot playground regenerates and compiles that exported surface
-  in every language.
-- **loose-file deps** — `eng/clipack/**`, `eng/dashboardpack/**`,
-  `eng/dcppack/**`, `eng/winget/**`, `eng/homebrew/**`,
+ `extension/**`. Checked-in `*.ats.txt` baselines under `src/**/api/**` are
+ generated artifacts dropped by the prefilter (see below) when they are the
+ only changed files, so no dedicated rule routes them here. Hosting integration
+ source changes additionally route to `job:polyglot` because those exports are
+ consumed by the per-language AppHost fixtures.
+- **loose-file deps** — `eng/clipack/**`, `eng/winget/**`, `eng/homebrew/**`,
   `src/Aspire.ProjectTemplates/**`, `playground/**`, `.github/workflows/**`,
   `eng/Bundle.proj`, and `tools/CreateLayout/**`. Runtime consumers are
   additive: CLI and extension E2E execute the CLI archive and its Dashboard/DCP

--- a/docs/ci/test-trigger-map.md
+++ b/docs/ci/test-trigger-map.md
@@ -331,7 +331,7 @@ it.
      target to schedule; record why in the adjacent YAML comment;
    - add a top-level skip pattern only when the path cannot affect main CI, or a
      dedicated workflow fully validates it; preserve any `keep_routed` carve-out;
-   - use `affected_project_rules` only when an affected non-matrix project
+   - use `affected_project_rules` only when an affected production/non-test project
      implies work beyond the graph-selected tests, and `derived_targets` only
      when selecting one test inherently requires another target;
    - keep `reason` to a short description of what the rule covers or why the

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -124,7 +124,7 @@ correct affected set *and* the genuine shortest hop chain to each project.
 
 The output is the affected project base names: the `.csproj` filename without
 extension. `TestSelector.Select(...)` intersects test-project names with the
-matrix and matches production-project names against `affected_project_rules`.
+matrix and matches non-matrix project names against `affected_project_rules`.
 
 #### Decision paths (traceability)
 
@@ -237,10 +237,11 @@ load-bearing at the design level:
   This is why `prefilter`, not `ignore`, is what stops a packed `README.md` from
   being attributed by the graph and fanned out: `ignore` only suppresses the
   Layer 2 run-all fallback, while Layer 1 still attributes an `ignore`d file.
-- **`affected_project_rules`** matches Layer 1's affected **production** project
-  names only; affected matrix *test* projects are filtered out first, so a
-  test-only change cannot fire production jobs (`typescript-api-compat`, `extension-e2e`, …)
-  through a glob like `Aspire.Hosting*`.
+- **`affected_project_rules`** matches Layer 1's affected **non-matrix** project
+  names; affected matrix *test* projects are filtered out first, so a test-only
+  matrix change cannot fire jobs (`typescript-api-compat`, `extension-e2e`, …)
+  through a glob like `Aspire.Hosting*`. Non-matrix test-support projects can
+  still match broad globs.
 
 ## The tool (`tools/SelectTests`)
 
@@ -285,9 +286,9 @@ Flow:
    treated as Layer-1-owned, so a link-compiled `src/Shared`/`tests/Shared`
    file does not trip the run-all fallback even though it is under no project
    directory.
-4. Apply `affected_project_rules` to Layer 1 **production**-project names only
-   (affected matrix test projects are filtered out first, so a test-only change
-   does not fire production jobs through a production-name glob).
+4. Apply `affected_project_rules` to Layer 1 **non-matrix** project names
+   (affected matrix test projects are filtered out first, so a matrix-test-only
+   change does not fire jobs through a broad project-name glob).
 5. Apply `derived_targets` to a cycle-safe fixpoint.
 6. Escalate to `ALL` for a kill switch, an `ALL` path rule, or any changed file
    that survived the prefilter but is not Layer-1-owned (neither under a project

--- a/docs/ci/test-trigger-selector-design.md
+++ b/docs/ci/test-trigger-selector-design.md
@@ -124,7 +124,8 @@ correct affected set *and* the genuine shortest hop chain to each project.
 
 The output is the affected project base names: the `.csproj` filename without
 extension. `TestSelector.Select(...)` intersects test-project names with the
-matrix and matches non-matrix project names against `affected_project_rules`.
+matrix, then matches production/non-test project names against
+`affected_project_rules`.
 
 #### Decision paths (traceability)
 
@@ -237,11 +238,11 @@ load-bearing at the design level:
   This is why `prefilter`, not `ignore`, is what stops a packed `README.md` from
   being attributed by the graph and fanned out: `ignore` only suppresses the
   Layer 2 run-all fallback, while Layer 1 still attributes an `ignore`d file.
-- **`affected_project_rules`** matches Layer 1's affected **non-matrix** project
-  names; affected matrix *test* projects are filtered out first, so a test-only
-  matrix change cannot fire jobs (`typescript-api-compat`, `extension-e2e`, …)
-  through a glob like `Aspire.Hosting*`. Non-matrix test-support projects can
-  still match broad globs.
+- **`affected_project_rules`** matches Layer 1's affected
+  **production/non-test** project names. Every project under `tests/`, including
+  non-matrix fixtures and support projects, is filtered out first, so test-only
+  changes cannot fire jobs (`typescript-api-compat`, `extension-e2e`, …) through
+  a glob like `Aspire.Hosting*`.
 
 ## The tool (`tools/SelectTests`)
 
@@ -286,8 +287,8 @@ Flow:
    treated as Layer-1-owned, so a link-compiled `src/Shared`/`tests/Shared`
    file does not trip the run-all fallback even though it is under no project
    directory.
-4. Apply `affected_project_rules` to Layer 1 **non-matrix** project names
-   (affected matrix test projects are filtered out first, so a matrix-test-only
+4. Apply `affected_project_rules` to Layer 1 **production/non-test** project
+   names (every project under `tests/` is filtered out first, so a test-only
    change does not fire jobs through a broad project-name glob).
 5. Apply `derived_targets` to a cycle-safe fixpoint.
 6. Escalate to `ALL` for a kill switch, an `ALL` path rule, or any changed file
@@ -471,29 +472,29 @@ regular PR matrix and PR-gated jobs. The summary shows:
 - any `ALL` or kill-switch escalation and why;
 - unattributed changed files that may need curated rules.
 
-The PR comment carries the same selection in a more scannable form. It leads
-with **what runs** — the flat list of selected PR test projects, the flat list
-of selected PR jobs, and a separate advisory schedule/outerloop section (test
-projects first, since they are the primary review signal) — so a reviewer sees
-the full impact at a glance even when many files changed. It then explains
-**how** the selection was reached in a collapsed
-`<details>` (the heading is the `<summary>`, so the rationale stays out of the
-way until expanded), grouping the selected projects under each trigger (changed
-file, affected project, or derived test) that pulled them in: a changed file
-and its graph fan-out appear under one heading, so a single edit's whole
-closure is stated once rather than repeated per project, and large fan-outs
-collapse into a nested `<details>`. Every cause is still shown — a project
-selected by several triggers appears under each — and a per-job table names
-what triggered each job. The comment is posted **one per pushed
-commit** and links the head commit it was computed for: a re-run of the same
-commit updates that commit's comment in place (no duplicate — re-runs are
-common), a new commit posts a fresh comment at the bottom, and comments from
-superseded commits are collapsed (minimized, never deleted) so the latest
-selection surfaces at the bottom while the per-push history is preserved. In
-audit mode the comment is advisory — the regular PR matrix and PR-gated jobs
-still run — so it is labelled "(audit mode)" and states that the PR lists are
-what selective CI **would** run under enforcement. Advisory-only targets remain
-explicitly labelled as schedule/outerloop impact.
+The PR comment carries the PR-gated selection in a more scannable form. It
+leads with **what runs** — the flat list of selected PR test projects and the
+flat list of selected PR jobs (test projects first, since they are the primary
+review signal) — so a reviewer sees the regular PR impact at a glance even when
+many files changed. It then explains **how** the PR-gated selection was reached
+in a collapsed `<details>` (the heading is the `<summary>`, so the rationale
+stays out of the way until expanded), grouping selected projects under each
+trigger (changed file, affected project, or derived test) that pulled them in:
+a changed file and its graph fan-out appear under one heading, so a single
+edit's whole closure is stated once rather than repeated per project, and large
+fan-outs collapse into a nested `<details>`. Every PR-gated cause is still shown
+— a project selected by several triggers appears under each — and a per-job
+table names what triggered each PR job. The full step summary, `--explain`
+output, and JSON artifact remain the diagnostic surfaces for advisory
+schedule/outerloop impact. The comment is posted **one per pushed commit** and
+links the head commit it was computed for: a re-run of the same commit updates
+that commit's comment in place (no duplicate — re-runs are common), a new commit
+posts a fresh comment at the bottom, and comments from superseded commits are
+collapsed (minimized, never deleted) so the latest selection surfaces at the
+bottom while the per-push history is preserved. In audit mode the comment is
+advisory — the regular PR matrix and PR-gated jobs still run — so it is labelled
+"(audit mode)" and states that the PR lists are what selective CI **would** run
+under enforcement.
 
 Any audit run where a would-be-skipped test would have failed is a map bug. Fix
 the map before returning to enforcing mode.

--- a/eng/github-ci/ci-skip-entirely-patterns.txt
+++ b/eng/github-ci/ci-skip-entirely-patterns.txt
@@ -36,7 +36,10 @@ eng/github-ci/ci-skip-entirely-patterns.txt
 
 # Generated API and ATS baselines
 # These files are generated release/API-surface artifacts and do not require PR CI.
-src/**/api/**
+src/*/api/*.cs
+src/*/api/*.ats.txt
+src/Components/*/api/*.cs
+src/Components/*/api/*.ats.txt
 
 # Engineering pipeline scripts (Azure DevOps, not used in the GitHub CI build)
 eng/pipelines/**

--- a/eng/github-ci/ci-skip-entirely-patterns.txt
+++ b/eng/github-ci/ci-skip-entirely-patterns.txt
@@ -85,16 +85,13 @@ pyrightconfig.json
 
 # Repository metadata with no build or test impact. Without these, a PR touching only one of them
 # would fall through the selective-CI run-all fallback and force the FULL test matrix (the fallback
-# escalates any file it cannot attribute -- see tools/SelectTests/TestSelector.cs). Issue forms,
-# CODEOWNERS, and the repo-root .gitignore cannot change what builds or how a test behaves.
+# escalates any file it cannot attribute -- see tools/SelectTests/TestSelector.cs). Issue forms and
+# CODEOWNERS cannot change what builds or how a test behaves.
 #
 # Deliberately NOT listed (each can change build/test outcomes, so they must still run CI):
 #   .editorconfig    -- analyzer severities feed TreatWarningsAsErrors
 #   .gitattributes   -- checkout normalization (line endings) can affect fixture-sensitive tests
-# The pattern below is the repo-ROOT .gitignore only (anchored, no '**'): nested .gitignore files
-# under src/Aspire.Cli/Templating/Templates/** and tests/** are shipped/owned assets that Layer 1 and
-# the conventions route to their projects -- they must not skip CI.
-.gitignore
+#   .gitignore       -- controls discovery of the extension's Java E2E workspace
 .github/CODEOWNERS
 .github/dependabot.yml
 .github/ISSUE_TEMPLATE/**

--- a/eng/github-ci/ci-skip-entirely-patterns.txt
+++ b/eng/github-ci/ci-skip-entirely-patterns.txt
@@ -34,6 +34,10 @@ eng/github-ci/ci-skip-entirely-patterns.txt
 # Documentation
 **.md
 
+# Generated API and ATS baselines
+# These files are generated release/API-surface artifacts and do not require PR CI.
+src/**/api/**
+
 # Engineering pipeline scripts (Azure DevOps, not used in the GitHub CI build)
 eng/pipelines/**
 eng/test-configuration.json

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -203,8 +203,9 @@ path_rules:
   # changes -- the same surface the per-language polyglot playground scripts regenerate and compile
   # (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). So an exported-surface
   # change must run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate+compile in every
-  # language), even when the author has not also touched the tests/PolyglotAppHosts fixtures. The baseline
-  # is not a compiled item, so Layer 1 is blind to it and these targets must be enumerated here.
+  # language), even when the author has not also touched the tests/PolyglotAppHosts fixtures. Layer 1 can
+  # attribute the baseline by project-directory containment, but this explicit rule preserves both jobs
+  # when Layer 1 is skipped and records the runtime polyglot dependency.
   - paths:
       - src/Aspire.Hosting*/api/*.ats.txt
     targets: [job:typescript-api-compat, job:polyglot]
@@ -219,24 +220,27 @@ path_rules:
     reason: extension_tests_win validates the root launch/task workspace wiring and extension tests; extension_bootstrap_linux builds the extension and validates the e2e bridge VSIX
   - paths:
       - extension/**
+      - src/Aspire.AppHost.Sdk/**
       - src/Aspire.Cli/**
-      - src/Aspire.Hosting*/**
       - src/Aspire.Dashboard*/**
-      - tests/Aspire.Cli.Tests/**
-      - tests/Aspire.Cli.EndToEnd.Tests/**
-      - tests/Aspire.Hosting.Tests/Cli/**
-      - eng/scripts/get-aspire-cli*
+      - src/Aspire.Hosting/**
+      - src/Aspire.Hosting.AppHost/**
+      - src/Aspire.Hosting.Azure.Functions/**
+      - src/Aspire.Hosting.CodeGeneration.Java/**
+      - src/Aspire.Hosting.CodeGeneration.TypeScript/**
+      - src/Aspire.Hosting.Docker/**
+      - src/Aspire.Hosting.Java/**
+      - src/Aspire.Hosting.JavaScript/**
+      - src/Aspire.Hosting.Redis/**
+      - src/Aspire.Hosting.RemoteHost/**
+      - src/Aspire.Managed/**
       - .github/workflows/tests.yml
       - .github/workflows/extension-unit-tests.yml
       - .github/workflows/extension-e2e-tests.yml
       - .github/workflows/build-packages.yml
       - .github/workflows/build-cli-native-archives.yml
     targets: [job:extension-e2e]
-    reason: >-
-      verbatim mirror of the tests.yml extension_e2e_changes regex. extension-e2e is
-      intentionally double-routed: its production triggers also live in affected_project_rules
-      (transitive coverage when Layer 1 runs), but these path globs keep the gate working without
-      Layer 1 -- a src/Aspire.Cli|Hosting*|Dashboard* change still fires it via pure path match.
+    reason: extension e2e inputs and runtime dependencies; path fallback when Layer 1 is unavailable
   - paths:
       - tests/Aspire.Deployment.EndToEnd.Tests/**
       - src/Aspire.ProjectTemplates/**
@@ -268,12 +272,23 @@ path_rules:
       - eng/scripts/get-aspire-cli.ps1
       - eng/scripts/get-aspire-cli-pr.sh
       - eng/scripts/get-aspire-cli-pr.ps1
-    targets: [test:Aspire.Acquisition.Tests, test:Aspire.Cli.EndToEnd.Tests, job:extension-e2e]
+    targets: [test:Aspire.Acquisition.Tests, test:Aspire.Cli.EndToEnd.Tests]
     reason: Acquisition.Tests asserts script behavior; CliE2EAutomatorHelpers.cs:406,415 invokes get-aspire-cli*.sh at runtime
   - paths:
       - eng/clipack/**
-    targets: [test:Aspire.Cli.Tests, test:Aspire.Cli.EndToEnd.Tests, test:Infrastructure.Tests, job:winget-installer, job:homebrew-installer]
-    reason: Cli.Tests/Npm/AspireJsLauncherTests reads eng/clipack/npm/aspire.js; Infrastructure.Tests reads eng/clipack/*; CLI archive consumed by e2e and packaged into the WinGet/Homebrew installer artifacts
+    targets: [test:Aspire.Cli.Tests, test:Infrastructure.Tests, job:winget-installer, job:homebrew-installer]
+    reason: CLI/package tests inspect packaging inputs; installer jobs package the native archives
+  - paths:
+      - eng/clipack/Common.projitems
+      - eng/clipack/Aspire.Cli.linux-x64.csproj
+    targets: [test:Aspire.Cli.EndToEnd.Tests]
+    reason: CLI e2e consumes the Linux x64 CLI archive
+  - paths:
+      - eng/clipack/Common.projitems
+      - eng/clipack/Aspire.Cli.linux-x64.csproj
+      - eng/clipack/Aspire.Cli.win-x64.csproj
+    targets: [job:extension-e2e]
+    reason: extension-e2e consumes the Linux and Windows x64 CLI archives
   - paths:
       - eng/clipack/Common.projitems
       - eng/clipack/Aspire.Cli.linux-x64.csproj
@@ -342,16 +357,20 @@ path_rules:
     reason: the Homebrew installer artifact job invokes this installed-CLI smoke test
   - paths:
       - eng/dashboardpack/**
-    targets: [test:Aspire.Hosting.Sdk.Tests]
-    reason: AppHostSdkTargetsTests asserts the per-RID dashboard package reference used when the CLI bundle is disabled
+    targets: [test:Aspire.Cli.EndToEnd.Tests, test:Aspire.Hosting.Sdk.Tests, test:Aspire.Templates.Tests, job:extension-e2e]
+    reason: Dashboard package consumers; the broad match keeps new packaging inputs covered
   - paths:
       - eng/dcppack/**
-    targets: [test:Aspire.Hosting.Sdk.Tests, test:Aspire.TerminalHost.Tests]
-    reason: AppHostSdkTargetsTests asserts the per-RID orchestration package reference; TerminalHost exercises packaged DCP
+    targets: [test:Aspire.Cli.EndToEnd.Tests, test:Aspire.Hosting.Sdk.Tests, test:Aspire.Templates.Tests, test:Aspire.TerminalHost.Tests, job:extension-e2e]
+    reason: DCP package consumers; the broad match keeps new packaging inputs covered
   - paths:
       - src/Aspire.ProjectTemplates/**
-    targets: [test:Aspire.Templates.Tests]
-    reason: Templates.Tests installs the template hive from src/Aspire.ProjectTemplates
+    targets: [test:Aspire.Cli.EndToEnd.Tests, test:Aspire.Templates.Tests, job:winget-installer, job:homebrew-installer]
+    reason: template package consumers; the broad match keeps new templates covered
+  - paths:
+      - playground/JavaSpringBoot/**
+    targets: [job:extension-e2e]
+    reason: Java extension e2e copies this playground into its workspace
   - paths:
       - src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
       - src/Aspire.ProjectTemplates/templates/aspire-starter/**
@@ -373,8 +392,9 @@ path_rules:
       - tools/SelectTests/**
       - eng/github-ci/test-trigger-map.yml
       - eng/github-ci/ci-skip-entirely-patterns.txt
+      - .gitignore
     targets: [test:Infrastructure.Tests]
-    reason: SelectTests acceptance/behavior tests live in Infrastructure.Tests/TestTriggerMap; the same project's verifier validates eng/github-ci/test-trigger-map.yml and reads eng/github-ci/ci-skip-entirely-patterns.txt (the prefilter source), so a change to any of them must run it
+    reason: Infrastructure.Tests validates the selector map, prefilter, and root ignore behavior
   - paths:
       - .github/workflows/**
       - eng/pipelines/**
@@ -382,15 +402,17 @@ path_rules:
       - eng/Publishing.props
     targets: [test:Infrastructure.Tests]
     reason: Infrastructure.Tests WorkflowScripts/Pipelines assert on workflow & pipeline files; NpmCliPackageTests reads eng/Signing.props, and Publishing.props is AzDO-publish-only infra grouped with it (no GH-CI build/test path -> not ALL)
-  - paths: [eng/Bundle.proj]
+  - paths:
+      - eng/Bundle.proj
+      - tools/CreateLayout/**
     targets: [CLI_BUNDLE]
-    reason: assembles the CLI bundle (Aspire.Managed + native CLI + DCP); consumed by CLI e2e/starter/extension, not integrations
+    reason: CreateLayout assembles the CLI bundle consumed by CLI e2e, extension e2e, and installers
 
-# Project rules: an affected PRODUCTION project (Layer 1, matched by project-NAME glob) -> targets.
+# Project rules: an affected non-matrix project (Layer 1, matched by project-NAME glob) -> targets.
 # This follows the graph's transitive closure: a change to a project's dependency marks it affected,
 # so its jobs fire too (more correct than a literal path glob, and additive -- never removes a
-# trigger). Matched only against the affected PRODUCTION projects (matrix test projects are handled
-# by the Layer 1 intersection), so a name glob like "Aspire.Hosting*" keys off production identity.
+# trigger). Matrix test projects are handled by the Layer 1 intersection and excluded here; broad
+# globs can also match non-matrix test-support projects.
 # Inert when Layer 1 did not run (--skip-layer1); the loose-file path_rules above still cover those
 # triggers.
 # Project Name == the .csproj base name (what Layer 1 emits).
@@ -428,18 +450,69 @@ affected_project_rules:
   - projects: [Aspire.Hosting*, Aspire.Cli]
     targets: [job:typescript-api-compat]
     reason: compares checked-in *.ats.txt baselines vs fresh `aspire sdk dump --format ci`
-  - projects: [Aspire.Cli, Aspire.Hosting*, Aspire.Dashboard*]
+  - projects: [Aspire.Dashboard]
+    targets: [test:Aspire.Templates.Tests]
+    reason: Templates.Tests launches generated AppHosts with the packaged dashboard
+  - projects:
+      - Aspire.AppHost.Sdk
+      - Aspire.Cli
+      - Aspire.Dashboard*
+      - Aspire.Hosting
+      - Aspire.Hosting.AppHost
+      - Aspire.Hosting.Azure.Functions
+      - Aspire.Hosting.CodeGeneration.Java
+      - Aspire.Hosting.CodeGeneration.TypeScript
+      - Aspire.Hosting.Docker
+      - Aspire.Hosting.Java
+      - Aspire.Hosting.JavaScript
+      - Aspire.Hosting.Redis
+      - Aspire.Hosting.RemoteHost
+      - Aspire.Managed
     targets: [job:extension-e2e]
-    reason: mirrors the production-project half of tests.yml extension_e2e_changes
+    reason: direct runtime and build dependencies of extension e2e
   - projects: [Aspire.Hosting.Azure*, Aspire.Cli, Aspire.TypeSystem, Aspire.Managed]
     targets: [job:deployment-e2e]
     reason: SCHEDULE/DISPATCH-ONLY today; deploys generated apps to Azure
   - projects: [Aspire.Hosting, Aspire.Hosting.AppHost, Aspire.Hosting.PostgreSQL, Aspire.Hosting.Redis]
     targets: [test:Aspire.EndToEnd.Tests]
     reason: OUTERLOOP-ONLY today; builds testproject apphost against built nugets
-  - projects: [Aspire.Cli, Aspire.TypeSystem, Aspire.Managed, Aspire.AppHost.Sdk]
+  - projects:
+      - Aspire.AppHost.Sdk
+      - Aspire.Cli
+      - Aspire.Hosting
+      - Aspire.Hosting.AppHost
+      - Aspire.Hosting.Blazor
+      - Aspire.Hosting.CodeGeneration.Java
+      - Aspire.Hosting.CodeGeneration.TypeScript
+      - Aspire.Hosting.Docker
+      - Aspire.Hosting.Dotnet
+      - Aspire.Hosting.EntityFrameworkCore
+      - Aspire.Hosting.Garnet
+      - Aspire.Hosting.Java
+      - Aspire.Hosting.JavaScript
+      - Aspire.Hosting.Kubernetes
+      - Aspire.Hosting.MongoDB
+      - Aspire.Hosting.MySql
+      - Aspire.Hosting.PostgreSQL
+      - Aspire.Hosting.Python
+      - Aspire.Hosting.RabbitMQ
+      - Aspire.Hosting.Radius
+      - Aspire.Hosting.Redis
+      - Aspire.Hosting.RemoteHost
+      - Aspire.Hosting.SqlServer
+      - Aspire.Hosting.Valkey
+      - Aspire.Managed
+      - Aspire.Microsoft.Data.SqlClient
+      - Aspire.MongoDB.Driver
+      - Aspire.MySqlConnector
+      - Aspire.Npgsql
+      - Aspire.Npgsql.EntityFrameworkCore.PostgreSQL
+      - Aspire.RabbitMQ.Client
+      - Aspire.StackExchange.Redis
+      - Aspire.StackExchange.Redis.OutputCaching
+      - Aspire.TypeSystem
     targets: [test:Aspire.Cli.EndToEnd.Tests]
-    reason: consumes the CLI native archive (RequiresCliArchive=true) built from these sources
+    reason: regular-lane runtime packages used by CLI e2e AppHosts, add/update, code generation, publish, and deploy scenarios
 
 # Derived targets: selected test project -> extra jobs/tests. Applied to the UNION of Layer 1 and
 # Layer 2 selected tests, to a fixpoint (a derived test is itself expanded; cycle-safe). This is how

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -205,12 +205,6 @@ path_rules:
   # baseline changes alongside real source (e.g. the integration whose [AspireExport] surface it
   # tracks), the source change is not blind to Layer 1/the project rules above and routes normally
   # -- no dedicated rule is needed here for the mixed-change case.
-  # Integration source changes also run polyglot because those exports are consumed by the
-  # per-language AppHost fixtures, while the prefilter keeps baseline-only changes out of CI.
-  - paths:
-      - src/Aspire.Hosting*/**
-    targets: [job:polyglot]
-    reason: hosting integration source feeds generated SDKs and polyglot AppHost validation
   - paths:
       - extension/**
       - .vscode/launch.json
@@ -443,8 +437,59 @@ affected_project_rules:
       - Aspire.Hosting.JavaScript
       - Aspire.Hosting.Python
       - Aspire.Hosting.Rust
+      - Aspire.Hosting
+      - Aspire.Hosting.Azure
+      - Aspire.Hosting.Azure.AppConfiguration
+      - Aspire.Hosting.Azure.AppContainers
+      - Aspire.Hosting.Azure.AppService
+      - Aspire.Hosting.Azure.ApplicationInsights
+      - Aspire.Hosting.Azure.CognitiveServices
+      - Aspire.Hosting.Azure.ContainerRegistry
+      - Aspire.Hosting.Azure.CosmosDB
+      - Aspire.Hosting.Azure.EventHubs
+      - Aspire.Hosting.Azure.Functions
+      - Aspire.Hosting.Azure.KeyVault
+      - Aspire.Hosting.Azure.Kusto
+      - Aspire.Hosting.Azure.Network
+      - Aspire.Hosting.Azure.OperationalInsights
+      - Aspire.Hosting.Azure.PostgreSQL
+      - Aspire.Hosting.Azure.Redis
+      - Aspire.Hosting.Azure.Sandboxes
+      - Aspire.Hosting.Azure.Search
+      - Aspire.Hosting.Azure.ServiceBus
+      - Aspire.Hosting.Azure.SignalR
+      - Aspire.Hosting.Azure.Sql
+      - Aspire.Hosting.Azure.Storage
+      - Aspire.Hosting.Azure.WebPubSub
+      - Aspire.Hosting.Blazor
+      - Aspire.Hosting.DevTunnels
+      - Aspire.Hosting.Docker
+      - Aspire.Hosting.Dotnet
+      - Aspire.Hosting.EntityFrameworkCore
+      - Aspire.Hosting.Foundry
+      - Aspire.Hosting.Garnet
+      - Aspire.Hosting.GitHub.Models
+      - Aspire.Hosting.Kafka
+      - Aspire.Hosting.Keycloak
+      - Aspire.Hosting.Kubernetes
+      - Aspire.Hosting.Maui
+      - Aspire.Hosting.Milvus
+      - Aspire.Hosting.MongoDB
+      - Aspire.Hosting.MySql
+      - Aspire.Hosting.Nats
+      - Aspire.Hosting.OpenAI
+      - Aspire.Hosting.Oracle
+      - Aspire.Hosting.Orleans
+      - Aspire.Hosting.PostgreSQL
+      - Aspire.Hosting.Qdrant
+      - Aspire.Hosting.RabbitMQ
+      - Aspire.Hosting.Redis
+      - Aspire.Hosting.Seq
+      - Aspire.Hosting.SqlServer
+      - Aspire.Hosting.Valkey
+      - Aspire.Hosting.Yarp
     targets: [job:polyglot]
-    reason: ATS typesystem -> per-language SDK generators -> RemoteHost server + CLI run + fixtures
+    reason: ATS typesystem and hosting integrations feed the per-language SDK generators and AppHost fixtures
   - projects: [Aspire.Hosting.CodeGeneration.TypeScript]
     targets: [job:typescript-sdk]
     reason: vitest unit tests over generated TS SDK (@aspire/transport, @aspire/base)

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -408,11 +408,11 @@ path_rules:
     targets: [CLI_BUNDLE]
     reason: CreateLayout assembles the CLI bundle consumed by CLI e2e, extension e2e, and installers
 
-# Project rules: an affected non-matrix project (Layer 1, matched by project-NAME glob) -> targets.
+# Project rules: an affected production/non-test project (Layer 1, matched by project-NAME glob) -> targets.
 # This follows the graph's transitive closure: a change to a project's dependency marks it affected,
 # so its jobs fire too (more correct than a literal path glob, and additive -- never removes a
-# trigger). Matrix test projects are handled by the Layer 1 intersection and excluded here; broad
-# globs can also match non-matrix test-support projects.
+# trigger). Every project under tests/ is excluded here; test projects are handled by the Layer 1
+# intersection or explicit test rules.
 # Inert when Layer 1 did not run (--skip-layer1); the loose-file path_rules above still cover those
 # triggers.
 # Project Name == the .csproj base name (what Layer 1 emits).

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -199,17 +199,18 @@ path_rules:
       - .github/workflows/typescript-api-compat.yml
     targets: [job:typescript-api-compat]
     reason: checked-in suppression baselines are not compiled items (Layer 1 blind); Hosting/Cli production projects are in affected_project_rules
-  # A checked-in *.ats.txt baseline changes EXACTLY when an integration's [AspireExport] surface
-  # changes -- the same surface the per-language polyglot playground scripts regenerate and compile
-  # (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). So an exported-surface
-  # change must run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate+compile in every
-  # language), even when the author has not also touched the tests/PolyglotAppHosts fixtures. Layer 1 can
-  # attribute the baseline by project-directory containment, but this explicit rule preserves both jobs
-  # when Layer 1 is skipped and records the runtime polyglot dependency.
+  # Checked-in API/ATS baselines under src/*/api/ (both *.cs and *.ats.txt) are generated
+  # release artifacts. They are dropped by the prefilter (ci-skip-entirely-patterns.txt) when
+  # they are the only changed files, so a baseline-only PR skips CI entirely. When an *.ats.txt
+  # baseline changes alongside real source (e.g. the integration whose [AspireExport] surface it
+  # tracks), the source change is not blind to Layer 1/the project rules above and routes normally
+  # -- no dedicated rule is needed here for the mixed-change case.
+  # Integration source changes also run polyglot because those exports are consumed by the
+  # per-language AppHost fixtures, while the prefilter keeps baseline-only changes out of CI.
   - paths:
-      - src/Aspire.Hosting*/api/*.ats.txt
-    targets: [job:typescript-api-compat, job:polyglot]
-    reason: an integration's *.ats.txt baseline tracks its exported ATS surface; the polyglot playground regenerates+compiles that surface per language, so a baseline change must run polyglot too
+      - src/Aspire.Hosting*/**
+    targets: [job:polyglot]
+    reason: hosting integration source feeds generated SDKs and polyglot AppHost validation
   - paths:
       - extension/**
       - .vscode/launch.json

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -71,6 +71,8 @@ prefilter:
 ignore:
   - src/Components/Common/**                            # link-compiled into many components; Layer 1 covers
   - src/Vendoring/OpenTelemetry.Instrumentation.*/**    # glob-compiled into the Redis/Kafka components; Layer 1 covers
+  # Benchmark harnesses have no GitHub PR-CI consumer and are not part of the Aspire.slnx graph.
+  - benchmarks/**
   # These verifiers run in every unconditional native CLI archive build. Selecting a test target for
   # them would add no coverage; accounting for them here avoids an unrelated full test matrix.
   - eng/scripts/verify-cli-npm-package.ps1

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -755,11 +755,11 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
 
     // Layer 1 reports the full affected set, which can include tests/ projects that are NOT in the
     // runnable matrix (shared fixtures/helpers like a TestFixtures or testproject project). Those names
-    // are intersected with the matrix before selection, so they must never be selected as a test (only
-    // an affected_project_rule may reference such a name by name). Failure mode: a non-runnable project
-    // leaking into the matrix.
+    // are intersected with the matrix before selection and excluded from affected_project_rules, so they
+    // must never be selected as a test or drive a project rule. Failure mode: a non-runnable project
+    // leaking into the matrix or production-project rules.
     [Fact]
-    public void Layer1AffectedNonMatrixTestNameIsNotSelected()
+    public void Layer1AffectedNonRunnableTestNameIsNotSelected()
     {
         var r = Select([], layer1: ["TestFixtures.Shared", "testproject"]);
 
@@ -768,12 +768,13 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Empty(r.Jobs);
     }
 
-    // Layer 1 reports both matrix and non-matrix projects. affected_project_rules key off project-name
-    // globs but exclude matrix test projects, which are already handled by the Layer 1 intersection.
-    // Without that exclusion, a test-only matrix project ("Aspire.Hosting.Foo.Tests") would spuriously
-    // fire jobs attached to a broad project rule such as "Aspire.Hosting*".
+    // Layer 1 reports both matrix test projects and production/non-test projects.
+    // affected_project_rules key off project-name globs but exclude every project under tests/,
+    // which is already handled by the Layer 1 intersection or explicit test rules. Without that
+    // exclusion, a test-only project ("Aspire.Hosting.Foo.Tests") would spuriously fire jobs
+    // attached to a broad project rule such as "Aspire.Hosting*".
     [Fact]
-    public void AffectedProjectRulesMatchNonMatrixProjectsNotMatrixTests()
+    public void AffectedProjectRulesMatchProductionProjectsNotTestProjects()
     {
         const string map = """
             version: 1
@@ -792,9 +793,9 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Contains("Aspire.Hosting.Foo.Tests", testOnly.TestProjects);
         Assert.DoesNotContain("job:prodjob", testOnly.Jobs);
 
-        // A non-matrix project of the same name prefix DOES drive the rule.
-        var nonMatrix = selector.Select([], ["Aspire.Hosting.Foo"], new SelectorOptions());
-        Assert.Contains("job:prodjob", nonMatrix.Jobs);
+        // A production/non-test project of the same name prefix DOES drive the rule.
+        var productionProject = selector.Select([], ["Aspire.Hosting.Foo"], new SelectorOptions());
+        Assert.Contains("job:prodjob", productionProject.Jobs);
     }
 
     // --- H. Real-map invariant smoke (computed from the filesystem; no hardcoded names) ------

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -828,6 +828,14 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.True(filter.IsExcluded(".vscode/settings.json"));
         Assert.True(filter.IsExcluded("pyrightconfig.json"));
 
+        // Generated API/ATS baselines under src/*/api/: no PR CI is needed when these are the only
+        // changed files.
+        Assert.True(filter.IsExcluded("src/Aspire.Hosting/api/Aspire.Hosting.cs"));
+        Assert.True(filter.IsExcluded("src/Aspire.Hosting/api/Aspire.Hosting.ats.txt"));
+        Assert.True(filter.IsExcluded("src/Aspire.Hosting.Redis/api/Aspire.Hosting.Redis.cs"));
+        Assert.True(filter.IsExcluded("src/Components/Aspire.Azure.AI.Inference/api/Aspire.Azure.AI.Inference.cs"));
+        Assert.False(filter.IsExcluded("src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.tscompat.suppression.txt"));
+
         // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore
         // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), root
         // launch/task files are validated by extension tests, root .gitignore controls discovery of the
@@ -841,6 +849,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
 
         // Kept: real source the patterns file does not list.
         Assert.False(filter.IsExcluded("src/Aspire.Cli/Program.cs"));
+        Assert.False(filter.IsExcluded("src/Aspire.Hosting/HostingExtensions.cs"));
 
         // keep_routed carve-outs: listed by the patterns file but routed by the selector -> NOT dropped.
         Assert.False(filter.IsExcluded(".github/workflows/backport.yml"));
@@ -1037,29 +1046,40 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Empty(result.Jobs);
     }
 
-    // An integration's checked-in *.ats.txt baseline tracks its exported [AspireExport] surface -- the
-    // same surface the per-language polyglot playground scripts regenerate and compile
-    // (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). A change to that
-    // baseline must therefore run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate +
-    // compile in every language), so a breaking surface change is caught even if the author did not also
-    // touch the tests/PolyglotAppHosts fixtures. Run with --skip-layer1 semantics (no Layer 1 affected
-    // set) to prove the curated layer independently preserves both targets.
+    // A checked-in API/ATS baseline under src/*/api/ is a generated release artifact: the top-level
+    // prefilter drops it (ci-skip-entirely-patterns.txt) before either layer runs, so a baseline-ONLY
+    // change selects nothing. When an integration's real source ALSO changes in the same PR, the
+    // baseline is still dropped by the prefilter, but the source file reaches Layer 1/the selector
+    // untouched and is selected via the normal project/path rules. This proves the mixed-change case
+    // still routes CI even though the dedicated *.ats.txt path rule was removed. Filters the changed
+    // files through ChangedFileFilter first, mirroring how Program.cs feeds Select (see RunCore).
     [Fact]
-    public void RealMapIntegrationAtsBaselineChangeRunsTypeScriptApiCompatAndPolyglot()
+    public void RealMapMixedAtsBaselineAndSourceChangeStillRoutesSourceNormally()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
         var matrix = EnumerateMatrixTestProjects();
         var selector = new TestSelector(mapPath, matrix, LoadProjectDirectories(), EnumerateAllTestProjects());
+        var map = TriggerMap.Load(mapPath);
+        var filter = ChangedFileFilter.Create(RepoRoot.Path, map.Prefilter);
 
         var atsBaseline = FirstIntegrationAtsBaselineWithPolyglotFixture();
+        Assert.True(filter.IsExcluded(atsBaseline));
 
-        var r = selector.Select([atsBaseline], [], new SelectorOptions());
+        // Baseline-only: the prefilter drops the file before Select ever sees it -- selects nothing.
+        var baselineOnly = selector.Select([], [], new SelectorOptions());
+        Assert.False(baselineOnly.SelectsAll);
+        Assert.Empty(baselineOnly.TestProjects);
+        Assert.Empty(baselineOnly.Jobs);
 
-        Assert.False(r.SelectsAll);
-        Assert.Contains("job:typescript-api-compat", r.Jobs);
-        Assert.Contains("job:polyglot", r.Jobs);
-        Assert.Contains(r.JobCauses["job:typescript-api-compat"], cause => cause.Kind == CauseKind.PathRule);
-        Assert.Contains(r.JobCauses["job:polyglot"], cause => cause.Kind == CauseKind.PathRule);
+        // Mixed: the baseline is still dropped by the prefilter, but the integration's own source file
+        // (Layer 1-owned, not a prefilter match) still routes normally through Layer 1 / project rules.
+        var integrationName = atsBaseline.Split('/')[1];
+        var sourceFile = $"src/{integrationName}/{integrationName}.csproj";
+        Assert.False(filter.IsExcluded(sourceFile));
+        var mixed = selector.Select([sourceFile], [integrationName], new SelectorOptions());
+        Assert.False(mixed.SelectsAll);
+        Assert.NotEmpty(mixed.TestProjects.Union(mixed.Jobs));
+        Assert.Contains("job:polyglot", mixed.Jobs);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -835,6 +835,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.True(filter.IsExcluded("src/Aspire.Hosting.Redis/api/Aspire.Hosting.Redis.cs"));
         Assert.True(filter.IsExcluded("src/Components/Aspire.Azure.AI.Inference/api/Aspire.Azure.AI.Inference.cs"));
         Assert.False(filter.IsExcluded("src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.tscompat.suppression.txt"));
+        Assert.False(filter.IsExcluded("src/Aspire.Cli/Templating/Templates/java-starter/api/Program.cs"));
 
         // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore
         // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), root

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -767,13 +767,12 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Empty(r.Jobs);
     }
 
-    // Regression (production-only affected_project_rules): Layer 1 reports affected production AND test
-    // projects. affected_project_rules key off project NAME globs and must match only PRODUCTION names.
-    // A matrix test project ("Aspire.Hosting.Foo.Tests") matches a production glob ("Aspire.Hosting*"),
-    // so without the production-only filter a TEST-ONLY change would spuriously fire that rule's
-    // production jobs (extension-e2e / typescript-api-compat / deployment-e2e).
+    // Layer 1 reports both matrix and non-matrix projects. affected_project_rules key off project-name
+    // globs but exclude matrix test projects, which are already handled by the Layer 1 intersection.
+    // Without that exclusion, a test-only matrix project ("Aspire.Hosting.Foo.Tests") would spuriously
+    // fire jobs attached to a broad project rule such as "Aspire.Hosting*".
     [Fact]
-    public void AffectedProjectRulesMatchProductionProjectsNotTestProjects()
+    public void AffectedProjectRulesMatchNonMatrixProjectsNotMatrixTests()
     {
         const string map = """
             version: 1
@@ -792,9 +791,9 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Contains("Aspire.Hosting.Foo.Tests", testOnly.TestProjects);
         Assert.DoesNotContain("job:prodjob", testOnly.Jobs);
 
-        // A production project of the same name prefix DOES drive the rule.
-        var prod = selector.Select([], ["Aspire.Hosting.Foo"], new SelectorOptions());
-        Assert.Contains("job:prodjob", prod.Jobs);
+        // A non-matrix project of the same name prefix DOES drive the rule.
+        var nonMatrix = selector.Select([], ["Aspire.Hosting.Foo"], new SelectorOptions());
+        Assert.Contains("job:prodjob", nonMatrix.Jobs);
     }
 
     // --- H. Real-map invariant smoke (computed from the filesystem; no hardcoded names) ------
@@ -819,7 +818,6 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
 
         // Repository metadata with no build/test impact: a PR touching only these must not force the
         // full matrix via the run-all fallback (the reason they are in the skip-gate patterns file).
-        Assert.True(filter.IsExcluded(".gitignore"));                    // repo-ROOT .gitignore (anchored)
         Assert.True(filter.IsExcluded(".github/CODEOWNERS"));
         Assert.True(filter.IsExcluded(".github/ISSUE_TEMPLATE/10_bug_report.yml"));
         Assert.True(filter.IsExcluded(".github/dependabot.yml"));
@@ -830,9 +828,10 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
 
         // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore
         // files are shipped CLI-template assets (Layer 1 / conventions route them to their projects), root
-        // launch/task files are validated by extension tests, and .editorconfig / .gitattributes affect the
-        // build and checkout.
+        // launch/task files are validated by extension tests, root .gitignore controls discovery of the
+        // Java extension E2E workspace, and .editorconfig / .gitattributes affect the build and checkout.
         Assert.False(filter.IsExcluded("src/Aspire.Cli/Templating/Templates/ts-starter/.gitignore"));
+        Assert.False(filter.IsExcluded(".gitignore"));
         Assert.False(filter.IsExcluded(".vscode/launch.json"));
         Assert.False(filter.IsExcluded(".vscode/tasks.json"));
         Assert.False(filter.IsExcluded(".editorconfig"));
@@ -884,6 +883,95 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.False(r.SelectsAll);
     }
 
+    [Theory]
+    [InlineData("tests/Aspire.Cli.Tests/CommandTests.cs", "Aspire.Cli.Tests")]
+    [InlineData("tests/Aspire.Cli.EndToEnd.Tests/CommandTests.cs", "Aspire.Cli.EndToEnd.Tests")]
+    [InlineData("tests/Aspire.Hosting.Tests/Cli/CommandTests.cs", "Aspire.Hosting.Tests")]
+    public void RealMapCliTestOnlyChangeDoesNotSelectExtensionE2e(string path, string testProject)
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select(
+            [path],
+            [testProject],
+            new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.Equal([testProject], r.TestProjects);
+        Assert.Empty(r.Jobs);
+    }
+
+    [Fact]
+    public void RealMapRepresentativeExtensionRuntimeConsumerSelectsExtensionE2e()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select([], ["Aspire.Hosting.Java"], new SelectorOptions());
+
+        Assert.Contains("job:extension-e2e", r.Jobs);
+    }
+
+    [Fact]
+    public void RealMapUnrelatedHostingProjectDoesNotSelectExtensionOrCliE2e()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var fromAffectedProject = selector.Select([], ["Aspire.Hosting.Qdrant"], new SelectorOptions());
+        var fromPath = selector.Select(
+            ["src/Aspire.Hosting.Qdrant/QdrantResource.cs"],
+            [],
+            new SelectorOptions());
+
+        Assert.False(fromAffectedProject.SelectsAll);
+        Assert.DoesNotContain("Aspire.Cli.EndToEnd.Tests", fromAffectedProject.TestProjects);
+        Assert.DoesNotContain("job:extension-e2e", fromAffectedProject.Jobs);
+        Assert.False(fromPath.SelectsAll);
+        Assert.DoesNotContain("Aspire.Cli.EndToEnd.Tests", fromPath.TestProjects);
+        Assert.DoesNotContain("job:extension-e2e", fromPath.Jobs);
+    }
+
+    [Theory]
+    [InlineData("Aspire.Hosting.Redis")]
+    [InlineData("Aspire.StackExchange.Redis")]
+    public void RealMapRepresentativeCliE2eRuntimeConsumerSelectsCliE2e(string project)
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select([], [project], new SelectorOptions());
+
+        Assert.Contains("Aspire.Cli.EndToEnd.Tests", r.TestProjects);
+    }
+
+    public static TheoryData<string> CliE2eExcludedRuntimeProjects => new()
+    {
+        // The regular PR test selects the published Azure Redis package rather than this repo-built package.
+        "Aspire.Hosting.Azure.Redis",
+        // These Hosting/client pairs are consumed only by quarantined tests.
+        "Aspire.Hosting.Azure.Storage",
+        "Aspire.Azure.Storage.Blobs",
+        "Aspire.Hosting.Nats",
+        "Aspire.NATS.Net",
+        // This package is consumed only by a LocalHive-only test that regular PR CI skips.
+        "Aspire.Hosting.Kafka",
+    };
+
+    [Theory]
+    [MemberData(nameof(CliE2eExcludedRuntimeProjects))]
+    public void RealMapCliE2eDoesNotRunForExcludedRuntimeProjects(string project)
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select([], [project], new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.DoesNotContain("Aspire.Cli.EndToEnd.Tests", r.TestProjects);
+    }
+
     [Fact]
     public void RealMapExtensionReleaseFilesSelectUnitAndE2eWithoutDotNetTests()
     {
@@ -907,9 +995,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     // (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). A change to that
     // baseline must therefore run BOTH typescript-api-compat (baseline diff) AND polyglot (regenerate +
     // compile in every language), so a breaking surface change is caught even if the author did not also
-    // touch the tests/PolyglotAppHosts fixtures. The baseline is not a compiled item, so Layer 1 is blind
-    // to it: routing here is the only thing that fires polyglot. Run with --skip-layer1 semantics (no
-    // Layer 1 affected set) to prove the curated layer alone carries both targets.
+    // touch the tests/PolyglotAppHosts fixtures. Run with --skip-layer1 semantics (no Layer 1 affected
+    // set) to prove the curated layer independently preserves both targets.
     [Fact]
     public void RealMapIntegrationAtsBaselineChangeRunsTypeScriptApiCompatAndPolyglot()
     {

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -834,7 +834,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.True(filter.IsExcluded("src/Aspire.Hosting/api/Aspire.Hosting.ats.txt"));
         Assert.True(filter.IsExcluded("src/Aspire.Hosting.Redis/api/Aspire.Hosting.Redis.cs"));
         Assert.True(filter.IsExcluded("src/Components/Aspire.Azure.AI.Inference/api/Aspire.Azure.AI.Inference.cs"));
-        Assert.False(filter.IsExcluded("src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.tscompat.suppression.txt"));
+        Assert.False(filter.IsExcluded("src/Aspire.Hosting/api/Aspire.Hosting.tscompat.suppression.txt"));
         Assert.False(filter.IsExcluded("src/Aspire.Cli/Templating/Templates/java-starter/api/Program.cs"));
 
         // Safety carve-outs: NOT dropped, because they can change build/test outcomes -- nested .gitignore

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -993,7 +993,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapCliE2eDoesNotRunForExcludedRuntimeProjects(string project)
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select([], [project], new SelectorOptions());
 

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -919,7 +919,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapCliTestOnlyChangeDoesNotSelectExtensionE2e(string path, string testProject)
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select(
             [path],
@@ -935,7 +935,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapRepresentativeExtensionRuntimeConsumerSelectsExtensionE2e()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select([], ["Aspire.Hosting.Java"], new SelectorOptions());
 
@@ -946,7 +946,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapUnrelatedHostingProjectDoesNotSelectExtensionOrCliE2e()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var fromAffectedProject = selector.Select([], ["Aspire.Hosting.Qdrant"], new SelectorOptions());
         var fromPath = selector.Select(
@@ -968,7 +968,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapRepresentativeCliE2eRuntimeConsumerSelectsCliE2e(string project)
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select([], [project], new SelectorOptions());
 

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -122,7 +122,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         return new TestSelector(
             path,
             s_matrix.ToHashSet(StringComparer.Ordinal),
-            (projectDirs ?? []).ToHashSet(StringComparer.Ordinal));
+            (projectDirs ?? []).ToHashSet(StringComparer.Ordinal),
+            s_matrix.ToHashSet(StringComparer.Ordinal));
     }
 
     private SelectionResult Select(string[] files, string[]? layer1 = null, IEnumerable<string>? projectDirs = null)
@@ -783,7 +784,7 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         var mapPath = Path.Combine(NewMapDir(), "map.yml");
         File.WriteAllText(mapPath, map);
         var matrix = new[] { "Aspire.Hosting.Foo.Tests" }.ToHashSet(StringComparer.Ordinal);
-        var selector = new TestSelector(mapPath, matrix, []);
+        var selector = new TestSelector(mapPath, matrix, [], matrix);
 
         // A test-only change: only the test project is affected. It is still selected as a test (Layer 1
         // intersection), but must NOT drive the production rule's job.
@@ -865,13 +866,41 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Empty(withAttribution.TestProjects);
     }
 
+    // A test project outside the matrix (for example a shared fixture) must never be treated as a
+    // production project when its name matches an affected-project glob. Failure mode: the same
+    // Aspire.Hosting* glob used for production integrations fires jobs such as prodjob for a test-only
+    // change, widening CI beyond the dependency boundary declared by the map.
+    [Fact]
+    public void AffectedTestSupportProjectDoesNotMatchProductionRules()
+    {
+        var mapPath = Path.Combine(NewMapDir(), "map.yml");
+        File.WriteAllText(
+            mapPath,
+            """
+            version: 1
+            affected_project_rules:
+              - projects: [Aspire.Hosting*]
+                targets: [job:prodjob]
+            """);
+        var selector = new TestSelector(
+            mapPath,
+            s_matrix.ToHashSet(StringComparer.Ordinal),
+            [],
+            new HashSet<string>(["Aspire.Hosting.Fixture.Tests"], StringComparer.Ordinal));
+
+        var result = selector.Select([], ["Aspire.Hosting.Fixture.Tests"], new SelectorOptions());
+
+        Assert.Empty(result.TestProjects);
+        Assert.Empty(result.Jobs);
+    }
+
     [Fact]
     public void RealMapLoadsAndConventionSelectsAComponentsTestWithoutSelectingAll()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
         var matrix = EnumerateMatrixTestProjects();
         var projectDirs = LoadProjectDirectories();
-        var selector = new TestSelector(mapPath, matrix, projectDirs);
+        var selector = new TestSelector(mapPath, matrix, projectDirs, EnumerateAllTestProjects());
 
         // Pick a real src/Components/<dir> whose same-named test exists; the convention must select
         // exactly that test name (derived from the dir, not hardcoded) and must not force ALL.
@@ -976,7 +1005,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapExtensionReleaseFilesSelectUnitAndE2eWithoutDotNetTests()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var matrix = EnumerateMatrixTestProjects();
+        var selector = new TestSelector(mapPath, matrix, LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select(
             ["extension/package.json", "extension/CHANGELOG.md"],
@@ -990,6 +1020,22 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
             r.Jobs.Order(StringComparer.Ordinal));
     }
 
+    [Fact]
+    public void RealMapTestSupportProjectDoesNotTriggerProductionJobs()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var matrix = EnumerateMatrixTestProjects();
+        var selector = new TestSelector(
+            mapPath,
+            matrix,
+            LoadProjectDirectories(),
+            EnumerateAllTestProjects());
+
+        var result = selector.Select([], ["Aspire.Hosting.TestUtilities"], new SelectorOptions());
+
+        Assert.Empty(result.Jobs);
+    }
+
     // An integration's checked-in *.ats.txt baseline tracks its exported [AspireExport] surface -- the
     // same surface the per-language polyglot playground scripts regenerate and compile
     // (aspire restore --apphost over tests/PolyglotAppHosts/<integration>/<lang>). A change to that
@@ -1001,7 +1047,8 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
     public void RealMapIntegrationAtsBaselineChangeRunsTypeScriptApiCompatAndPolyglot()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var matrix = EnumerateMatrixTestProjects();
+        var selector = new TestSelector(mapPath, matrix, LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var atsBaseline = FirstIntegrationAtsBaselineWithPolyglotFixture();
 
@@ -1010,13 +1057,16 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.False(r.SelectsAll);
         Assert.Contains("job:typescript-api-compat", r.Jobs);
         Assert.Contains("job:polyglot", r.Jobs);
+        Assert.Contains(r.JobCauses["job:typescript-api-compat"], cause => cause.Kind == CauseKind.PathRule);
+        Assert.Contains(r.JobCauses["job:polyglot"], cause => cause.Kind == CauseKind.PathRule);
     }
 
     [Fact]
     public void RealMapBlazorRuntimeAssetChangeRunsPackageAndPolyglotRegressions()
     {
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+        var matrix = EnumerateMatrixTestProjects();
+        var selector = new TestSelector(mapPath, matrix, LoadProjectDirectories(), EnumerateAllTestProjects());
 
         var r = selector.Select(
             ["src/Aspire.Hosting.Blazor/targets/GenerateScripts.targets"],
@@ -1084,6 +1134,16 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         return Directory.EnumerateDirectories(testsDir)
             .Select(Path.GetFileName)
             .Where(name => name is not null && File.Exists(Path.Combine(testsDir, name!, $"{name}.csproj")))
+            .Select(name => name!)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static IReadOnlySet<string> EnumerateAllTestProjects()
+    {
+        var testsDir = Path.Combine(RepoRoot.Path, "tests");
+        return Directory.EnumerateFiles(testsDir, "*.csproj", SearchOption.AllDirectories)
+            .Select(path => Path.GetFileNameWithoutExtension(path))
+            .Where(name => name is not null)
             .Select(name => name!)
             .ToHashSet(StringComparer.Ordinal);
     }

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -76,6 +76,79 @@ public sealed class SelectTestsCliTests
         });
     }
 
+    [Fact]
+    public void ExplainWritesTheComputedSummaryToStandardOutput()
+    {
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var changed = WriteChangedFiles(repoRoot, "trigger.txt");
+            var previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, explain: true));
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            Assert.Contains("## SelectTests", output.ToString());
+            Assert.Contains("trigger.txt", output.ToString());
+            Assert.Contains("## SelectTests", File.ReadAllText(Path.Combine(repoRoot, "summary")));
+        });
+    }
+
+    [Fact]
+    public void ExplainIncludesTransitiveDerivedJobDependencies()
+    {
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var changed = WriteChangedFiles(repoRoot, "other.txt");
+            var previousOut = Console.Out;
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            try
+            {
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, explain: true));
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            var explanation = output.ToString();
+            Assert.Contains("job:derived-only-job", explanation);
+            Assert.Contains("derived from selected test `Aspire.Cli.Tests`", explanation);
+        });
+    }
+
+    [Fact]
+    public void ExplainDoesNotDuplicateSummaryToStandardError()
+    {
+        RunInTempRepo((repoRoot, propsPath, _) =>
+        {
+            var changed = WriteChangedFiles(repoRoot, "trigger.txt");
+            var previousSummary = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+            var previousError = Console.Error;
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", null);
+            using var error = new StringWriter();
+            Console.SetError(error);
+            try
+            {
+                Selection.Run(Options(repoRoot, propsPath, changedFilesPath: changed, skipLayer1: true, explain: true));
+            }
+            finally
+            {
+                Console.SetError(previousError);
+                Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", previousSummary);
+            }
+
+            Assert.Empty(error.ToString());
+        });
+    }
+
     // The --slnx option points the selector at a solution outside the default <repo-root>/Aspire.slnx.
     // Failure mode: if SlnxPath were ignored and the tool fell back to <repo-root>/Aspire.slnx, the
     // universe would be read from the wrong (here: absent) file and LoadTestProjects would throw, so a
@@ -1186,7 +1259,8 @@ public sealed class SelectTestsCliTests
         bool forceAll = false,
         bool enforce = false,
         string? slnxPath = null,
-        string? forceAllReason = null) =>
+        string? forceAllReason = null,
+        bool explain = false) =>
         new(
             RepoRoot: repoRoot,
             MapPath: Path.Combine(repoRoot, "map.yml"),
@@ -1198,7 +1272,8 @@ public sealed class SelectTestsCliTests
             ForceAll: forceAll,
             Enforce: enforce,
             BeforeBuildProps: propsPath,
-            ForceAllReason: forceAllReason);
+            ForceAllReason: forceAllReason,
+            Explain: explain);
 
     private static string WriteChangedFiles(string repoRoot, params string[] paths)
     {

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsCliTests.cs
@@ -411,7 +411,7 @@ public sealed class SelectTestsCliTests
                 Assert.Contains("**would**", comment);
                 Assert.Contains("under enforcement", comment);
                 Assert.Contains("regular PR test matrix and PR-gated jobs", comment);
-                Assert.Contains("Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates", comment);
+                Assert.DoesNotContain("Advisory-only targets", comment);
                 Assert.DoesNotContain("do not run on PRs", comment);
             }
             finally
@@ -455,9 +455,9 @@ public sealed class SelectTestsCliTests
                 var comment = File.ReadAllText(commentPath);
                 Assert.Contains("### Selected PR test projects (1 / 1)", comment);
                 Assert.Contains("### Selected PR jobs (1)", comment);
-                Assert.Contains("### Advisory workflow impact (2)", comment);
-                Assert.Contains("`Aspire.EndToEnd.Tests` *(outerloop-only)*", comment);
-                Assert.Contains("`deployment-e2e` *(schedule/dispatch-only)*", comment);
+                Assert.DoesNotContain("Advisory workflow impact", comment);
+                Assert.DoesNotContain("deployment-e2e", comment);
+                Assert.Contains("How these were chosen", comment);
 
                 var summary = File.ReadAllText(Path.Combine(repoRoot, "summary"));
                 Assert.Contains("- selected PR test projects: 1 / 1", summary);
@@ -507,8 +507,8 @@ public sealed class SelectTestsCliTests
 
                 var comment = File.ReadAllText(commentPath);
                 Assert.Contains("**Selects the full PR test matrix + all PR-gated jobs (ALL)**", comment);
-                Assert.Contains("### Advisory workflow impact (2)", comment);
-                Assert.Contains("Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates", comment);
+                Assert.DoesNotContain("Advisory workflow impact", comment);
+                Assert.DoesNotContain("deployment-e2e", comment);
                 Assert.DoesNotContain("do not run on PRs", comment);
             }
             finally
@@ -583,12 +583,9 @@ public sealed class SelectTestsCliTests
 
                 var comment = File.ReadAllText(commentPath);
                 Assert.Contains("### Selected PR test projects (1 / 1)", comment);
-                Assert.Contains(
-                    $"### Advisory workflow impact ({expectedAdvisoryProjects.Count})",
-                    comment);
                 foreach (var project in expectedAdvisoryProjects)
                 {
-                    Assert.Contains($"`{project}`", comment);
+                    Assert.DoesNotContain($"`{project}`", comment);
                 }
             }
             finally

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsLayer1IntegrationTests.cs
@@ -58,6 +58,48 @@ public sealed class SelectTestsLayer1IntegrationTests
         });
     }
 
+    // Failure mode: LoadTestProjectSets forgets to include non-matrix tests/ projects in AllProjects, so
+    // affected_project_rules treats a test-only support project as production code and turns on a
+    // broad matching job.
+    [Fact]
+    public void NonMatrixTestProjectDoesNotDriveAffectedProjectRules()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        using var fixture = new GraphRepoFixture(workspace, withTestSupportProject: true);
+        fixture.WriteFile(
+            "map.yml",
+            """
+            version: 1
+            affected_project_rules:
+              - projects: [Aspire*]
+                targets: [job:prodjob]
+            """);
+
+        var changed = fixture.WriteChangedFiles("tests/Aspire.TestUtilities/Aspire.TestUtilities.cs");
+        var propsPath = System.IO.Path.Combine(fixture.Path, "BeforeBuildProps.props");
+
+        fixture.WithGitHubEnvRedirected(output =>
+        {
+            var exit = Selection.Run(new RunOptions(
+                RepoRoot: fixture.Path,
+                MapPath: System.IO.Path.Combine(fixture.Path, "map.yml"),
+                SlnxPath: System.IO.Path.Combine(fixture.Path, "Aspire.slnx"),
+                From: null,
+                To: null,
+                ChangedFilesPath: changed,
+                SkipLayer1: false,
+                ForceAll: false,
+                Enforce: true,
+                BeforeBuildProps: propsPath));
+
+            Assert.Equal(0, exit);
+            Assert.Equal("false", output()["has_dotnet_tests"]);
+
+            using var selection = System.Text.Json.JsonDocument.Parse(output()["selection"]);
+            Assert.False(selection.RootElement.GetProperty("run_prodjob").GetBoolean());
+        });
+    }
+
     // The merge-base rebind feeds BOTH layers: Layer 1's graph closure must diff from the branch point
     // too, not the base tip. The existing CLI-level merge-base test runs with --skip-layer1, so nothing
     // pins that Layer 1 also honors it. Diverge the history so the two diff bases disagree: the PR edits
@@ -244,7 +286,7 @@ public sealed class SelectTestsLayer1IntegrationTests
 
         public string Path => _workspace.Path;
 
-        public GraphRepoFixture(TemporaryWorkspace workspace, bool withIntermediateProject = false, bool withSecondProject = false)
+        public GraphRepoFixture(TemporaryWorkspace workspace, bool withIntermediateProject = false, bool withSecondProject = false, bool withTestSupportProject = false)
         {
             _workspace = workspace;
 
@@ -281,6 +323,22 @@ public sealed class SelectTestsLayer1IntegrationTests
 
             Write("tests/Core.Tests/Core.Tests.cs", "namespace Core.Tests; public class T(ITestOutputHelper outputHelper) { }");
             WriteProject("tests/Core.Tests/Core.Tests.csproj", compiles: ["Core.Tests.cs"], references: [@"..\..\src\Core\Core.csproj"]);
+
+            if (withTestSupportProject)
+            {
+                Write("tests/Aspire.TestUtilities/Aspire.TestUtilities.cs", "namespace Aspire.TestUtilities; public class Helper { }");
+                WriteProject("tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj", compiles: ["Aspire.TestUtilities.cs"], references: []);
+
+                Write("Aspire.slnx",
+                    """
+                    <Solution>
+                      <Project Path="src/Core/Core.csproj" />
+                      <Project Path="tests/Core.Tests/Core.Tests.csproj" />
+                      <Project Path="tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj" />
+                    </Solution>
+                    """);
+                return;
+            }
 
             if (withSecondProject)
             {

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -414,11 +414,13 @@ public sealed class TestTriggerMapTests
             ["job:homebrew-installer"]
         },
         {
-            "eng/dashboardpack/Sdk.targets",
+            // These paths do not exist intentionally: they prove new packaging inputs stay covered
+            // without requiring this test to enumerate every current RID-specific project.
+            "eng/dashboardpack/future-package-input.targets",
             ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
         },
         {
-            "eng/dcppack/Aspire.Hosting.Orchestration.targets",
+            "eng/dcppack/future-package-input.targets",
             ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
         },
         {
@@ -513,32 +515,8 @@ public sealed class TestTriggerMapTests
             ["test:Infrastructure.Tests", "job:cli-starter-validation"]
         },
         {
-            "eng/dashboardpack/Aspire.Dashboard.Sdk.linux-x64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
-        },
-        {
-            "eng/dashboardpack/Aspire.Dashboard.Sdk.win-x64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
-        },
-        {
-            "eng/dashboardpack/Aspire.Dashboard.Sdk.win-arm64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
-        },
-        {
             "eng/clipack/Aspire.Cli.linux-x64.csproj",
             ["test:Aspire.Cli.Tests", "test:Aspire.Cli.EndToEnd.Tests", "test:Infrastructure.Tests", "job:cli-starter-validation", "job:extension-e2e", "job:winget-installer", "job:homebrew-installer"]
-        },
-        {
-            "eng/dcppack/Aspire.Hosting.Orchestration.linux-x64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
-        },
-        {
-            "eng/dcppack/Aspire.Hosting.Orchestration.win-x64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
-        },
-        {
-            "eng/dcppack/Aspire.Hosting.Orchestration.osx-arm64.csproj",
-            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
         },
         {
             "tools/CreateLayout/Program.cs",
@@ -665,9 +643,9 @@ public sealed class TestTriggerMapTests
 
     [Theory]
     [InlineData("src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj")]
-    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json")]
-    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json")]
-    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json")]
+    // This path does not exist intentionally: it proves a newly added template is covered by the
+    // package-wide rule instead of repeating the current template inventory in the test.
+    [InlineData("src/Aspire.ProjectTemplates/templates/future-template/.template.config/template.json")]
     public void CliE2eRunsForProjectTemplatePackageInputs(string path)
     {
         var result = SelectWithRealMap(path);
@@ -934,6 +912,52 @@ public sealed class TestTriggerMapTests
                 .Order(StringComparer.Ordinal));
     }
 
+    [Theory]
+    [InlineData("tests_requires_cli_archive", "test:Aspire.Cli.EndToEnd.Tests")]
+    [InlineData("extension_e2e_tests", "job:extension-e2e")]
+    public void CliArchivePathsMatchWorkflowDependencies(string workflowJobId, string target)
+    {
+        var expectedArchivePaths = ArchiveRidsRequiredByJob(workflowJobId)
+            .Select(rid => $"eng/clipack/Aspire.Cli.{rid}.csproj")
+            .Order(StringComparer.Ordinal);
+        var archiveRule = Assert.Single(
+            s_map.PathRules,
+            rule => rule.Targets.Contains(target, StringComparer.Ordinal)
+                && rule.Paths.Contains("eng/clipack/Common.projitems", StringComparer.Ordinal));
+
+        Assert.Equal(
+            expectedArchivePaths,
+            archiveRule.Paths
+                .Where(path => path != "eng/clipack/Common.projitems")
+                .Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void ExtensionE2eWorkflowRidsMatchArchiveDependencies()
+    {
+        var workflow = new YamlStream();
+        using (var reader = new StringReader(File.ReadAllText(
+            Path.Combine(RepoRoot.Path, ".github", "workflows", "extension-e2e-tests.yml"))))
+        {
+            workflow.Load(reader);
+        }
+
+        var root = Assert.IsType<YamlMappingNode>(workflow.Documents[0].RootNode);
+        var jobs = Assert.IsType<YamlMappingNode>(root.Children[new YamlScalarNode("jobs")]);
+        var extensionE2e = Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode("extension_e2e")]);
+        var strategy = Assert.IsType<YamlMappingNode>(extensionE2e.Children[new YamlScalarNode("strategy")]);
+        var matrix = Assert.IsType<YamlMappingNode>(strategy.Children[new YamlScalarNode("matrix")]);
+        var include = Assert.IsType<YamlSequenceNode>(matrix.Children[new YamlScalarNode("include")]);
+        var consumedRids = include.Children
+            .Select(node => Assert.IsType<YamlMappingNode>(node).Children[new YamlScalarNode("rid")].ToString())
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal);
+
+        Assert.Equal(
+            consumedRids,
+            ArchiveRidsRequiredByJob("extension_e2e_tests").Order(StringComparer.Ordinal));
+    }
+
     [Fact]
     public void CliStarterValidationSkipChecksAreRequiredOnlyWhenSelected()
     {
@@ -1086,6 +1110,57 @@ public sealed class TestTriggerMapTests
         var selector = new TestSelector(mapPath, testProjects, projectDirectories);
 
         return selector.Select([path], layer1Affected, new SelectorOptions());
+    }
+
+    private static IReadOnlyList<string> ArchiveRidsRequiredByJob(string jobId)
+    {
+        // Resolve workflow dependencies shaped as:
+        //   extension_e2e_tests:
+        //     needs: [..., build_cli_archive_linux]
+        //   build_cli_archive_linux:
+        //     with:
+        //       targets: '[{"os":"ubuntu-latest","runner":"8-core-ubuntu-latest","rids":"linux-x64"}]'
+        var workflow = new YamlStream();
+        using (var reader = new StringReader(File.ReadAllText(
+            Path.Combine(RepoRoot.Path, ".github", "workflows", "tests.yml"))))
+        {
+            workflow.Load(reader);
+        }
+
+        var root = Assert.IsType<YamlMappingNode>(workflow.Documents[0].RootNode);
+        var jobs = Assert.IsType<YamlMappingNode>(root.Children[new YamlScalarNode("jobs")]);
+        var job = Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode(jobId)]);
+        var needs = Assert.IsType<YamlSequenceNode>(job.Children[new YamlScalarNode("needs")]);
+        var archiveJobIds = needs.Children
+            .OfType<YamlScalarNode>()
+            .Select(node => node.Value)
+            .Where(value => value?.StartsWith("build_cli_archive_", StringComparison.Ordinal) is true)
+            .Select(value => value!)
+            .ToList();
+        Assert.NotEmpty(archiveJobIds);
+
+        var rids = new List<string>();
+        foreach (var archiveJobId in archiveJobIds)
+        {
+            var archiveJob = Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode(archiveJobId)]);
+            Assert.Equal(
+                "./.github/workflows/build-cli-native-archives.yml",
+                archiveJob.Children[new YamlScalarNode("uses")].ToString());
+            var inputs = Assert.IsType<YamlMappingNode>(archiveJob.Children[new YamlScalarNode("with")]);
+            var targetsJson = Assert.IsType<YamlScalarNode>(inputs.Children[new YamlScalarNode("targets")]).Value;
+            Assert.False(string.IsNullOrWhiteSpace(targetsJson), $"CLI archive build job '{archiveJobId}' has no targets input.");
+
+            using var targets = JsonDocument.Parse(targetsJson);
+            foreach (var target in targets.RootElement.EnumerateArray())
+            {
+                Assert.True(target.TryGetProperty("rids", out var rid), $"CLI archive build job '{archiveJobId}' has no RID target.");
+                var ridValue = rid.GetString();
+                Assert.False(string.IsNullOrWhiteSpace(ridValue), $"CLI archive build job '{archiveJobId}' has an empty RID target.");
+                rids.Add(ridValue);
+            }
+        }
+
+        return rids.Distinct(StringComparer.Ordinal).ToList();
     }
 
     private static string TextBetween(string text, string startMarker, string endMarker)

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -1131,21 +1131,21 @@ public sealed class TestTriggerMapTests
         var jobs = Assert.IsType<YamlMappingNode>(root.Children[new YamlScalarNode("jobs")]);
         var job = Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode(jobId)]);
         var needs = Assert.IsType<YamlSequenceNode>(job.Children[new YamlScalarNode("needs")]);
-        var archiveJobIds = needs.Children
+        var archiveJobs = needs.Children
             .OfType<YamlScalarNode>()
             .Select(node => node.Value)
-            .Where(value => value?.StartsWith("build_cli_archive_", StringComparison.Ordinal) is true)
-            .Select(value => value!)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => (
+                Id: value!,
+                Job: Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode(value!)])))
+            .Where(entry => entry.Job.Children.TryGetValue(new YamlScalarNode("uses"), out var uses)
+                && uses.ToString() == "./.github/workflows/build-cli-native-archives.yml")
             .ToList();
-        Assert.NotEmpty(archiveJobIds);
+        Assert.NotEmpty(archiveJobs);
 
         var rids = new List<string>();
-        foreach (var archiveJobId in archiveJobIds)
+        foreach (var (archiveJobId, archiveJob) in archiveJobs)
         {
-            var archiveJob = Assert.IsType<YamlMappingNode>(jobs.Children[new YamlScalarNode(archiveJobId)]);
-            Assert.Equal(
-                "./.github/workflows/build-cli-native-archives.yml",
-                archiveJob.Children[new YamlScalarNode("uses")].ToString());
             var inputs = Assert.IsType<YamlMappingNode>(archiveJob.Children[new YamlScalarNode("with")]);
             var targetsJson = Assert.IsType<YamlScalarNode>(inputs.Children[new YamlScalarNode("targets")]).Value;
             Assert.False(string.IsNullOrWhiteSpace(targetsJson), $"CLI archive build job '{archiveJobId}' has no targets input.");

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.SelectTests;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.FileSystemGlobbing;
 using System.Text.Json;
 using Xunit;
@@ -53,6 +54,26 @@ public sealed class TestTriggerMapTests
 
         Assert.Contains("job:extension-unit", targets);
         Assert.Contains("job:extension-e2e", targets);
+    }
+
+    [Fact]
+    public void ExtensionE2eProjectAndPathRulesCoverTheSameConsumers()
+    {
+        var affectedProjects = Assert.Single(
+            s_map.AffectedProjectRules,
+            rule => rule.Targets.Contains("job:extension-e2e", StringComparer.Ordinal))
+            .Projects
+            .Select(project => $"src/{project}/**");
+        var directPaths = Assert.Single(
+            s_map.PathRules,
+            rule => rule.Targets.Contains("job:extension-e2e", StringComparer.Ordinal)
+                && rule.Paths.Contains("extension/**", StringComparer.Ordinal))
+            .Paths
+            .Where(path => path.StartsWith("src/", StringComparison.Ordinal));
+
+        Assert.Equal(
+            affectedProjects.Order(StringComparer.Ordinal),
+            directPaths.Order(StringComparer.Ordinal));
     }
 
     [Fact]
@@ -394,11 +415,11 @@ public sealed class TestTriggerMapTests
         },
         {
             "eng/dashboardpack/Sdk.targets",
-            ["test:Aspire.Hosting.Sdk.Tests"]
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
         },
         {
             "eng/dcppack/Aspire.Hosting.Orchestration.targets",
-            ["test:Aspire.Hosting.Sdk.Tests", "test:Aspire.TerminalHost.Tests"]
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
         },
         {
             "eng/scripts/load-cli-e2e-images.sh",
@@ -411,6 +432,7 @@ public sealed class TestTriggerMapTests
                 "test:Aspire.Cli.EndToEnd.Tests",
                 "test:Infrastructure.Tests",
                 "job:cli-starter-validation",
+                "job:extension-e2e",
                 "job:homebrew-installer",
                 "job:winget-installer"
             ]
@@ -419,9 +441,9 @@ public sealed class TestTriggerMapTests
             "eng/clipack/Aspire.Cli.win-x64.csproj",
             [
                 "test:Aspire.Cli.Tests",
-                "test:Aspire.Cli.EndToEnd.Tests",
                 "test:Infrastructure.Tests",
                 "job:cli-starter-validation",
+                "job:extension-e2e",
                 "job:homebrew-installer",
                 "job:winget-installer"
             ]
@@ -430,8 +452,17 @@ public sealed class TestTriggerMapTests
             "eng/clipack/Aspire.Cli.linux-musl-x64.csproj",
             [
                 "test:Aspire.Cli.Tests",
-                "test:Aspire.Cli.EndToEnd.Tests",
                 "test:Infrastructure.Tests",
+                "job:homebrew-installer",
+                "job:winget-installer"
+            ]
+        },
+        {
+            "eng/clipack/Aspire.Cli.linux-arm64.csproj",
+            [
+                "test:Aspire.Cli.Tests",
+                "test:Infrastructure.Tests",
+                "job:cli-starter-validation",
                 "job:homebrew-installer",
                 "job:winget-installer"
             ]
@@ -440,7 +471,6 @@ public sealed class TestTriggerMapTests
             "eng/clipack/npm/aspire.js",
             [
                 "test:Aspire.Cli.Tests",
-                "test:Aspire.Cli.EndToEnd.Tests",
                 "test:Infrastructure.Tests",
                 "job:homebrew-installer",
                 "job:winget-installer"
@@ -450,7 +480,6 @@ public sealed class TestTriggerMapTests
             "eng/clipack/Aspire.Cli.NativeSymbols.proj",
             [
                 "test:Aspire.Cli.Tests",
-                "test:Aspire.Cli.EndToEnd.Tests",
                 "test:Infrastructure.Tests",
                 "job:homebrew-installer",
                 "job:winget-installer"
@@ -466,7 +495,6 @@ public sealed class TestTriggerMapTests
                 "test:Aspire.Acquisition.Tests",
                 "test:Aspire.Cli.EndToEnd.Tests",
                 "job:cli-starter-validation",
-                "job:extension-e2e",
                 "job:homebrew-installer",
                 "job:winget-installer"
             ]
@@ -476,7 +504,6 @@ public sealed class TestTriggerMapTests
             [
                 "test:Aspire.Acquisition.Tests",
                 "test:Aspire.Cli.EndToEnd.Tests",
-                "job:extension-e2e",
                 "job:homebrew-installer",
                 "job:winget-installer"
             ]
@@ -484,6 +511,50 @@ public sealed class TestTriggerMapTests
         {
             ".github/workflows/cli-starter-validation.yml",
             ["test:Infrastructure.Tests", "job:cli-starter-validation"]
+        },
+        {
+            "eng/dashboardpack/Aspire.Dashboard.Sdk.linux-x64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
+        },
+        {
+            "eng/dashboardpack/Aspire.Dashboard.Sdk.win-x64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
+        },
+        {
+            "eng/dashboardpack/Aspire.Dashboard.Sdk.win-arm64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "job:extension-e2e"]
+        },
+        {
+            "eng/clipack/Aspire.Cli.linux-x64.csproj",
+            ["test:Aspire.Cli.Tests", "test:Aspire.Cli.EndToEnd.Tests", "test:Infrastructure.Tests", "job:cli-starter-validation", "job:extension-e2e", "job:winget-installer", "job:homebrew-installer"]
+        },
+        {
+            "eng/dcppack/Aspire.Hosting.Orchestration.linux-x64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
+        },
+        {
+            "eng/dcppack/Aspire.Hosting.Orchestration.win-x64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
+        },
+        {
+            "eng/dcppack/Aspire.Hosting.Orchestration.osx-arm64.csproj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "test:Aspire.Hosting.Sdk.Tests", "test:Aspire.Templates.Tests", "test:Aspire.TerminalHost.Tests", "job:extension-e2e"]
+        },
+        {
+            "tools/CreateLayout/Program.cs",
+            ["test:Aspire.Cli.EndToEnd.Tests", "job:cli-starter-validation", "job:extension-e2e", "job:winget-installer", "job:homebrew-installer"]
+        },
+        {
+            "eng/Bundle.proj",
+            ["test:Aspire.Cli.EndToEnd.Tests", "job:cli-starter-validation", "job:extension-e2e", "job:winget-installer", "job:homebrew-installer"]
+        },
+        {
+            "playground/JavaSpringBoot/JavaSpringBoot.AppHost.Java/aspire.config.json",
+            ["test:Aspire.Playground.Tests", "job:extension-e2e"]
+        },
+        {
+            ".gitignore",
+            ["test:Infrastructure.Tests"]
         },
     };
 
@@ -500,6 +571,38 @@ public sealed class TestTriggerMapTests
             .Concat(result.Jobs)
             .Order(StringComparer.Ordinal);
         Assert.Equal(expectedTargets.Order(StringComparer.Ordinal), actualTargets);
+    }
+
+    [Fact]
+    [RequiresTools(["git"])]
+    public void ExtensionJavaE2eDiscoveryInputsAreNotGitIgnored()
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo("git")
+        {
+            WorkingDirectory = RepoRoot.Path,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("--no-pager");
+        startInfo.ArgumentList.Add("check-ignore");
+        startInfo.ArgumentList.Add("--");
+        startInfo.ArgumentList.Add("extension/java-e2e-workspace/AppHost.java");
+        startInfo.ArgumentList.Add("extension/java-e2e-workspace/aspire.config.json");
+        startInfo.ArgumentList.Add("extension/java-e2e-workspace/JavaSpringBoot.AppHost.Java/AppHost.java");
+        startInfo.ArgumentList.Add("extension/java-e2e-workspace/JavaSpringBoot.AppHost.Java/aspire.config.json");
+
+        using var process = System.Diagnostics.Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git.");
+        var ignoredPaths = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 1,
+            process.ExitCode == 0
+                ? $"Git ignore rules must not exclude Java AppHost discovery inputs because aspire ls discovers them through git: {ignoredPaths}"
+                : $"git check-ignore failed ({process.ExitCode}): {stderr}");
     }
 
     [Theory]
@@ -560,6 +663,19 @@ public sealed class TestTriggerMapTests
         Assert.Contains("job:cli-starter-validation", result.Jobs);
     }
 
+    [Theory]
+    [InlineData("src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj")]
+    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json")]
+    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json")]
+    [InlineData("src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json")]
+    public void CliE2eRunsForProjectTemplatePackageInputs(string path)
+    {
+        var result = SelectWithRealMap(path);
+
+        Assert.False(result.SelectsAll);
+        Assert.Contains("Aspire.Cli.EndToEnd.Tests", result.TestProjects);
+    }
+
     [Fact]
     public void CliBundleConsumersRunWhenCreateLayoutIsAffected()
     {
@@ -570,6 +686,17 @@ public sealed class TestTriggerMapTests
         Assert.Equal(
             ["job:cli-starter-validation", "job:extension-e2e", "job:homebrew-installer", "job:winget-installer"],
             result.Jobs.Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void DashboardChangesRunTemplatesTestsThatStartAppHosts()
+    {
+        var result = SelectWithRealMap(
+            "src/Aspire.Dashboard/Program.cs",
+            "Aspire.Dashboard");
+
+        Assert.False(result.SelectsAll);
+        Assert.Contains("Aspire.Templates.Tests", result.TestProjects);
     }
 
     [Fact]
@@ -601,13 +728,18 @@ public sealed class TestTriggerMapTests
     }
 
     [Fact]
-    public void CliStarterValidationDoesNotRunForUnrelatedProjectTemplateChange()
+    public void UnrelatedProjectTemplateChangeRunsCliE2eAndTemplatesTestsWithoutStarterValidation()
     {
         var result = SelectWithRealMap(
             "src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json");
 
         Assert.False(result.SelectsAll);
-        Assert.Equal(["job:deployment-e2e"], result.Jobs);
+        Assert.Equal(
+            ["Aspire.Cli.EndToEnd.Tests", "Aspire.Templates.Tests"],
+            result.TestProjects.Order(StringComparer.Ordinal));
+        Assert.Equal(
+            ["job:deployment-e2e", "job:homebrew-installer", "job:winget-installer"],
+            result.Jobs.Order(StringComparer.Ordinal));
     }
 
     [Fact]
@@ -635,7 +767,7 @@ public sealed class TestTriggerMapTests
 
         Assert.False(result.SelectsAll);
         Assert.Equal(
-            ["job:extension-e2e", "job:typescript-api-compat"],
+            ["job:typescript-api-compat"],
             result.Jobs.Order(StringComparer.Ordinal));
     }
 

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -627,6 +627,7 @@ public sealed class TestTriggerMapTests
 
         Assert.False(result.SelectsAll);
         Assert.Contains("job:cli-starter-validation", result.Jobs);
+        Assert.Contains(result.JobCauses["job:cli-starter-validation"], cause => cause.Kind == CauseKind.AffectedProject);
     }
 
     [Theory]
@@ -661,6 +662,9 @@ public sealed class TestTriggerMapTests
 
         Assert.False(result.SelectsAll);
         Assert.Contains("Aspire.Cli.EndToEnd.Tests", result.TestProjects);
+        Assert.Contains(
+            result.TestCauses["Aspire.Cli.EndToEnd.Tests"],
+            cause => cause.Kind == CauseKind.AffectedProject);
         Assert.Equal(
             ["job:cli-starter-validation", "job:extension-e2e", "job:homebrew-installer", "job:winget-installer"],
             result.Jobs.Order(StringComparer.Ordinal));
@@ -744,9 +748,7 @@ public sealed class TestTriggerMapTests
             "Aspire.Hosting.Sdk.Tests");
 
         Assert.False(result.SelectsAll);
-        Assert.Equal(
-            ["job:typescript-api-compat"],
-            result.Jobs.Order(StringComparer.Ordinal));
+        Assert.Empty(result.Jobs);
     }
 
     [Fact]
@@ -1103,11 +1105,17 @@ public sealed class TestTriggerMapTests
             .Select(projectPath => Path.GetFileNameWithoutExtension(projectPath)!)
             .Where(name => name.EndsWith(".Tests", StringComparison.Ordinal))
             .ToHashSet(StringComparer.Ordinal);
+        var allTestProjectNames = Directory.EnumerateFiles(
+                Path.Combine(RepoRoot.Path, "tests"), "*.csproj", SearchOption.AllDirectories)
+            .Select(Path.GetFileNameWithoutExtension)
+        .Where(name => name is not null)
+        .Select(name => name!)
+        .ToHashSet(StringComparer.Ordinal);
         var projectDirectories = projectPaths
             .Select(projectPath => Path.GetDirectoryName(projectPath)!.Replace('\\', '/'))
             .ToHashSet(StringComparer.Ordinal);
         var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
-        var selector = new TestSelector(mapPath, testProjects, projectDirectories);
+        var selector = new TestSelector(mapPath, testProjects, projectDirectories, allTestProjectNames);
 
         return selector.Select([path], layer1Affected, new SelectorOptions());
     }

--- a/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/TestTriggerMapTests.cs
@@ -157,14 +157,20 @@ public sealed class TestTriggerMapTests
     }
 
     [Fact]
-    public void EverySourceProjectIsReachableByLayer1OrACuratedRule()
+    public void EveryProjectOutsideTheSolutionIsCoveredByACuratedRule()
     {
         // The graph closure is owned by the Layer 1 graph (GraphAffectedProjects), which discovers
-        // projects from Aspire.slnx. So a src project is "covered" if it is in the solution (∴ Layer 1 sees it)
-        // OR matched by a curated glob (the deliberately out-of-slnx ones — e.g. the template
-        // placeholders that crash discovery — are covered by loose_file_deps). A new src project
-        // that is neither in the solution nor curated would silently never run any test, so it
-        // must fail here.
+        // projects from Aspire.slnx. Every tracked project outside the solution must therefore be
+        // matched by a curated glob so it is intentionally routed or explicitly ignored. Otherwise,
+        // changing the project falls through to the unattributed-file run-all fallback.
+        var allowList = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["tools/GenerateCITimeline/GenerateCITimeline.csproj"] =
+                "Invoked by the unconditional test-results job after selector-gated work completes.",
+        };
+
+        Assert.All(allowList, entry => Assert.False(string.IsNullOrWhiteSpace(entry.Value)));
+
         var inSolution = LoadSolutionProjectPaths();
 
         var selecting = new Matcher(StringComparison.Ordinal);
@@ -177,13 +183,16 @@ public sealed class TestTriggerMapTests
             .ToHashSet(StringComparer.Ordinal);
 
         var uncovered = s_trackedFiles
-            .Where(f => f.StartsWith("src/", StringComparison.Ordinal) && f.EndsWith(".csproj", StringComparison.Ordinal))
-            .Where(csproj => !inSolution.Contains(csproj) && !curatedCovered.Contains(csproj))
+            .Where(f => f.EndsWith(".csproj", StringComparison.Ordinal))
+            .Where(csproj => !inSolution.Contains(csproj)
+                && !curatedCovered.Contains(csproj)
+                && !allowList.ContainsKey(csproj))
             .Order(StringComparer.Ordinal)
             .ToList();
 
         Assert.True(uncovered.Count == 0,
-            $"src projects neither in Aspire.slnx nor matched by a curated rule: {string.Join(", ", uncovered)}");
+            $"tracked projects neither in Aspire.slnx nor matched by a curated rule " +
+            $"(changes would be reported as unattributed and force ALL): {string.Join(", ", uncovered)}");
     }
 
     // Repo-relative '/'-separated project paths listed in Aspire.slnx (the Layer 1 graph root).

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -751,9 +751,9 @@ internal static class Selection
 
         if (!options.Enforce)
         {
-            // Audit mode runs all regular PR work regardless of the selection. Schedule/outerloop-only
-            // targets are reported separately because the PR selector cannot cause them to run.
-            sb.AppendLine("_The regular PR test matrix and PR-gated jobs still run in audit mode. The PR tests and jobs below are what selective CI **would** run under enforcement. Advisory-only targets are reported here but are not scheduled through the regular PR matrix or job gates; independent workflows may still run them for a PR._");
+            // Audit mode runs all regular PR work regardless of the selection. The projects and jobs
+            // below are what selective CI **would** run under enforcement.
+            sb.AppendLine("_The regular PR test matrix and PR-gated jobs still run in audit mode. The projects and jobs below are what selective CI **would** run under enforcement._");
             sb.AppendLine();
         }
 
@@ -762,23 +762,20 @@ internal static class Selection
         var jobs = result.Jobs.OrderBy(j => j, StringComparer.Ordinal).ToList();
         var prTests = tests.Where(test => !s_advisoryTestTargets.ContainsKey(test)).ToList();
         var prJobs = jobs.Where(job => !s_advisoryJobTargets.ContainsKey(job)).ToList();
-        var advisoryTargets = GetAdvisoryTargets(tests, jobs);
         var allPrTestProjects = allTestProjects.Count(test => !s_advisoryTestTargets.ContainsKey(test));
 
         if (result.SelectsAll)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"**Selects the full PR test matrix + all PR-gated jobs (ALL)** — {result.EscalationReason}");
             sb.AppendLine();
-            AppendAdvisoryTargets(sb, advisoryTargets);
             WriteCommentFile(commentPath, sb.ToString());
             return;
         }
 
         var fileWord = changedFiles.Count == 1 ? "changed file" : "changed files";
         var jobWord = prJobs.Count == 1 ? "job" : "jobs";
-        var advisoryWord = advisoryTargets.Count == 1 ? "target" : "targets";
         sb.AppendLine(CultureInfo.InvariantCulture,
-            $"**{prTests.Count} / {allPrTestProjects} PR test projects · {prJobs.Count} PR {jobWord} · {advisoryTargets.Count} advisory-only {advisoryWord}**, from {changedFiles.Count} {fileWord}.");
+            $"**{prTests.Count} / {allPrTestProjects} PR test projects · {prJobs.Count} PR {jobWord}**, from {changedFiles.Count} {fileWord}.");
         sb.AppendLine();
 
         // WHAT runs -- the flat lists up front. A reviewer scanning a large selection sees the complete
@@ -798,10 +795,8 @@ internal static class Selection
             : string.Join(", ", prJobs.Select(j => $"`{StripJobPrefix(j)}`")));
         sb.AppendLine();
 
-        AppendAdvisoryTargets(sb, advisoryTargets);
-
         // HOW it was chosen -- the per-trigger grouping.
-        AppendSelectionRationale(sb, result, tests, jobs);
+        AppendSelectionRationale(sb, result, prTests, prJobs);
 
         sb.AppendLine();
         WriteCommentFile(commentPath, sb.ToString());
@@ -820,24 +815,6 @@ internal static class Selection
             .Select(job => new AdvisoryTarget(job, StripJobPrefix(job), s_advisoryJobTargets[job])));
 
         return targets;
-    }
-
-    private static void AppendAdvisoryTargets(StringBuilder sb, IReadOnlyList<AdvisoryTarget> targets)
-    {
-        sb.AppendLine(CultureInfo.InvariantCulture, $"### Advisory workflow impact ({targets.Count})");
-        sb.AppendLine();
-        if (targets.Count == 0)
-        {
-            sb.AppendLine("_none_");
-        }
-        else
-        {
-            foreach (var target in targets)
-            {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"- `{target.DisplayName}` *({target.Qualifier})*");
-            }
-        }
-        sb.AppendLine();
     }
 
     // Renders the "how these were chosen" section: every selected test project grouped under each

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -354,7 +354,7 @@ internal static class Selection
         foreach (var name in selectedTestProjects.OrderBy(n => n, StringComparer.Ordinal))
         {
             // A selected name not in the slnx test-project set is not a buildable test project (e.g. a
-            // non-matrix project name from affected_project_rules); it contributes no OverrideProjectToBuild item.
+            // production/non-test project name from affected_project_rules); it contributes no OverrideProjectToBuild item.
             if (testProjectsByName.TryGetValue(name, out var relPath))
             {
                 sb.AppendLine(CultureInfo.InvariantCulture, $"    <OverrideProjectToBuild Include=\"$(RepoRoot){relPath}\" />");
@@ -485,7 +485,7 @@ internal static class Selection
     // Layer 1: build the MSBuild ProjectGraph from Aspire.slnx (HEAD-only) and report every project
     // hit by the diff — the union of *changed* (incl. cross-project linked-file consumers) and
     // *affected* (downstream dependents). We return the full set of project names: the selector
-    // intersects the matrix test projects and matches the non-matrix projects against
+    // intersects the matrix test projects and matches production/non-test projects against
     // affected_project_rules. See GraphAffectedProjects for why this replaced dotnet-affected.
     private static AffectedResult RunLayer1(RunOptions options, ChangedFileFilter filter, SelectionTrace trace)
     {

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -339,7 +339,7 @@ internal static class Selection
         foreach (var name in selectedTestProjects.OrderBy(n => n, StringComparer.Ordinal))
         {
             // A selected name not in the slnx test-project set is not a buildable test project (e.g. a
-            // production project name from project_rules); it contributes no OverrideProjectToBuild item.
+            // non-matrix project name from affected_project_rules); it contributes no OverrideProjectToBuild item.
             if (testProjectsByName.TryGetValue(name, out var relPath))
             {
                 sb.AppendLine(CultureInfo.InvariantCulture, $"    <OverrideProjectToBuild Include=\"$(RepoRoot){relPath}\" />");
@@ -470,8 +470,8 @@ internal static class Selection
     // Layer 1: build the MSBuild ProjectGraph from Aspire.slnx (HEAD-only) and report every project
     // hit by the diff — the union of *changed* (incl. cross-project linked-file consumers) and
     // *affected* (downstream dependents). We return the full set of project names: the selector
-    // intersects the test projects into the matrix and matches the production projects against
-    // project_rules. See GraphAffectedProjects for why this replaced dotnet-affected.
+    // intersects the matrix test projects and matches the non-matrix projects against
+    // affected_project_rules. See GraphAffectedProjects for why this replaced dotnet-affected.
     private static AffectedResult RunLayer1(RunOptions options, ChangedFileFilter filter, SelectionTrace trace)
     {
         try

--- a/tools/SelectTests/Program.cs
+++ b/tools/SelectTests/Program.cs
@@ -80,11 +80,16 @@ var beforeBuildPropsOption = new Option<string?>("--before-build-props")
                   "otherwise nothing is written so enumerate-tests enumerates everything."
 };
 
+var explainOption = new Option<bool>("--explain")
+{
+    Description = "Print the computed selection summary to standard output for local inspection."
+};
+
 var rootCommand = new RootCommand("Select the relevant CI test subset for a PR's changed files.");
 foreach (var option in new Option[]
 {
     repoRootOption, mapOption, slnxOption, fromOption, toOption, changedFilesOption,
-    skipLayer1Option, forceAllOption, forceAllReasonOption, enforceOption, beforeBuildPropsOption
+    skipLayer1Option, forceAllOption, forceAllReasonOption, enforceOption, beforeBuildPropsOption, explainOption
 })
 {
     rootCommand.Options.Add(option);
@@ -105,10 +110,11 @@ rootCommand.SetAction(parseResult =>
     var forceAllReason = parseResult.GetValue(forceAllReasonOption);
     var enforce = parseResult.GetValue(enforceOption);
     var beforeBuildProps = parseResult.GetValue(beforeBuildPropsOption);
+    var explain = parseResult.GetValue(explainOption);
 
     return Selection.Run(new RunOptions(
         repoRoot, mapPath, slnxPath, from, to, changedFilesPath,
-        skipLayer1, forceAll, enforce, beforeBuildProps, forceAllReason));
+        skipLayer1, forceAll, enforce, beforeBuildProps, forceAllReason, explain));
 });
 
 return rootCommand.Parse(args).Invoke();
@@ -124,7 +130,8 @@ internal sealed record RunOptions(
     bool ForceAll,
     bool Enforce,
     string? BeforeBuildProps,
-    string? ForceAllReason = null);
+    string? ForceAllReason = null,
+    bool Explain = false);
 
 internal static class Selection
 {
@@ -168,7 +175,8 @@ internal static class Selection
         // selector now runs BEFORE enumerate-tests. Maps each test project name to its repo-relative
         // .csproj path so a selected name can be written as an OverrideProjectToBuild item.
         trace.EnterStage("load test projects from slnx");
-        var testProjectsByName = LoadTestProjects(options.SlnxPath);
+        var testProjectSets = LoadTestProjectSets(options.SlnxPath);
+        var testProjectsByName = testProjectSets.MatrixProjects;
         var allTestProjects = testProjectsByName.Keys.ToHashSet(StringComparer.Ordinal);
 
         // The prefilter (the map's `prefilter` block): read the CI skip-gate patterns file at runtime
@@ -243,7 +251,7 @@ internal static class Selection
             : LoadProjectDirectories(options.SlnxPath);
 
         trace.EnterStage("select (Layer 2 trigger map + Layer 1 union)");
-        var selector = new TestSelector(options.MapPath, allTestProjects, projectDirectories);
+        var selector = new TestSelector(options.MapPath, allTestProjects, projectDirectories, testProjectSets.AllProjects);
         var result = selector.Select(changedFiles, layer1Affected, new SelectorOptions(options.ForceAll, options.ForceAllReason), layer1.AttributedPaths, layer1.Paths);
 
         trace.EnterStage("write summary and outputs");
@@ -286,10 +294,15 @@ internal static class Selection
 
     // Repo-relative, '/'-separated paths of the test projects in Aspire.slnx, keyed by project name
     // (the .csproj base name == the matrix projectName == the map's test: target). The universe is
-    // the tests/<Name>/<Name>.csproj projects whose name ends in ".Tests"; the other tests/ projects
-    // (Aspire.TestUtilities, TestingAppHost1, testproject, ...) are shared fixtures/helpers, not test
-    // projects, and are excluded so they are never selected or enumerated on their own.
-    private static IReadOnlyDictionary<string, string> LoadTestProjects(string slnxPath)
+    private sealed record TestProjectSets(
+        IReadOnlyDictionary<string, string> MatrixProjects,
+        IReadOnlySet<string> AllProjects);
+
+    // The matrix contains tests/<Name>/<Name>.csproj projects whose name ends in ".Tests"; the other
+    // tests/ projects (Aspire.TestUtilities, TestingAppHost1, testproject, ...) are shared
+    // fixtures/helpers. Keep those names in AllProjects so affected-project rules cannot mistake a
+    // test-only fixture for a production project.
+    private static TestProjectSets LoadTestProjectSets(string slnxPath)
     {
         if (!File.Exists(slnxPath))
         {
@@ -297,7 +310,8 @@ internal static class Selection
         }
 
         var slnx = File.ReadAllText(slnxPath);
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        var matrixProjects = new Dictionary<string, string>(StringComparer.Ordinal);
+        var allProjects = new HashSet<string>(StringComparer.Ordinal);
         // <Project Path="tests/Foo.Tests/Foo.Tests.csproj" /> -- normalize separators, keep tests/ + .Tests.
         foreach (System.Text.RegularExpressions.Match m in
                  System.Text.RegularExpressions.Regex.Matches(slnx, "Path=\"([^\"]+\\.csproj)\""))
@@ -309,13 +323,14 @@ internal static class Selection
             }
 
             var name = Path.GetFileNameWithoutExtension(relPath);
+            allProjects.Add(name);
             if (name.EndsWith(".Tests", StringComparison.Ordinal))
             {
-                map[name] = relPath;
+                matrixProjects[name] = relPath;
             }
         }
 
-        return map;
+        return new TestProjectSets(matrixProjects, allProjects);
     }
 
     // Writes the MSBuild props file that eng/Build.props imports via $(BeforeBuildPropsPath): an
@@ -1251,15 +1266,20 @@ internal static class Selection
             builder.AppendLine();
         }
 
-        static void WriteOut(StringBuilder builder)
+        void WriteOut(StringBuilder builder)
         {
             var markdown = builder.ToString();
+            if (options.Explain)
+            {
+                Console.Out.Write(markdown);
+            }
+
             var summaryPath = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
             if (summaryPath is not null)
             {
                 File.AppendAllText(summaryPath, markdown);
             }
-            else
+            else if (!options.Explain)
             {
                 Console.Error.Write(markdown);
             }

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -110,6 +110,7 @@ public sealed class TestSelector
     private readonly string _mapPath;
     private readonly IReadOnlyCollection<string> _allTestProjects;
     private readonly IReadOnlyCollection<string> _projectDirectories;
+    private readonly IReadOnlySet<string> _allTestProjectNames;
 
     /// <param name="mapPath">Path to <c>eng/github-ci/test-trigger-map.yml</c>.</param>
     /// <param name="allTestProjects">All matrix test project names — the universe an <c>ALL</c> selection expands to.</param>
@@ -119,14 +120,20 @@ public sealed class TestSelector
     /// under one of these dirs is attributed by the graph, so it never triggers the run-all
     /// fallback. May be empty (then no file is treated as owned).
     /// </param>
+    /// <param name="allTestProjectNames">
+    /// All project names under <c>tests/</c>, including shared fixtures that are not part of the CI
+    /// matrix. These names are excluded from affected production-project rules.
+    /// </param>
     public TestSelector(
         string mapPath,
         IReadOnlyCollection<string> allTestProjects,
-        IReadOnlyCollection<string> projectDirectories)
+        IReadOnlyCollection<string> projectDirectories,
+        IReadOnlySet<string> allTestProjectNames)
     {
         _mapPath = mapPath;
         _allTestProjects = allTestProjects;
         _projectDirectories = projectDirectories;
+        _allTestProjectNames = allTestProjectNames;
     }
 
     /// <param name="changedFiles">Repo-relative, '/'-separated paths changed in the PR.</param>
@@ -263,12 +270,14 @@ public sealed class TestSelector
         // affected). Keyed on the affected-project set, so it contributes nothing when Layer 1
         // produced none (e.g. --skip-layer1) -- the path_rules still cover the loose-file triggers.
         //
-        // Exclude matrix test project names because they are already selected via the intersection
-        // above. Without this filter, an affected matrix test name (e.g.
-        // "Aspire.Hosting.Python.Tests") would match a broad glob like "Aspire.Hosting*" and
-        // spuriously fire jobs for a test-only change.
-        var affectedNonMatrixProjects = layer1Affected
-            .Where(name => !_allTestProjects.Contains(name))
+        // Match ONLY production project names: Layer 1 reports production AND test projects, and the
+        // affected test projects are already selected via the intersection above. Without this filter
+        // an affected matrix test name (e.g. "Aspire.Hosting.Python.Tests") would match a production
+        // glob like "Aspire.Hosting*" and spuriously fire production jobs (extension-e2e /
+        // typescript-api-compat / deployment-e2e) for a TEST-ONLY change. See test-trigger-map.yml's
+        // affected_project_rules comment ("matched against the affected PRODUCTION projects").
+        var affectedProductionProjects = layer1Affected
+            .Where(name => !_allTestProjectNames.Contains(name))
             .ToList();
         foreach (var rule in map.AffectedProjectRules)
         {

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -283,7 +283,7 @@ public sealed class TestSelector
         {
             // Attribute the rule to the first affected project that matched it, so the cause names a
             // concrete project rather than the rule's whole glob set.
-            var matchedProject = affectedNonMatrixProjects.FirstOrDefault(name => rule.Projects.Any(p => TriggerMap.ProjectNameMatches(p, name)));
+            var matchedProject = affectedProductionProjects.FirstOrDefault(name => rule.Projects.Any(p => TriggerMap.ProjectNameMatches(p, name)));
             if (matchedProject is not null)
             {
                 ApplyTargets(rule.Targets, map, testCauses, jobCauses, ref selectsAll, ref reason,

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -32,7 +32,7 @@ public enum CauseKind
     /// <summary>A changed file matched a <c>path_rules</c> glob (<see cref="Cause.Trigger"/> is the file; <see cref="Cause.Reason"/> is the rule's <c>reason</c>).</summary>
     PathRule,
 
-    /// <summary>An affected non-matrix project matched an <c>affected_project_rules</c> glob (<see cref="Cause.Trigger"/> is the project name).</summary>
+    /// <summary>An affected production/non-test project matched an <c>affected_project_rules</c> glob (<see cref="Cause.Trigger"/> is the project name).</summary>
     AffectedProject,
 
     /// <summary>The Layer 1 MSBuild graph marked this test project affected by a changed source file (<see cref="Cause.Trigger"/> is the project name).</summary>
@@ -138,9 +138,9 @@ public sealed class TestSelector
 
     /// <param name="changedFiles">Repo-relative, '/'-separated paths changed in the PR.</param>
     /// <param name="layer1Affected">
-    /// The full affected project set reported by the graph tool — matrix <em>and</em> non-matrix
-    /// project names (the union of its <em>changed</em> and <em>affected</em> sets). Matrix test names
-    /// are intersected and selected; non-matrix names drive <c>affected_project_rules</c>. May be empty.
+    /// The full affected project set reported by the graph tool. The selector splits this by
+    /// current CI boundaries: matrix test projects are intersected and selected; production/non-test
+    /// project names drive <c>affected_project_rules</c>. May be empty.
     /// </param>
     /// <param name="options">Selection overrides (kill switch).</param>
     /// <param name="layer1AttributedPaths">
@@ -247,7 +247,7 @@ public sealed class TestSelector
         }
 
         // Layer 1 reports the full affected set. Affected matrix test projects are always part of the
-        // answer; non-matrix project names drive affected_project_rules below.
+        // answer; production/non-test project names drive affected_project_rules below.
         foreach (var project in layer1Affected)
         {
             if (_allTestProjects.Contains(project))
@@ -264,7 +264,7 @@ public sealed class TestSelector
             }
         }
 
-        // affected_project_rules: an affected non-matrix project (matched by name glob) pulls in
+        // affected_project_rules: an affected production/non-test project (matched by name glob) pulls in
         // jobs/tests. This replaces the duplicated src/<Project>/** path globs the job rules used to
         // carry, and follows the graph's transitive closure (a dependency change marks the project
         // affected). Keyed on the affected-project set, so it contributes nothing when Layer 1

--- a/tools/SelectTests/TestSelector.cs
+++ b/tools/SelectTests/TestSelector.cs
@@ -32,7 +32,7 @@ public enum CauseKind
     /// <summary>A changed file matched a <c>path_rules</c> glob (<see cref="Cause.Trigger"/> is the file; <see cref="Cause.Reason"/> is the rule's <c>reason</c>).</summary>
     PathRule,
 
-    /// <summary>An affected production project matched an <c>affected_project_rules</c> glob (<see cref="Cause.Trigger"/> is the project name).</summary>
+    /// <summary>An affected non-matrix project matched an <c>affected_project_rules</c> glob (<see cref="Cause.Trigger"/> is the project name).</summary>
     AffectedProject,
 
     /// <summary>The Layer 1 MSBuild graph marked this test project affected by a changed source file (<see cref="Cause.Trigger"/> is the project name).</summary>
@@ -131,10 +131,9 @@ public sealed class TestSelector
 
     /// <param name="changedFiles">Repo-relative, '/'-separated paths changed in the PR.</param>
     /// <param name="layer1Affected">
-    /// The full affected project set reported by the graph tool — production <em>and</em> test
-    /// project names (the union of its <em>changed</em> and <em>affected</em> sets). Test names are
-    /// intersected with the matrix and selected; production names drive <c>project_rules</c>. May be
-    /// empty.
+    /// The full affected project set reported by the graph tool — matrix <em>and</em> non-matrix
+    /// project names (the union of its <em>changed</em> and <em>affected</em> sets). Matrix test names
+    /// are intersected and selected; non-matrix names drive <c>affected_project_rules</c>. May be empty.
     /// </param>
     /// <param name="options">Selection overrides (kill switch).</param>
     /// <param name="layer1AttributedPaths">
@@ -240,9 +239,8 @@ public sealed class TestSelector
             reason ??= $"run-all fallback: '{file}' is neither Layer-1-owned nor matched by a Layer 2 rule";
         }
 
-        // Layer 1: the graph tool reports the full affected set (production + test projects). The
-        // affected TEST projects are always part of the answer; the production names drive
-        // project_rules below.
+        // Layer 1 reports the full affected set. Affected matrix test projects are always part of the
+        // answer; non-matrix project names drive affected_project_rules below.
         foreach (var project in layer1Affected)
         {
             if (_allTestProjects.Contains(project))
@@ -259,26 +257,24 @@ public sealed class TestSelector
             }
         }
 
-        // affected_project_rules: an affected PRODUCTION project (matched by name glob) pulls in
+        // affected_project_rules: an affected non-matrix project (matched by name glob) pulls in
         // jobs/tests. This replaces the duplicated src/<Project>/** path globs the job rules used to
         // carry, and follows the graph's transitive closure (a dependency change marks the project
         // affected). Keyed on the affected-project set, so it contributes nothing when Layer 1
         // produced none (e.g. --skip-layer1) -- the path_rules still cover the loose-file triggers.
         //
-        // Match ONLY production project names: Layer 1 reports production AND test projects, and the
-        // affected test projects are already selected via the intersection above. Without this filter
-        // an affected matrix test name (e.g. "Aspire.Hosting.Python.Tests") would match a production
-        // glob like "Aspire.Hosting*" and spuriously fire production jobs (extension-e2e /
-        // typescript-api-compat / deployment-e2e) for a TEST-ONLY change. See test-trigger-map.yml's
-        // affected_project_rules comment ("matched against the affected PRODUCTION projects").
-        var affectedProductionProjects = layer1Affected
+        // Exclude matrix test project names because they are already selected via the intersection
+        // above. Without this filter, an affected matrix test name (e.g.
+        // "Aspire.Hosting.Python.Tests") would match a broad glob like "Aspire.Hosting*" and
+        // spuriously fire jobs for a test-only change.
+        var affectedNonMatrixProjects = layer1Affected
             .Where(name => !_allTestProjects.Contains(name))
             .ToList();
         foreach (var rule in map.AffectedProjectRules)
         {
             // Attribute the rule to the first affected project that matched it, so the cause names a
             // concrete project rather than the rule's whole glob set.
-            var matchedProject = affectedProductionProjects.FirstOrDefault(name => rule.Projects.Any(p => TriggerMap.ProjectNameMatches(p, name)));
+            var matchedProject = affectedNonMatrixProjects.FirstOrDefault(name => rule.Projects.Any(p => TriggerMap.ProjectNameMatches(p, name)));
             if (matchedProject is not null)
             {
                 ApplyTargets(rule.Targets, map, testCauses, jobCauses, ref selectsAll, ref reason,


### PR DESCRIPTION
**Benchmark-only PRs fell through the selector's unattributed-file fallback and forced the full test matrix.** The selector reported benchmark project files under:

```text
Unattributed changed files
benchmarks/Aspire.Dashboard.Benchmarks/Aspire.Dashboard.Benchmarks.csproj
```

Both benchmark projects are outside the `Aspire.slnx` ProjectGraph, and no GitHub PR-CI job consumes either benchmark harness.

This classifies `benchmarks/**` as intentionally ignored by Layer 2, so benchmark-only changes select no tests or jobs instead of `ALL`. It also generalizes the real-map invariant to require every tracked project outside `Aspire.slnx` to be covered by a curated rule or a reasoned allow-list.

**Verification**

- `Infrastructure.Tests.TestTriggerMap`: 218 passed
- Enforcing selector probe with both benchmark project files: 0 unattributed files, 0 selected tests, no triggered jobs

Fixes #19986
