### PR TITLE
Breaking change: update StackExchange.Redis to 3.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -146,7 +146,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.2" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.2.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.12" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />

--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using Aspire;
 using Aspire.StackExchange.Redis;
 using Microsoft.Extensions.Configuration;
@@ -215,7 +220,7 @@ public static class AspireRedisExtensions
     private static ConfigurationOptions BindToConfiguration(ConfigurationOptions options, IConfiguration configuration)
     {
         var configurationOptionsSection = configuration.GetSection("ConfigurationOptions");
-        configurationOptionsSection.Bind(options);
+        configurationOptionsSection.Bind(new BindableConfigurationOptions(options));
 
         return options;
     }
@@ -277,5 +282,281 @@ public static class AspireRedisExtensions
     {
         // Disable aborting on connect fail since we want to retry, even in local development.
         public override bool AbortOnConnectFail => false;
+
+        // StackExchange.Redis 3 prefers RESP3 and falls back to RESP2 when the server doesn't support it.
+        public override RedisProtocol? Protocol => RedisProtocol.Resp3;
+    }
+
+    /// <summary>
+    /// Limits source-generated configuration binding to supported Redis options.
+    /// </summary>
+    /// <remarks>
+    /// StackExchange.Redis 3.2 retains several properties that are marked as compile-time errors or experimental.
+    /// A forwarding type lets the configuration binder remain AOT-compatible without generating references to
+    /// those properties.
+    /// </remarks>
+    internal sealed class BindableConfigurationOptions(ConfigurationOptions options)
+    {
+        private readonly ConfigurationOptions _options = options;
+
+        public bool AbortOnConnectFail
+        {
+            get => _options.AbortOnConnectFail;
+            set => _options.AbortOnConnectFail = value;
+        }
+
+        public bool AllowAdmin
+        {
+            get => _options.AllowAdmin;
+            set => _options.AllowAdmin = value;
+        }
+
+        public int AsyncTimeout
+        {
+            get => _options.AsyncTimeout;
+            set => _options.AsyncTimeout = value;
+        }
+
+        public BacklogPolicy BacklogPolicy
+        {
+            get => _options.BacklogPolicy;
+            set => _options.BacklogPolicy = value;
+        }
+
+        public Action<EndPoint, ConnectionType, Socket>? BeforeSocketConnect
+        {
+            get => _options.BeforeSocketConnect;
+            set => _options.BeforeSocketConnect = value;
+        }
+
+        public RedisChannel ChannelPrefix
+        {
+            get => _options.ChannelPrefix;
+            set => _options.ChannelPrefix = value;
+        }
+
+        public bool CheckCertificateRevocation
+        {
+            get => _options.CheckCertificateRevocation;
+            set => _options.CheckCertificateRevocation = value;
+        }
+
+        public string? ClientName
+        {
+            get => _options.ClientName;
+            set => _options.ClientName = value;
+        }
+
+        public CommandMap CommandMap
+        {
+            get => _options.CommandMap;
+            set => _options.CommandMap = value;
+        }
+
+        public int ConfigCheckSeconds
+        {
+            get => _options.ConfigCheckSeconds;
+            set => _options.ConfigCheckSeconds = value;
+        }
+
+        public string ConfigurationChannel
+        {
+            get => _options.ConfigurationChannel;
+            set => _options.ConfigurationChannel = value;
+        }
+
+        public int ConnectRetry
+        {
+            get => _options.ConnectRetry;
+            set => _options.ConnectRetry = value;
+        }
+
+        public int ConnectTimeout
+        {
+            get => _options.ConnectTimeout;
+            set => _options.ConnectTimeout = value;
+        }
+
+        public int? DefaultDatabase
+        {
+            get => _options.DefaultDatabase;
+            set => _options.DefaultDatabase = value;
+        }
+
+        public DefaultOptionsProvider Defaults
+        {
+            get => _options.Defaults;
+            set => _options.Defaults = value;
+        }
+
+        public Version DefaultVersion
+        {
+            get => _options.DefaultVersion;
+            set => _options.DefaultVersion = value;
+        }
+
+        public EndPointCollection EndPoints => _options.EndPoints;
+
+        public bool HeartbeatConsistencyChecks
+        {
+            get => _options.HeartbeatConsistencyChecks;
+            set => _options.HeartbeatConsistencyChecks = value;
+        }
+
+        public TimeSpan HeartbeatInterval
+        {
+            get => _options.HeartbeatInterval;
+            set => _options.HeartbeatInterval = value;
+        }
+
+        public bool HighIntegrity
+        {
+            get => _options.HighIntegrity;
+            set => _options.HighIntegrity = value;
+        }
+
+        public bool IncludeDetailInExceptions
+        {
+            get => _options.IncludeDetailInExceptions;
+            set => _options.IncludeDetailInExceptions = value;
+        }
+
+        public bool IncludePerformanceCountersInExceptions
+        {
+            get => _options.IncludePerformanceCountersInExceptions;
+            set => _options.IncludePerformanceCountersInExceptions = value;
+        }
+
+        public int KeepAlive
+        {
+            get => _options.KeepAlive;
+            set => _options.KeepAlive = value;
+        }
+
+        public string? LibraryName
+        {
+            get => _options.LibraryName;
+            set => _options.LibraryName = value;
+        }
+
+        public ILoggerFactory? LoggerFactory
+        {
+            get => _options.LoggerFactory;
+            set => _options.LoggerFactory = value;
+        }
+
+        public string? Password
+        {
+            get => _options.Password;
+            set => _options.Password = value;
+        }
+
+        public RedisProtocol? Protocol
+        {
+            get => _options.Protocol;
+            set => _options.Protocol = value;
+        }
+
+        public Proxy Proxy
+        {
+            get => _options.Proxy;
+            set => _options.Proxy = value;
+        }
+
+        public MemoryPool<byte>? RequestBufferPool
+        {
+            get => _options.RequestBufferPool;
+            set => _options.RequestBufferPool = value;
+        }
+
+        public bool ResolveDns
+        {
+            get => _options.ResolveDns;
+            set => _options.ResolveDns = value;
+        }
+
+        public MemoryPool<byte>? ResponseBufferPool
+        {
+            get => _options.ResponseBufferPool;
+            set => _options.ResponseBufferPool = value;
+        }
+
+        public string? SentinelPassword
+        {
+            get => _options.SentinelPassword;
+            set => _options.SentinelPassword = value;
+        }
+
+        public string? SentinelUser
+        {
+            get => _options.SentinelUser;
+            set => _options.SentinelUser = value;
+        }
+
+        public string? ServiceName
+        {
+            get => _options.ServiceName;
+            set => _options.ServiceName = value;
+        }
+
+        public bool SetClientLibrary
+        {
+            get => _options.SetClientLibrary;
+            set => _options.SetClientLibrary = value;
+        }
+
+        public bool Ssl
+        {
+            get => _options.Ssl;
+            set => _options.Ssl = value;
+        }
+
+        public Func<string, SslClientAuthenticationOptions>? SslClientAuthenticationOptions
+        {
+            get => _options.SslClientAuthenticationOptions;
+            set => _options.SslClientAuthenticationOptions = value;
+        }
+
+        public string? SslHost
+        {
+            get => _options.SslHost;
+            set => _options.SslHost = value;
+        }
+
+        public SslProtocols? SslProtocols
+        {
+            get => _options.SslProtocols;
+            set => _options.SslProtocols = value;
+        }
+
+        public int SyncTimeout
+        {
+            get => _options.SyncTimeout;
+            set => _options.SyncTimeout = value;
+        }
+
+        public bool TcpKeepAlive
+        {
+            get => _options.TcpKeepAlive;
+            set => _options.TcpKeepAlive = value;
+        }
+
+        public string TieBreaker
+        {
+            get => _options.TieBreaker;
+            set => _options.TieBreaker = value;
+        }
+
+        public Tunnel? Tunnel
+        {
+            get => _options.Tunnel;
+            set => _options.Tunnel = value;
+        }
+
+        public string? User
+        {
+            get => _options.User;
+            set => _options.User = value;
+        }
     }
 }

--- a/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
@@ -6,6 +6,21 @@ using Aspire;
 using StackExchange.Redis;
 
 [assembly: ConfigurationSchema("Aspire:StackExchange:Redis", typeof(StackExchangeRedisSettings))]
-[assembly: ConfigurationSchema("Aspire:StackExchange:Redis:ConfigurationOptions", typeof(ConfigurationOptions))]
+// Redis 3.2 marks the availability policies as experimental and legacy settings as errors.
+// Excluding them keeps configuration binding limited to supported, effective options.
+[assembly: ConfigurationSchema(
+    "Aspire:StackExchange:Redis:ConfigurationOptions",
+    typeof(ConfigurationOptions),
+    exclusionPaths: [
+        "CircuitBreaker",
+        "HighPrioritySocketThreads",
+        "PreserveAsyncOrder",
+        "ReconnectRetryPolicy",
+        "ResponseTimeout",
+        "RetryPolicy",
+        "SocketManager",
+        "UseSsl",
+        "WriteBuffer"
+    ])]
 
 [assembly: LoggingCategories("StackExchange.Redis")]

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -128,6 +128,14 @@
                       "type": "boolean",
                       "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
                     },
+                    "SentinelPassword": {
+                      "type": "string",
+                      "description": "The password to use to authenticate with Sentinel servers, only when different from the Redis server password (optional). If not specified, 'StackExchange.Redis.ConfigurationOptions.Password' is used when communicating with Sentinels."
+                    },
+                    "SentinelUser": {
+                      "type": "string",
+                      "description": "The username to use to authenticate with Sentinel servers, only when different from the Redis server password (optional). If not specified, 'StackExchange.Redis.ConfigurationOptions.User' is used when communicating with Sentinels."
+                    },
                     "ServiceName": {
                       "type": "string",
                       "description": "The service name used to resolve a service via sentinel."
@@ -160,6 +168,10 @@
                     "SyncTimeout": {
                       "type": "integer",
                       "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
+                    },
+                    "TcpKeepAlive": {
+                      "type": "boolean",
+                      "description": "Gets or sets whether to enable TCP keep-alive when appropriate (endpoint- and platform-dependent)."
                     },
                     "TieBreaker": {
                       "type": "string",

--- a/src/Components/Aspire.StackExchange.Redis/README.md
+++ b/src/Components/Aspire.StackExchange.Redis/README.md
@@ -96,6 +96,30 @@ You can also setup the [ConfigurationOptions](https://stackexchange.github.io/St
 builder.AddRedisClient("cache", configureOptions: options => options.ConnectTimeout = 3000);
 ```
 
+### RESP protocol
+
+StackExchange.Redis 3 uses RESP3 by default for endpoints that support it. Typed operations are generally transparent, but applications that process `RedisResult` values from `Execute`, `ExecuteAsync`, `ScriptEvaluate`, or `ScriptEvaluateAsync` may observe different result types and structures.
+
+To retain the StackExchange.Redis 2 behavior while migrating result-processing code, set `protocol=resp2` in the connection string:
+
+```json
+{
+  "ConnectionStrings": {
+    "cache": "localhost:6379,protocol=resp2"
+  }
+}
+```
+
+Alternatively, configure the protocol in code:
+
+```csharp
+builder.AddRedisClient(
+    "cache",
+    configureOptions: options => options.Protocol = RedisProtocol.Resp2);
+```
+
+See the [StackExchange.Redis RESP3 migration notes](https://seredis.dev/Resp3.html) for affected commands and result-processing guidance.
+
 ## AppHost extensions
 
 In your AppHost project, install the `Aspire.Hosting.Redis` library with [NuGet](https://www.nuget.org):

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisProtocolTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisProtocolTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Aspire.StackExchange.Redis.Tests;
+
+public class AspireRedisProtocolTests
+{
+    [Fact]
+    public void BindsSupportedConfigurationOptions()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:redis", "localhost"),
+            new KeyValuePair<string, string?>("Aspire:StackExchange:Redis:ConfigurationOptions:ConnectTimeout", "3000"),
+            new KeyValuePair<string, string?>("Aspire:StackExchange:Redis:ConfigurationOptions:HeartbeatInterval", "00:00:02"),
+            new KeyValuePair<string, string?>("Aspire:StackExchange:Redis:ConfigurationOptions:Ssl", "true")
+        ]);
+
+        builder.AddRedisClient("redis");
+
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<ConfigurationOptions>>().Value;
+
+        Assert.Equal(3000, options.ConnectTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(2), options.HeartbeatInterval);
+        Assert.True(options.Ssl);
+    }
+
+    [Theory]
+    [InlineData(null, RedisProtocol.Resp3)]
+    [InlineData("resp2", RedisProtocol.Resp2)]
+    public void UsesExpectedRespProtocol(string? protocol, RedisProtocol expectedProtocol)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionString = protocol is null ? "localhost" : $"localhost,protocol={protocol}";
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:redis", connectionString)
+        ]);
+
+        builder.AddRedisClient("redis");
+
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<ConfigurationOptions>>().Value;
+
+        Assert.Equal(expectedProtocol, options.Protocol ?? options.Defaults.Protocol);
+    }
+}


### PR DESCRIPTION
## Description

Updates `StackExchange.Redis` from 2.13.1 to 3.2.0 as a separate change so the customer-visible protocol default can be reviewed, released, and rolled back independently from routine third-party dependency updates.

StackExchange.Redis 3 rewrites its internal I/O implementation and defaults supported endpoints to RESP3. Aspire now explicitly preserves that default in its custom options provider, while continuing to honor `protocol=resp2` and `ConfigurationOptions.Protocol` overrides.

Redis 3.2 also exposes experimental and compile-time-obsolete `ConfigurationOptions` properties that cannot be visited by the .NET configuration binding source generator. This change:

- binds through an AOT-compatible forwarding options type containing supported settings;
- excludes experimental, obsolete, and non-bindable settings from the generated configuration schema;
- keeps `IConnectionMultiplexer` registration and `Microsoft.Azure.StackExchangeRedis` authentication behavior unchanged;
- documents the RESP3 migration and RESP2 opt-out.

### Dependency blocker

This draft is not ready to merge because the approved `dotnet-public` feed does not yet contain:

- `StackExchange.Redis` 3.2.0 (nearest available version is 3.1.31)
- `RESPite` 3.2.0, a new exact transitive dependency of StackExchange.Redis 3.2.0

The internal package migration queue is paused after pipeline run 3072323 failed its intermediate quarantine. No external feed or fallback source is added by this PR. The packages must be imported through the approved `dotnet-migrate-package` pipeline before this PR can restore in CI.

### Validation

- Built `Aspire.StackExchange.Redis`, distributed caching, and output caching for .NET 8, .NET 9, and .NET 10 using the published packages from nuget.org for pre-mirror validation.
- Added focused tests for supported configuration binding, the RESP3 default, and the RESP2 opt-out across .NET 8, .NET 9, and .NET 10.
- Ran `Aspire.Microsoft.Azure.StackExchangeRedis.Tests` across .NET 8, .NET 9, and .NET 10.
- Built the Redis playground containing Redis, Garnet, and Valkey resources.
- Confirmed an approved-feed-only restore fails specifically because `StackExchange.Redis` 3.2.0 is not mirrored.

Fixes # (issue)

## Breaking changes

**Old default:** StackExchange.Redis 2.13 uses RESP2 for non-Azure-Managed-Redis endpoints and RESP3 for Azure Managed Redis endpoints.

**New default:** StackExchange.Redis 3 uses RESP3 for every endpoint that supports it. Servers that do not support RESP3 fall back to RESP2.

Most typed `IDatabase` and cache operations are transparent. Users are affected when they or a library process raw `RedisResult` values from:

- `Execute` / `ExecuteAsync`
- `ScriptEvaluate` / `ScriptEvaluateAsync`
- Lua scripts, modules, or ad-hoc commands whose RESP3 reply shape differs from RESP2

RESP3 can return richer types or different structures, such as maps instead of nested arrays. Applications should validate raw command and script result handling under RESP3. StackExchange.Redis 3.2 also enforces `AllowAdmin` for admin commands issued through `Execute` / `ExecuteAsync`.

To temporarily preserve the previous protocol while migrating:

```text
localhost:6379,protocol=resp2
```

or:

```csharp
builder.AddRedisClient(
    "cache",
    configureOptions: options => options.Protocol = RedisProtocol.Resp2);
```

This opt-out should be applied only where raw result handling requires it; Aspire does not blanket-disable RESP3. Redis Enterprise requires a RESP3-capable version (7.2 or later). Garnet and Valkey support RESP3, but applications using product-specific commands should validate those commands independently.

Rollback is an independent revert of this PR, restoring the StackExchange.Redis 2.13.x package and its prior protocol defaults.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No