### PR TITLE
Fix signing failures for dashboard SDK packages

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -63,12 +63,13 @@
     <FileSignInfo Include="OpenTelemetry.Instrumentation.AspNetCore.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.Abstractions.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.FileSystem.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="BouncyCastle.Cryptography.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Semver.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="Sigstore.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.batteries_v2.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="SQLitePCLRaw.provider.e_sqlite3.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="BouncyCastle.Cryptography.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="e_sqlite3.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Semver.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Sigstore.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Tuf.dll" CertificateName="3PartySHA2" />
 
     <!-- Aspire is a Microsoft product rather than a .NET runtime binary, so use Arcade's general Microsoft certificate. -->

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FileSignInfo Include="Dapper.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Fractions.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Hex1b.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="IdentityModel.dll" CertificateName="3PartySHA2" />
@@ -59,11 +60,15 @@
     <FileSignInfo Include="OpenTelemetry.Exporter.Console.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.Extensions.Hosting.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OpenTelemetry.Instrumentation.AspNetCore.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.Abstractions.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.FileSystem.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="BouncyCastle.Cryptography.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Semver.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Sigstore.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SQLitePCLRaw.batteries_v2.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SQLitePCLRaw.core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="SQLitePCLRaw.provider.e_sqlite3.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Tuf.dll" CertificateName="3PartySHA2" />
 
     <!-- Aspire is a Microsoft product rather than a .NET runtime binary, so use Arcade's general Microsoft certificate. -->


### PR DESCRIPTION
## Description

**Failure:** The manual internal build for #19999 failed in the Windows Build signing step: [build 3071407](https://dev.azure.com/dnceng/internal/_build/results?buildId=3071407).

```text
error SIGN004: Signing 3rd party library '.../tools/Dapper.dll' with Microsoft certificate 'Microsoft400'.
error SIGN004: Signing 3rd party library '.../tools/OpenTelemetry.Instrumentation.AspNetCore.dll' with Microsoft certificate 'Microsoft400'.
error SIGN004: Signing 3rd party library '.../tools/SQLitePCLRaw.core.dll' with Microsoft certificate 'Microsoft400'.
```

**Why:** Dashboard persistence added in #18924 brought Dapper, OpenTelemetry instrumentation, and SQLite binaries into the `Aspire.Dashboard.Sdk.*` package payloads. These files had no explicit rules in `eng/Signing.props`, so Arcade assigned its default `Microsoft400` certificate and rejected the third-party assemblies.

The failure did not appear on `main` because automatic `main` builds use `PostBuildSign=true`. Arcade consequently omits managed NuGet packages from the signing inputs, and the current rolling publishing flow does not add another managed-package signing step.

Manual and release builds use `PostBuildSign=false`, which recursively signs and validates managed NuGet package contents. The manual build therefore exercised the release signing path and caught a failure that would also occur in a release build.

**Fix:** Classify the affected dashboard dependencies as `3PartySHA2`, consistent with the repository's other third-party binaries.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
