### PR TITLE
[release/14.0] Bump repository version to 14.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,8 @@
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
+    <!-- The advance 14.0 branch precedes its dashboard image. Remove this override once the 14.0 tag is published. -->
+    <AspireDashboardImageTag>13.6</AspireDashboardImageTag>
     <DefaultTargetFramework>net8.0</DefaultTargetFramework>
     <AllTargetFrameworks>$(DefaultTargetFramework);net9.0;net10.0</AllTargetFrameworks>
     <!-- dotnet versions for running template tests -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <MajorVersion>13</MajorVersion>
-    <MinorVersion>6</MinorVersion>
+    <MajorVersion>14</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>

--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyMetadata Include="AspireDashboardImageTag" Value="$(AspireDashboardImageTag)" Condition="'$(AspireDashboardImageTag)' != ''" />
     <InternalsVisibleTo Include="Aspire.Hosting.Docker.Tests" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyMetadata Include="AspireDashboardImageTag" Value="$(AspireDashboardImageTag)" Condition="'$(AspireDashboardImageTag)' != ''" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Kubernetes" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Kubernetes.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes.Tests" />

--- a/src/Shared/DashboardImage.cs
+++ b/src/Shared/DashboardImage.cs
@@ -19,17 +19,9 @@ internal static class DashboardImage
     public const string Name = "mcr.microsoft.com/dotnet/nightly/aspire-dashboard";
 
     /// <summary>
-    /// Resolves the tag to pin the dashboard image to, derived from the running Aspire product
+    /// Resolves the dashboard image tag from a build-time override, or the running Aspire product
     /// version's <c>major.minor</c> (for example <c>13.5</c>).
     /// </summary>
-    /// <remarks>
-    /// The publishers previously emitted the image without a tag, which Docker and Kubernetes both
-    /// resolve to the mutable <c>:latest</c> tag. That made generated manifests non-reproducible and
-    /// let the dashboard drift away from the app's Aspire version. Pinning to <c>major.minor</c> keeps
-    /// the dashboard on the same Aspire line that generated the manifest and always resolves to a tag
-    /// that exists on the registry — including for prerelease/CI builds, where a full
-    /// <c>major.minor.patch-prerelease</c> tag is not published.
-    /// </remarks>
     public static string ResolveTag()
         => ResolveTag(typeof(DashboardImage).Assembly);
 
@@ -39,12 +31,22 @@ internal static class DashboardImage
         //   "13.5.0-preview.1.25111.1+ad18db0213e9db8209bca0feb83fc801f34634f5"
         // The assembly version (e.g. "13.5.0.0") is used as a fallback when it is unavailable.
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var imageTag = assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .SingleOrDefault(attribute => attribute.Key == "AspireDashboardImageTag")?.Value;
 
-        return ResolveTag(informationalVersion, assembly.GetName().Version?.ToString());
+        return ResolveTag(informationalVersion, assembly.GetName().Version?.ToString(), imageTag);
     }
 
-    internal static string ResolveTag(string? informationalVersion, string? assemblyVersion)
+    internal static string ResolveTag(string? informationalVersion, string? assemblyVersion, string? imageTag)
     {
+        // Advance release branches can bump the product version before the matching image is
+        // published. Honor their explicit build-time pin instead of requesting a nonexistent tag
+        // or silently switching to the mutable ":latest" image.
+        if (!string.IsNullOrEmpty(imageTag))
+        {
+            return imageTag;
+        }
+
         if (TryGetMajorMinor(informationalVersion, out var majorMinor) ||
             TryGetMajorMinor(assemblyVersion, out majorMinor))
         {

--- a/tests/Aspire.Hosting.Docker.Tests/DashboardImageTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DashboardImageTests.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Shared;
+
+namespace Aspire.Hosting.Docker.Tests;
+
+public class DashboardImageTests
+{
+    [Fact]
+    public void ResolveTag_FromRunningAssembly_UsesBuildTimeImageTag()
+    {
+        Assert.Equal("13.6", DashboardImage.ResolveTag());
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/DashboardImageTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/DashboardImageTests.cs
@@ -19,7 +19,17 @@ public class DashboardImageTests
     [InlineData("not-a-version", "10.3.0.0", "10.3")]
     public void ResolveTag_ReturnsMajorMinor(string? informationalVersion, string? assemblyVersion, string expected)
     {
-        Assert.Equal(expected, DashboardImage.ResolveTag(informationalVersion, assemblyVersion));
+        Assert.Equal(expected, DashboardImage.ResolveTag(informationalVersion, assemblyVersion, imageTag: null));
+    }
+
+    [Theory]
+    [InlineData("14.0.0-preview.1+commit", "14.0.0.0", "13.6", "13.6")]
+    [InlineData("14.0.0", "14.0.0.0", "13.6", "13.6")]
+    [InlineData(null, null, "13.6", "13.6")]
+    [InlineData("14.0.0-preview.1", "14.0.0.0", "", "14.0")]
+    public void ResolveTag_PrefersBuildTimeImageTag(string? informationalVersion, string? assemblyVersion, string imageTag, string expected)
+    {
+        Assert.Equal(expected, DashboardImage.ResolveTag(informationalVersion, assemblyVersion, imageTag));
     }
 
     [Theory]
@@ -29,16 +39,12 @@ public class DashboardImageTests
     [InlineData("garbage", "also-garbage")]
     public void ResolveTag_WithoutParseableVersion_FallsBackToLatest(string? informationalVersion, string? assemblyVersion)
     {
-        Assert.Equal("latest", DashboardImage.ResolveTag(informationalVersion, assemblyVersion));
+        Assert.Equal("latest", DashboardImage.ResolveTag(informationalVersion, assemblyVersion, imageTag: null));
     }
 
     [Fact]
-    public void ResolveTag_FromRunningAssembly_MatchesPinnedImageName()
+    public void ResolveTag_FromRunningAssembly_UsesBuildTimeImageTag()
     {
-        // The running assembly always carries a version, so a real tag (never "latest") is produced.
-        var tag = DashboardImage.ResolveTag();
-
-        Assert.NotEqual("latest", tag);
-        Assert.Matches(@"^\d+\.\d+$", tag);
+        Assert.Equal("13.6", DashboardImage.ResolveTag());
     }
 }


### PR DESCRIPTION
## Description

Prepare `release/14.0` as the advance integration branch for the November 14.0 release while `main` remains on 13.6.

Update the repository version in `eng/Versions.props`: `MajorVersion` changes from `13` to `14` and `MinorVersion` from `6` to `0`, resulting in `14.0.0-preview.1`. Retain `PatchVersion` at `0`, the `preview.1` prerelease label, and existing package dependencies.

The initial CI run exposed a coupled deployment dependency: Docker Compose and Kubernetes derive their dashboard container tag from the product version, but `mcr.microsoft.com/dotnet/nightly/aspire-dashboard:14.0` has not been published. That caused deployment failures and snapshot differences across Docker, Kubernetes, and Yarp.

Add a temporary `AspireDashboardImageTag=13.6` build-time override, stamped into both publisher assemblies and honored by the shared image resolver. This preserves the previously used, published dashboard image and existing snapshots without falling back to mutable `latest`. Remove the override once the `14.0` image is published; without an override, the existing product-version resolution remains unchanged.

Validation: 57 targeted Kubernetes tests, 67 Docker snapshot/resolver tests, and the failing Yarp snapshot test passed. The Docker deployment test could not run successfully locally because the Docker daemon is unavailable; Linux deployment E2E coverage is left to CI. XML/version assertions and `git diff --check` passed.

A separate failure in `TypeScriptPolyglotTests.CreateTypeScriptAppHostWithViteApp_UsesConfiguredToolchain(deno)` is unrelated to the version bump: `create-vite@latest` generated a `vite ^8.3.0` dependency that Deno rejected under its minimum dependency age policy. This PR does not weaken that policy or change unrelated E2E tests.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No