### PR TITLE
Breaking change: update OpenTelemetry to 1.18.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -158,15 +158,15 @@
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryExporterOpenTelemetryProtocolVersion)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryInstrumentationExtensionsHostingVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationAspNetCoreVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.18.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryInstrumentationHttpVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryInstrumentationRuntimeVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.18.0" />
     <!-- build dependencies -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
@@ -202,7 +202,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.8.0" />
     <!-- playground apps dependencies for javascript -->
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.61.0" />
+    <PackageVersion Include="Azure.Core" Version="1.62.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,12 +50,12 @@
     <MicrosoftExtensionsServiceDiscoveryVersion>10.9.0</MicrosoftExtensionsServiceDiscoveryVersion>
     <MicrosoftExtensionsServiceDiscoveryYarpVersion>10.9.0</MicrosoftExtensionsServiceDiscoveryYarpVersion>
     <!-- OpenTelemetry (OTel) -->
-    <OpenTelemetryInstrumentationAspNetCoreVersion>1.17.0</OpenTelemetryInstrumentationAspNetCoreVersion>
-    <OpenTelemetryInstrumentationHttpVersion>1.17.0</OpenTelemetryInstrumentationHttpVersion>
-    <OpenTelemetryInstrumentationExtensionsHostingVersion>1.17.0</OpenTelemetryInstrumentationExtensionsHostingVersion>
-    <OpenTelemetryInstrumentationRuntimeVersion>1.17.0</OpenTelemetryInstrumentationRuntimeVersion>
-    <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.17.0</OpenTelemetryExporterOpenTelemetryProtocolVersion>
-    <AzureMonitorOpenTelemetryExporterVersion>1.8.3</AzureMonitorOpenTelemetryExporterVersion>
+    <OpenTelemetryInstrumentationAspNetCoreVersion>1.18.0</OpenTelemetryInstrumentationAspNetCoreVersion>
+    <OpenTelemetryInstrumentationHttpVersion>1.18.0</OpenTelemetryInstrumentationHttpVersion>
+    <OpenTelemetryInstrumentationExtensionsHostingVersion>1.18.0</OpenTelemetryInstrumentationExtensionsHostingVersion>
+    <OpenTelemetryInstrumentationRuntimeVersion>1.18.0</OpenTelemetryInstrumentationRuntimeVersion>
+    <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.18.0</OpenTelemetryExporterOpenTelemetryProtocolVersion>
+    <AzureMonitorOpenTelemetryExporterVersion>1.9.0</AzureMonitorOpenTelemetryExporterVersion>
     <!-- Aspire.Cli uses a preview version of StreamJsonRpc which is needed for native AOT support. -->
     <StreamJsonRpcPackageVersionForCli>2.23.32-alpha</StreamJsonRpcPackageVersionForCli>
     <!-- MicroBuild.Core version for VS Code extension signing -->


### PR DESCRIPTION
## Description

Updates the coordinated OpenTelemetry package family from 1.17.0 to 1.18.0 and `OpenTelemetry.Instrumentation.GrpcNetClient` from 1.15.1-beta.1 to 1.18.0-beta.1. It also updates `Azure.Monitor.OpenTelemetry.Exporter` from 1.8.3 to 1.9.0 and the required `Azure.Core` dependency from 1.61.0 to 1.62.0.

This intentionally keeps the OpenTelemetry and Azure Monitor exporter versions coherent. Azure Monitor 1.9.0 requires `OpenTelemetry.Extensions.Hosting` 1.18.0 and changes shutdown handling used by the Aspire CLI.

Upstream release notes:

- [OpenTelemetry .NET 1.18.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.18.0)
- [Azure Monitor OpenTelemetry Exporter 1.9.0](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Monitor.OpenTelemetry.Exporter_1.9.0/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md)

The ServiceDefaults templates derive their package versions from `eng/Versions.props`, so newly generated projects use OpenTelemetry 1.18.0. Existing customer projects keep the package versions written when they were generated and are not automatically changed by this PR. The non-CPM MAUI ServiceDefaults project also resolves its explicit OpenTelemetry version properties to 1.18.0.

### Dependency blocker

`OpenTelemetry.Instrumentation.GrpcNetClient` 1.18.0-beta.1 is the only updated package not currently available from the approved internal feeds. The required `dotnet-migrate-package` import is paused because the preceding unrelated Testcontainers import [run 3072323](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072323) failed the same intermediate quarantine that previously blocked the bUnit import. The quarantine has not been bypassed, and no follow-up import was queued.

## Breaking changes

OpenTelemetry 1.18.0 reduces the default maximum serialized OTLP export request from **128 MiB to 64 MiB**. If an entire serialized batch exceeds 64 MiB, the exporter does not send it and drops the whole batch. Users that intentionally rely on requests between 64 MiB and 128 MiB can preserve the previous limit:

```csharp
using OpenTelemetry.Exporter;

builder.Services.Configure<OtlpExporterOptions>(options =>
{
    options.MaxRequestSizeBytes = 128 * 1024 * 1024;
});

builder.Services.AddOpenTelemetry()
    .UseOtlpExporter();
```

`MaxRequestSizeBytes` supports values up to 256 MiB. OpenTelemetry 1.18.0 also introduces a **4 MiB** default maximum OTLP response size; an oversized response is discarded and treated as non-retryable. Server-provided retry delays are clamped to at least 100 ms, and certain non-transient HTTP failures are no longer retried.

Aspire does not override these limits. Newly generated ServiceDefaults projects and Aspire's own OTLP-exporting processes therefore use the new defaults. Existing generated customer projects remain on their current OpenTelemetry versions unless they update those package references.

Azure Monitor OpenTelemetry Exporter 1.9.0 changes provider shutdown and `Dispose()` so pending telemetry is first persisted to offline storage and then drained in the background during the available shutdown window. This directly affects the Aspire CLI, which configures Azure Monitor with a storage directory and disposes its provider at process exit. To restore the previous shutdown behavior, set:

```csharp
AppContext.SetSwitch(
    "Azure.Monitor.OpenTelemetry.Exporter.DisablePersistOnShutdown",
    isEnabled: true);
```

Short-lived processes that want persistence without waiting for the background drain can set `Azure.Monitor.OpenTelemetry.Exporter.ShutdownDrainBudgetMilliseconds` to `0` with `AppContext.SetData` or a `runtimeconfig.json` config property. `ForceFlush` behavior is unchanged unless `Azure.Monitor.OpenTelemetry.Exporter.PersistOnForceFlush` is enabled.

Rollback is limited to restoring OpenTelemetry packages to 1.17.0, `OpenTelemetry.Instrumentation.GrpcNetClient` to 1.15.1-beta.1, Azure Monitor OpenTelemetry Exporter to 1.8.3, and Azure.Core to 1.61.0.

Validation:

- Built the OpenTelemetry-consuming `Aspire.Hosting` project for net8.0, net9.0, and net10.0.
- Built `Aspire.Cli` with Azure Monitor OpenTelemetry Exporter 1.9.0.
- Built the template pack and verified generated ServiceDefaults package references resolve to OpenTelemetry 1.18.0.
- Verified the MAUI ServiceDefaults explicit package references evaluate to OpenTelemetry 1.18.0.
- Ran the targeted CLI Azure Monitor and OTLP provider tests.
- Full repository restore remains blocked until `OpenTelemetry.Instrumentation.GrpcNetClient` 1.18.0-beta.1 can be imported through the approved pipeline.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No