### PR TITLE
Derive Azure Front Door origin names from backend hostnames

### DIFF
--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -120,13 +120,18 @@ public static class AzureFrontDoorExtensions
                 };
                 infrastructure.Add(originGroup);
 
-                // Origin
                 var origin = new FrontDoorOrigin($"{originBicepId}Origin")
                 {
                     Parent = originGroup,
                     HostName = hostParam,
                     OriginHostHeader = hostParam
                 };
+                // The same Aspire resource can resolve to a different backend hostname between deployments.
+                // Include the hostname in the resource-group-scoped hash so a backend change creates a new
+                // origin instead of reusing the existing origin's Azure identity.
+                origin.Name = BicepFunction.Take(
+                    BicepFunction.Interpolate($"{originBicepId.Replace('_', '-')}Origin-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id, hostParam)}"),
+                    origin.GetResourceNameRequirements().MaxLength);
                 infrastructure.Add(origin);
 
                 // Route

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithMultipleOriginsGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithMultipleOriginsGeneratesBicep.verified.bicep
@@ -39,7 +39,7 @@ resource apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('apiOrigin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('apiOrigin-${uniqueString(resourceGroup().id, api_host)}', 90)
   properties: {
     hostName: api_host
     originHostHeader: api_host
@@ -89,7 +89,7 @@ resource webOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource webOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('webOrigin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('webOrigin-${uniqueString(resourceGroup().id, web_host)}', 90)
   properties: {
     hostName: web_host
     originHostHeader: web_host

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithSingleOriginGeneratesBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFrontDoorTests.AddAzureFrontDoorWithSingleOriginGeneratesBicep.verified.bicep
@@ -37,7 +37,7 @@ resource my_apiOriginGroup 'Microsoft.Cdn/profiles/originGroups@2025-06-01' = {
 }
 
 resource my_apiOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2025-06-01' = {
-  name: take('myapiOrigin-${uniqueString(resourceGroup().id)}', 90)
+  name: take('my-apiOrigin-${uniqueString(resourceGroup().id, my_api_host)}', 90)
   properties: {
     hostName: my_api_host
     originHostHeader: my_api_host


### PR DESCRIPTION
## Description

Azure Front Door origins currently retain the same Azure name when an Aspire compute resource resolves to a different backend hostname between deployments. Include the hostname in the origin's name so switching backends creates a distinct origin instead of reusing the existing origin's Azure identity.

Combine the resource-group ID and hostname in a single `uniqueString` suffix, retain a readable resource-based prefix, and use `FrontDoorOrigin.GetResourceNameRequirements().MaxLength` for the name limit. Add a production comment explaining the rationale and update the single- and multiple-origin Bicep snapshots.

Endpoint, origin-group, and route names remain unchanged. Existing deployments receive new origin names the first time this naming scheme is applied.

### Examples

AppHost configuration is unchanged:

```csharp
var frontDoor = builder.AddAzureFrontDoor("frontdoor")
    .WithOrigin(api);
```

```typescript
const frontDoor = await builder.addAzureFrontDoor("frontdoor")
    .withOrigin(api);
```

Generated origin name before:

```bicep
name: take('apiOrigin-${uniqueString(resourceGroup().id)}', 90)
```

Generated origin name after:

```bicep
name: take('apiOrigin-${uniqueString(resourceGroup().id, api_host)}', 90)
```

### Breaking changes

This is a breaking deployment change for existing users of the Azure Front Door integration, even though the integration is still in preview. Upgrading changes origin resource names even when the backend hostname has not changed. [Incremental ARM deployments](https://learn.microsoft.com/azure/azure-resource-manager/templates/deployment-modes#incremental-mode) do not remove resources omitted from the new template, so existing origins can remain alongside the newly named origins in the same origin group.

To preserve the previous default origin names, override them with `ConfigureInfrastructure` before the first deployment after upgrading:

```csharp
using Azure.Provisioning;
using Azure.Provisioning.Cdn;
using Azure.Provisioning.Expressions;

builder.AddAzureFrontDoor("frontdoor")
    .WithOrigin(api)
    .ConfigureInfrastructure(infrastructure =>
    {
        foreach (var origin in infrastructure.GetProvisionableResources()
            .OfType<FrontDoorOrigin>())
        {
            // Match the previous default: remove underscores and hash only the resource-group ID.
            origin.Name = BicepFunction.Take(
                BicepFunction.Interpolate($"{origin.BicepIdentifier.Replace("_", "")}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"),
                origin.GetResourceNameRequirements().MaxLength);
        }
    });
```

The callback runs after the integration's defaults and applies to every configured origin. Removing underscores, rather than replacing them with hyphens, preserves the old prefix exactly: for example, `my_apiOrigin` becomes `myapiOrigin`.

This override opts out of hostname-based origin identity changes. If the new naming scheme has already been deployed, applying the override does not delete the newly created origins; disable or remove the unwanted origins separately after confirming which origins should serve traffic. Users keeping the new naming scheme likewise need to account for cleanup of origins left behind by incremental deployments.

### Validation

All 13 `AzureFrontDoorTests` passed, including the updated Bicep snapshots. Quarantined and outerloop tests were excluded.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No