### PR TITLE
Flatten dashboard persistence directory layout

### DIFF
--- a/docs/specs/dashboard-persistence.md
+++ b/docs/specs/dashboard-persistence.md
@@ -92,11 +92,11 @@ The standalone `aspire dashboard run` command accepts `--application-name` and `
 
 When no data directory is configured, persistent modes use the `dashboard` directory under `ASPIRE_HOME`, whose default is the current user's `.aspire` directory. The configured directory must be scoped to and protected for the current user.
 
-On Unix, the per-application directory beneath the data root is created with owner-only (`0700`) permissions. Existing application directories are also restricted to that mode before persistent data is accessed. On Windows, the directory is created without Unix permission flags and uses the inherited ACL.
+On Unix, the shared `runs` and `resumes` directories are created with owner-only (`0700`) permissions. Resume application directories are also restricted to that mode before persistent data is accessed. Existing directories are repaired to that mode. On Windows, directories are created without Unix permission flags and use inherited ACLs.
 
 ## Storage layout
 
-Persistent data is partitioned by application. The application directory name contains a readable prefix and a stable hash:
+Persistent data uses an application storage key that contains a readable prefix and a stable hash:
 
 ```text
 <sanitized-application-name>-<16-character-xxhash3>
@@ -117,15 +117,15 @@ The Dashboard creates the directory with `Directory.CreateTempSubdirectory`, rem
 
 ```text
 <data-root>/
-└── <application-directory>/
-    └── runs/
-        ├── <utc-run-id>.lock
-        └── <utc-run-id>/
-            ├── dashboard.db
-            └── run.json
+└── runs/
+    ├── <utc-run-id>.lock
+    └── <utc-run-id>/
+        ├── <application-storage-key>
+        ├── dashboard.db
+        └── run.json
 ```
 
-Run IDs use the UTC start time in `yyyyMMddTHHmmssfffZ` format. `run.json` contains:
+All applications store run directories directly beneath the shared `runs` directory. Run IDs use the UTC start time in `yyyyMMddTHHmmssfffZ` format. Each run directory contains an empty file named with the application storage key. Discovery checks for this marker before opening `run.json`, avoiding metadata reads for other applications. `run.json` contains:
 
 - schema version
 - run ID
@@ -140,9 +140,10 @@ The metadata is written only after the database schema is initialized, so an int
 
 ```text
 <data-root>/
-├── <application-directory>.lock
-└── <application-directory>/
-    └── dashboard.db
+└── resumes/
+    ├── <application-storage-key>.lock
+    └── <application-storage-key>/
+        └── dashboard.db
 ```
 
 Later Dashboard processes continue writing to the same database. This mode does not create run metadata or expose the run selector.
@@ -151,11 +152,12 @@ SQLite can also create `dashboard.db-wal` and `dashboard.db-shm` beside a writab
 
 ## Run ownership and retention
 
-Each writable run has an adjacent lock file held open with exclusive sharing and `DeleteOnClose`. An adjacent lock lets a cooperating process hold the lock while deleting the run directory on Windows. A second Dashboard cannot use the same `Run` directory or `Resume` application database while its owner holds the lock.
+Each working directory has an adjacent lock file held open with exclusive sharing and `DeleteOnClose`. For `Run` mode, an adjacent lock lets a cooperating process hold the lock while deleting the run directory on Windows. A second Dashboard cannot use the same `Run` directory or `Resume` application database while its owner holds the lock.
 
 Historical discovery only includes directories that:
 
 - are not the current run;
+- contain the marker for the current application storage key;
 - are not locked by another Dashboard process;
 - have readable, valid `run.json` metadata; and
 - have the current metadata schema version.

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -133,6 +133,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                 DirectoryHelper.CreateWithOwnerOnlyPermissions(_runsDirectory);
                 CurrentWorkingDirectory = Path.Combine(_runsDirectory, runId);
                 DatabasePath = Path.Combine(CurrentWorkingDirectory, DatabaseFileName);
+                // Assume that if the run directory can be created, then files in the run directory can be written as well.
                 Directory.CreateDirectory(CurrentWorkingDirectory);
                 var runLock = OpenRequiredRunLock(
                     CurrentWorkingDirectory,

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -78,6 +78,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     private readonly string? _runsDirectory;
     private readonly string? _metadataPath;
+    private readonly string _applicationMarkerFileName;
     private readonly string? _temporaryDirectory;
     private readonly FileLock? _runLock;
     private DashboardRunMetadata _metadata;
@@ -103,6 +104,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         _timeProvider = timeProvider;
         _deleteRunDirectory = deleteRunDirectory;
         var applicationName = string.IsNullOrWhiteSpace(options.Value.ApplicationName) ? "Aspire" : options.Value.ApplicationName;
+        _applicationMarkerFileName = GetApplicationDirectoryName(applicationName);
         var startedAt = timeProvider.GetUtcNow();
         // A millisecond timestamp collision is very unlikely. The exclusive run lock below also ensures that if two
         // Dashboard instances resolve the same run ID concurrently, the second fails instead of sharing the database.
@@ -113,35 +115,48 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         PersistenceMode = options.Value.Data.PersistenceMode;
 
         // Persistent data can contain environment variables, telemetry, and console logs. Restrict the
-        // application directory so the database, WAL, shared-memory, and metadata files aren't exposed
+        // persistence directory so the database, WAL, shared-memory, and metadata files aren't exposed
         // to other local users even when the data root was created with a permissive umask.
         switch (PersistenceMode)
         {
             case DashboardPersistenceMode.None:
+                // CreateTempSubdirectory uses owner-only permissions (0700) on Unix and inherits the
+                // current user's temporary directory ACL on Windows.
                 _temporaryDirectory = Directory.CreateTempSubdirectory(TemporaryDirectoryPrefix).FullName;
-                RunDirectory = _temporaryDirectory;
-                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
-                _runLock = OpenRunLock(RunDirectory);
+                CurrentWorkingDirectory = _temporaryDirectory;
+                DatabasePath = Path.Combine(CurrentWorkingDirectory, DatabaseFileName);
+                _runLock = OpenRunLock(CurrentWorkingDirectory);
                 DeleteAbandonedTemporaryDirectories(deleteRunDirectory);
                 break;
             case DashboardPersistenceMode.Run:
-                var applicationDirectory = GetApplicationDirectory(options.Value.Data.Directory, applicationName);
-                DirectoryHelper.CreateWithOwnerOnlyPermissions(applicationDirectory);
-                _runsDirectory = Path.Combine(applicationDirectory, "runs");
-                RunDirectory = Path.Combine(_runsDirectory, runId);
-                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
-                Directory.CreateDirectory(RunDirectory);
-                _runLock = OpenRequiredRunLock(
-                    RunDirectory,
+                _runsDirectory = GetRunsDirectory(options.Value.Data.Directory);
+                DirectoryHelper.CreateWithOwnerOnlyPermissions(_runsDirectory);
+                CurrentWorkingDirectory = Path.Combine(_runsDirectory, runId);
+                DatabasePath = Path.Combine(CurrentWorkingDirectory, DatabaseFileName);
+                Directory.CreateDirectory(CurrentWorkingDirectory);
+                var runLock = OpenRequiredRunLock(
+                    CurrentWorkingDirectory,
                     $"Dashboard run '{runId}' is already in use by another dashboard process.");
-                _metadataPath = Path.Combine(RunDirectory, "run.json");
+                try
+                {
+                    File.WriteAllText(Path.Combine(CurrentWorkingDirectory, _applicationMarkerFileName), string.Empty);
+                    _runLock = runLock;
+                }
+                catch
+                {
+                    runLock.Dispose();
+                    throw;
+                }
+                _metadataPath = Path.Combine(CurrentWorkingDirectory, "run.json");
                 break;
             case DashboardPersistenceMode.Resume:
-                RunDirectory = GetApplicationDirectory(options.Value.Data.Directory, applicationName);
-                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
-                DirectoryHelper.CreateWithOwnerOnlyPermissions(RunDirectory);
+                var resumesDirectory = GetResumesDirectory(options.Value.Data.Directory);
+                DirectoryHelper.CreateWithOwnerOnlyPermissions(resumesDirectory);
+                CurrentWorkingDirectory = Path.Combine(resumesDirectory, _applicationMarkerFileName);
+                DatabasePath = Path.Combine(CurrentWorkingDirectory, DatabaseFileName);
+                DirectoryHelper.CreateWithOwnerOnlyPermissions(CurrentWorkingDirectory);
                 var resumeRunLock = OpenRequiredRunLock(
-                    RunDirectory,
+                    CurrentWorkingDirectory,
                     $"Dashboard data for application '{applicationName}' is already in use by another dashboard process. Database path: '{DatabasePath}'.");
                 try
                 {
@@ -185,18 +200,18 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         _runs = new(LoadRuns);
 
         _logger.LogDebug(
-            "Dashboard run store initialized with persistence mode '{PersistenceMode}'. Run directory: '{RunDirectory}'. Database path: '{DatabasePath}'.",
+            "Dashboard run store initialized with persistence mode '{PersistenceMode}'. Current working directory: '{CurrentWorkingDirectory}'. Database path: '{DatabasePath}'.",
             PersistenceMode,
-            RunDirectory,
+            CurrentWorkingDirectory,
             DatabasePath);
     }
 
     private void DeleteAbandonedTemporaryDirectories(Action<string> deleteRunDirectory)
     {
-        var temporaryRoot = Directory.GetParent(RunDirectory)!.FullName;
+        var temporaryRoot = Directory.GetParent(CurrentWorkingDirectory)!.FullName;
         foreach (var directory in Directory.EnumerateDirectories(temporaryRoot, $"{TemporaryDirectoryPrefix}*"))
         {
-            if (string.Equals(directory, RunDirectory, StringComparison.OrdinalIgnoreCase) ||
+            if (string.Equals(directory, CurrentWorkingDirectory, StringComparison.OrdinalIgnoreCase) ||
                 !File.Exists(Path.Combine(directory, DatabaseFileName)))
             {
                 continue;
@@ -222,7 +237,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         }
     }
 
-    public string RunDirectory { get; }
+    public string CurrentWorkingDirectory { get; }
     public string DatabasePath { get; }
     public string RunId => _metadata.RunId;
     public DashboardPersistenceMode PersistenceMode { get; }
@@ -337,14 +352,21 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
     {
         var runs = new List<DashboardRunDescriptor>
         {
-            CreateDescriptor(_metadata, RunDirectory, isCurrent: true)
+            CreateDescriptor(_metadata, CurrentWorkingDirectory, isCurrent: true)
         };
 
         if (SupportsRunSelection && Directory.Exists(_runsDirectory))
         {
             foreach (var directory in Directory.EnumerateDirectories(_runsDirectory))
             {
-                if (string.Equals(directory, RunDirectory, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(directory, CurrentWorkingDirectory, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Each run has an empty file named with its application directory key. Checking that marker first
+                // avoids opening and deserializing run.json for every other application in the shared runs directory.
+                if (!File.Exists(Path.Combine(directory, _applicationMarkerFileName)))
                 {
                     continue;
                 }
@@ -376,7 +398,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             .ToArray();
         _logger.LogDebug(
             "Dashboard run discovery completed in directory '{RunsDirectory}'. Run count: {RunCount}. Run IDs: {RunIds}.",
-            _runsDirectory ?? RunDirectory,
+            _runsDirectory ?? CurrentWorkingDirectory,
             orderedRuns.Length,
             string.Join(", ", orderedRuns.Select(run => run.RunId)));
 
@@ -395,11 +417,11 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             {
                 Directory.Delete(_temporaryDirectory, recursive: true);
             }
-            else if (PersistenceMode == DashboardPersistenceMode.Run && Directory.Exists(RunDirectory))
+            else if (PersistenceMode == DashboardPersistenceMode.Run && Directory.Exists(CurrentWorkingDirectory))
             {
                 // Run metadata is published only after the host starts listening. If startup fails first, remove
                 // the initialized database so the attempted run never appears as empty historical data.
-                _deleteRunDirectory(RunDirectory);
+                _deleteRunDirectory(CurrentWorkingDirectory);
             }
         }
         finally
@@ -537,13 +559,17 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     internal static string GetApplicationDirectory(string? dataRoot, string applicationName)
     {
-        if (string.IsNullOrWhiteSpace(dataRoot))
-        {
-            dataRoot = Path.Combine(AspireHomeDirectory.GetDefault(), "dashboard");
-        }
-
-        return Path.Combine(Path.GetFullPath(dataRoot), GetApplicationDirectoryName(applicationName));
+        return Path.Combine(GetResumesDirectory(dataRoot), GetApplicationDirectoryName(applicationName));
     }
+
+    internal static string GetRunsDirectory(string? dataRoot) => Path.Combine(GetDataRoot(dataRoot), "runs");
+
+    internal static string GetResumesDirectory(string? dataRoot) => Path.Combine(GetDataRoot(dataRoot), "resumes");
+
+    private static string GetDataRoot(string? dataRoot) => Path.GetFullPath(
+        string.IsNullOrWhiteSpace(dataRoot)
+            ? Path.Combine(AspireHomeDirectory.GetDefault(), "dashboard")
+            : dataRoot);
 
     private static void DeleteDatabaseFiles(string databasePath)
     {

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -1069,9 +1069,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
         const string applicationName = "Failed startup";
-        var runsDirectory = Path.Combine(
-            DashboardRunStore.GetApplicationDirectory(workspace.Path, applicationName),
-            "runs");
+        var runsDirectory = DashboardRunStore.GetRunsDirectory(workspace.Path);
 
         int exitCode;
         await using (var app = new DashboardWebApplication(preConfigureBuilder: builder =>

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -27,7 +27,7 @@ namespace Aspire.Dashboard.Tests.Model;
 public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    public void RunDirectory_IsNestedUnderApplicationDirectoryAndRuns()
+    public void RunDirectory_IsNestedUnderSharedRunsDirectoryAndHasApplicationMarker()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
         var options = CreateOptions(workspace, "My Dashboard");
@@ -35,17 +35,34 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using var runStore = CreateRunStore(options);
 
         var applicationDirectoryName = DashboardRunStore.GetApplicationDirectoryName("My Dashboard");
-        var expectedRunsDirectory = Path.Combine(workspace.Path, applicationDirectoryName, "runs");
-        Assert.Equal(expectedRunsDirectory, Directory.GetParent(runStore.RunDirectory)!.FullName);
+        var expectedRunsDirectory = Path.Combine(workspace.Path, "runs");
+        Assert.Equal(expectedRunsDirectory, Directory.GetParent(runStore.CurrentWorkingDirectory)!.FullName);
+        Assert.True(File.Exists(Path.Combine(runStore.CurrentWorkingDirectory, applicationDirectoryName)));
+        Assert.False(Directory.Exists(Path.Combine(workspace.Path, applicationDirectoryName)));
     }
 
     [Fact]
-    public void ApplicationDirectory_WithoutDataDirectory_UsesDashboardDirectoryInAspireHome()
+    public void ResumeDirectory_IsNestedUnderSharedResumesDirectoryWithAdjacentLock()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, "My Dashboard", DashboardPersistenceMode.Resume);
+
+        using var runStore = CreateRunStore(options);
+
+        var applicationDirectoryName = DashboardRunStore.GetApplicationDirectoryName("My Dashboard");
+        var expectedResumesDirectory = Path.Combine(workspace.Path, "resumes");
+        Assert.Equal(Path.Combine(expectedResumesDirectory, applicationDirectoryName), runStore.CurrentWorkingDirectory);
+        Assert.True(File.Exists(Path.Combine(expectedResumesDirectory, $"{applicationDirectoryName}.lock")));
+    }
+
+    [Fact]
+    public void ResumeApplicationDirectory_WithoutDataDirectory_UsesResumesDirectoryInAspireHome()
     {
         var applicationDirectoryName = DashboardRunStore.GetApplicationDirectoryName("My Dashboard");
         var expectedDirectory = Path.Combine(
             AspireHomeDirectory.GetDefault(),
             "dashboard",
+            "resumes",
             applicationDirectoryName);
 
         Assert.Equal(expectedDirectory, DashboardRunStore.GetApplicationDirectory(dataRoot: null, "My Dashboard"));
@@ -54,7 +71,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(DashboardPersistenceMode.Run)]
     [InlineData(DashboardPersistenceMode.Resume)]
-    public void PersistentApplicationDirectory_HasOwnerOnlyPermissionsOnUnix(DashboardPersistenceMode persistenceMode)
+    public void PersistentDataDirectory_HasOwnerOnlyPermissionsOnUnix(DashboardPersistenceMode persistenceMode)
     {
         if (OperatingSystem.IsWindows())
         {
@@ -62,19 +79,31 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         }
 
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
-        var applicationDirectory = DashboardRunStore.GetApplicationDirectory(workspace.Path, "My Dashboard");
-        Directory.CreateDirectory(applicationDirectory);
-        File.SetUnixFileMode(
-            applicationDirectory,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        var persistenceDirectories = persistenceMode == DashboardPersistenceMode.Run
+            ? [DashboardRunStore.GetRunsDirectory(workspace.Path)]
+            : new[]
+            {
+                DashboardRunStore.GetResumesDirectory(workspace.Path),
+                DashboardRunStore.GetApplicationDirectory(workspace.Path, "My Dashboard")
+            };
+        foreach (var persistenceDirectory in persistenceDirectories)
+        {
+            Directory.CreateDirectory(persistenceDirectory);
+            File.SetUnixFileMode(
+                persistenceDirectory,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
 
         using var runStore = CreateRunStore(CreateOptions(workspace, "My Dashboard", persistenceMode));
 
-        Assert.Equal(
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
-            File.GetUnixFileMode(applicationDirectory));
+        foreach (var persistenceDirectory in persistenceDirectories)
+        {
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(persistenceDirectory));
+        }
     }
 
     [Fact]
@@ -86,7 +115,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using var runStore = CreateRunStore(CreateOptions(workspace), timeProvider);
 
         Assert.Equal("20260720T123456789Z", runStore.RunId);
-        Assert.Equal(runStore.RunId, Path.GetFileName(runStore.RunDirectory));
+        Assert.Equal(runStore.RunId, Path.GetFileName(runStore.CurrentWorkingDirectory));
     }
 
     [Fact]
@@ -108,7 +137,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
         var options = CreateOptions(workspace);
         using var runStore = CreateRunStore(options);
-        var metadataPath = Path.Combine(runStore.RunDirectory, "run.json");
+        var metadataPath = Path.Combine(runStore.CurrentWorkingDirectory, "run.json");
         using var lifetime = new TestHostApplicationLifetime();
 
         Assert.False(File.Exists(metadataPath));
@@ -147,7 +176,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
             currentRunStore.SetRunPinned(currentRun, isPinned: true);
 
             Assert.True(currentRun.IsPinned);
-            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(currentRunStore.RunDirectory, "run.json")));
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(currentRunStore.CurrentWorkingDirectory, "run.json")));
             Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
             pinnedRunId = currentRun.RunId;
         }
@@ -175,7 +204,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => dataSourcePool.InitializeAsync(CancellationToken.None));
 
-        Assert.False(File.Exists(Path.Combine(runStore.RunDirectory, "run.json")));
+        Assert.False(File.Exists(Path.Combine(runStore.CurrentWorkingDirectory, "run.json")));
     }
 
     [Fact]
@@ -201,14 +230,14 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
             {
                 Assert.Equal(LogLevel.Debug, initializationLog.LogLevel);
                 Assert.Equal(
-                    $"Dashboard run store initialized with persistence mode 'Run'. Run directory: '{runStore.RunDirectory}'. Database path: '{runStore.DatabasePath}'.",
+                    $"Dashboard run store initialized with persistence mode 'Run'. Current working directory: '{runStore.CurrentWorkingDirectory}'. Database path: '{runStore.DatabasePath}'.",
                     initializationLog.Message);
             },
             discoveryLog =>
             {
                 Assert.Equal(LogLevel.Debug, discoveryLog.LogLevel);
                 Assert.Equal(
-                    $"Dashboard run discovery completed in directory '{Directory.GetParent(runStore.RunDirectory)!.FullName}'. Run count: 1. Run IDs: {runStore.RunId}.",
+                    $"Dashboard run discovery completed in directory '{Directory.GetParent(runStore.CurrentWorkingDirectory)!.FullName}'. Run count: 1. Run IDs: {runStore.RunId}.",
                     discoveryLog.Message);
             });
     }
@@ -223,7 +252,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 
         using (var runStore = CreateRunStore(options))
         {
-            runDirectory = runStore.RunDirectory;
+            runDirectory = runStore.CurrentWorkingDirectory;
             databasePath = runStore.DatabasePath;
             using var database = new DashboardSqliteDatabase(databasePath, pooling: false);
             await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
@@ -267,7 +296,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
                 // Starting the pool creates its current lease after the run store, so DI disposes the pool first.
                 // Schema initialization leaves a physical connection in the SQLite provider pool to be cleared.
                 await serviceProvider.GetRequiredService<DashboardDataSourcePool>().InitializeAsync(CancellationToken.None);
-                runDirectory = runStore.RunDirectory;
+                runDirectory = runStore.CurrentWorkingDirectory;
             }
 
             // None mode owns its temporary directory, and an unpublished Run directory represents a failed startup.
@@ -322,8 +351,8 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 
         using var secondRunStore = CreateRunStore(options);
 
-        Assert.True(Directory.Exists(activeRunStore.RunDirectory));
-        Assert.True(Directory.Exists(secondRunStore.RunDirectory));
+        Assert.True(Directory.Exists(activeRunStore.CurrentWorkingDirectory));
+        Assert.True(Directory.Exists(secondRunStore.CurrentWorkingDirectory));
     }
 
     [Fact]
@@ -535,6 +564,33 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task GetRuns_ReturnsOnlyRunsWithMatchingApplicationMarker()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var startedAt = new DateTimeOffset(2026, 7, 20, 12, 34, 56, TimeSpan.Zero);
+
+        using (var otherApplicationRunStore = CreateRunStore(
+            CreateOptions(workspace, "OtherApp"),
+            new FixedTimeProvider(startedAt)))
+        {
+            await InitializeAndPublishRunAsync(otherApplicationRunStore);
+        }
+
+        var options = CreateOptions(workspace, "TestApp");
+        using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMilliseconds(1))))
+        {
+            await InitializeAndPublishRunAsync(historicalRunStore);
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMilliseconds(2)));
+
+        Assert.Collection(
+            currentRunStore.GetRuns(),
+            currentRun => Assert.True(currentRun.IsCurrent),
+            historicalRun => Assert.Equal("TestApp", historicalRun.ApplicationName));
+    }
+
+    [Fact]
     public void GetRuns_ReusesLazySnapshot()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
@@ -605,18 +661,18 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns))
         {
             using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
-            historicalRunDirectories.Add(historicalRunStore.RunDirectory);
+            historicalRunDirectories.Add(historicalRunStore.CurrentWorkingDirectory);
             await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
         }
 
         using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
         await InitializeAndPublishRunAsync(currentRunStore);
 
-        var runsDirectory = Path.GetDirectoryName(currentRunStore.RunDirectory)!;
+        var runsDirectory = Path.GetDirectoryName(currentRunStore.CurrentWorkingDirectory)!;
         Assert.Equal(DashboardRunStore.MaxRuns, Directory.GetDirectories(runsDirectory).Length);
         Assert.False(Directory.Exists(historicalRunDirectories[^1]));
         Assert.All(historicalRunDirectories[..^1], directory => Assert.True(Directory.Exists(directory)));
-        Assert.True(Directory.Exists(currentRunStore.RunDirectory));
+        Assert.True(Directory.Exists(currentRunStore.CurrentWorkingDirectory));
     }
 
     [Fact]
@@ -733,8 +789,8 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
         await InitializeAndPublishRunAsync(currentRunStore);
 
-        var runsDirectory = Path.GetDirectoryName(currentRunStore.RunDirectory)!;
-        Assert.True(Directory.Exists(activeRunStore.RunDirectory));
+        var runsDirectory = Path.GetDirectoryName(currentRunStore.CurrentWorkingDirectory)!;
+        Assert.True(Directory.Exists(activeRunStore.CurrentWorkingDirectory));
         Assert.Equal(DashboardRunStore.MaxRuns + 1, Directory.GetDirectories(runsDirectory).Length);
     }
 
@@ -750,7 +806,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt)))
         {
             historicalRunId = historicalRunStore.RunId;
-            historicalRunDirectory = historicalRunStore.RunDirectory;
+            historicalRunDirectory = historicalRunStore.CurrentWorkingDirectory;
             using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
             historicalRunStore.PublishRun();
         }
@@ -879,7 +935,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns))
         {
             using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
-            historicalRunDirectories.Add(historicalRunStore.RunDirectory);
+            historicalRunDirectories.Add(historicalRunStore.CurrentWorkingDirectory);
             await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
         }
 
@@ -901,7 +957,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         Assert.Contains(expiredRunDirectory, warning.Message, StringComparison.Ordinal);
         Assert.IsType<IOException>(warning.Exception);
         Assert.True(Directory.Exists(expiredRunDirectory));
-        Assert.True(Directory.Exists(currentRunStore.RunDirectory));
+        Assert.True(Directory.Exists(currentRunStore.CurrentWorkingDirectory));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Dashboard persistence currently nests historical runs under an application-specific directory. This makes the storage hierarchy harder to inspect and prevents all run snapshots from sharing one predictable location.

This change:

- Stores all run snapshots directly under the shared `runs` directory.
- Adds an empty marker file named with the application's stable storage key to each run directory, allowing discovery to reject unrelated applications before reading and deserializing `run.json`.
- Stores resume-mode databases and their adjacent lock files under a shared `resumes` directory.
- Renames the cross-mode working directory property to `CurrentWorkingDirectory`.
- Preserves application-scoped retention, pinning, locking, and historical run selection.

### User-facing usage

No configuration changes are required. With a configured dashboard data directory, persisted data now has this shape:

```text
<data-root>/
├── runs/
│   ├── <run-id>/
│   │   ├── <application-key>
│   │   ├── dashboard.db
│   │   └── run.json
│   └── <run-id>.lock
└── resumes/
    ├── <application-key>/
    │   └── dashboard.db
    └── <application-key>.lock
```

### Security considerations

Persisted dashboard data can contain telemetry, environment variables, and console logs. The shared `runs` and `resumes` directories and resume application directories are restricted to owner-only permissions (`0700`) on Unix. Windows uses inherited ACLs. Temporary mode uses `Directory.CreateTempSubdirectory`, which creates an owner-only directory on Unix and inherits the current user's temporary-directory ACL on Windows.

Validation:

```text
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-class "*.DashboardDataSourceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 44
```

The focused failed-startup cleanup test also passed with the shared runs directory.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
