### PR TITLE
[release/13.5] Hide Azure environment when all resources use emulators

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE003
+#pragma warning disable ASPIREAZURE001
 #pragma warning disable ASPIREPIPELINES002
 
 using Aspire.Dashboard.Model;
@@ -32,6 +33,15 @@ internal sealed class AzureResourcePreparer(
         var azureResources = GetAzureResourcesFromAppModel(model);
         if (azureResources.Count == 0)
         {
+            // AddAzureProvisioning creates the environment before resources are configured, so wait until
+            // preparation to hide it when the final run-mode model contains only local emulators.
+            if (executionContext.IsRunMode &&
+                model.Resources.OfType<AzureEnvironmentResource>().SingleOrDefault() is { } environmentResource &&
+                !environmentResource.HasAnnotationOfType<HiddenAnnotation>())
+            {
+                environmentResource.Annotations.Add(new HiddenAnnotation(HiddenBehavior.Always));
+            }
+
             return;
         }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRunAsEmulatorModeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRunAsEmulatorModeTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECOSMOSDB001
+#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -49,5 +51,41 @@ public class AzureRunAsEmulatorModeTests
         Assert.False(resource.IsEmulator(), $"{resourceType} should not be configured as an emulator in publish mode.");
         Assert.False(resource.IsContainer(), $"{resourceType} should not be configured as a local container in publish mode.");
         Assert.DoesNotContain(builder.Resources, resource => resource.Annotations.OfType<ContainerImageAnnotation>().Any());
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_WhenAllAzureResourcesUseEmulators_HidesAzureEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+        builder.AddAzureStorage("storage").RunAsEmulator();
+        builder.AddAzureEventHubs("eventhubs").RunAsEmulator();
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var preparer = app.Services.GetRequiredService<AzureResourcePreparer>();
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var environment = Assert.Single(model.Resources.OfType<AzureEnvironmentResource>());
+        var hidden = Assert.Single(environment.Annotations.OfType<HiddenAnnotation>());
+        Assert.Equal(HiddenBehavior.Always, hidden.Behavior);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_WhenAzureResourceRequiresProvisioning_ShowsAzureEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureStorage("emulated-storage").RunAsEmulator();
+        builder.AddAzureStorage("provisioned-storage");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var preparer = app.Services.GetRequiredService<AzureResourcePreparer>();
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var environment = Assert.Single(model.Resources.OfType<AzureEnvironmentResource>());
+        Assert.Empty(environment.Annotations.OfType<HiddenAnnotation>());
     }
 }


### PR DESCRIPTION
## Description

Backport of #19843 to `release/13.5`.

Emulator-only AppHosts currently show an unused `azure-environment` resource stuck in **Not started**. This backport hides that resource when no Azure resources require provisioning, while keeping it visible for mixed emulator/cloud models.

Cherry-picks main commit `efbfe185b7a8c99536661768b3fa9bddd07f332b`. The test-file conflict was resolved by retaining the release branch's `ASPIRECOSMOSDB001` suppression alongside the new `ASPIREAZURE001` suppression. Existing `RunAsPreviewEmulator` coverage is unchanged.

### User-facing usage

Existing emulator-only AppHosts require no changes:

```csharp
builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
builder.AddAzureStorage("storage").RunAsEmulator();
builder.AddAzureEventHubs("eventhubs").RunAsEmulator();
```

The dashboard omits `azure-environment` for this model. Adding an Azure resource that requires provisioning keeps it visible.

Fixes #19617

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

## Customer Impact

AppHosts using only local Azure emulators display a misleading `azure-environment` resource in **Not started**, even though no Azure provisioning is needed. This removes that dashboard noise without hiding the environment when cloud provisioning is required.

## Testing

All 44 tests in `AzureRunAsEmulatorModeTests` and `AzureResourcePreparerTests` passed on `release/13.5`, including both backported test cases. Quarantined and outerloop tests were excluded.

## Risk

Low. The change only adds a hidden annotation in run mode when there are no provisionable Azure resources; cloud provisioning and publish behavior are unchanged. No public API changes.

## Regression?

Sort of. User experience changed for the worse. Per the triage on #19617; this addresses existing cosmetic dashboard behavior.