### PR TITLE
Label unassigned Copilot-authored PRs

### DIFF
--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -196,7 +196,7 @@ function isCopilotReviewer(login) {
 }
 function isCopilotLogin(login) {
   const n = String(login || "").toLowerCase();
-  return n === "copilot" || n === "copilot[bot]" || n === "github-copilot[bot]" || n.endsWith("/copilot");
+  return n === "copilot" || n === "copilot-swe-agent" || n === "copilot[bot]" || n === "github-copilot[bot]" || n.endsWith("/copilot");
 }
 
 // Copilot attribution (mirrors GitHubModels.ResolveAuthor): a Copilot-authored PR with

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -196,7 +196,7 @@ function isCopilotReviewer(login) {
 }
 function isCopilotLogin(login) {
   const n = String(login || "").toLowerCase();
-  return n === "copilot" || n === "copilot-swe-agent" || n === "copilot[bot]" || n === "github-copilot[bot]" || n.endsWith("/copilot");
+  return n === "copilot" || n === "copilot-swe-agent" || n === "copilot-swe-agent[bot]" || n === "copilot[bot]" || n === "github-copilot[bot]" || n.endsWith("/copilot");
 }
 
 // Copilot attribution (mirrors GitHubModels.ResolveAuthor): a Copilot-authored PR with

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -100,6 +100,38 @@ test("loadDashboard ranks review-ready PRs by time waiting for review", async ()
   assert.deepEqual(reviewQueue.items.map((item) => item.pr.number), [2, 1]);
 });
 
+test("loadDashboard attributes a copilot-swe-agent PR to its sole human assignee", async () => {
+  const copilotPr = prNode(19893, new Date().toISOString());
+  copilotPr.author = { __typename: "Bot", login: "copilot-swe-agent", avatarUrl: null };
+  copilotPr.assignees.nodes = [{ login: "ellahathaway" }];
+
+  globalThis.fetch = async (_url, options = {}) => {
+    const body = JSON.parse(options.body);
+    if (body.query.includes("pullRequests")) {
+      return jsonResponse({ data: { repository: {
+        isPrivate: false,
+        pullRequests: {
+          nodes: [copilotPr],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      } } });
+    }
+    throw new Error(`Unexpected query: ${body.query}`);
+  };
+
+  const dashboard = await loadDashboard({
+    accounts: [{ token: "token", login: "davidfowl", repos: ["microsoft/aspire"] }],
+    mode: "review",
+    release: "9.5",
+    prefs: {},
+    dismissed: [],
+  });
+
+  const pullRequests = dashboard.attention.buckets.flatMap((bucket) => bucket.items.map((item) => item.pr));
+  const attributed = pullRequests.find((pr) => pr.number === copilotPr.number);
+  assert.equal(attributed.author, "ellahathaway/copilot");
+});
+
 test("loadDashboard paginates open issues for each watched repo", async () => {
   const seenAfter = [];
   globalThis.fetch = async (_url, options = {}) => {

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -100,36 +100,38 @@ test("loadDashboard ranks review-ready PRs by time waiting for review", async ()
   assert.deepEqual(reviewQueue.items.map((item) => item.pr.number), [2, 1]);
 });
 
-test("loadDashboard attributes a copilot-swe-agent PR to its sole human assignee", async () => {
-  const copilotPr = prNode(19893, new Date().toISOString());
-  copilotPr.author = { __typename: "Bot", login: "copilot-swe-agent", avatarUrl: null };
-  copilotPr.assignees.nodes = [{ login: "ellahathaway" }];
+test("loadDashboard attributes copilot-swe-agent identities to their sole human assignee", async () => {
+  for (const login of ["copilot-swe-agent", "copilot-swe-agent[bot]"]) {
+    const copilotPr = prNode(19893, new Date().toISOString());
+    copilotPr.author = { __typename: "Bot", login, avatarUrl: null };
+    copilotPr.assignees.nodes = [{ login: "ellahathaway" }];
 
-  globalThis.fetch = async (_url, options = {}) => {
-    const body = JSON.parse(options.body);
-    if (body.query.includes("pullRequests")) {
-      return jsonResponse({ data: { repository: {
-        isPrivate: false,
-        pullRequests: {
-          nodes: [copilotPr],
-          pageInfo: { hasNextPage: false, endCursor: null },
-        },
-      } } });
-    }
-    throw new Error(`Unexpected query: ${body.query}`);
-  };
+    globalThis.fetch = async (_url, options = {}) => {
+      const body = JSON.parse(options.body);
+      if (body.query.includes("pullRequests")) {
+        return jsonResponse({ data: { repository: {
+          isPrivate: false,
+          pullRequests: {
+            nodes: [copilotPr],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        } } });
+      }
+      throw new Error(`Unexpected query: ${body.query}`);
+    };
 
-  const dashboard = await loadDashboard({
-    accounts: [{ token: "token", login: "davidfowl", repos: ["microsoft/aspire"] }],
-    mode: "review",
-    release: "9.5",
-    prefs: {},
-    dismissed: [],
-  });
+    const dashboard = await loadDashboard({
+      accounts: [{ token: "token", login: "davidfowl", repos: ["microsoft/aspire"] }],
+      mode: "review",
+      release: "9.5",
+      prefs: {},
+      dismissed: [],
+    });
 
-  const pullRequests = dashboard.attention.buckets.flatMap((bucket) => bucket.items.map((item) => item.pr));
-  const attributed = pullRequests.find((pr) => pr.number === copilotPr.number);
-  assert.equal(attributed.author, "ellahathaway/copilot");
+    const pullRequests = dashboard.attention.buckets.flatMap((bucket) => bucket.items.map((item) => item.pr));
+    const attributed = pullRequests.find((pr) => pr.number === copilotPr.number);
+    assert.equal(attributed.author, "ellahathaway/copilot");
+  }
 });
 
 test("loadDashboard paginates open issues for each watched repo", async () => {

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -63,6 +63,7 @@ jobs:
             const label = 'needs-assignee';
             const copilotAuthors = new Set([
               'copilot',
+              'copilot[bot]',
               'copilot-swe-agent',
               'copilot-swe-agent[bot]',
               'github-copilot[bot]',

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -11,9 +11,10 @@ on:
   # or steal any secrets you use in your workflow. This event allows your workflow to do things
   # like label or comment on pull requests from forks.
   #
-  # Only automatically predict area labels when pull requests are first opened
+  # Predict area labels when pull requests are first opened. Assignment events keep the
+  # needs-assignee label on Copilot-authored pull requests in sync.
   pull_request_target:
-    types: opened
+    types: [opened, assigned, unassigned]
 
     # Configure the branches that need to have PRs labeled
     branches:
@@ -46,6 +47,67 @@ env:
   EXCLUDED_AUTHORS: "" # Comma-separated list of authors to exclude from training data
 
 jobs:
+  update-copilot-assignee-label:
+    if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'microsoft' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: copilot-assignee-label-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
+    permissions:
+      pull-requests: write
+    steps:
+      - name: "Update Copilot PR assignee label"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = 'needs-assignee';
+            const copilotAuthors = new Set([
+              'copilot',
+              'copilot-swe-agent',
+              'copilot-swe-agent[bot]',
+              'github-copilot[bot]',
+            ]);
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+
+            if (!copilotAuthors.has(pullRequest.user?.login?.toLowerCase())) {
+              return;
+            }
+
+            const hasHumanAssignee = pullRequest.assignees.some((assignee) => assignee.type !== 'Bot');
+            const hasLabel = pullRequest.labels.some((existing) => existing.name.toLowerCase() === label);
+            const needsAssignee = pullRequest.state === 'open' && !hasHumanAssignee;
+
+            if (needsAssignee && !hasLabel) {
+              // This label is pre-created as repository configuration so the job can retain
+              // pull-request-only permissions.
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: [label],
+              });
+            } else if (!needsAssignee && hasLabel) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  name: label,
+                });
+              } catch (error) {
+                // An assignment or manual label update can remove the label after the refetch.
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
   poll-pull-requests:
     # Run on schedule trigger or workflow_dispatch without PR numbers, within the 'dotnet' org
     if: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.pulls == '')) && github.repository_owner == 'dotnet' }}
@@ -88,7 +150,7 @@ jobs:
   predict-pull-label:
     # The 'if' uses always() so this job runs even when poll-pull-requests is skipped
     # Do not automatically run the workflow on forks outside the 'dotnet' org
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.repository_owner == 'microsoft') }}
+    if: ${{ always() && (github.event_name != 'pull_request_target' || github.event.action == 'opened') && (github.event_name == 'workflow_dispatch' || github.repository_owner == 'microsoft') }}
     needs: [poll-pull-requests]
     runs-on: ubuntu-latest
     permissions:

--- a/tests/Infrastructure.Tests/WorkflowScripts/LabelerPredictPullsWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/LabelerPredictPullsWorkflowTests.cs
@@ -69,11 +69,16 @@ public sealed class LabelerPredictPullsWorkflowTests : IDisposable
             StringComparison.Ordinal);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData("Copilot")]
+    [InlineData("copilot[bot]")]
+    [InlineData("copilot-swe-agent")]
+    [InlineData("copilot-swe-agent[bot]")]
+    [InlineData("github-copilot[bot]")]
     [RequiresTools(["node"])]
-    public async Task UnassignedCopilotPullRequestGetsNeedsAssigneeLabel()
+    public async Task UnassignedCopilotPullRequestGetsNeedsAssigneeLabel(string author)
     {
-        var result = await RunScriptAsync(PullRequest(author: "Copilot"));
+        var result = await RunScriptAsync(PullRequest(author));
 
         Assert.Equal(["needs-assignee"], result.Labels);
         Assert.Equal(["pulls.get", "addLabels"], result.Calls);

--- a/tests/Infrastructure.Tests/WorkflowScripts/LabelerPredictPullsWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/LabelerPredictPullsWorkflowTests.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.TestUtilities;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Infrastructure.Tests;
+
+public sealed class LabelerPredictPullsWorkflowTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TemporaryWorkspace _workspace;
+    private readonly string _repoRoot = RepoRoot.Path;
+    private readonly string _harnessPath;
+    private readonly string _script;
+    private readonly ITestOutputHelper _output;
+
+    public LabelerPredictPullsWorkflowTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _workspace = TemporaryWorkspace.Create(output);
+        _harnessPath = Path.Combine(
+            _repoRoot,
+            "tests",
+            "Infrastructure.Tests",
+            "WorkflowScripts",
+            "labeler-predict-pulls.harness.js");
+        _script = ExtractAssigneeLabelScript(LoadWorkflow());
+    }
+
+    public void Dispose() => _workspace.Dispose();
+
+    [Fact]
+    public void WorkflowHandlesAssignmentLifecycleWithoutRerunningAreaPrediction()
+    {
+        var workflow = LoadWorkflow();
+        var root = Assert.IsType<YamlMappingNode>(workflow.Documents[0].RootNode);
+        var trigger = Mapping(Mapping(root, "on"), "pull_request_target");
+        var types = Sequence(trigger, "types").Children.Cast<YamlScalarNode>().Select(node => node.Value);
+
+        Assert.Equal(["opened", "assigned", "unassigned"], types);
+
+        var jobs = Mapping(root, "jobs");
+        var updateJob = Mapping(jobs, "update-copilot-assignee-label");
+        Assert.Equal(
+            "${{ github.event_name == 'pull_request_target' && github.repository_owner == 'microsoft' }}",
+            Scalar(updateJob, "if"));
+        var concurrency = Mapping(updateJob, "concurrency");
+        Assert.Equal(
+            "copilot-assignee-label-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}",
+            Scalar(concurrency, "group"));
+        Assert.Equal("false", Scalar(concurrency, "cancel-in-progress"));
+        Assert.Equal("write", Scalar(Mapping(updateJob, "permissions"), "pull-requests"));
+
+        var updateStep = Assert.Single(
+            Sequence(updateJob, "steps").Children.Cast<YamlMappingNode>(),
+            step => Scalar(step, "name") == "Update Copilot PR assignee label");
+        Assert.Equal(
+            "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+            Scalar(updateStep, "uses"));
+
+        var predictionJob = Mapping(jobs, "predict-pull-label");
+        Assert.Contains(
+            "github.event.action == 'opened'",
+            Scalar(predictionJob, "if"),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task UnassignedCopilotPullRequestGetsNeedsAssigneeLabel()
+    {
+        var result = await RunScriptAsync(PullRequest(author: "Copilot"));
+
+        Assert.Equal(["needs-assignee"], result.Labels);
+        Assert.Equal(["pulls.get", "addLabels"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AssignedCopilotPullRequestLosesNeedsAssigneeLabel()
+    {
+        var result = await RunScriptAsync(
+            PullRequest(
+                author: "Copilot",
+                assignees: [new { login = "ellahathaway", type = "User" }],
+                labels: [new { name = "needs-assignee" }]));
+
+        Assert.Empty(result.Labels);
+        Assert.Equal(["pulls.get", "removeLabel"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ConcurrentPullRequestLabelRemovalIsIdempotent()
+    {
+        var result = await RunScriptAsync(
+            PullRequest(
+                author: "Copilot",
+                assignees: [new { login = "ellahathaway", type = "User" }],
+                labels: [new { name = "needs-assignee" }]),
+            removeLabelNotFound: true);
+
+        Assert.Empty(result.Labels);
+        Assert.Equal(["pulls.get", "removeLabel"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ClosedCopilotPullRequestLosesNeedsAssigneeLabel()
+    {
+        var result = await RunScriptAsync(
+            PullRequest(
+                author: "Copilot",
+                state: "closed",
+                labels: [new { name = "needs-assignee" }]));
+
+        Assert.Empty(result.Labels);
+        Assert.Equal(["pulls.get", "removeLabel"], result.Calls);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task NonCopilotPullRequestIsUnchanged()
+    {
+        var result = await RunScriptAsync(PullRequest(author: "outside-contributor"));
+
+        Assert.Empty(result.Labels);
+        Assert.Equal(["pulls.get"], result.Calls);
+    }
+
+    private static object PullRequest(
+        string author,
+        string state = "open",
+        object[]? assignees = null,
+        object[]? labels = null) => new
+        {
+            user = new { login = author },
+            state,
+            assignees = assignees ?? [],
+            labels = labels ?? [],
+        };
+
+    private async Task<ScriptResult> RunScriptAsync(
+        object pullRequest,
+        bool removeLabelNotFound = false)
+    {
+        var requestPath = Path.Combine(_workspace.Path, $"{Guid.NewGuid():N}.json");
+        var outputPath = Path.Combine(_workspace.Path, $"{Guid.NewGuid():N}.result.json");
+        await File.WriteAllTextAsync(
+            requestPath,
+            JsonSerializer.Serialize(
+                new
+                {
+                    script = _script,
+                    pullRequest,
+                    removeLabelNotFound,
+                },
+                s_jsonOptions));
+
+        using var command = new NodeCommand(_output, "labeler-predict-pulls");
+        command.WithWorkingDirectory(_repoRoot);
+
+        var result = await command.ExecuteScriptAsync(_harnessPath, requestPath, outputPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var response = JsonSerializer.Deserialize<HarnessResponse>(
+            await File.ReadAllTextAsync(outputPath),
+            s_jsonOptions);
+        Assert.NotNull(response);
+
+        return response.Result;
+    }
+
+    private YamlStream LoadWorkflow()
+    {
+        var workflow = new YamlStream();
+        using var reader = File.OpenText(
+            Path.Combine(_repoRoot, ".github", "workflows", "labeler-predict-pulls.yml"));
+        workflow.Load(reader);
+
+        return workflow;
+    }
+
+    private static string ExtractAssigneeLabelScript(YamlStream workflow)
+    {
+        var root = Assert.IsType<YamlMappingNode>(workflow.Documents[0].RootNode);
+        var job = Mapping(Mapping(root, "jobs"), "update-copilot-assignee-label");
+        var step = Assert.Single(
+            Sequence(job, "steps").Children.Cast<YamlMappingNode>(),
+            candidate => Scalar(candidate, "name") == "Update Copilot PR assignee label");
+
+        return Scalar(Mapping(step, "with"), "script");
+    }
+
+    private static YamlMappingNode Mapping(YamlMappingNode node, string key)
+        => Assert.IsType<YamlMappingNode>(node.Children[new YamlScalarNode(key)]);
+
+    private static YamlSequenceNode Sequence(YamlMappingNode node, string key)
+        => Assert.IsType<YamlSequenceNode>(node.Children[new YamlScalarNode(key)]);
+
+    private static string Scalar(YamlMappingNode node, string key)
+        => Assert.IsType<YamlScalarNode>(node.Children[new YamlScalarNode(key)]).Value!;
+
+    private sealed record HarnessResponse(ScriptResult Result);
+
+    private sealed record ScriptResult(string[] Labels, string[] Calls);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/labeler-predict-pulls.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/labeler-predict-pulls.harness.js
@@ -1,0 +1,67 @@
+const fs = require('node:fs/promises');
+
+async function main() {
+    const inputPath = process.argv[2];
+    const outputPath = process.argv[3];
+    if (!inputPath || !outputPath) {
+        throw new Error('Expected input and output file paths.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const labels = new Set(request.pullRequest.labels.map(label => label.name));
+    const calls = [];
+
+    const github = {
+        rest: {
+            pulls: {
+                get: async () => {
+                    calls.push('pulls.get');
+                    return { data: request.pullRequest };
+                },
+            },
+            issues: {
+                addLabels: async ({ labels: addedLabels }) => {
+                    calls.push('addLabels');
+                    for (const label of addedLabels) {
+                        labels.add(label);
+                    }
+                },
+                removeLabel: async ({ name }) => {
+                    calls.push('removeLabel');
+                    if (request.removeLabelNotFound) {
+                        labels.delete(name);
+                        const error = new Error('Not Found');
+                        error.status = 404;
+                        throw error;
+                    }
+                    if (!labels.delete(name)) {
+                        const error = new Error('Not Found');
+                        error.status = 404;
+                        throw error;
+                    }
+                },
+            },
+        },
+    };
+    const context = {
+        repo: { owner: 'microsoft', repo: 'aspire' },
+        payload: { pull_request: { number: 19893 } },
+    };
+
+    // github-script wraps this block in an async function and provides github/context as arguments.
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const run = new AsyncFunction('github', 'context', request.script);
+    await run(github, context);
+
+    await fs.writeFile(outputPath, JSON.stringify({
+        result: {
+            labels: [...labels].sort(),
+            calls,
+        },
+    }));
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

Copilot-authored pull requests need a deterministic way to enter the Aspire team's ownership flow without inferring ownership from commit text or posting potentially unsafe mentions.

This extends the existing pull request labeler to:

- Add `needs-assignee` when a Copilot-authored pull request is opened without a human assignee.
- Remove or restore the label as human assignees are added or removed.
- Serialize updates per pull request and tolerate a label that was removed concurrently.
- Keep area-label prediction limited to the original `opened` event.

The Aspire Team App also recognizes GitHub's GraphQL `copilot-swe-agent` identities. A Copilot-authored pull request with one human assignee is therefore attributed to `<assignee>/copilot` and appears in that person's existing queue.

**Important**: This does not automate assignment or review. Someone still needs to notice the label, assign an owner, and move the pull request through the normal review flow. This is intended as a visibility and ownership signal—one step toward resolving the broader issue of team-created Copilot pull requests being missed.

The `needs-assignee` repository label must be created manually before this workflow is enabled. Existing open Copilot pull requests are intentionally not backfilled.

### Security considerations

The label job runs on `pull_request_target` with `pull-requests: write`. It executes only the base branch's fixed inline script, never checks out pull request content, and uses fixed label and account values plus GitHub API metadata. It does not generate comments or mentions.

Validation:

- `LabelerPredictPullsWorkflowTests`: 10 passed.
- Aspire Team App GitHub tests: 7 passed.
- Verified pull request #19893 renders as `ellahathaway/copilot` in the reloaded Team App canvas.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
