### PR TITLE
Add daily main to release/14.0 synchronization

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,10 +7,17 @@ up to date while `main` develops 13.6. It runs daily at **08:23 UTC** and can be
 dispatched manually, but only from `main` in `microsoft/aspire`.
 
 The workflow uses the existing Aspire App secrets (`ASPIRE_BOT_APP_ID` and
-`ASPIRE_BOT_PRIVATE_KEY`) with repository-scoped contents, pull-request, and workflow
-write permissions. Workflow write is needed to synchronize batches that change
-`.github/workflows` files. It only calls GitHub APIs; it never checks out or executes branch
+`ASPIRE_BOT_PRIVATE_KEY`) with repository-scoped contents and pull-request write
+permissions. It only calls GitHub APIs; it never checks out or executes branch
 code with the bot token.
+
+The token deliberately uses the App's existing permissions, without requesting
+workflow-write access or requiring an installation permission update. Synchronizing
+already-existing workflow files with these permissions still needs live validation.
+If GitHub rejects a sync involving workflow files, the run fails visibly and a
+maintainer can complete that sync manually, using a merge commit. Investigate the
+actual failure before requesting broader App permissions; do not drop workflow
+changes from the sync or substitute more privileged credentials automatically.
 
 Each batch creates a `sync/main-to-release-14.0/<main-sha>` branch pointing at a
 snapshot of `main`, then opens a PR into `release/14.0`. There is at most one open
@@ -21,9 +28,6 @@ while that PR is open are picked up by the next run after it merges.
 ### Auto-merge prerequisites
 
 - Enable **Allow merge commits** and **Allow auto-merge** in repository settings.
-- Grant the Aspire App **Workflows: Read and write** and approve the installation's
-  updated permissions if needed; the token action cannot grant permissions the
-  installation does not have.
 - Allow merge commits in every ruleset applying to `release/14.0`. A separate
   `main` ruleset can continue requiring squash merges for normal feature PRs.
 - Ensure branch push restrictions allow the Aspire App to merge. Required status

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,86 @@
 # GitHub Workflows
 
+## Main to Release 14.0 Synchronization
+
+`sync-main-to-release-14.yml` keeps the advance `release/14.0` integration branch
+up to date while `main` develops 13.6. It runs daily at **08:23 UTC** and can be
+dispatched manually, but only from `main` in `microsoft/aspire`.
+
+The workflow uses the existing Aspire App secrets (`ASPIRE_BOT_APP_ID` and
+`ASPIRE_BOT_PRIVATE_KEY`) with repository-scoped contents and pull-request write
+permissions. It only calls GitHub APIs; it never checks out or executes branch
+code with the bot token.
+
+Each batch creates a `sync/main-to-release-14.0/<main-sha>` branch pointing at a
+snapshot of `main`, then opens a PR into `release/14.0`. There is at most one open
+sync PR. An open PR is reconciled rather than replaced or force-pushed, preserving
+manual conflict resolutions and avoiding CI churn. Commits arriving on `main`
+while that PR is open are picked up by the next run after it merges.
+
+### Auto-merge prerequisites
+
+- Enable **Allow merge commits** and **Allow auto-merge** in repository settings.
+- Allow merge commits in every ruleset applying to `release/14.0`. A separate
+  `main` ruleset can continue requiring squash merges for normal feature PRs.
+- Ensure branch push restrictions allow the Aspire App to merge. Required status
+  checks and reviews are respected, not bypassed or self-approved by the bot.
+
+With an approval requirement, a maintainer still needs to approve each PR; it
+then merges automatically when the remaining requirements pass. Fully unattended
+merges also require a deliberate branch-policy decision about reviews. The
+workflow does not change any repository settings or branch protections.
+
+To exempt only the App from approvals, use an approval-only ruleset targeting
+exactly `release/14.0`, with the Aspire App in its bypass list using **For pull
+requests only**. Keep required CI (including `Final Results`) in a **separate**
+ruleset without an App bypass. Keep force-push and deletion protections outside
+the bypassable ruleset too. Remove or adjust overlapping approval requirements,
+including classic branch protection: a more permissive ruleset does not override
+another rule. The bypass is granted to the merging App, not to a PR author; this
+workflow additionally verifies the PR's bot author, repository, branch prefix,
+and workflow marker before requesting a merge.
+
+Native auto-merge is intentionally the only deferred merge mechanism here.
+There are [reports that App approval bypasses are not honored by native
+auto-merge](https://github.com/orgs/community/discussions/190610), even when the
+normal merge API honors them. If a sync PR remains blocked on approval after CI
+passes, approve it manually; a CI-completion merge handler can be considered
+later. Do not solve that problem by giving the App permission to bypass CI.
+See GitHub's [bypass configuration](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset)
+and [rule layering](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets#about-rule-layering)
+documentation.
+
+If repository merge commits or auto-merge are disabled, the workflow leaves the
+PR open, warns in the run summary, and retries on the next run. Conflicts likewise
+leave an actionable PR open. An already-ready PR is merged normally with a
+merge commit and an expected-head check, without an administrative bypass. If
+GitHub has not computed mergeability after a short retry window, rerun the
+workflow from `main` or let the next daily run reconcile it. Other API or
+permission failures fail the run and are covered by the scheduled-workflow watchdog.
+
+### Resolving conflicts
+
+Fetch and check out the sync PR's branch, merge `origin/release/14.0` into it,
+resolve conflicts, and push to that same branch. Keep the **14.0** version in
+`eng/Versions.props` when resolving version conflicts; other dependency changes
+from `main` should still flow forward. The next run retries enabling auto-merge.
+
+Never resolve these conflicts by merging `release/14.0` into `main`: doing so
+would leak 14.0-only changes into 13.6. Always merge sync PRs using **merge commits**,
+not squash or rebase, so Git can recognize already-integrated main commits.
+
+### Ending the temporary branch arrangement
+
+1. Create `release/13.6` from `main` for stabilization.
+2. Disable this workflow in Actions, cancel any queued/active runs, and merge or
+   close any outstanding sync PR before starting the reverse integration.
+3. Merge `release/14.0` back into `main`, preserving its 14.0 version. Prefer a
+   merge commit for this one-off integration too; a squash-only `main` ruleset
+   needs a temporary exception if preserving that ancestry.
+4. Remove the temporary synchronization workflow and its watchdog entry from
+   `monitor-scheduled-workflows.config.json`. `main` now develops 14.0; 13.6 fixes
+   can follow the normal release-branch backmerge process.
+
 ## Quarantine/Disable Test Workflow
 
 The `apply-test-attributes.yml` workflow allows repository maintainers to quarantine, unquarantine, disable, or enable tests directly from issue or PR comments.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,9 @@ up to date while `main` develops 13.6. It runs daily at **08:23 UTC** and can be
 dispatched manually, but only from `main` in `microsoft/aspire`.
 
 The workflow uses the existing Aspire App secrets (`ASPIRE_BOT_APP_ID` and
-`ASPIRE_BOT_PRIVATE_KEY`) with repository-scoped contents and pull-request write
-permissions. It only calls GitHub APIs; it never checks out or executes branch
+`ASPIRE_BOT_PRIVATE_KEY`) with repository-scoped contents, pull-request, and workflow
+write permissions. Workflow write is needed to synchronize batches that change
+`.github/workflows` files. It only calls GitHub APIs; it never checks out or executes branch
 code with the bot token.
 
 Each batch creates a `sync/main-to-release-14.0/<main-sha>` branch pointing at a
@@ -20,6 +21,9 @@ while that PR is open are picked up by the next run after it merges.
 ### Auto-merge prerequisites
 
 - Enable **Allow merge commits** and **Allow auto-merge** in repository settings.
+- Grant the Aspire App **Workflows: Read and write** and approve the installation's
+  updated permissions if needed; the token action cannot grant permissions the
+  installation does not have.
 - Allow merge commits in every ruleset applying to `release/14.0`. A separate
   `main` ruleset can continue requiring squash merges for normal feature PRs.
 - Ensure branch push restrictions allow the Aspire App to merge. Required status
@@ -52,8 +56,10 @@ documentation.
 
 If repository merge commits or auto-merge are disabled, the workflow leaves the
 PR open, warns in the run summary, and retries on the next run. Conflicts likewise
-leave an actionable PR open. An already-ready PR is merged normally with a
-merge commit and an expected-head check, without an administrative bypass. If
+leave an actionable PR open. Immediately mergeable states (`clean`, `has_hooks`,
+and `unstable`, matching GitHub CLI) use a normal merge commit with an expected-head
+check, without an administrative bypass. GitHub still enforces non-bypassable
+required checks, and a rejected merge fails the run rather than being ignored. If
 GitHub has not computed mergeability after a short retry window, rerun the
 workflow from `main` or let the next daily run reconcile it. Other API or
 permission failures fail the run and are covered by the scheduled-workflow watchdog.

--- a/.github/workflows/monitor-scheduled-workflows.config.json
+++ b/.github/workflows/monitor-scheduled-workflows.config.json
@@ -13,6 +13,7 @@
     { "file": "warm-cli-e2e-image-cache.yml", "name": "Warm CLI E2E Image Cache" },
     { "file": "locker.yml", "name": "Lock Threads" },
     { "file": "backmerge-release.yml", "name": "Backmerge Release to Main" },
+    { "file": "sync-main-to-release-14.yml", "name": "Sync Main to Release 14.0" },
 
     { "file": "tests-outerloop.yml", "name": "Outerloop Tests", "selfReports": true },
     { "file": "tests-quarantine.yml", "name": "Quarantined Tests", "selfReports": true },

--- a/.github/workflows/sync-main-to-release-14.yml
+++ b/.github/workflows/sync-main-to-release-14.yml
@@ -30,6 +30,7 @@ jobs:
           repositories: aspire
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write # Sync batches can include workflow-file changes.
           skip-token-revoke: false
 
       # Metadata-only: no checkout, local merge, or execution of either branch's code.
@@ -165,10 +166,11 @@ jobs:
               await report('Enable repository merge commits and auto-merge, and allow merge commits for release/14.0. The PR remains open; the next run will retry.', true);
               return;
             }
-            // Like `gh pr merge --auto`, merge an already-ready PR normally:
-            // GitHub rejects enabling auto-merge when its state is already clean.
-            // Pin the reviewed head; do not request an administrative bypass.
-            if (pull.mergeable_state === 'clean') {
+            // Match gh's isImmediatelyMergeable: auto-merge cannot be enabled
+            // for an already-mergeable PR, including has_hooks and unstable.
+            // https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/merge/merge.go
+            // Pin the head; required CI must remain non-bypassable in branch policy.
+            if (['clean', 'has_hooks', 'unstable'].includes(pull.mergeable_state)) {
               const { data: result } = await github.rest.pulls.merge({
                 owner, repo, pull_number: pull.number,
                 sha: pull.head.sha, merge_method: 'merge'

--- a/.github/workflows/sync-main-to-release-14.yml
+++ b/.github/workflows/sync-main-to-release-14.yml
@@ -30,7 +30,6 @@ jobs:
           repositories: aspire
           permission-contents: write
           permission-pull-requests: write
-          permission-workflows: write # Sync batches can include workflow-file changes.
           skip-token-revoke: false
 
       # Metadata-only: no checkout, local merge, or execution of either branch's code.

--- a/.github/workflows/sync-main-to-release-14.yml
+++ b/.github/workflows/sync-main-to-release-14.yml
@@ -1,0 +1,192 @@
+# Temporary integration branch while main builds 13.6. Disable before merging
+# release/14.0 back into main. See the lifecycle instructions in README.md.
+name: Sync Main to Release 14.0
+
+on:
+  schedule:
+    - cron: '23 8 * * *' # Daily at 08:23 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-main-to-release-14
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # Never mint the bot token for a fork or a manual run of unreviewed branch code.
+    if: github.repository == 'microsoft/aspire' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Create Aspire App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+          private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+          owner: microsoft
+          repositories: aspire
+          permission-contents: write
+          permission-pull-requests: write
+          skip-token-revoke: false
+
+      # Metadata-only: no checkout, local merge, or execution of either branch's code.
+      - name: Create or reconcile synchronization PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SYNC_BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          retries: 0
+          script: |
+            const owner = 'microsoft';
+            const repo = 'aspire';
+            const base = 'release/14.0';
+            const prefix = 'sync/main-to-release-14.0/';
+            const marker = '<!-- sync-main-to-release-14 -->';
+            if (context.repo.owner !== owner || context.repo.repo !== repo ||
+                context.ref !== 'refs/heads/main' ||
+                !['schedule', 'workflow_dispatch'].includes(context.eventName)) {
+              throw new Error('This workflow only runs from main in microsoft/aspire.');
+            }
+            const bot = process.env.SYNC_BOT_LOGIN;
+            if (!bot || bot === '[bot]') {
+              throw new Error('Missing Aspire App bot identity.');
+            }
+            async function report(message, warning = false) {
+              if (warning) {
+                core.warning(message);
+              } else {
+                core.info(message);
+              }
+              await core.summary.addRaw(`${message}\n`).write();
+            }
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner, repo, base, state: 'open', per_page: 100
+            });
+            const pending = pulls.filter(pull =>
+              pull.head.repo?.full_name === `${owner}/${repo}` &&
+              pull.head.ref.startsWith(prefix));
+            if (pending.length > 1) {
+              throw new Error('Multiple synchronization PRs are open; reconcile them manually.');
+            }
+            let pull = pending[0];
+            if (!pull) {
+              const { data: source } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
+              const { data: target } = await github.rest.repos.getBranch({ owner, repo, branch: base });
+              const sha = source.commit.sha;
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner, repo, basehead: `${target.commit.sha}...${sha}`
+              });
+              if (comparison.ahead_by === 0) {
+                await report('release/14.0 already contains all commits from main.');
+                return;
+              }
+              // Snapshot main, never use main itself as the PR head: resolving a
+              // conflict must not accidentally bring 14.0-only changes into 13.6.
+              const head = `${prefix}${sha}`;
+              let ref;
+              try {
+                ({ data: ref } = await github.rest.git.getRef({ owner, repo, ref: `heads/${head}` }));
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                ({ data: ref } = await github.rest.git.createRef({
+                  owner, repo, ref: `refs/heads/${head}`, sha
+                }));
+              }
+              // Reuse an orphaned ref after a failed PR request, but never reset
+              // someone's conflict resolution or force-push an existing branch.
+              if (ref.object.sha !== sha) {
+                throw new Error(`Existing ${head} no longer matches main's snapshot; inspect it manually.`);
+              }
+              ({ data: pull } = await github.rest.pulls.create({
+                owner, repo, head, base,
+                title: '[Automated] Sync main to release/14.0',
+                body: [
+                  marker,
+                  '## Automated integration branch sync',
+                  '',
+                  `Merge main at ${sha} into \`release/14.0\` while main builds 13.6.`,
+                  '',
+                  'Auto-merge uses a **merge commit**, preserving ancestry and all 14.0-only changes.',
+                  'Required approvals and status checks still apply; this workflow does not bypass them.',
+                  '',
+                  'If there are conflicts, merge `origin/release/14.0` into this PR branch and resolve',
+                  'them there. Keep the 14.0 version in `eng/Versions.props`. Never resolve by merging',
+                  '`release/14.0` into `main`, and never squash or rebase this PR.',
+                  '',
+                  'This branch is not overwritten while the PR is open. Newer main commits are picked',
+                  'up by the next run after this PR merges. Disable this workflow before reintegrating',
+                  '`release/14.0` into `main` after cutting `release/13.6`.'
+                ].join('\n')
+              }));
+            }
+            // Re-read before enabling auto-merge: a maintainer may have closed,
+            // retargeted, or resolved the PR since it was listed.
+            // A newly created PR commonly returns mergeable: null until GitHub
+            // finishes its background merge check. Give it a bounded retry window.
+            for (let attempt = 0; attempt < 5; attempt++) {
+              ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pull.number }));
+              if (pull.mergeable !== null || pull.state !== 'open' || attempt === 4) {
+                break;
+              }
+              await new Promise(resolve => setTimeout(resolve, 2000));
+            }
+            if (pull.state !== 'open' || pull.draft || pull.base.ref !== base ||
+                pull.base.repo?.full_name !== `${owner}/${repo}` ||
+                pull.head.repo?.full_name !== `${owner}/${repo}` ||
+                !pull.head.ref.startsWith(prefix) ||
+                pull.user?.type !== 'Bot' || pull.user.login !== bot ||
+                !pull.body?.includes(marker)) {
+              throw new Error('Synchronization PR identity or state changed; inspect it manually.');
+            }
+            await report(`Synchronization PR: ${pull.html_url}. Pending branches are never overwritten.`);
+            if (pull.auto_merge) {
+              if (pull.auto_merge.merge_method !== 'merge') {
+                throw new Error('Synchronization PR must use a merge commit, not squash or rebase.');
+              }
+              await report('Merge-commit auto-merge is already enabled; waiting for conflicts, approvals, and checks.');
+              return;
+            }
+            if (pull.mergeable === false) {
+              await report('Merge conflicts need manual resolution on the synchronization PR branch. Auto-merge will be retried on the next run.', true);
+              return;
+            }
+            if (pull.mergeable !== true) {
+              await report('GitHub is still computing mergeability. Re-run from main or wait for the next daily run.', true);
+              return;
+            }
+            const { data: settings } = await github.rest.repos.get({ owner, repo });
+            if (!settings.allow_merge_commit || !settings.allow_auto_merge) {
+              await report('Enable repository merge commits and auto-merge, and allow merge commits for release/14.0. The PR remains open; the next run will retry.', true);
+              return;
+            }
+            // Like `gh pr merge --auto`, merge an already-ready PR normally:
+            // GitHub rejects enabling auto-merge when its state is already clean.
+            // Pin the reviewed head; do not request an administrative bypass.
+            if (pull.mergeable_state === 'clean') {
+              const { data: result } = await github.rest.pulls.merge({
+                owner, repo, pull_number: pull.number,
+                sha: pull.head.sha, merge_method: 'merge'
+              });
+              if (!result.merged) {
+                throw new Error(`GitHub did not merge the synchronization PR: ${result.message}`);
+              }
+              await report('Merged the ready synchronization PR with a merge commit.');
+              return;
+            }
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: MERGE
+                }) {
+                  pullRequest { number }
+                }
+              }
+            `, { pullRequestId: pull.node_id });
+            await report('Enabled merge-commit auto-merge. Required approvals, checks, and branch restrictions still apply.');

--- a/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Infrastructure.Tests;
+
+public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
+{
+    [Fact]
+    public void WorkflowRestrictsBotAccessToMainAndDoesNotExecuteBranchCode()
+    {
+        var root = LoadWorkflow();
+        Assert.Empty(Mapping(root, "permissions").Children);
+        var triggers = Mapping(root, "on");
+        Assert.Equal(["schedule", "workflow_dispatch"], triggers.Children.Keys.Select(key => key.ToString()));
+        var schedule = Assert.IsType<YamlMappingNode>(Assert.Single(Assert.IsType<YamlSequenceNode>(triggers.Children[new YamlScalarNode("schedule")])));
+        Assert.Equal("23 8 * * *", Scalar(schedule, "cron"));
+        var concurrency = Mapping(root, "concurrency");
+        Assert.Equal("sync-main-to-release-14", Scalar(concurrency, "group"));
+        Assert.Equal("false", Scalar(concurrency, "cancel-in-progress"));
+
+        var job = Assert.IsType<YamlMappingNode>(Assert.Single(Mapping(root, "jobs").Children).Value);
+        Assert.Equal("github.repository == 'microsoft/aspire' && github.ref == 'refs/heads/main'", Scalar(job, "if"));
+        Assert.Equal("10", Scalar(job, "timeout-minutes"));
+        var steps = Assert.IsType<YamlSequenceNode>(job.Children[new YamlScalarNode("steps")]);
+        Assert.Equal(2, steps.Children.Count);
+        var tokenStep = Assert.IsType<YamlMappingNode>(steps.Children[0]);
+        Assert.Equal(["name", "id", "uses", "with"], tokenStep.Children.Keys.Select(key => key.ToString()));
+        Assert.Matches("^actions/create-github-app-token@[a-f0-9]{40}$", Scalar(tokenStep, "uses"));
+        var token = Mapping(tokenStep, "with");
+        Assert.Equal(["client-id", "private-key", "owner", "repositories", "permission-contents", "permission-pull-requests", "skip-token-revoke"],
+            token.Children.Keys.Select(key => key.ToString()));
+        Assert.Equal("${{ secrets.ASPIRE_BOT_APP_ID }}", Scalar(token, "client-id"));
+        Assert.Equal("${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}", Scalar(token, "private-key"));
+        Assert.Equal("microsoft", Scalar(token, "owner"));
+        Assert.Equal("aspire", Scalar(token, "repositories"));
+        Assert.Equal("write", Scalar(token, "permission-contents"));
+        Assert.Equal("write", Scalar(token, "permission-pull-requests"));
+        Assert.Equal("false", Scalar(token, "skip-token-revoke"));
+
+        var scriptStep = Assert.IsType<YamlMappingNode>(steps.Children[1]);
+        Assert.Equal(["name", "uses", "env", "with"], scriptStep.Children.Keys.Select(key => key.ToString()));
+        Assert.Matches("^actions/github-script@[a-f0-9]{40}$", Scalar(scriptStep, "uses"));
+        Assert.Equal("${{ steps.app-token.outputs.app-slug }}[bot]", Scalar(Mapping(scriptStep, "env"), "SYNC_BOT_LOGIN"));
+        var options = Mapping(scriptStep, "with");
+        Assert.Equal("${{ steps.app-token.outputs.token }}", Scalar(options, "github-token"));
+        Assert.Equal("0", Scalar(options, "retries"));
+        Assert.Equal(-1, Scalar(options, "script").IndexOf("${{", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("up-to-date")]
+    [InlineData("create")]
+    [InlineData("existing")]
+    [InlineData("orphaned-ref")]
+    [InlineData("changed-ref")]
+    [InlineData("multiple-prs")]
+    [InlineData("conflict")]
+    [InlineData("unknown-mergeability")]
+    [InlineData("mergeability-ready-on-retry")]
+    [InlineData("manual-dispatch")]
+    [InlineData("ready")]
+    [InlineData("merge-rejected")]
+    [InlineData("merge-error")]
+    [InlineData("merge-disabled")]
+    [InlineData("auto-merge-disabled")]
+    [InlineData("already-enabled")]
+    [InlineData("squash-enabled")]
+    [InlineData("closed")]
+    [InlineData("draft")]
+    [InlineData("retargeted")]
+    [InlineData("wrong-author")]
+    [InlineData("missing-marker")]
+    [InlineData("fork-head")]
+    [InlineData("changed-head-branch")]
+    [InlineData("unrelated-pr")]
+    [InlineData("wrong-repository")]
+    [InlineData("untrusted-dispatch")]
+    [InlineData("unsupported-event")]
+    [InlineData("missing-bot")]
+    [InlineData("list-error")]
+    [InlineData("ref-read-error")]
+    [InlineData("ref-write-error")]
+    [InlineData("create-pr-error")]
+    [InlineData("auto-merge-error")]
+    [RequiresTools(["node"])]
+    public async Task SynchronizationPreservesHistoryAndRespectsPolicy(string scenario)
+    {
+        using var workspace = TemporaryWorkspace.Create(output);
+        var job = Mapping(Mapping(LoadWorkflow(), "jobs"), "sync");
+        var steps = Assert.IsType<YamlSequenceNode>(job.Children[new YamlScalarNode("steps")]);
+        var script = Scalar(Mapping(Assert.IsType<YamlMappingNode>(steps.Children[1]), "with"), "script");
+        var scriptPath = Path.Combine(workspace.Path, "sync-script.js");
+        await File.WriteAllTextAsync(scriptPath, script);
+        using var node = new NodeCommand(output, nameof(SyncMainToRelease14Tests))
+            .WithTimeout(TimeSpan.FromMinutes(1));
+        var result = await node.ExecuteScriptAsync(
+            Path.Combine(RepoRoot.Path, "tests", "Infrastructure.Tests", "WorkflowScripts", "sync-main-to-release-14.harness.mjs"),
+            scriptPath,
+            scenario);
+        Assert.True(result.ExitCode == 0, result.Output);
+    }
+
+    private static YamlMappingNode LoadWorkflow()
+    {
+        using var reader = File.OpenText(Path.Combine(RepoRoot.Path, ".github", "workflows", "sync-main-to-release-14.yml"));
+        var yaml = new YamlStream();
+        yaml.Load(reader);
+        return Assert.IsType<YamlMappingNode>(yaml.Documents[0].RootNode);
+    }
+
+    private static YamlMappingNode Mapping(YamlMappingNode node, string key)
+        => Assert.IsType<YamlMappingNode>(node.Children[new YamlScalarNode(key)]);
+
+    private static string Scalar(YamlMappingNode node, string key)
+        => Assert.IsType<YamlScalarNode>(node.Children[new YamlScalarNode(key)]).Value!;
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
@@ -31,7 +31,7 @@ public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
         Assert.Equal(["name", "id", "uses", "with"], tokenStep.Children.Keys.Select(key => key.ToString()));
         Assert.Matches("^actions/create-github-app-token@[a-f0-9]{40}$", Scalar(tokenStep, "uses"));
         var token = Mapping(tokenStep, "with");
-        Assert.Equal(["client-id", "private-key", "owner", "repositories", "permission-contents", "permission-pull-requests", "permission-workflows", "skip-token-revoke"],
+        Assert.Equal(["client-id", "private-key", "owner", "repositories", "permission-contents", "permission-pull-requests", "skip-token-revoke"],
             token.Children.Keys.Select(key => key.ToString()));
         Assert.Equal("${{ secrets.ASPIRE_BOT_APP_ID }}", Scalar(token, "client-id"));
         Assert.Equal("${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}", Scalar(token, "private-key"));
@@ -39,7 +39,6 @@ public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
         Assert.Equal("aspire", Scalar(token, "repositories"));
         Assert.Equal("write", Scalar(token, "permission-contents"));
         Assert.Equal("write", Scalar(token, "permission-pull-requests"));
-        Assert.Equal("write", Scalar(token, "permission-workflows"));
         Assert.Equal("false", Scalar(token, "skip-token-revoke"));
 
         var scriptStep = Assert.IsType<YamlMappingNode>(steps.Children[1]);

--- a/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/SyncMainToRelease14Tests.cs
@@ -31,7 +31,7 @@ public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
         Assert.Equal(["name", "id", "uses", "with"], tokenStep.Children.Keys.Select(key => key.ToString()));
         Assert.Matches("^actions/create-github-app-token@[a-f0-9]{40}$", Scalar(tokenStep, "uses"));
         var token = Mapping(tokenStep, "with");
-        Assert.Equal(["client-id", "private-key", "owner", "repositories", "permission-contents", "permission-pull-requests", "skip-token-revoke"],
+        Assert.Equal(["client-id", "private-key", "owner", "repositories", "permission-contents", "permission-pull-requests", "permission-workflows", "skip-token-revoke"],
             token.Children.Keys.Select(key => key.ToString()));
         Assert.Equal("${{ secrets.ASPIRE_BOT_APP_ID }}", Scalar(token, "client-id"));
         Assert.Equal("${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}", Scalar(token, "private-key"));
@@ -39,6 +39,7 @@ public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
         Assert.Equal("aspire", Scalar(token, "repositories"));
         Assert.Equal("write", Scalar(token, "permission-contents"));
         Assert.Equal("write", Scalar(token, "permission-pull-requests"));
+        Assert.Equal("write", Scalar(token, "permission-workflows"));
         Assert.Equal("false", Scalar(token, "skip-token-revoke"));
 
         var scriptStep = Assert.IsType<YamlMappingNode>(steps.Children[1]);
@@ -63,7 +64,11 @@ public sealed class SyncMainToRelease14Tests(ITestOutputHelper output)
     [InlineData("mergeability-ready-on-retry")]
     [InlineData("manual-dispatch")]
     [InlineData("ready")]
+    [InlineData("ready-has-hooks")]
+    [InlineData("ready-unstable")]
     [InlineData("merge-rejected")]
+    [InlineData("has-hooks-merge-rejected")]
+    [InlineData("unstable-merge-rejected")]
     [InlineData("merge-error")]
     [InlineData("merge-disabled")]
     [InlineData("auto-merge-disabled")]

--- a/tests/Infrastructure.Tests/WorkflowScripts/sync-main-to-release-14.harness.mjs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/sync-main-to-release-14.harness.mjs
@@ -46,6 +46,7 @@ const calls = [];
 const messages = [];
 let getCount = 0;
 let delayCount = 0;
+let mergeRejected = false;
 
 switch (scenario) {
     case 'up-to-date':
@@ -66,12 +67,18 @@ switch (scenario) {
         context.eventName = 'workflow_dispatch';
         break;
     case 'ready':
+    case 'ready-has-hooks':
+    case 'ready-unstable':
     case 'merge-rejected':
+    case 'has-hooks-merge-rejected':
+    case 'unstable-merge-rejected':
     case 'merge-error':
-        pull.mergeable_state = 'clean';
+        pull.mergeable_state = scenario.includes('has-hooks') ? 'has_hooks'
+            : scenario.includes('unstable') ? 'unstable' : 'clean';
+        mergeRejected = scenario.endsWith('merge-rejected');
         expectedWrites = ['merge'];
         expectedMessage = 'Merged the ready synchronization PR';
-        if (scenario === 'merge-rejected') {
+        if (mergeRejected) {
             expectedError = 'GitHub did not merge';
         } else if (scenario === 'merge-error') {
             fail = 'merge-error';
@@ -222,7 +229,7 @@ const github = {
                 assert.equal(args.merge_method, 'merge');
                 assert.deepEqual(Object.keys(args).sort(), ['merge_method', 'owner', 'pull_number', 'repo', 'sha']);
                 writes.push('merge');
-                return { data: { merged: scenario !== 'merge-rejected', message: 'Branch policy prevented merging.' } };
+                return { data: { merged: !mergeRejected, message: 'Branch policy prevented merging.' } };
             },
             create: async args => {
                 check('create-pr-error', args);

--- a/tests/Infrastructure.Tests/WorkflowScripts/sync-main-to-release-14.harness.mjs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/sync-main-to-release-14.harness.mjs
@@ -1,0 +1,318 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+// Match the other inline-workflow harnesses: no TypeScript loader/toolchain is
+// available in Infrastructure.Tests, which runs the Node supplied by the runner.
+const source = readFileSync(process.argv[2], 'utf8');
+const scenario = process.argv[3];
+const sha = 'a'.repeat(40);
+const target = 'b'.repeat(40);
+const head = `sync/main-to-release-14.0/${sha}`;
+const bot = 'aspire-repo-bot[bot]';
+const context = {
+    repo: { owner: 'microsoft', repo: 'aspire' },
+    ref: 'refs/heads/main',
+    eventName: 'schedule'
+};
+const env = { SYNC_BOT_LOGIN: bot };
+const pull = {
+    number: 42,
+    node_id: 'PR_42',
+    state: 'open',
+    draft: false,
+    base: { ref: 'release/14.0', repo: { full_name: 'microsoft/aspire' } },
+    head: { ref: head, sha, repo: { full_name: 'microsoft/aspire' } },
+    user: { type: 'Bot', login: bot },
+    body: '<!-- sync-main-to-release-14 -->',
+    html_url: 'https://github.com/microsoft/aspire/pull/42',
+    mergeable: true,
+    mergeable_state: 'blocked',
+    auto_merge: null
+};
+const settings = { allow_merge_commit: true, allow_auto_merge: true };
+let existing = true;
+let refExists = false;
+let ahead = 1;
+let expectedWrites = ['auto-merge'];
+let expectedError = '';
+let expectedMessage = 'Enabled merge-commit auto-merge';
+let fail = '';
+const writes = [];
+const calls = [];
+const messages = [];
+let getCount = 0;
+let delayCount = 0;
+
+switch (scenario) {
+    case 'up-to-date':
+        existing = false;
+        ahead = 0;
+        expectedWrites = [];
+        expectedMessage = 'already contains all commits';
+        break;
+    case 'create':
+    case 'orphaned-ref':
+        existing = false;
+        refExists = scenario === 'orphaned-ref';
+        expectedWrites = refExists ? ['create-pr', 'auto-merge'] : ['create-ref', 'create-pr', 'auto-merge'];
+        break;
+    case 'existing':
+        break;
+    case 'manual-dispatch':
+        context.eventName = 'workflow_dispatch';
+        break;
+    case 'ready':
+    case 'merge-rejected':
+    case 'merge-error':
+        pull.mergeable_state = 'clean';
+        expectedWrites = ['merge'];
+        expectedMessage = 'Merged the ready synchronization PR';
+        if (scenario === 'merge-rejected') {
+            expectedError = 'GitHub did not merge';
+        } else if (scenario === 'merge-error') {
+            fail = 'merge-error';
+            expectedWrites = [];
+            expectedError = 'API failed: merge-error';
+        }
+        break;
+    case 'unrelated-pr':
+        existing = false;
+        expectedWrites = ['create-ref', 'create-pr', 'auto-merge'];
+        break;
+    case 'changed-ref':
+        existing = false;
+        refExists = true;
+        expectedWrites = [];
+        expectedError = 'no longer matches';
+        break;
+    case 'multiple-prs':
+        expectedWrites = [];
+        expectedError = 'Multiple synchronization PRs';
+        break;
+    case 'conflict':
+        pull.mergeable = false;
+        expectedWrites = [];
+        expectedMessage = 'Merge conflicts need manual resolution';
+        break;
+    case 'unknown-mergeability':
+        pull.mergeable = null;
+        expectedWrites = [];
+        expectedMessage = 'still computing mergeability';
+        break;
+    case 'mergeability-ready-on-retry':
+        pull.mergeable = null;
+        break;
+    case 'merge-disabled':
+    case 'auto-merge-disabled':
+        settings[scenario === 'merge-disabled' ? 'allow_merge_commit' : 'allow_auto_merge'] = false;
+        expectedWrites = [];
+        expectedMessage = 'Enable repository merge commits and auto-merge';
+        break;
+    case 'already-enabled':
+        pull.auto_merge = { merge_method: 'merge' };
+        expectedWrites = [];
+        expectedMessage = 'auto-merge is already enabled';
+        break;
+    case 'squash-enabled':
+        pull.auto_merge = { merge_method: 'squash' };
+        expectedWrites = [];
+        expectedError = 'must use a merge commit';
+        break;
+    case 'closed':
+    case 'draft':
+    case 'retargeted':
+    case 'wrong-author':
+    case 'missing-marker':
+    case 'fork-head':
+    case 'changed-head-branch':
+        if (scenario === 'closed') {
+            pull.state = 'closed';
+        } else if (scenario === 'draft') {
+            pull.draft = true;
+        } else if (scenario === 'retargeted') {
+            pull.base.ref = 'main';
+        } else if (scenario === 'wrong-author') {
+            pull.user = { type: 'User', login: bot };
+        } else if (scenario === 'fork-head') {
+            pull.head.repo.full_name = 'external/fork';
+        } else if (scenario === 'changed-head-branch') {
+            pull.head.ref = 'main';
+        } else {
+            pull.body = '';
+        }
+        expectedWrites = [];
+        expectedError = 'identity or state changed';
+        break;
+    case 'wrong-repository':
+    case 'untrusted-dispatch':
+    case 'unsupported-event':
+        if (scenario === 'wrong-repository') {
+            context.repo.owner = 'external';
+        } else if (scenario === 'untrusted-dispatch') {
+            context.eventName = 'workflow_dispatch';
+            context.ref = 'refs/heads/feature';
+        } else {
+            context.eventName = 'pull_request';
+        }
+        expectedWrites = [];
+        expectedError = 'only runs from main';
+        break;
+    case 'missing-bot':
+        env.SYNC_BOT_LOGIN = '[bot]';
+        expectedWrites = [];
+        expectedError = 'Missing Aspire App bot identity';
+        break;
+    case 'list-error':
+    case 'ref-read-error':
+    case 'ref-write-error':
+    case 'create-pr-error':
+    case 'auto-merge-error':
+        fail = scenario;
+        existing = scenario === 'list-error' || scenario === 'auto-merge-error';
+        expectedWrites = scenario === 'create-pr-error' ? ['create-ref'] : [];
+        expectedError = `API failed: ${scenario}`;
+        break;
+    default:
+        throw new Error(`Unknown scenario: ${scenario}`);
+}
+
+function check(endpoint, args) {
+    calls.push(endpoint);
+    assert.equal(args.owner, 'microsoft');
+    assert.equal(args.repo, 'aspire');
+    if (fail === endpoint) {
+        throw Object.assign(new Error(`API failed: ${endpoint}`), { status: 403 });
+    }
+}
+const github = {
+    paginate: async (route, args) => {
+        assert.equal(route, 'list-pulls');
+        check('list-error', args);
+        assert.equal(args.base, 'release/14.0');
+        assert.equal(args.state, 'open');
+        assert.equal(args.per_page, 100);
+        // Listing and re-reading are separate API snapshots. Exercise retargeting
+        // and head changes during reconciliation, not just preexisting bad data.
+        const listed = { ...pull, head: { ref: head, repo: { full_name: 'microsoft/aspire' } } };
+        if (scenario === 'unrelated-pr') {
+            return [{ ...listed, head: { ref: 'unrelated-feature', repo: { full_name: 'microsoft/aspire' } } }];
+        }
+        return existing ? (scenario === 'multiple-prs' ? [listed, { ...listed, number: 43 }] : [listed]) : [];
+    },
+    rest: {
+        pulls: {
+            list: 'list-pulls',
+            get: async args => {
+                check('get-pr', args);
+                assert.equal(args.pull_number, 42);
+                getCount++;
+                if (scenario === 'mergeability-ready-on-retry' && getCount === 3) {
+                    pull.mergeable = true;
+                }
+                return { data: pull };
+            },
+            merge: async args => {
+                check('merge-error', args);
+                assert.equal(args.pull_number, 42);
+                assert.equal(args.sha, sha);
+                assert.equal(args.merge_method, 'merge');
+                assert.deepEqual(Object.keys(args).sort(), ['merge_method', 'owner', 'pull_number', 'repo', 'sha']);
+                writes.push('merge');
+                return { data: { merged: scenario !== 'merge-rejected', message: 'Branch policy prevented merging.' } };
+            },
+            create: async args => {
+                check('create-pr-error', args);
+                assert.equal(args.head, head);
+                assert.equal(args.base, 'release/14.0');
+                assert.match(args.body, /Keep the 14\.0 version/);
+                assert.match(args.body, /never squash or rebase/);
+                assert.match(args.body, /<!-- sync-main-to-release-14 -->/);
+                writes.push('create-pr');
+                return { data: pull };
+            }
+        },
+        repos: {
+            getBranch: async args => {
+                check('get-branch', args);
+                assert.ok(['main', 'release/14.0'].includes(args.branch));
+                return { data: { commit: { sha: args.branch === 'main' ? sha : target } } };
+            },
+            compareCommitsWithBasehead: async args => {
+                check('compare', args);
+                assert.equal(args.basehead, `${target}...${sha}`);
+                return { data: { ahead_by: ahead } };
+            },
+            get: async args => {
+                check('get-settings', args);
+                return { data: settings };
+            }
+        },
+        git: {
+            getRef: async args => {
+                check('ref-read-error', args);
+                assert.equal(args.ref, `heads/${head}`);
+                if (!refExists) {
+                    throw Object.assign(new Error('Not found'), { status: 404 });
+                }
+                return { data: { object: { sha: scenario === 'changed-ref' ? target : sha } } };
+            },
+            createRef: async args => {
+                check('ref-write-error', args);
+                assert.equal(args.ref, `refs/heads/${head}`);
+                assert.equal(args.sha, sha);
+                writes.push('create-ref');
+                return { data: { object: { sha } } };
+            }
+        }
+    },
+    graphql: async (query, args) => {
+        if (fail === 'auto-merge-error') {
+            throw new Error('API failed: auto-merge-error');
+        }
+        assert.match(query, /enablePullRequestAutoMerge/);
+        assert.match(query, /mergeMethod: MERGE/);
+        assert.equal(args.pullRequestId, 'PR_42');
+        writes.push('auto-merge');
+    }
+};
+const summary = {
+    addRaw() { return this; },
+    async write() {}
+};
+const core = {
+    info: message => messages.push(message),
+    warning: message => messages.push(message),
+    summary
+};
+let error;
+try {
+    await runInNewContext(`(async () => { ${source}\n })()`, {
+        github, context, core, process: { env },
+        setTimeout: (callback, delay) => {
+            assert.equal(delay, 2000);
+            delayCount++;
+            callback();
+        }
+    }, { timeout: 1000 });
+} catch (caught) {
+    error = caught;
+}
+if (expectedError) {
+    assert.ok(error?.message.includes(expectedError), `Expected "${expectedError}", got ${error?.stack}`);
+} else {
+    assert.ifError(error);
+    assert.ok(messages.some(message => message.includes(expectedMessage)), messages.join('\n'));
+}
+assert.deepEqual(writes, expectedWrites);
+assert.equal(delayCount, scenario === 'unknown-mergeability' ? 4 : scenario === 'mergeability-ready-on-retry' ? 2 : 0);
+if (existing) {
+    assert.equal(calls.includes('get-branch'), false, 'Never advance or overwrite a pending PR branch');
+}
+if (['wrong-repository', 'untrusted-dispatch', 'unsupported-event', 'missing-bot'].includes(scenario)) {
+    assert.deepEqual(calls, []);
+}
+console.log(`PASS: ${scenario}`);


### PR DESCRIPTION
## Description

Keep the advance `release/14.0` integration branch current while `main` develops 13.6, without introducing 14.0-only changes into 13.6.

- Add a daily 08:23 UTC workflow plus manual dispatch from `main`, using the existing Aspire repository App.
- Open one snapshot-branch PR at a time from `main` into `release/14.0`, requesting native auto-merge with a merge commit. Preserve ancestry, leave conflicts in an actionable PR, and never overwrite a pending branch or a maintainer's conflict resolution.
- Respect applicable approvals, checks, and push restrictions. Immediately mergeable states (`clean`, `has_hooks`, and `unstable`) use a normal merge with a pinned head SHA, matching `gh pr merge --auto` behavior. No CI-completion merge handler or administrative override is added.
- Register failures with the scheduled-workflow watchdog and document conflict resolution, approval-only App bypass rulesets, and disabling the sync before merging 14.0 back into `main` after cutting `release/13.6`.

### Repository configuration

Repository merge commits must be enabled, while a separate `main` ruleset can remain squash-only. Merge commits must be allowed for `release/14.0`, and branch push restrictions must permit the App.

The token deliberately requests only existing contents and pull-request write permissions. The previously added `permission-workflows: write` request was removed to avoid requiring an App installation permission update before any sync can run. Synchronizing already-existing workflow files with the existing App permissions still needs live validation. If GitHub rejects a sync involving workflow files, the run fails visibly and a maintainer can complete that sync manually using a merge commit. Investigate an actual failure before requesting broader permissions; do not drop workflow changes or automatically substitute more privileged credentials.

For approval-free bot merges, scope an approval-only ruleset to `release/14.0` and grant the App pull-request-only bypass there; retain required CI in a separate ruleset without App bypass. Overlapping classic branch protection currently requires one approval and must also be accounted for. Native auto-merge has reported limitations honoring approval bypass; keep a manual approval fallback rather than bypassing CI. This PR changes no repository or App settings.

The separate version PR is #20037, targeting `release/14.0` and setting 14.0.0-preview.1.

### Validation

Passed all 39 `SyncMainToRelease14Tests` cases after removing the permission request, including the exact token permission contract, immediate merge and rejection paths for `has_hooks` and `unstable`, API behavior, mergeability retries, conflicts, settings, idempotency, identity changes, and failure propagation. The previous revision also passed the targeted scheduled-workflow watchdog integration tests. Existing `.github/workflows/**` routing already selects `Infrastructure.Tests`; no test-trigger map update is required.

### Security considerations

The workflow creates an explicitly repository-scoped, short-lived App token with contents and pull-request write permissions. It runs only from `main` in `microsoft/aspire`, never checks out or executes branch code, validates the synchronization PR's identity before merge requests, and does not modify protection settings. Required CI must remain outside any approval-bypass ruleset configured by maintainers. A normal merge rejected by GitHub fails the workflow instead of being ignored.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No