### PR TITLE
Update ModelContextProtocol to 2.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -129,7 +129,7 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="$(MicrosoftFluentUIAspNetCoreComponentsVersion)" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="5.0.0-rc.6.26241.1" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.5.0" />

--- a/playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj
+++ b/playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" VersionOverride="1.12.0-preview.260629.1" />
     <PackageReference Include="Microsoft.Extensions.AI" VersionOverride="10.7.0" />
-    <PackageReference Include="ModelContextProtocol" VersionOverride="1.1.0" />
+    <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Azure.Core" VersionOverride="1.59.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Updates `ModelContextProtocol` from 1.3.0 to 2.2.0 as a separate, rollbackable breaking-change PR rather than combining the major SDK migration with the bulk third-party dependency update.

The package is consumed by the production Aspire CLI MCP server, the AppHost resource-MCP proxy, CLI tests, hosting tests, and the Foundry hosted-agent playground. The playground's `VersionOverride="1.1.0"` is removed so it does not defeat the central 2.2.0 version. No `Microsoft.Extensions.AI`, `Microsoft.Extensions.AI.OpenAI`, `OpenAI`, or unrelated Foundry package versions are changed.

The existing Aspire source compiles against 2.2.0 without API adaptations:

- `aspire agent mcp` remains a stdio MCP server through `StdioMcpTransportFactory` / `StdioServerTransport`.
- AppHost resource MCP integration remains an HTTP client through `HttpClientTransport` / `McpClient.CreateAsync` for tool discovery and invocation.
- Aspire's built-in tools already emit `Tool.InputSchema`.
- Aspire's built-in CLI tools manually construct content blocks and do not use the SDK's reflection-based non-object structured-result wrapping.

Dependency restore resolved 2.2.0 from the approved `dotnet-public` feed; no mirror pipeline was triggered.

### Breaking changes

**Affected scenario:** user-defined MCP servers attached to Aspire resources with `WithMcpServer(...)`, then discovered and invoked through the Aspire CLI MCP server.

| | Behavior |
|---|---|
| Before | SDK 1.3 tolerated a `tools/list` entry that omitted `inputSchema` and supplied a default schema. |
| After | SDK 2.2 requires every `Tool` payload to contain `inputSchema`; malformed entries throw during deserialization. Aspire's AppHost discovery logs the failure and omits that resource's tools from the CLI tool list. |

Custom MCP servers and proxies must include an input schema for every tool. An empty object is sufficient for tools without arguments:

```json
{
  "name": "restart",
  "description": "Restarts the resource",
  "inputSchema": {}
}
```

A more descriptive schema remains preferred:

```json
{
  "name": "query",
  "description": "Runs a query",
  "inputSchema": {
    "type": "object",
    "properties": {
      "sql": { "type": "string" }
    },
    "required": ["sql"]
  }
}
```

**Compatibility assumptions and exclusions:**

- This does not mean every older MCP peer breaks. SDK 2 clients probe `server/discover` first and fall back to the down-level `initialize` handshake when communicating with older servers; older compliant servers that include `inputSchema` remain supported.
- The SDK 2 stateless-by-default HTTP **server** change does not apply to `aspire agent mcp`, because Aspire serves that endpoint over stdio, not `HttpServerTransport`.
- Aspire is only an HTTP MCP **client** for resource endpoints; this PR does not change a hosted Aspire HTTP MCP server's session mode.
- Aspire does not configure SDK OAuth callbacks or dynamic client registration for resource endpoints, so SDK 2's stricter PKCE S256, issuer metadata, and callback validation does not change an existing Aspire-managed OAuth flow.
- The SDK's raw non-object `structuredContent` behavior does not change Aspire's built-in tool result shape. Resource MCP results continue to pass through the SDK `CallToolResult` over the AppHost backchannel.

**Rollback:** revert the central package version to 1.3.0 and restore the Foundry playground's 1.1.0 override. No data or configuration migration is required.

Upstream references:

- [ModelContextProtocol C# SDK 2.0.0 release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.0.0)
- [ModelContextProtocol C# SDK 2.1.0 release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.1.0)
- [ModelContextProtocol C# SDK 2.2.0 release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.2.0)

### Test evidence

- Built `src/Aspire.Cli/Aspire.Cli.csproj`, `src/Aspire.Hosting/Aspire.Hosting.csproj`, and `playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj` with no warnings or errors.
- Passed 18 focused CLI MCP server and backchannel serialization tests.
- Passed 80 hosting MCP endpoint, resource discovery, and auxiliary backchannel tests.
- Resolved Foundry graph remains `Microsoft.Extensions.AI` 10.7.0, `Microsoft.Extensions.AI.OpenAI` 10.9.0, `OpenAI` 2.12.0, and `ModelContextProtocol` 2.2.0.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No