### PR TITLE
Pass execution context to Bicep parameter value providers

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.Provisioning;
@@ -37,8 +36,10 @@ internal static class BicepUtilities
     /// <summary>
     /// Converts the parameters to a JSON object compatible with the ARM template.
     /// </summary>
-    public static async Task SetParametersAsync(JsonObject parameters, AzureBicepResource resource, bool skipKnownValues = false, CancellationToken cancellationToken = default)
+    public static async Task SetParametersAsync(JsonObject parameters, AzureBicepResource resource, DistributedApplicationExecutionContext executionContext, bool skipKnownValues = false, CancellationToken cancellationToken = default)
     {
+        var valueProviderContext = new ValueProviderContext { ExecutionContext = executionContext, Caller = resource };
+
         // Convert the parameters to a JSON object
         foreach (var parameter in resource.Parameters)
         {
@@ -62,7 +63,7 @@ internal static class BicepUtilities
                     bool b => b,
                     Guid g => g.ToString(),
                     JsonNode node => node,
-                    IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
+                    IValueProvider v => await v.GetValueAsync(valueProviderContext, cancellationToken).ConfigureAwait(false),
                     null => null,
                     _ => throw new NotSupportedException($"The parameter value type {parameterValue.GetType()} is not supported.")
                 }
@@ -119,54 +120,9 @@ internal static class BicepUtilities
     }
 
     /// <summary>
-    /// Gets the current checksum for a Bicep resource from configuration.
-    /// </summary>
-    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, IConfiguration section, CancellationToken cancellationToken = default)
-    {
-        // Fill in parameters from configuration
-        if (section[DeploymentStateParametersKey] is not string jsonString)
-        {
-            return null;
-        }
-
-        try
-        {
-            var parameters = JsonNode.Parse(jsonString)?.AsObject();
-            var scope = section[DeploymentStateScopeKey] is string scopeString
-                ? JsonNode.Parse(scopeString)?.AsObject()
-                : GetExistingResourceScope(resource) is not null
-                    ? new JsonObject()
-                    : null;
-
-            if (parameters is null)
-            {
-                return null;
-            }
-
-            // Force evaluation of the Bicep template to ensure parameters are expanded
-            _ = resource.GetBicepTemplateString();
-
-            // Now overwrite with live object values skipping known values.
-            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (scope is not null)
-            {
-                await SetScopeAsync(scope, resource, cancellationToken).ConfigureAwait(false);
-            }
-
-            // Get the checksum of the new values
-            return GetChecksum(resource, parameters, scope);
-        }
-        catch
-        {
-            // Unable to parse the JSON, to treat it as not existing
-            return null;
-        }
-    }
-
-    /// <summary>
     /// Gets the current checksum for a Bicep resource from deployment state.
     /// </summary>
-    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, DeploymentStateSection section, ILogger logger, CancellationToken cancellationToken = default)
+    public static async ValueTask<string?> GetCurrentChecksumAsync(AzureBicepResource resource, DeploymentStateSection section, DistributedApplicationExecutionContext executionContext, ILogger logger, CancellationToken cancellationToken = default)
     {
         if (section.Data[DeploymentStateParametersKey]?.GetValue<string>() is not { Length: > 0 } jsonString)
         {
@@ -189,7 +145,7 @@ internal static class BicepUtilities
 
             _ = resource.GetBicepTemplateString();
 
-            await SetParametersAsync(parameters, resource, skipKnownValues: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await SetParametersAsync(parameters, resource, executionContext, skipKnownValues: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (scope is not null)
             {
                 await SetScopeAsync(scope, resource, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -64,7 +64,7 @@ internal sealed class BicepProvisioner(
             return false;
         }
 
-        var currentCheckSum = await BicepUtilities.GetCurrentChecksumAsync(resource, stateSection, logger, cancellationToken).ConfigureAwait(false);
+        var currentCheckSum = await BicepUtilities.GetCurrentChecksumAsync(resource, stateSection, executionContext, logger, cancellationToken).ConfigureAwait(false);
         var configCheckSum = stateSection.Data[BicepUtilities.DeploymentStateChecksumKey]?.GetValue<string>();
 
         if (string.IsNullOrEmpty(configCheckSum))
@@ -566,7 +566,7 @@ internal sealed class BicepProvisioner(
         logger.LogDebug("Setting parameters and scope for resource {ResourceName}", resource.Name);
         // Convert the parameters to a JSON object
         var parameters = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters, resource, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await BicepUtilities.SetParametersAsync(parameters, resource, executionContext, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var scope = new JsonObject();
         await BicepUtilities.SetScopeAsync(scope, resource, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -1840,7 +1840,7 @@ public class AzureBicepProvisionerTests
     private static async Task SeedRunningDeploymentStateAsync(IDeploymentStateManager deploymentStateManager, AzureBicepResource resource, string deploymentId)
     {
         var parameters = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters, resource);
+        await BicepUtilities.SetParametersAsync(parameters, resource, new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         var scope = new JsonObject();
         await BicepUtilities.SetScopeAsync(scope, resource);

--- a/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPIPELINES002 // Type is for evaluation purposes only
+
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Provisioning;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -20,7 +23,7 @@ public class BicepUtilitiesTests
                .WithParameter("name", "david");
 
         var parameters = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters, bicep0.Resource, builder.ExecutionContext);
 
         Assert.Single(parameters);
         Assert.Equal("david", parameters["name"]?["value"]?.ToString());
@@ -56,7 +59,7 @@ public class BicepUtilitiesTests
                .WithParameter("endpoint", container.GetEndpoint("http"));
 
         var parameters = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters, bicep0.Resource, builder.ExecutionContext);
 
         Assert.Equal(8, parameters.Count);
         Assert.Equal("john", parameters["name"]?["value"]?.ToString());
@@ -89,6 +92,38 @@ public class BicepUtilitiesTests
             });
     }
 
+    [Theory]
+    [InlineData(DistributedApplicationOperation.Run)]
+    [InlineData(DistributedApplicationOperation.Publish)]
+    public async Task SetParametersAsync_PassesExecutionContextToValueProviders(DistributedApplicationOperation operation)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(operation);
+        var bicep = builder.AddBicepTemplateString("test", "param value string").Resource;
+        using var cts = new CancellationTokenSource();
+        var callCount = 0;
+        var valueProvider = new TestContextValueProvider((context, cancellationToken) =>
+        {
+            Assert.Same(builder.ExecutionContext, context.ExecutionContext);
+            Assert.Same(bicep, context.Caller);
+            Assert.Equal(cts.Token, cancellationToken);
+            callCount++;
+            return new("context-value");
+        });
+
+        bicep.Parameters["value"] = valueProvider;
+        bicep.Parameters["deferred"] = () => valueProvider;
+        bicep.Parameters["expression"] = ReferenceExpression.Create($"{valueProvider}/suffix");
+
+        var parameters = new JsonObject();
+        await BicepUtilities.SetParametersAsync(parameters, bicep, builder.ExecutionContext, cancellationToken: cts.Token);
+
+        Assert.Equal(3, callCount);
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("context-value", parameters["value"]?["value"]?.GetValue<string>());
+        Assert.Equal("context-value", parameters["deferred"]?["value"]?.GetValue<string>());
+        Assert.Equal("context-value/suffix", parameters["expression"]?["value"]?.GetValue<string>());
+    }
+
     [Fact]
     public async Task ResourceWithTheSameBicepTemplateAndParametersHaveTheSameCheckSum()
     {
@@ -107,11 +142,11 @@ public class BicepUtilitiesTests
                        .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
 
         var parameters0 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource, builder.ExecutionContext);
         var checkSum0 = BicepUtilities.GetChecksum(bicep0.Resource, parameters0, null);
 
         var parameters1 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource);
+        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource, builder.ExecutionContext);
         var checkSum1 = BicepUtilities.GetChecksum(bicep1.Resource, parameters1, null);
 
         Assert.Equal(checkSum0, checkSum1);
@@ -134,11 +169,11 @@ public class BicepUtilitiesTests
                        .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
 
         var parameters0 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource, builder.ExecutionContext);
         var checkSum0 = BicepUtilities.GetChecksum(bicep0.Resource, parameters0, null);
 
         var parameters1 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource);
+        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource, builder.ExecutionContext);
         var checkSum1 = BicepUtilities.GetChecksum(bicep1.Resource, parameters1, null);
 
         Assert.NotEqual(checkSum0, checkSum1);
@@ -159,13 +194,13 @@ public class BicepUtilitiesTests
 
         var parameters0 = new JsonObject();
         var scope0 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource, builder.ExecutionContext);
         await BicepUtilities.SetScopeAsync(scope0, bicep0.Resource);
         var checkSum0 = BicepUtilities.GetChecksum(bicep0.Resource, parameters0, scope0);
 
         var parameters1 = new JsonObject();
         var scope1 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource);
+        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource, builder.ExecutionContext);
         await BicepUtilities.SetScopeAsync(scope1, bicep1.Resource);
         var checkSum1 = BicepUtilities.GetChecksum(bicep1.Resource, parameters1, scope1);
 
@@ -187,13 +222,13 @@ public class BicepUtilitiesTests
 
         var parameters0 = new JsonObject();
         var scope0 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource);
+        await BicepUtilities.SetParametersAsync(parameters0, bicep0.Resource, builder.ExecutionContext);
         await BicepUtilities.SetScopeAsync(scope0, bicep0.Resource);
         var checkSum0 = BicepUtilities.GetChecksum(bicep0.Resource, parameters0, scope0);
 
         var parameters1 = new JsonObject();
         var scope1 = new JsonObject();
-        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource);
+        await BicepUtilities.SetParametersAsync(parameters1, bicep1.Resource, builder.ExecutionContext);
         await BicepUtilities.SetScopeAsync(scope1, bicep1.Resource);
         var checkSum1 = BicepUtilities.GetChecksum(bicep1.Resource, parameters1, scope1);
 
@@ -319,7 +354,7 @@ public class BicepUtilitiesTests
         var parameters = new JsonObject();
 
         // Act
-        await BicepUtilities.SetParametersAsync(parameters, bicep);
+        await BicepUtilities.SetParametersAsync(parameters, bicep, builder.ExecutionContext);
 
         // Assert
         Assert.Equal(3, parameters.Count);
@@ -427,9 +462,9 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        var config = new ConfigurationBuilder().Build();
+        var stateSection = new DeploymentStateSection("test", [], 0);
 
-        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, stateSection, builder.ExecutionContext, NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -440,14 +475,12 @@ public class BicepUtilitiesTests
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
 
-        var configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        var stateSection = new DeploymentStateSection("test", new JsonObject
         {
-            ["Parameters"] = "invalid-json"
-        });
-        var config = configurationBuilder.Build();
+            [BicepUtilities.DeploymentStateParametersKey] = "invalid-json"
+        }, 0);
 
-        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, stateSection, builder.ExecutionContext, NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -464,14 +497,12 @@ public class BicepUtilitiesTests
             ["param1"] = new JsonObject { ["value"] = "value1" }
         };
 
-        var configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        var stateSection = new DeploymentStateSection("test", new JsonObject
         {
-            ["Parameters"] = parameters.ToJsonString()
-        });
-        var config = configurationBuilder.Build();
+            [BicepUtilities.DeploymentStateParametersKey] = parameters.ToJsonString()
+        }, 0);
 
-        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, stateSection, builder.ExecutionContext, NullLogger.Instance);
 
         Assert.NotNull(result);
         Assert.NotEmpty(result);
@@ -486,23 +517,21 @@ public class BicepUtilitiesTests
             .Resource;
 
         var legacyParameters = new JsonObject();
-        await BicepUtilities.SetParametersAsync(legacyParameters, bicep);
+        await BicepUtilities.SetParametersAsync(legacyParameters, bicep, builder.ExecutionContext);
         var legacyChecksum = BicepUtilities.GetChecksum(bicep, legacyParameters, scope: null);
 
         bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
-        var configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        var stateSection = new DeploymentStateSection("test", new JsonObject
         {
-            ["Parameters"] = legacyParameters.ToJsonString()
-        });
-        var config = configurationBuilder.Build();
+            [BicepUtilities.DeploymentStateParametersKey] = legacyParameters.ToJsonString()
+        }, 0);
 
-        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, stateSection, builder.ExecutionContext, NullLogger.Instance);
 
         var currentParameters = new JsonObject();
         var currentScope = new JsonObject();
-        await BicepUtilities.SetParametersAsync(currentParameters, bicep, skipKnownValues: true);
+        await BicepUtilities.SetParametersAsync(currentParameters, bicep, builder.ExecutionContext, skipKnownValues: true);
         await BicepUtilities.SetScopeAsync(currentScope, bicep);
         var expected = BicepUtilities.GetChecksum(bicep, currentParameters, currentScope);
 
@@ -530,20 +559,18 @@ public class BicepUtilitiesTests
             [AzureBicepResource.KnownParameters.PrincipalId] = new JsonObject { ["value"] = "1234" },
         };
 
-        var configurationBuilder = new ConfigurationBuilder();
-        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        var stateSection = new DeploymentStateSection("test", new JsonObject
         {
-            ["Parameters"] = parameters.ToJsonString()
-        });
-        var config = configurationBuilder.Build();
+            [BicepUtilities.DeploymentStateParametersKey] = parameters.ToJsonString()
+        }, 0);
 
         // Act
-        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, stateSection, builder.ExecutionContext, NullLogger.Instance);
 
         // Assert
         Assert.NotNull(result);
 
-        // verify the checksum is the same as using the config parameters directly
+        // Verify the checksum is the same as using the saved parameters directly.
         var expected = BicepUtilities.GetChecksum(bicep, parameters, scope: null);
         Assert.Equal(expected, result);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/TestContextValueProvider.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/TestContextValueProvider.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+internal sealed class TestContextValueProvider(Func<ValueProviderContext, CancellationToken, ValueTask<string?>> callback) : IValueProvider, IManifestExpressionProvider
+{
+    public string ValueExpression => "{test.value}";
+
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException("A value provider context is required.");
+
+    public ValueTask<string?> GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken = default) =>
+        callback(context, cancellationToken);
+}


### PR DESCRIPTION
## Description

Bicep parameter values were resolved without the distributed application execution context or requesting resource. Context-aware value providers now receive that information during provisioning and cached-deployment checksum calculation, so they can resolve values consistently with the application's run or publish mode.

- Call the `IValueProvider.GetValueAsync(ValueProviderContext, CancellationToken)` overload with the execution context and Bicep resource as the caller.
- Pass the execution context through the provisioner and deployment-state checksum path.
- Remove the unused `IConfiguration` checksum overload and migrate its tests to `DeploymentStateSection`.
- Cover context, caller, and cancellation-token forwarding for direct providers, deferred providers, and reference expressions in both run and publish modes.

Validation: all 88 tests in `BicepUtilitiesTests` and `AzureBicepProvisionerTests` passed, excluding quarantined and outerloop tests.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No