### PR TITLE
Update to .NET 11 RC1 SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,12 +14,8 @@
     <DotNetRuntimeNet10VersionForTesting>10.0.8</DotNetRuntimeNet10VersionForTesting>
     <DotNetSdkNet8VersionForTesting>8.0.415</DotNetSdkNet8VersionForTesting>
     <DotNetSdkNet9VersionForTesting>9.0.306</DotNetSdkNet9VersionForTesting>
-    <DotNetSdkNet11VersionForTesting>11.0.100-preview.6.26359.118</DotNetSdkNet11VersionForTesting>
-    <!-- Keep these aliases for global.json and non-template test infrastructure. -->
-    <DotNetRuntimePreviousVersionForTesting>$(DotNetRuntimeNet8VersionForTesting)</DotNetRuntimePreviousVersionForTesting>
-    <DotNetRuntimeCurrentVersionForTesting>$(DotNetRuntimeNet9VersionForTesting)</DotNetRuntimeCurrentVersionForTesting>
-    <DotNetSdkPreviousVersionForTesting>$(DotNetSdkNet8VersionForTesting)</DotNetSdkPreviousVersionForTesting>
-    <DotNetSdkCurrentVersionForTesting>$(DotNetSdkNet9VersionForTesting)</DotNetSdkCurrentVersionForTesting>
+    <DotNetSdkNet10VersionForTesting>10.0.400</DotNetSdkNet10VersionForTesting>
+    <DotNetSdkNet11VersionForTesting>11.0.100-rc.1.26425.128</DotNetSdkNet11VersionForTesting>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>
@@ -71,11 +67,11 @@
        Versions must be available on the dnceng dotnet-public mirror (originally published to nuget.org). -->
   <PropertyGroup Label="BlazorAssets">
     <MicrosoftAspNetCoreAppInternalAssetsNet10Version>10.0.8</MicrosoftAspNetCoreAppInternalAssetsNet10Version>
-    <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
+    <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-rc.1.26425.128</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
   </PropertyGroup>
   <!-- .NET 11.0 Package Versions used by project templates -->
   <PropertyGroup Label="Net11Preview">
-    <MicrosoftAspNetCoreOpenApiNet11Version>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreOpenApiNet11Version>
+    <MicrosoftAspNetCoreOpenApiNet11Version>11.0.0-rc.1.26425.128</MicrosoftAspNetCoreOpenApiNet11Version>
   </PropertyGroup>
   <!-- .NET 10.0 Package Versions -->
   <PropertyGroup Label="Preview">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,6 @@
     <DotNetSdkNet8VersionForTesting>8.0.415</DotNetSdkNet8VersionForTesting>
     <DotNetSdkNet9VersionForTesting>9.0.306</DotNetSdkNet9VersionForTesting>
     <DotNetSdkNet10VersionForTesting>10.0.400</DotNetSdkNet10VersionForTesting>
-    <DotNetSdkNet11VersionForTesting>11.0.100-rc.1.26425.128</DotNetSdkNet11VersionForTesting>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <DotNetRuntimeNet10VersionForTesting>10.0.8</DotNetRuntimeNet10VersionForTesting>
     <DotNetSdkNet8VersionForTesting>8.0.415</DotNetSdkNet8VersionForTesting>
     <DotNetSdkNet9VersionForTesting>9.0.306</DotNetSdkNet9VersionForTesting>
-    <DotNetSdkNet10VersionForTesting>10.0.400</DotNetSdkNet10VersionForTesting>
+    <DotNetSdkNet10VersionForTesting>10.0.401</DotNetSdkNet10VersionForTesting>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -190,7 +190,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_SharedPackToolProperties Include="CreateRidSpecificToolPackages=true" />
       <_SharedPackToolProperties Include="PreBuiltCliBinaryPath=$(_ExtractedNativeBinaryPath)" />
       <_SharedPackToolProperties Include="PublishAot=true" />
       <_SharedPackToolProperties Include="BundlePayloadPath=" />
@@ -223,6 +222,7 @@
   <Target Name="_PackRidSpecificDotnetTool">
     <ItemGroup>
       <_PackToolProperties Include="@(_SharedPackToolProperties)" />
+      <_PackToolProperties Include="CreateRidSpecificToolPackages=true" />
       <_PackToolProperties Include="RuntimeIdentifier=$(CliRuntime)" />
       <_PackToolProperties Include="PublishDir=$(_CliToolPublishDir)" />
     </ItemGroup>
@@ -244,6 +244,8 @@
   <Target Name="_PackPointerDotnetTool">
     <ItemGroup>
       <_PackPointerProperties Include="@(_SharedPackToolProperties)" />
+      <!-- RID-specific packages are packed separately from their matching native archives. -->
+      <_PackPointerProperties Include="CreateRidSpecificToolPackages=false" />
       <_PackPointerProperties Include="PublishDir=$(_CliToolPointerPublishDir)" />
       <_PackPointerProperties Include="NoBuild=true" />
     </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.401",
+    "version": "11.0.100-rc.1.26425.128",
     "rollForward": "major",
     "allowPrerelease": true,
     "paths": [
@@ -10,23 +10,27 @@
     "errorMessage": "The .NET SDK could not be found. Run ./restore.sh (Linux/macOS) or ./restore.cmd (Windows) to install the local SDK."
   },
   "tools": {
-    "dotnet": "10.0.401",
+    "dotnet": "11.0.100-rc.1.26425.128",
     "runtimes": {
       "dotnet/x64": [
-        "$(DotNetRuntimePreviousVersionForTesting)",
-        "$(DotNetRuntimeCurrentVersionForTesting)"
+        "$(DotNetRuntimeNet8VersionForTesting)",
+        "$(DotNetRuntimeNet9VersionForTesting)",
+        "$(DotNetRuntimeNet10VersionForTesting)"
       ],
       "dotnet/arm64": [
-        "$(DotNetRuntimePreviousVersionForTesting)",
-        "$(DotNetRuntimeCurrentVersionForTesting)"
+        "$(DotNetRuntimeNet8VersionForTesting)",
+        "$(DotNetRuntimeNet9VersionForTesting)",
+        "$(DotNetRuntimeNet10VersionForTesting)"
       ],
       "aspnetcore/x64": [
-        "$(DotNetRuntimePreviousVersionForTesting)",
-        "$(DotNetRuntimeCurrentVersionForTesting)"
+        "$(DotNetRuntimeNet8VersionForTesting)",
+        "$(DotNetRuntimeNet9VersionForTesting)",
+        "$(DotNetRuntimeNet10VersionForTesting)"
       ],
       "aspnetcore/arm64": [
-        "$(DotNetRuntimePreviousVersionForTesting)",
-        "$(DotNetRuntimeCurrentVersionForTesting)"
+        "$(DotNetRuntimeNet8VersionForTesting)",
+        "$(DotNetRuntimeNet9VersionForTesting)",
+        "$(DotNetRuntimeNet10VersionForTesting)"
       ]
     }
   },

--- a/playground/BlazorHosted/BlazorHosted.Client/BlazorHosted.Client.csproj
+++ b/playground/BlazorHosted/BlazorHosted.Client/BlazorHosted.Client.csproj
@@ -37,14 +37,4 @@
     <ProjectReference Include="..\BlazorHosted.ClientServiceDefaults\BlazorHosted.ClientServiceDefaults.csproj" />
   </ItemGroup>
 
-  <!-- This target prototypes the WebAssembly SDK side of project discovery.
-       Returning the evaluated full path lets the referencing project consume TargetOutputs
-       without parsing the referenced project file or depending on its physical XML shape. -->
-  <Target Name="GetWebAssemblyProjectReference"
-          Returns="@(_WebAssemblyProjectReference)">
-    <ItemGroup>
-      <_WebAssemblyProjectReference Include="$(MSBuildProjectFullPath)" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/playground/BlazorHosted/BlazorHosted.Server/BlazorHosted.csproj
+++ b/playground/BlazorHosted/BlazorHosted.Server/BlazorHosted.csproj
@@ -15,17 +15,4 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />
   </ItemGroup>
 
-  <!-- These targets prototype the contract that will eventually be provided by the SDKs.
-       The server asks every evaluated ProjectReference whether it is a WebAssembly
-       project and collects the project paths returned by references that recognize the target. -->
-  <Target Name="ResolveWebAssemblyProjectReferences">
-    <MSBuild
-        Projects="@(ProjectReference)"
-        Targets="GetWebAssemblyProjectReference"
-        BuildInParallel="true"
-        SkipNonexistentTargets="true">
-      <Output TaskParameter="TargetOutputs" ItemName="WebAssemblyProjectReference" />
-    </MSBuild>
-  </Target>
-
 </Project>

--- a/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorHostedExtensions.cs
@@ -203,9 +203,7 @@ public static class BlazorHostedExtensions
             return null;
         }
 
-        // ResolveWebAssemblyProjectReferences is temporarily defined by the BlazorHosted sample
-        // because Aspire currently builds with the .NET 10 SDK. The target has moved into the
-        // .NET 11 Static Web Assets SDK, so the sample copy can be removed once Aspire adopts it:
+        // ResolveWebAssemblyProjectReferences is provided by the .NET 11 Static Web Assets SDK:
         // https://github.com/dotnet/sdk/blob/c0fb107a5474a2993546bc574fd7a6daac9fd7aa/src/StaticWebAssetsSdk/Sdk/Sdk.targets
         //
         // The target returns each evaluated WASM ProjectReference. An empty collection is valid

--- a/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/BlazorHostedExtensionsTests.cs
@@ -195,6 +195,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         using var fileSystemService = new TestFileSystemService();
         using var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("blazor-hosted");
         var (serverProjectPath, clientProjectPath) = CreateBlazorHostedProjects(tempDirectory);
+        await RestoreProjectAsync(serverProjectPath);
 
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         ConfigureBrowserDebugging(builder);
@@ -224,6 +225,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         using var fileSystemService = new TestFileSystemService();
         using var tempDirectory = fileSystemService.TempDirectory.CreateTempSubdirectory("blazor-hosted");
         var serverProjectPath = CreateBlazorHostedServerWithoutClient(tempDirectory);
+        await RestoreProjectAsync(serverProjectPath);
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         ConfigureBrowserDebugging(builder);
 
@@ -562,6 +564,20 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
             """{"protocols_supported":["2024-03-03"],"supported_launch_configurations":["browser"]}""";
     }
 
+    private static async Task RestoreProjectAsync(string projectPath)
+    {
+        var result = await BlazorDotNetCliRunner.RunAsync(
+            projectPath,
+            "restore",
+            ["--ignore-failed-sources", "-nologo"],
+            machineReadableOutput: false,
+            CancellationToken.None);
+
+        Assert.True(
+            result.Started && result.ExitCode == 0,
+            $"Failed to restore '{projectPath}'.{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}{result.StandardError}");
+    }
+
     private static (string ServerProjectPath, string ClientProjectPath) CreateBlazorHostedProjects(TempDirectory tempDirectory)
     {
         var serverDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.Path, "Server"));
@@ -571,27 +587,15 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
 
         File.WriteAllText(serverProjectPath, """
             <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
               <ItemGroup>
                 <ProjectReference Include="../Client/Client.csproj" />
               </ItemGroup>
-              <Target Name="ResolveWebAssemblyProjectReferences">
-                <MSBuild Projects="@(ProjectReference)"
-                         Targets="GetWebAssemblyProjectReference"
-                         BuildInParallel="true"
-                         SkipNonexistentTargets="true">
-                  <Output TaskParameter="TargetOutputs" ItemName="WebAssemblyProjectReference" />
-                </MSBuild>
-              </Target>
             </Project>
             """);
         File.WriteAllText(clientProjectPath, """
             <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-              <Target Name="GetWebAssemblyProjectReference"
-                      Returns="@(_WebAssemblyProjectReference)">
-                <ItemGroup>
-                  <_WebAssemblyProjectReference Include="$(MSBuildProjectFullPath)" />
-                </ItemGroup>
-              </Target>
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
             </Project>
             """);
 
@@ -603,7 +607,7 @@ public class BlazorHostedExtensionsTests(ITestOutputHelper testOutputHelper)
         var serverProjectPath = Path.Combine(tempDirectory.Path, "Server.csproj");
         File.WriteAllText(serverProjectPath, """
             <Project Sdk="Microsoft.NET.Sdk.Web">
-              <Target Name="ResolveWebAssemblyProjectReferences" />
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
             </Project>
             """);
         return serverProjectPath;

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -289,6 +289,10 @@ public class DistributedApplicationTests
             Assert.Equal("http", u.Name);
         });
 
+        await startTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.WaitForTextAsync("Application started.", notStartedResourceName, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var serviceAClient = app.CreateHttpClientWithResilience(notStartedResourceName, "http");
+
         logger.LogInformation("Stop resource.");
         await orchestrator.StopResourceAsync(notStartedResourceEvent.ResourceId, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Finished, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
@@ -296,8 +300,8 @@ public class DistributedApplicationTests
         logger.LogInformation("Start resource again");
         await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await serviceAClient.GetStringAsync("/", token);
 
-        await startTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await app.StopAsync(token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
     }
 
@@ -1264,6 +1268,8 @@ public class DistributedApplicationTests
         var executablePattern = $"{testName}-servicea-{ReplicaIdRegex}-{suffix}";
         var serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(serviceA);
+        await app.WaitForTextAsync("Application started.", testProgram.ServiceABuilder.Resource.Name, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var serviceAClient = app.CreateHttpClientWithResilience(testProgram.ServiceABuilder.Resource.Name, "http");
 
         await orchestrator.StopResourceAsync(serviceA.Metadata.Name, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
@@ -1274,6 +1280,7 @@ public class DistributedApplicationTests
 
         serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running, token).DefaultTimeout(TestConstants.LongTimeoutDuration);
         Assert.NotNull(serviceA);
+        await serviceAClient.GetStringAsync("/", token);
 
         await app.StopAsync(token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -290,8 +290,8 @@ public class DistributedApplicationTests
         });
 
         await startTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        await app.WaitForTextAsync("Application started.", notStartedResourceName, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         using var serviceAClient = app.CreateHttpClientWithResilience(notStartedResourceName, "http");
+        Assert.Equal("Hello World!", await serviceAClient.GetStringAsync("/", token));
 
         logger.LogInformation("Stop resource.");
         await orchestrator.StopResourceAsync(notStartedResourceEvent.ResourceId, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
@@ -300,7 +300,7 @@ public class DistributedApplicationTests
         logger.LogInformation("Start resource again");
         await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        await serviceAClient.GetStringAsync("/", token);
+        Assert.Equal("Hello World!", await serviceAClient.GetStringAsync("/", token));
 
         await app.StopAsync(token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
     }
@@ -1268,8 +1268,8 @@ public class DistributedApplicationTests
         var executablePattern = $"{testName}-servicea-{ReplicaIdRegex}-{suffix}";
         var serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(serviceA);
-        await app.WaitForTextAsync("Application started.", testProgram.ServiceABuilder.Resource.Name, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         using var serviceAClient = app.CreateHttpClientWithResilience(testProgram.ServiceABuilder.Resource.Name, "http");
+        Assert.Equal("Hello World!", await serviceAClient.GetStringAsync("/", token));
 
         await orchestrator.StopResourceAsync(serviceA.Metadata.Name, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
@@ -1280,7 +1280,7 @@ public class DistributedApplicationTests
 
         serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running, token).DefaultTimeout(TestConstants.LongTimeoutDuration);
         Assert.NotNull(serviceA);
-        await serviceAClient.GetStringAsync("/", token);
+        Assert.Equal("Hello World!", await serviceAClient.GetStringAsync("/", token));
 
         await app.StopAsync(token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -975,6 +976,9 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
                     && e.Snapshot.Urls.Length == resourceB.Resource.GetEndpoints().ToArray().Length + 1
                     && e.Snapshot.Urls.All(u => !u.IsInactive),
             default).DefaultTimeout();
+        await Task.WhenAll(
+            app.WaitForTextAsync("Application started.", resourceA.Resource.Name),
+            app.WaitForTextAsync("Application started.", resourceB.Resource.Name)).DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
 
@@ -1027,6 +1031,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Start resource A. Resource B never changes state itself, but its cross-resource URL should become active.
         var startResult = await app.ResourceCommands.ExecuteCommandAsync(resourceA.Resource, KnownResourceCommands.StartCommand).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
         Assert.True(startResult.Success, startResult.Message);
+        await app.WaitForTextAsync("Application started.", resourceA.Resource.Name).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         resourceEvent = await rns.WaitForResourceAsync(
             resourceB.Resource.Name,

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Eventing;
-using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Testing.Tests;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -976,9 +976,12 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
                     && e.Snapshot.Urls.Length == resourceB.Resource.GetEndpoints().ToArray().Length + 1
                     && e.Snapshot.Urls.All(u => !u.IsInactive),
             default).DefaultTimeout();
-        await Task.WhenAll(
-            app.WaitForTextAsync("Application started.", resourceA.Resource.Name),
-            app.WaitForTextAsync("Application started.", resourceB.Resource.Name)).DefaultTimeout();
+        using var resourceAClient = app.CreateHttpClientWithResilience(resourceA.Resource.Name, "api");
+        using var resourceBClient = app.CreateHttpClientWithResilience(resourceB.Resource.Name, "http");
+        var responses = await Task.WhenAll(
+            resourceAClient.GetStringAsync("/"),
+            resourceBClient.GetStringAsync("/")).DefaultTimeout();
+        Assert.All(responses, response => Assert.Equal("Hello World!", response));
 
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
 
@@ -1031,7 +1034,8 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         // Start resource A. Resource B never changes state itself, but its cross-resource URL should become active.
         var startResult = await app.ResourceCommands.ExecuteCommandAsync(resourceA.Resource, KnownResourceCommands.StartCommand).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
         Assert.True(startResult.Success, startResult.Message);
-        await app.WaitForTextAsync("Application started.", resourceA.Resource.Name).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        using var resourceAClient = app.CreateHttpClientWithResilience(resourceA.Resource.Name, "api");
+        Assert.Equal("Hello World!", await resourceAClient.GetStringAsync("/").DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout));
 
         resourceEvent = await rns.WaitForResourceAsync(
             resourceB.Resource.Name,

--- a/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- net10.0 (not DefaultTargetFramework=net8.0): references tools/SelectTests, which targets
-         net10.0 for its Microsoft.Build ProjectGraph dependency, and loads that graph at runtime. -->
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- net11.0 (not DefaultTargetFramework=net8.0): references tools/SelectTests, which runs on
+         the repo SDK's runtime and loads its Microsoft.Build ProjectGraph at runtime. -->
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/tests/Shared/Aspire.Templates.Testing.targets
+++ b/tests/Shared/Aspire.Templates.Testing.targets
@@ -13,7 +13,11 @@
     <SdkVersionForNet8TFM>$(DotNetSdkNet8VersionForTesting)</SdkVersionForNet8TFM>
     <SdkVersionForNet9TFM>$(DotNetSdkNet9VersionForTesting)</SdkVersionForNet9TFM>
     <SdkVersionForNet10TFM>$(DotNetSdkNet10VersionForTesting)</SdkVersionForNet10TFM>
-    <SdkVersionForNet11TFM>$(DotNetSdkNet11VersionForTesting)</SdkVersionForNet11TFM>
+
+    <!-- global.json uses the .NET 11 SDK. -->
+    <_GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</_GlobalJsonContent>
+    <_DotNetCliVersionFromGlobalJson>$([System.Text.RegularExpressions.Regex]::Match($(_GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</_DotNetCliVersionFromGlobalJson>
+    <SdkVersionForNet11TFM>$(_DotNetCliVersionFromGlobalJson)</SdkVersionForNet11TFM>
 
     <SdkDirForNet8TFM>$(ArtifactsBinDir)dotnet-8\</SdkDirForNet8TFM>
     <SdkStampPathForNet8TFM>$(SdkDirForNet8TFM).version-$(SdkVersionForNet8TFM).stamp</SdkStampPathForNet8TFM>

--- a/tests/Shared/Aspire.Templates.Testing.targets
+++ b/tests/Shared/Aspire.Templates.Testing.targets
@@ -12,12 +12,8 @@
   <PropertyGroup>
     <SdkVersionForNet8TFM>$(DotNetSdkNet8VersionForTesting)</SdkVersionForNet8TFM>
     <SdkVersionForNet9TFM>$(DotNetSdkNet9VersionForTesting)</SdkVersionForNet9TFM>
+    <SdkVersionForNet10TFM>$(DotNetSdkNet10VersionForTesting)</SdkVersionForNet10TFM>
     <SdkVersionForNet11TFM>$(DotNetSdkNet11VersionForTesting)</SdkVersionForNet11TFM>
-
-    <!-- global.json uses the .NET 10 SDK. -->
-    <_GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</_GlobalJsonContent>
-    <_DotNetCliVersionFromGlobalJson>$([System.Text.RegularExpressions.Regex]::Match($(_GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</_DotNetCliVersionFromGlobalJson>
-    <SdkVersionForNet10TFM>$(_DotNetCliVersionFromGlobalJson)</SdkVersionForNet10TFM>
 
     <SdkDirForNet8TFM>$(ArtifactsBinDir)dotnet-8\</SdkDirForNet8TFM>
     <SdkStampPathForNet8TFM>$(SdkDirForNet8TFM).version-$(SdkVersionForNet8TFM).stamp</SdkStampPathForNet8TFM>

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -13,7 +13,7 @@
     <!-- Disable playwright tests on helix/linux. Issue: https://github.com/microsoft/aspire/issues/4921 -->
     <DisablePlaywrightTests Condition="'$(OS)' != 'Windows_NT'">true</DisablePlaywrightTests>
 
-    <DotNetCliVersion>$(DotNetSdkPreviousVersionForTesting)</DotNetCliVersion>
+    <DotNetCliVersion>$(DotNetSdkNet8VersionForTesting)</DotNetCliVersion>
 
     <!-- dotnet-coverage tool version -->
     <_DotNetToolJsonPath>$(RepoRoot).config/dotnet-tools.json</_DotNetToolJsonPath>

--- a/tools/CreateLayout/CreateLayout.csproj
+++ b/tools/CreateLayout/CreateLayout.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/GenerateCITimeline/GenerateCITimeline.csproj
+++ b/tools/GenerateCITimeline/GenerateCITimeline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/GenerateTestSummary/GenerateTestSummary.csproj
+++ b/tools/GenerateTestSummary/GenerateTestSummary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/SelectTests/SelectTests.csproj
+++ b/tools/SelectTests/SelectTests.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- net10.0: Microsoft.Build 18.3.x (used by the Layer 1 ProjectGraph) ships only net10.0/net472
-         managed assets, and the graph is loaded from the repo-local net10.0 SDK via MSBuildLocator. -->
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Run on the repo SDK's runtime. Microsoft.Build 18.3.x supplies compatible net10.0 managed
+         assets, and the graph is loaded from the repo-local SDK via MSBuildLocator. -->
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Update the repository build SDK to .NET 11 RC1 so development and CI use the supported release-candidate toolchain instead of .NET 10. The existing .NET 11 template test assets and ASP.NET Core template asset versions are also updated from Preview 6 to the matching RC1 build.

The SDK is pinned to `11.0.100-rc.1.26425.128`, with matching runtime assets pinned to `11.0.0-rc.1.26425.128`. The repository toolset explicitly installs the .NET 8, 9, and 10 Core and ASP.NET Core runtimes for both x64 and arm64 so template tests and remaining framework-dependent test assets can run alongside the .NET 11 SDK.

Build and CI utilities that run in SDK-only jobs now target `net11.0`, including `SelectTests`, `CreateLayout`, `GenerateTestSummary`, and `GenerateCITimeline`. In particular, moving `CreateLayout` to the active SDK runtime avoids a Windows ARM64 failure where the ARM64 host attempted to load the x64 .NET 10 `hostpolicy.dll` from the repository toolset root. Microsoft.Build's `net10.0` managed assets remain compatible with the `net11.0` selector.

The template test matrix keeps explicit SDK properties for .NET 8, 9, and 10 while the active .NET 11 SDK follows `global.json`. This preserves the .NET 10 SDK test slot at `10.0.401` after `global.json` moves to .NET 11 and avoids duplicating the repository SDK version.

CLI dotnet-tool packaging now enables RID-specific package orchestration only while packing the explicit RID package. The cross-platform pointer package retains all seven RID mappings without asking the .NET 11 SDK to rebuild those RID packages concurrently into one publish directory.

The Blazor hosted playground and tests now use the `ResolveWebAssemblyProjectReferences` implementation provided by the .NET 11 Static Web Assets SDK. Synthetic test projects declare a target framework and restore before invoking the SDK target.

Validation:

- `restore.cmd` completed successfully and provisioned the .NET 8, 9, and 10 Core and ASP.NET Core runtime toolsets alongside SDK `11.0.100-rc.1.26425.128`.
- The template test SDK properties evaluate to `8.0.415`, `9.0.306`, `10.0.401`, and `11.0.100-rc.1.26425.128`.
- Arcade's `Sign.proj` completed in dry-run/test-sign mode against `Aspire.Dashboard.Sdk.win-x64`, including the five third-party assemblies reported by `SIGN004`.
- `SelectTestsWorkflowTests` passed on `net11.0` (6 tests).
- `SelectTests --help` ran successfully with runtime roll-forward disabled, confirming direct use of the .NET 11 runtime.
- `Aspire.Hosting.Blazor.Tests` passed (88 tests).
- The .NET 11 SDK's `ResolveWebAssemblyProjectReferences` target resolved the real BlazorHosted client project.
- The actual clipack target produced both `Aspire.Cli.win-x64` and the payload-free `Aspire.Cli` pointer package. The pointer settings retain all seven RID mappings.
- `dotnet build tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj --no-restore /p:SkipNativeBuild=true` succeeded.
- The Windows equivalent of the CLI bundle payload build completed successfully: `.\dotnet.cmd msbuild eng\Bundle.proj /restore /p:Configuration=Debug /p:TargetRid=win-x64 /p:BundleVersion=ci-bundlepayload /p:SkipNativeBuild=true /p:ContinuousIntegrationBuild=true`.
- The four affected hosting lifecycle/URL tests passed with HTTP readiness probes and response assertions.
- `git diff --check` passed.
- All unlocked projects compiled successfully with .NET 11 RC1. The full repository build could not complete because existing `Stress.ApiService`, `Stress.Empty`, `Stress.TelemetryService`, and `Aspire.Dashboard` processes were locking their output binaries.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No