### PR TITLE
Use cloud icon for Azure environment

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
@@ -40,6 +40,7 @@ public static class AzureEnvironmentResourceExtensions
         if (builder.ExecutionContext.IsRunMode)
         {
             var resourceBuilder = builder.AddResource(resource)
+                .WithIconName("CloudCube")
                 .OnInitializeResource(ProvisionAzureResourcesAsync)
                 .WithInitialState(new CustomResourceSnapshot
                 {
@@ -79,6 +80,7 @@ public static class AzureEnvironmentResourceExtensions
         // needs to show up in the app model during run mode so that we can discover
         // the pipeline step annotations on it but it needs to be hidden from the end-user.
         return builder.AddResource(resource)
+            .WithIconName("CloudCube")
             .ExcludeFromManifest()
             .WithInitialState(new()
             {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -4890,13 +4890,10 @@ public class AzureEnvironmentResourceExtensionsTests
     [Fact]
     public void AddAzureEnvironment_UsesCloudCubeIcon()
     {
-        // Arrange
         var builder = CreateBuilder(isRunMode: true);
 
-        // Act
         var resourceBuilder = builder.AddAzureEnvironment();
 
-        // Assert
         var icon = Assert.Single(resourceBuilder.Resource.Annotations.OfType<ResourceIconAnnotation>());
         Assert.Equal("CloudCube", icon.IconName);
         Assert.Equal(IconVariant.Filled, icon.IconVariant);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -4888,6 +4888,21 @@ public class AzureEnvironmentResourceExtensionsTests
     }
 
     [Fact]
+    public void AddAzureEnvironment_UsesCloudCubeIcon()
+    {
+        // Arrange
+        var builder = CreateBuilder(isRunMode: true);
+
+        // Act
+        var resourceBuilder = builder.AddAzureEnvironment();
+
+        // Assert
+        var icon = Assert.Single(resourceBuilder.Resource.Annotations.OfType<ResourceIconAnnotation>());
+        Assert.Equal("CloudCube", icon.IconName);
+        Assert.Equal(IconVariant.Filled, icon.IconVariant);
+    }
+
+    [Fact]
     public void AzureEnvironmentResource_PreservesDefaultResourceNameValidation()
     {
         var builder = CreateBuilder(isRunMode: true);


### PR DESCRIPTION
## Description

The new `azure-environment` control resource currently uses the dashboard's generic cog fallback, which makes it difficult to distinguish from other unknown resource types. This change assigns the Fluent UI `CloudCube` icon to better represent an Azure environment that contains and manages cloud resources.

### User-facing usage

The Resources page now displays a filled cloud-and-cube icon next to the `azure-environment` resource instead of the generic cog.

The Azure environment builder test verifies that the resource publishes the expected icon annotation.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
