### PR TITLE
Constrain aspire-starter port replacers to localhost: URLs

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -184,7 +184,10 @@
         "sourceVariableName": "appHostHttpPort",
         "fallbackVariableName": "appHostHttpPortGenerated"
       },
-      "replaces": "15000"
+      "replaces": "15000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "appHostOtlpHttpPort": {
       "type": "parameter",
@@ -206,7 +209,10 @@
         "sourceVariableName": "appHostOtlpHttpPort",
         "fallbackVariableName": "appHostOtlpHttpPortGenerated"
       },
-      "replaces": "19000"
+      "replaces": "19000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "appHostResourceHttpPort": {
       "type": "parameter",
@@ -228,7 +234,10 @@
         "sourceVariableName": "appHostResourceHttpPort",
         "fallbackVariableName": "appHostResourceHttpPortGenerated"
       },
-      "replaces": "20000"
+      "replaces": "20000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "appHostHttpsPort": {
       "type": "parameter",
@@ -250,7 +259,10 @@
         "sourceVariableName": "appHostHttpsPort",
         "fallbackVariableName": "appHostHttpsPortGenerated"
       },
-      "replaces": "17000"
+      "replaces": "17000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "appHostOtlpHttpsPort": {
       "type": "parameter",
@@ -272,7 +284,10 @@
         "sourceVariableName": "appHostOtlpHttpsPort",
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
-      "replaces": "21000"
+      "replaces": "21000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",
@@ -294,7 +309,10 @@
         "sourceVariableName": "appHostResourceHttpsPort",
         "fallbackVariableName": "appHostResourceHttpsPortGenerated"
       },
-      "replaces": "22000"
+      "replaces": "22000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "webHttpPort": {
       "type": "parameter",
@@ -316,7 +334,10 @@
         "sourceVariableName": "webHttpPort",
         "fallbackVariableName": "webHttpPortGenerated"
       },
-      "replaces": "5000"
+      "replaces": "5000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "webHttpsPort": {
       "type": "parameter",
@@ -338,7 +359,10 @@
         "sourceVariableName": "webHttpsPort",
         "fallbackVariableName": "webHttpsPortGenerated"
       },
-      "replaces": "7000"
+      "replaces": "7000",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "apiServiceHttpPort": {
       "type": "parameter",
@@ -360,7 +384,10 @@
         "sourceVariableName": "apiServiceHttpPort",
         "fallbackVariableName": "apiServiceHttpPortGenerated"
       },
-      "replaces": "5301"
+      "replaces": "5301",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "apiServiceHttpsPort": {
       "type": "parameter",
@@ -382,7 +409,10 @@
         "sourceVariableName": "apiServiceHttpsPort",
         "fallbackVariableName": "apiServiceHttpsPortGenerated"
       },
-      "replaces": "7301"
+      "replaces": "7301",
+      "onlyIf": [{
+        "after": "localhost:"
+      }]
     },
     "skipRestore": {
       "type": "parameter",


### PR DESCRIPTION
## Description

The dynamic port symbols (`webHttpPortReplacer`, `apiServiceHttpPortReplacer`, `appHostHttpPortReplacer`, etc.) used a bare numeric "replaces" value, so the template engine substituted that number everywhere in generated content, not just in `launchSettings.json`. Since the default ports (5000, 7000, 5301, 7301, 15000, 17000, 19000, 20000, 21000, 22000) also occur as plain numeric literals in vendored files such as `wwwroot/lib/bootstrap/dist/js/bootstrap.bundle.js` (e.g. carousel interval: 5000), those files ended up with churned values that differ between generated projects, making diffs across template runs noisy.

Add `"onlyIf": [{"after": "localhost:"}]` to each port replacer so substitution only fires in "localhost:<port>" contexts, matching the fix already applied upstream for the same class of bug (dotnet/aspnetcore#65165, dotnet/sdk#48811).

Fixes #20030

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No, tested manually (see below)
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

## Manual testing outcome

I tested it by installing both the pre-fix and post-fix versions of the `aspire-starter` template locally (via `dotnet new install`, using the global .NET 10 SDK on the machine to avoid needing this repo's pinned .NET 11 RC1 SDK) and generating two projects with deliberately different ports each time.

**Before the fix** (template.json at HEAD~1), generating with `--webHttpPort 5010` vs `--webHttpPort 5222` produced two `bootstrap.bundle.js` files that differed:

```
1131c1131
<     interval: 5010,
---
>     interval: 5222,
6140c6140
<     delay: 5010
---
>     delay: 5222
```

This reproduces the exact bug from #20030 — the port number leaking into an unrelated numeric literal in the vendored JS file.

**After the fix** (current working tree), the same two-port test produced `launchSettings.json` files with the expected different ports (`5010` vs `5222`), but `bootstrap.bundle.js` was **byte-for-byte identical** between the two generated projects.

That confirms the `onlyIf: [{"after": "localhost:"}]` constraint does what it's supposed to: the port substitution now only fires in `localhost:<port>` contexts and no longer corrupts unrelated numeric literals elsewhere in the template output.

> [!NOTE]
> This PR was produced using Sonnet 5 (effort High) in Claude Code.