### PR TITLE
Breaking change: Update Foundry agent dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Azure.AI.AgentServer.AgentFramework" Version="1.0.0-beta.11" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
-    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.1" />
+    <PackageVersion Include="Azure.AI.Projects" Version="3.0.0-beta.2" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
@@ -202,7 +202,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.8.0" />
     <!-- playground apps dependencies for javascript -->
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.61.0" />
+    <PackageVersion Include="Azure.Core" Version="1.62.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj
+++ b/playground/FoundryAgents/DotNetHostedAgent/DotNetHostedAgent.csproj
@@ -9,12 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.Projects" VersionOverride="2.1.0-beta.3" />
+    <PackageReference Include="Azure.AI.Projects" VersionOverride="3.0.0-beta.2" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" VersionOverride="1.12.0-preview.260629.1" />
-    <PackageReference Include="Microsoft.Extensions.AI" VersionOverride="10.7.0" />
-    <PackageReference Include="ModelContextProtocol" VersionOverride="1.1.0" />
-    <PackageReference Include="Azure.Core" VersionOverride="1.59.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" VersionOverride="1.20.0-preview.260831.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="ModelContextProtocol" VersionOverride="2.2.0" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Storage.Blobs" VersionOverride="12.29.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FoundryHostedAgentDeploymentTests.cs
@@ -775,12 +775,13 @@ public sealed class FoundryHostedAgentDeploymentTests(ITestOutputHelper output)
                     <NoWarn>$(NoWarn);OPENAI001;MAIF001;MAAI001</NoWarn>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="Azure.AI.Projects" Version="2.1.0-beta.3" />
+                    <PackageReference Include="Azure.AI.Projects" Version="3.0.0-beta.2" />
                     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-                    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" Version="1.12.0-preview.260629.1" />
-                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
-                    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
-                    <PackageReference Include="Azure.Core" Version="1.59.0" />
+                    <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" Version="1.20.0-preview.260831.1" />
+                    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
+                    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
+                    <PackageReference Include="Azure.Core" Version="1.62.0" />
+                    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
                   </ItemGroup>
                 </Project>
                 """);


### PR DESCRIPTION
## Description

Updates the Microsoft Foundry dependency set independently from the bulk dependency refresh so the customer-facing Azure AI Projects major-version change can be reviewed and rolled back on its own.

- Updates `Azure.AI.Projects` from `2.1.0-beta.1` (with a `2.1.0-beta.3` playground override) to `3.0.0-beta.2`.
- Updates the hosted-agent playground and generated deployment-test project from `Microsoft.Agents.AI.Foundry.Hosting` `1.12.0-preview.260629.1` to `1.20.0-preview.260831.1`.
- Aligns the hosted-agent project with the dependency prerequisites already being updated by the dependency refresh: Azure Core 1.62, Microsoft.Extensions.AI 10.9, Model Context Protocol 2.2, and Azure Storage Blobs 12.29.1.
- Keeps the playground project and the out-of-tree project generated by `FoundryHostedAgentDeploymentTests` on the same explicit package set.

No Aspire source migration is required. Aspire does not call the Projects 3 APIs whose signatures changed and does not use the renamed Agent optimization types. The existing Aspire hosted-agent implementation already configured Responses protocol `2.0.0` and already used `ResponseContext.PlatformContext` with `HostedSessionContext(UserId)` before this dependency update; this PR does not migrate or change that runtime protocol configuration.

### Breaking changes

**Affected users:** Applications that reference `Aspire.Hosting.Foundry` and also compile directly against Azure AI Projects APIs changed in 3.0. The Foundry Hosting update is limited to Aspire's playground and generated deployment-test application; it does not add a new Aspire runtime protocol migration.

**Old behavior:**

- `Aspire.Hosting.Foundry` restored Azure AI Projects 2.1.
- `AIProjectConnectionsOperations.GetConnection[Async]` returned `AIProjectConnection` directly.
- Routine listing accepted the `before` parameter, and routine-run listing used `name`.
- Agent optimization model types used names such as `OptimizationJob` and `OptimizationOptions`.
- The Aspire hosted-agent playground already declared Responses protocol `2.0.0` and used the protocol-2 platform context APIs.

**New behavior:**

- `Aspire.Hosting.Foundry` restores Azure AI Projects 3.0.
- `GetConnection` returns `ClientResult<AIProjectConnection>` and `GetConnectionAsync` returns `Task<ClientResult<AIProjectConnection>>`.
- Routine listing no longer accepts `before`; routine-run listing uses `routineName`.
- Agent optimization types are prefixed with `Agent`, for example `AgentOptimizationJob` and `AgentOptimizationOptions`.
- The playground consumes Foundry Hosting 1.20, which only supports Responses container protocol `2.0`; Aspire's configured protocol remains `2.0.0`. Upstream `HostedSessionContext.ChatId` and the `PerChat` / `PerUserAndChat` memory scopes are removed, but Aspire does not use those APIs.

**Migration:**

```csharp
ClientResult<AIProjectConnection> result =
    await projectClient.Connections.GetConnectionAsync(connectionName);
AIProjectConnection connection = result.Value;
```

Remove the `before` argument from routine-list calls, rename the routine-run `name` argument to `routineName`, and use the new `AgentOptimization*` type names. Consumers extending Foundry Hosting should continue targeting Responses protocol `2.0`, partition by `HostedSessionContext.UserId`, and use the `PerUser` memory scope instead of removed chat-scoped values.

**Rollback:** Revert this PR. That restores `Azure.AI.Projects` 2.1 and `Microsoft.Agents.AI.Foundry.Hosting` 1.12 without reverting unrelated dependency updates.

### Coordination and validation

- Model Context Protocol 2.2 is tracked separately in #20045. The parent bulk dependency refresh is #20046 and carries shared dependency prerequisites.
- Repository SDK restore completed successfully.
- A targeted restore was retried on September 11 against the unchanged approved feeds and remains blocked because they do not contain:
  - `Azure.AI.Projects` `3.0.0-beta.2` (nearest: `2.1.0-beta.3`)
  - `Azure.AI.AgentServer.Core` `1.0.0-beta.28` (nearest: `1.0.0-beta.26`)
  - `Azure.AI.AgentServer.Responses` `1.0.0-beta.8` (nearest: `1.0.0-beta.6`)
- No package-import pipeline was queued and no feed bypass was used.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No