### PR TITLE
Stabilize Deno debugger breakpoint setup

### DIFF
--- a/extension/src/debugger/languages/deno.ts
+++ b/extension/src/debugger/languages/deno.ts
@@ -7,14 +7,14 @@ import { extensionLogOutputChannel } from "../../utils/logging";
 import { ResourceDebuggerExtension } from "../debuggerExtensions";
 import { getJavaScriptRuntimeDisplayName, getJavaScriptRuntimeTargetPath, jsRuntimeBaseFileTypes, launchMethodDirect, launchMethodPackageManager, resolveJavaScriptLaunchMethod } from "./javascriptRuntime";
 
-// Deno exposes a V8 inspector; --inspect-wait blocks execution until a debugger attaches (unlike
-// --inspect-brk it guarantees no early code — including module top-level — runs before attach, which
-// is what makes IDE attach reliable).
+// Deno exposes a V8 inspector. Use --inspect-brk for IDE launches so the runtime remains paused at
+// the first line while js-debug configures user breakpoints. js-debug's simple-port launch path sets
+// continueOnAttach, so it resumes automatically after configuration without surfacing the entry pause.
 const denoInspectorHost = '127.0.0.1';
 const reservedDenoInspectorPorts = new Set<number>();
 
-// Deno sub-commands that accept runtime flags (so --inspect-wait must be inserted AFTER this token,
-// not before it — `deno --inspect-wait run` is invalid).
+// Deno sub-commands that accept runtime flags (so --inspect-brk must be inserted AFTER this token,
+// not before it — `deno --inspect-brk run` is invalid).
 const denoSubcommandsAcceptingRuntimeFlags = new Set(['run', 'serve', 'test', 'bench']);
 const denoFlagsWithSeparateValue = new Set(['--cert', '--config', '--env-file', '--import-map', '--lock', '--location', '--v8-flags']);
 
@@ -174,7 +174,7 @@ function registerDenoInspectorPortRelease(port: number, launchOptions: LaunchOpt
 }
 
 /**
- * Injects `--inspect-wait` into a Deno argument vector so VS Code's built-in js-debug (pwa-node) can
+ * Injects `--inspect-brk` into a Deno argument vector so VS Code's built-in js-debug (pwa-node) can
  * attach. The flag is placed immediately after a leading sub-command that accepts runtime flags
  * (run/serve/test/bench) so it is parsed as a runtime flag rather than a script argument. `deno task`
  * does not accept inspector flags, so debug task launches fail fast instead of starting a
@@ -182,7 +182,7 @@ function registerDenoInspectorPortRelease(port: number, launchOptions: LaunchOpt
  * with a concrete nonzero port is preserved; a bare flag or port 0 is rewritten with an allocated
  * port so js-debug has a usable attach target.
  */
-async function withDenoInspectWait(args: string[], config: JavaScriptRuntimeLaunchConfiguration, launchOptions: LaunchOptions): Promise<{ runtimeArgs: string[]; port?: number }> {
+async function withDenoInspector(args: string[], config: JavaScriptRuntimeLaunchConfiguration, launchOptions: LaunchOptions): Promise<{ runtimeArgs: string[]; port?: number }> {
     if (!launchOptions.debug) {
         return { runtimeArgs: [...args] };
     }
@@ -209,7 +209,7 @@ async function withDenoInspectWait(args: string[], config: JavaScriptRuntimeLaun
     registerDenoInspectorPortRelease(port, launchOptions);
     const runtimeArgs = [...args];
     const insertAt = runtimeArgs.length > 0 && denoSubcommandsAcceptingRuntimeFlags.has(runtimeArgs[0]) ? 1 : 0;
-    runtimeArgs.splice(insertAt, 0, `--inspect-wait=${denoInspectorHost}:${port}`);
+    runtimeArgs.splice(insertAt, 0, `--inspect-brk=${denoInspectorHost}:${port}`);
     return { runtimeArgs, port };
 }
 
@@ -247,12 +247,12 @@ export const denoDebuggerExtension: ResourceDebuggerExtension = {
             throw new Error(denoTaskDebuggingUnsupported);
         }
 
-        const { runtimeArgs, port } = await withDenoInspectWait(args ?? [], config, launchOptions);
+        const { runtimeArgs, port } = await withDenoInspector(args ?? [], config, launchOptions);
         debugConfiguration.runtimeArgs = runtimeArgs;
 
         if (port !== undefined) {
             // attachSimplePort tells js-debug to spawn the runtime and then attach to this inspector port
-            // rather than expecting a Node bootstrap. Paired with --inspect-wait this is the reliable
+            // rather than expecting a Node bootstrap. Paired with --inspect-brk this is the reliable
             // Deno attach path.
             debugConfiguration.attachSimplePort = port;
         }

--- a/extension/src/test/denoDebugger.test.ts
+++ b/extension/src/test/denoDebugger.test.ts
@@ -42,9 +42,9 @@ suite('Deno Debugger Tests', () => {
         await denoDebuggerExtension.createDebugSessionConfigurationCallback!(launchConfig, args, [], { debug, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
     }
 
-    function assertInjectedInspectWaitArg(arg: string | undefined, debugConfig: AspireResourceExtendedDebugConfiguration): number {
+    function assertInspectorArg(arg: string | undefined, flagName: '--inspect-brk' | '--inspect-wait', debugConfig: AspireResourceExtendedDebugConfiguration): number {
         assert.ok(arg);
-        const match = /^--inspect-wait=127\.0\.0\.1:(\d+)$/.exec(arg);
+        const match = new RegExp(`^${flagName}=127\\.0\\.0\\.1:(\\d+)$`).exec(arg);
         assert.ok(match);
 
         const port = Number(match[1]);
@@ -68,7 +68,7 @@ suite('Deno Debugger Tests', () => {
         assert.ok(fileTypes.includes('.jsx'));
     });
 
-    test('injects --inspect-wait after the run sub-command and drives js-debug via runtimeArgs', async () => {
+    test('injects --inspect-brk after the run sub-command and drives js-debug via runtimeArgs', async () => {
         const launchConfig: DenoLaunchConfiguration = {
             type: 'deno',
             runtime_executable: 'deno',
@@ -84,9 +84,9 @@ suite('Deno Debugger Tests', () => {
         assert.strictEqual(debugConfig.outputCapture, 'std');
         assert.strictEqual(debugConfig.cwd, '/workspace/app');
         assert.strictEqual(debugConfig.runtimeExecutable, 'deno');
-        // --inspect-wait must be inserted AFTER "run" (it is a runtime flag, not a script arg).
+        // --inspect-brk must be inserted AFTER "run" (it is a runtime flag, not a script arg).
         assert.strictEqual(debugConfig.runtimeArgs?.[0], 'run');
-        assertInjectedInspectWaitArg(debugConfig.runtimeArgs?.[1], debugConfig);
+        assertInspectorArg(debugConfig.runtimeArgs?.[1], '--inspect-brk', debugConfig);
         assert.deepStrictEqual(debugConfig.runtimeArgs?.slice(2), ['-A', 'main.ts']);
         assert.strictEqual(registeredCleanupCount, 1);
         // The pwa-node simple-attach path drives the launch purely through runtimeExecutable + runtimeArgs.
@@ -107,8 +107,8 @@ suite('Deno Debugger Tests', () => {
         await configure(launchConfig, ['run', '-A', 'main.ts'], firstDebugConfig);
         await configure(launchConfig, ['run', '-A', 'main.ts'], secondDebugConfig);
 
-        const firstPort = assertInjectedInspectWaitArg(firstDebugConfig.runtimeArgs?.[1], firstDebugConfig);
-        const secondPort = assertInjectedInspectWaitArg(secondDebugConfig.runtimeArgs?.[1], secondDebugConfig);
+        const firstPort = assertInspectorArg(firstDebugConfig.runtimeArgs?.[1], '--inspect-brk', firstDebugConfig);
+        const secondPort = assertInspectorArg(secondDebugConfig.runtimeArgs?.[1], '--inspect-brk', secondDebugConfig);
         assert.notStrictEqual(firstPort, secondPort);
         assert.strictEqual(registeredCleanupCount, 2);
     });
@@ -239,7 +239,7 @@ suite('Deno Debugger Tests', () => {
         // Attaching to 0 would never connect; the flag must be rewritten to a concrete allocated port.
         await configure(launchConfig, ['run', '--inspect-wait=127.0.0.1:0', '-A', 'main.ts'], debugConfig);
 
-        const injectedPort = assertInjectedInspectWaitArg(debugConfig.runtimeArgs?.[1], debugConfig);
+        const injectedPort = assertInspectorArg(debugConfig.runtimeArgs?.[1], '--inspect-wait', debugConfig);
         assert.notStrictEqual(injectedPort, 0);
         assert.deepStrictEqual(debugConfig.runtimeArgs, ['run', `--inspect-wait=127.0.0.1:${injectedPort}`, '-A', 'main.ts']);
         assert.strictEqual(registeredCleanupCount, 1);
@@ -278,7 +278,7 @@ suite('Deno Debugger Tests', () => {
         await configure(launchConfig, ['run', '-A', 'main.ts', '--inspect=9229'], debugConfig);
 
         assert.strictEqual(debugConfig.runtimeArgs?.[0], 'run');
-        const injectedPort = assertInjectedInspectWaitArg(debugConfig.runtimeArgs?.[1], debugConfig);
+        const injectedPort = assertInspectorArg(debugConfig.runtimeArgs?.[1], '--inspect-brk', debugConfig);
         assert.notStrictEqual(injectedPort, 9229);
         assert.deepStrictEqual(debugConfig.runtimeArgs?.slice(2), ['-A', 'main.ts', '--inspect=9229']);
         assert.strictEqual(registeredCleanupCount, 1);
@@ -298,11 +298,11 @@ suite('Deno Debugger Tests', () => {
         await configure(launchConfig, ['run', '--inspect-wait', '-A', 'main.ts'], secondDebugConfig);
 
         assert.strictEqual(firstDebugConfig.runtimeArgs?.[0], 'run');
-        const firstPort = assertInjectedInspectWaitArg(firstDebugConfig.runtimeArgs?.[1], firstDebugConfig);
+        const firstPort = assertInspectorArg(firstDebugConfig.runtimeArgs?.[1], '--inspect-wait', firstDebugConfig);
         assert.deepStrictEqual(firstDebugConfig.runtimeArgs?.slice(2), ['-A', 'main.ts']);
 
         assert.strictEqual(secondDebugConfig.runtimeArgs?.[0], 'run');
-        const secondPort = assertInjectedInspectWaitArg(secondDebugConfig.runtimeArgs?.[1], secondDebugConfig);
+        const secondPort = assertInspectorArg(secondDebugConfig.runtimeArgs?.[1], '--inspect-wait', secondDebugConfig);
         assert.deepStrictEqual(secondDebugConfig.runtimeArgs?.slice(2), ['-A', 'main.ts']);
 
         assert.notStrictEqual(firstPort, secondPort);
@@ -320,7 +320,7 @@ suite('Deno Debugger Tests', () => {
         await configure(launchConfig, ['run', '-A', 'main.ts'], debugConfig);
 
         assert.strictEqual(debugConfig.runtimeExecutable, 'deno');
-        assertInjectedInspectWaitArg(debugConfig.runtimeArgs?.[1], debugConfig);
+        assertInspectorArg(debugConfig.runtimeArgs?.[1], '--inspect-brk', debugConfig);
     });
 });
 


### PR DESCRIPTION
## Description

Fixes a timing race in the VS Code extension's generated Deno debug launch that intermittently caused the Linux `deno-debugger` E2E test to time out waiting for its TypeScript breakpoint.

The failures in [run 33911967287](https://github.com/microsoft/aspire/actions/runs/33911967287/job/101157882436) and [run 33807224647](https://github.com/microsoft/aspire/actions/runs/33807224647/job/100824549214) both successfully:

- started the Deno resource,
- attached js-debug's `pwa-node` adapter,
- created the remote debug child session, and
- verified the breakpoint at `deno-app/main.ts:2`.

However, neither run received a DAP `stopped` event. The generated launch used `--inspect-wait`, which releases Deno as soon as the debugger connects. js-debug still needs to discover the target and configure the requested breakpoint after that connection, so the three-line E2E program can execute past line 2 before the breakpoint is active.

This changes only Aspire-generated inspector arguments to `--inspect-brk`. Deno remains paused on entry while js-debug configures user breakpoints, and js-debug's simple-port launch path then resumes automatically through its existing `continueOnAttach` behavior. Explicit user-provided `--inspect`, `--inspect-wait`, and `--inspect-brk` modes remain unchanged.

This is a timing flake rather than a deterministic regression: nearby passing and failing Linux runs used the same Deno 2.9.0, VS Code 1.130.0, and Deno debugger implementation. `--inspect-wait` was introduced in #18628 to prevent execution before debugger attachment, but attachment alone does not guarantee that DAP breakpoint configuration has completed.

### User-facing behavior

Deno resources debugged through the Aspire VS Code extension can reliably hit breakpoints in startup code without any configuration changes. The automatically injected launch argument changes from:

```text
deno run --inspect-wait=127.0.0.1:<port> ...
```

to:

```text
deno run --inspect-brk=127.0.0.1:<port> ...
```

Users who explicitly select an inspector mode through the Deno hosting APIs retain that mode.

### Validation

- `extension/build.ps1`
- `corepack yarn run compile-tests`
- `corepack yarn run lint`
- Targeted `denoDebugger.test.ts`: 15 passed
- A local Windows E2E attempt did not reach the Deno scenario because the test harness timed out switching to the generated E2E workspace. The draft PR is intended to obtain the Linux `deno-debugger` shard confirmation.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No