### PR TITLE
Preselect CLI-default Aspire agent assets in VS Code

### DIFF
--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -27,7 +27,7 @@ export interface IInteractionService extends vscode.Disposable {
     promptForFilePath: (promptText: string, defaultValue: string | null, directory: boolean) => Promise<string | null>;
     confirm: (promptText: string, defaultValue: boolean) => Promise<boolean | null>;
     promptForSelection: (promptText: string, choices: string[]) => Promise<string | null>;
-    promptForSelections: (promptText: string, choices: string[]) => Promise<string[] | null>;
+    promptForSelections: (promptText: string, choices: string[], preSelected?: string[]) => Promise<string[] | null>;
     displayIncompatibleVersionError: (requiredCapability: string, appHostHostingSdkVersion: string, rpcClient: ICliRpcClient) => Promise<void>;
     displayError: (errorMessage: string, actions?: InteractionMessageAction[]) => Promise<void>;
     displayMessage: (emoji: string, message: string, actions?: InteractionMessageAction[]) => Promise<void>;
@@ -324,16 +324,21 @@ export class InteractionService implements IInteractionService {
         return selected ?? null;
     }
 
-    async promptForSelections(promptText: string, choices: string[]): Promise<string[] | null> {
+    async promptForSelections(promptText: string, choices: string[], preSelected: string[] = []): Promise<string[] | null> {
         extensionLogOutputChannel.info(`Prompting for multiple selections: ${promptText}`);
 
-        const selected = await vscode.window.showQuickPick(choices, {
+        const preSelectedSet = new Set(preSelected);
+        const items: vscode.QuickPickItem[] = choices.map(label => ({
+            label,
+            picked: preSelectedSet.has(label)
+        }));
+        const selected = await vscode.window.showQuickPick(items, {
             placeHolder: formatText(promptText),
             canPickMany: true,
             ignoreFocusOut: true
         });
 
-        return selected ?? null;
+        return selected?.map(item => item.label) ?? null;
     }
 
     async displayIncompatibleVersionError(requiredCapabilityStr: string, appHostHostingSdkVersion: string, rpcClient: ICliRpcClient) {

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -160,6 +160,88 @@ suite('InteractionService endpoints', () => {
 		showQuickPickStub.restore();
 	});
 
+	// promptForSelections
+	test('promptForSelections preselects CLI defaults', async () => {
+		const testInfo = await createTestRpcServer();
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves([
+			{ label: 'Aspire skill', picked: true },
+		] as never);
+
+		try {
+			const result = await testInfo.interactionService.promptForSelections(
+				'Select skills:',
+				['Aspire skill', 'Playwright CLI'],
+				['Aspire skill']);
+
+			const quickPickItems = showQuickPickStub.firstCall.args[0] as readonly vscode.QuickPickItem[];
+			assert.deepStrictEqual(quickPickItems, [
+				{ label: 'Aspire skill', picked: true },
+				{ label: 'Playwright CLI', picked: false },
+			]);
+			assert.deepStrictEqual(result, ['Aspire skill']);
+		}
+		finally {
+			showQuickPickStub.restore();
+		}
+	});
+
+	test('promptForSelections returns the user changed selections', async () => {
+		const testInfo = await createTestRpcServer();
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves([
+			{ label: 'Playwright CLI', picked: false },
+		] as never);
+
+		try {
+			const result = await testInfo.interactionService.promptForSelections(
+				'Select skills:',
+				['Aspire skill', 'Playwright CLI'],
+				['Aspire skill']);
+
+			assert.deepStrictEqual(result, ['Playwright CLI']);
+		}
+		finally {
+			showQuickPickStub.restore();
+		}
+	});
+
+	test('promptForSelections returns null when user cancels', async () => {
+		const testInfo = await createTestRpcServer();
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
+
+		try {
+			const result = await testInfo.interactionService.promptForSelections(
+				'Select skills:',
+				['Aspire skill'],
+				['Aspire skill']);
+
+			assert.strictEqual(result, null);
+		}
+		finally {
+			showQuickPickStub.restore();
+		}
+	});
+
+	test('promptForSelections supports older CLI calls without defaults', async () => {
+		const testInfo = await createTestRpcServer();
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves([] as never);
+
+		try {
+			const result = await testInfo.interactionService.promptForSelections(
+				'Select skills:',
+				['Aspire skill', 'Playwright CLI']);
+
+			const quickPickItems = showQuickPickStub.firstCall.args[0] as readonly vscode.QuickPickItem[];
+			assert.deepStrictEqual(quickPickItems, [
+				{ label: 'Aspire skill', picked: false },
+				{ label: 'Playwright CLI', picked: false },
+			]);
+			assert.deepStrictEqual(result, []);
+		}
+		finally {
+			showQuickPickStub.restore();
+		}
+	});
+
 	test('startDebugSession forwards CLI environment to the debug configuration', async () => {
 		const testInfo = await createTestRpcServer();
 		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').resolves(true);

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -34,7 +34,7 @@ internal interface IExtensionBackchannel
     Task DisplayDashboardUrlsAsync(DashboardUrlsState dashboardUrls, CancellationToken cancellationToken);
     Task ShowStatusAsync(string? status, CancellationToken cancellationToken);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken) where T : notnull;
-    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken) where T : notnull;
+    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected, CancellationToken cancellationToken) where T : notnull;
     Task<bool> ConfirmAsync(string promptText, bool defaultValue, CancellationToken cancellationToken);
     Task<string> PromptForStringAsync(string promptText, string? defaultValue, Func<string, ValidationResult>? validator, bool required, CancellationToken cancellationToken);
     Task<string> PromptForSecretStringAsync(string promptText, Func<string, ValidationResult>? validator, bool required, CancellationToken cancellationToken);
@@ -563,13 +563,16 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        CancellationToken cancellationToken) where T : notnull
+        IEnumerable<T>? preSelected, CancellationToken cancellationToken) where T : notnull
     {
         await ConnectAsync(cancellationToken);
 
         var choicesList = choices.ToList();
         // this will throw if formatting results in non-distinct values. that should happen because we cannot send the formatter over the wire.
         var choicesByFormattedValue = choicesList.ToDictionary(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)), choice => choice);
+        var preSelectedArray = preSelected?
+            .Select(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)))
+            .ToArray() ?? [];
 
         using var activity = _activitySource.StartActivity();
 
@@ -580,7 +583,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
         var choicesArray = choicesByFormattedValue.Keys.ToArray();
         var result = await rpc.InvokeWithCancellationAsync<string[]?>(
             "promptForSelections",
-            [_token, promptText, choicesArray],
+            [_token, promptText, choicesArray, preSelectedArray],
             cancellationToken);
 
         if (result is null)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -361,9 +361,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
             {
                 try
                 {
-                    // Note: The extension backchannel protocol does not yet support preSelected items.
-                    // Pre-selected items are applied only when falling back to the console interaction service.
-                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
+                    var result = await Backchannel.PromptForSelectionsAsync(StringUtils.RemoveMarkup(promptText), choices, choiceFormatter, preSelected, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }
                 catch (Exception ex)

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -309,6 +309,42 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PromptForSelectionsAsync_ForwardsFormattedDefaultsAndMapsSelectedValues()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        SelectionChoice[] choices =
+        [
+            new("Aspire skill"),
+            new("Playwright CLI")
+        ];
+        string? capturedPrompt = null;
+        IReadOnlyList<string>? capturedChoices = null;
+        IReadOnlyList<string>? capturedPreSelected = null;
+        var backchannel = new TestExtensionBackchannel
+        {
+            PromptForSelectionsAsyncCallback = (prompt, formattedChoices, formattedPreSelected) =>
+            {
+                capturedPrompt = prompt;
+                capturedChoices = formattedChoices;
+                capturedPreSelected = formattedPreSelected;
+                return Task.FromResult<IReadOnlyList<string>>(["Playwright CLI"]);
+            }
+        };
+        using var interactionService = CreateExtensionInteractionService(workspace, backchannel);
+
+        var result = await interactionService.PromptForSelectionsAsync(
+            "[bold]Select skills:[/]",
+            choices,
+            choice => $"[bold]{choice.Label}[/]",
+            preSelected: [choices[0]]);
+
+        Assert.Equal("Select skills:", capturedPrompt);
+        Assert.Equal(["Aspire skill", "Playwright CLI"], capturedChoices);
+        Assert.Equal(["Aspire skill"], capturedPreSelected);
+        Assert.Same(choices[1], Assert.Single(result));
+    }
+
+    [Fact]
     public async Task PromptForFilePathAsync_RetriesAfterInvalidSelection()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -470,4 +506,6 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
             extensionPromptEnabled: true,
             logger: NullLogger<ExtensionInteractionService>.Instance);
     }
+
+    private sealed record SelectionChoice(string Label);
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.InternalTesting;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -48,6 +49,7 @@ internal sealed class TestExtensionBackchannel : IExtensionBackchannel
     public TaskCompletionSource? PromptForSelectionAsyncCalled { get; set; }
 
     public TaskCompletionSource? PromptForSelectionsAsyncCalled { get; set; }
+    public Func<string, IReadOnlyList<string>, IReadOnlyList<string>, Task<IReadOnlyList<string>>>? PromptForSelectionsAsyncCallback { get; set; }
 
     public TaskCompletionSource? ConfirmAsyncCalled { get; set; }
     public Func<string, bool, Task<bool>>? ConfirmAsyncCallback { get; set; }
@@ -189,16 +191,28 @@ internal sealed class TestExtensionBackchannel : IExtensionBackchannel
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken) where T : notnull
+    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected, CancellationToken cancellationToken) where T : notnull
     {
         PromptForSelectionsAsyncCalled?.SetResult();
 
-        if (!choices.Any())
+        var choicesList = choices.ToList();
+        if (choicesList.Count == 0)
         {
             throw new InvalidOperationException($"No items available for selection: {promptText}");
         }
 
-        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
+        if (PromptForSelectionsAsyncCallback is null)
+        {
+            return choicesList;
+        }
+
+        var choicesByFormattedValue = choicesList.ToDictionary(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)), choice => choice);
+        var formattedPreSelected = preSelected?
+            .Select(choice => StringUtils.RemoveMarkup(choiceFormatter(choice)))
+            .ToList() ?? [];
+        var selectedValues = await PromptForSelectionsAsyncCallback(promptText, choicesByFormattedValue.Keys.ToList(), formattedPreSelected);
+
+        return selectedValues.Select(value => choicesByFormattedValue[value]).ToList();
     }
 
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

When `aspire new` or `aspire init` runs through VS Code, the extension currently drops the agent asset defaults computed by the Aspire CLI. As a result, the Quick Pick opens with no checked items even though the equivalent terminal prompt preselects the recommended Aspire skill location and applicable bundled skills.

This change keeps the CLI as the source of truth. It forwards formatted defaults as a trailing multi-selection RPC argument, renders matching VS Code `QuickPickItem` entries as initially picked, and maps the user's final selections back to the CLI's typed values.

Cancellation behavior and opt-in choices remain unchanged. CLI-defined skills, MCP configuration, and other optional assets are not selected unless the CLI explicitly includes them in its defaults.

### Compatibility

- Older CLI -> new extension: the new `preSelected` argument is optional and defaults to an empty list, preserving the existing unselected Quick Pick behavior.
- New CLI -> older extension: defaults are sent as a trailing RPC argument, which older JavaScript handlers ignore.

No capability gate or coordinated CLI/extension upgrade is required.

### User-facing usage

Starting project creation or initialization from VS Code now shows the same initial agent asset selections as the Aspire CLI:

- `aspire new` preselects the default skill location and applicable bundled Aspire skills.
- `aspire init` applies those defaults and includes the one-time `aspireify` skill according to existing CLI policy.
- Users can still change or clear the selections before confirming.

### Screenshots / Recordings

https://github.com/user-attachments/assets/ada19fea-5d33-4c1d-8d65-52eeb2a14c20

### Validation

- Built the Aspire CLI and VS Code extension together with `extension\build.ps1`.
- Ran the focused `ExtensionInteractionServiceTests`.
- Compiled the extension source and tests.
- Ran the extension linter.

The Extension Development Host test run is omitted because the current Windows ARM64 VS Code test archive is missing its workbench entrypoint.

Fixes: #19629

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No