### PR TITLE
Handle SQLite errors during dashboard read cancellation

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using SQLitePCL;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
@@ -153,9 +152,9 @@ public sealed partial class SqliteTelemetryRepository : ITelemetryRepository, IT
     /// Runs a cancellable database read on the thread pool.
     /// </summary>
     /// <remarks>
-    /// The read registers <c>sqlite3_interrupt</c> for <paramref name="cancellationToken"/>, which surfaces as
-    /// a <see cref="SqliteException"/> with <c>SQLITE_INTERRUPT</c> rather than an <see cref="OperationCanceledException"/>.
-    /// Translate it here so callers see normal cancellation semantics.
+    /// The read registers <c>sqlite3_interrupt</c> for <paramref name="cancellationToken"/>, which usually surfaces as
+    /// a <see cref="SqliteException"/> with <c>SQLITE_INTERRUPT</c>. Cancellation during statement preparation can
+    /// surface as a different SQLite error, so translate any SQLite failure after cancellation was requested.
     /// </remarks>
     internal static Task<T> RunReadAsync<T>(Func<CancellationToken, T> read, CancellationToken cancellationToken) =>
         Task.Run(() =>
@@ -164,7 +163,7 @@ public sealed partial class SqliteTelemetryRepository : ITelemetryRepository, IT
             {
                 return read(cancellationToken);
             }
-            catch (SqliteException ex) when (ex.SqliteErrorCode == raw.SQLITE_INTERRUPT)
+            catch (SqliteException)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 throw;

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/SqliteTelemetryPersistenceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/SqliteTelemetryPersistenceTests.cs
@@ -66,6 +66,25 @@ public sealed class SqliteTelemetryPersistenceTests(ITestOutputHelper testOutput
     }
 
     [Fact]
+    public async Task RunReadAsync_CancellationTranslatesOtherSqliteErrors()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+
+        var queryTask = SqliteTelemetryRepository.RunReadAsync<object?>(_ =>
+        {
+            cancellationSource.Cancel();
+
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "INVALID SQL";
+            return command.ExecuteScalar();
+        }, cancellationSource.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queryTask).DefaultTimeout();
+    }
+
+    [Fact]
     public async Task Cache_UsesCanonicalResourceViewAndScopeAcrossSignals()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);


### PR DESCRIPTION
## Description

Fixes an intermittent dashboard metrics failure where canceling a SQLite read during statement preparation could surface an unrelated SQLite error instead of normal cancellation.

SQLite usually reports `SQLITE_INTERRUPT` after `sqlite3_interrupt`, but cancellation during statement preparation can produce another SQLite error, such as `expected 0 columns for '' but got 18`. Treat any SQLite failure as cancellation when the caller's token is already canceled. SQLite failures continue to propagate normally when cancellation has not been requested.

Adds deterministic regression coverage for a non-`SQLITE_INTERRUPT` error racing with cancellation.

Validation:

- `SqliteTelemetryPersistenceTests`: 19/19 passed
- `ChangeResource_MeterAndInstrumentNotOnNewResources_InstrumentCleared`: passed after rebuild and in 25/25 repeated runs

Fixes #19742

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No