### PR TITLE
Detect coding agents from process environment variables

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/tests/Aspire.Cli.EndToEnd.Tests"
+    groups:
+      npm:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
+++ b/src/Aspire.Cli/Telemetry/CodingAgentDetector.cs
@@ -1,14 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Configuration;
-
 namespace Aspire.Cli.Telemetry;
 
 /// <summary>
-/// Detects coding agents from known environment variables.
+/// Detects coding agents from known process environment variables.
 /// </summary>
-internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodingAgentDetector
+internal sealed class CodingAgentDetector(IEnvironment environment) : ICodingAgentDetector
 {
     // Keep this in sync with the dotnet CLI's LLMEnvironmentDetectorForTelemetry detection
     // order so Aspire reports the same agent names when the same environment variables are set.
@@ -48,7 +46,8 @@ internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodin
         new("generic_agent", ["AGENT_CLI"])
     ];
 
-    private readonly IConfiguration _configuration = configuration;
+    // Settings files must not introduce or override process-level agent markers.
+    private readonly IEnvironment _environment = environment;
 
     /// <inheritdoc />
     public string? GetCodingAgent()
@@ -57,7 +56,7 @@ internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodin
 
         foreach (var rule in s_detectionRules)
         {
-            if (rule.IsMatch(_configuration))
+            if (rule.IsMatch(_environment))
             {
                 agentNames ??= [];
                 if (!agentNames.Contains(rule.AgentName, StringComparer.Ordinal))
@@ -77,11 +76,11 @@ internal sealed class CodingAgentDetector(IConfiguration configuration) : ICodin
 
         public string AgentName { get; } = agentName;
 
-        public bool IsMatch(IConfiguration configuration)
+        public bool IsMatch(IEnvironment environment)
         {
             foreach (var variableName in _variableNames)
             {
-                var value = configuration[variableName];
+                var value = environment.GetEnvironmentVariable(variableName);
                 if (_expectedValue is null)
                 {
                     if (!string.IsNullOrEmpty(value))

--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -51,6 +51,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Keep dependency pins with the test assembly when CI runs from an archive. -->
+    <EmbeddedResource Include="package.json" LogicalName="Aspire.Cli.EndToEnd.Tests.package.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Hex1b" />
     <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
     <PackageReference Include="ModelContextProtocol" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/ViteTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/ViteTestHelpers.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+internal static class ViteTestHelpers
+{
+    internal static string GetCreateCommand(string projectDirectory)
+    {
+        // Read devDependencies["create-vite"] from the embedded npm manifest so Dependabot
+        // owns the pin instead of adopting newly published templates during a test run.
+        using var stream = typeof(ViteTestHelpers).Assembly.GetManifestResourceStream("Aspire.Cli.EndToEnd.Tests.package.json")
+            ?? throw new InvalidOperationException("The E2E npm dependency manifest is missing from the test assembly.");
+        using var manifest = JsonDocument.Parse(stream);
+        var version = manifest.RootElement.GetProperty("devDependencies").GetProperty("create-vite").GetString();
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            throw new InvalidOperationException("The E2E npm dependency manifest must specify a create-vite version.");
+        }
+
+        return $"npm create -y {AspireCliShellCommandHelpers.QuoteBashArg($"vite@{version}")} {AspireCliShellCommandHelpers.QuoteBashArg(projectDirectory)} -- --template vanilla-ts --no-interactive";
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotApphostDirectoryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotApphostDirectoryTests.cs
@@ -57,7 +57,7 @@ public sealed class JavaPolyglotApphostDirectoryTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created AppHost.java", timeout: TimeSpan.FromMinutes(2));
         await auto.DeclineAgentInitPromptAsync(counter);
 
-        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("viteapp"));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JavaPolyglotTests.cs
@@ -39,7 +39,7 @@ public sealed class JavaPolyglotTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created AppHost.java", timeout: TimeSpan.FromMinutes(2));
         await auto.DeclineAgentInitPromptAsync(counter);
 
-        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("viteapp"));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Cli.EndToEnd.Tests/README.md
@@ -106,6 +106,22 @@ await sequence.ApplyAsync(Terminal);
 
 ## Running Tests Locally
 
+### npm test dependencies
+
+The project-level `package.json` pins npm tools used to scaffold test fixtures.
+`ViteTestHelpers.GetCreateCommand` reads the `create-vite` version from this manifest
+instead of using `vite@latest`. The manifest is embedded in the test assembly so
+local runs and CI test archives use the same version; no local `npm install` is
+needed for this manifest.
+
+Dependabot checks this directory weekly and waits seven days before proposing
+new versions. The cooldown avoids adopting freshly published Vite templates whose
+dependencies can be rejected by Deno's minimum dependency age policy. Keep tool
+versions exact in the manifest, and use the shared helper rather than embedding
+versions in individual tests.
+
+### Commands
+
 ```bash
 # Build the test project
 ./build.sh -restore -build -projects tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotApphostDirectoryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotApphostDirectoryTests.cs
@@ -63,7 +63,7 @@ public sealed class TypeScriptPolyglotApphostDirectoryTests(ITestOutputHelper ou
             CliE2ETestHelpers.WriteLocalChannelSettings(projectRoot, localChannel.SdkVersion);
         }
 
-        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("viteapp"));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -75,7 +75,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         // Using --template vanilla-ts for a minimal TypeScript Vite app
         // Use -y to skip npm prompts and -- to pass args to create-vite
         // Use --no-interactive to skip vite's interactive prompts (rolldown, install now, etc.)
-        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("viteapp"));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
@@ -190,7 +190,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
             CliE2ETestHelpers.WriteLocalChannelSettings(workspace.WorkspaceRoot.FullName, localChannel.SdkVersion);
         }
 
-        await auto.TypeAsync("npm create -y vite@latest viteapp -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("viteapp"));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
@@ -439,7 +439,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        await auto.TypeAsync("npm create -y vite@latest . -- --template vanilla-ts --no-interactive");
+        await auto.TypeAsync(ViteTestHelpers.GetCreateCommand("."));
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ViteTestHelpersTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ViteTestHelpersTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+public sealed class ViteTestHelpersTests
+{
+    [Theory]
+    [InlineData("viteapp", "'viteapp'")]
+    [InlineData(".", "'.'")]
+    [InlineData("vite app", "'vite app'")]
+    [InlineData("vite'app", "'vite'\"'\"'app'")]
+    public void GetCreateCommand_UsesPinnedManifestVersion(string projectDirectory, string quotedDirectory)
+    {
+        using var stream = typeof(ViteTestHelpers).Assembly.GetManifestResourceStream("Aspire.Cli.EndToEnd.Tests.package.json");
+        Assert.NotNull(stream);
+        using var manifest = JsonDocument.Parse(stream);
+        var version = manifest.RootElement.GetProperty("devDependencies").GetProperty("create-vite").GetString();
+        Assert.NotNull(version);
+        Assert.Matches(@"^\d+\.\d+\.\d+$", version);
+
+        var command = ViteTestHelpers.GetCreateCommand(projectDirectory);
+
+        Assert.Equal($"npm create -y 'vite@{version}' {quotedDirectory} -- --template vanilla-ts --no-interactive", command);
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/package.json
+++ b/tests/Aspire.Cli.EndToEnd.Tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "aspire-cli-e2e-dependencies",
+  "private": true,
+  "devDependencies": {
+    "create-vite": "9.2.0"
+  }
+}

--- a/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
@@ -3,7 +3,9 @@
 
 using System.Diagnostics;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -713,25 +715,77 @@ public class AspireCliTelemetryTests
     }
 
     [Theory]
+    [InlineData("CLAUDECODE", null, "1", null)]
+    [InlineData("CLAUDECODE", "1", "", "claude")]
+    [InlineData("CLAUDECODE", "1", null, "claude")]
+    [InlineData("AI_AGENT", null, "github_copilot_app_agent", null)]
+    [InlineData("AI_AGENT", "github_copilot_app_agent", "github_copilot_vscode_agent", "copilot-app")]
+    [InlineData("OR_APP_NAME", "Aider", "plandex", "aider")]
+    public void CodingAgentDetector_IgnoresConfigurationValues(string variableName, string? environmentValue, string? configuredValue, string? expectedCodingAgent)
+    {
+        var environmentVariables = new Dictionary<string, string?>
+        {
+            [variableName] = environmentValue
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(environmentVariables)
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [variableName] = configuredValue
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<IEnvironment>(new TestEnvironment(environmentVariables));
+        services.AddTelemetryServices();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var detector = serviceProvider.GetRequiredService<ICodingAgentDetector>();
+
+        Assert.Equal(expectedCodingAgent, detector.GetCodingAgent());
+    }
+
+    [Theory]
     [MemberData(nameof(CodingAgentTelemetryTestCases))]
     public void CodingAgentDetector_DetectsKnownCodingAgents((string, string?)[] environmentVariables, string? expectedCodingAgent)
     {
-        var configurationValues = new Dictionary<string, string?>();
-        foreach (var environmentVariable in environmentVariables)
-        {
-            if (environmentVariable.Item1.Length > 0)
-            {
-                configurationValues.Add(environmentVariable.Item1, environmentVariable.Item2);
-            }
-        }
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(configurationValues)
-            .Build();
-
-        var detector = new CodingAgentDetector(configuration);
+        var environment = new TestEnvironment(environmentVariables.ToDictionary(variable => variable.Item1, variable => variable.Item2, StringComparer.Ordinal));
+        var detector = new CodingAgentDetector(environment);
 
         Assert.Equal(expectedCodingAgent, detector.GetCodingAgent());
+    }
+
+    [Theory]
+    [InlineData(true, "claude")]
+    [InlineData(false, null)]
+    public void CodingAgentDetector_PreservesEnvironmentVariableNameComparison(bool ignoreCase, string? expectedCodingAgent)
+    {
+        var comparer = ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var environment = new TestEnvironment(new Dictionary<string, string?>(comparer)
+        {
+            ["claudecode"] = "1"
+        });
+        var detector = new CodingAgentDetector(environment);
+
+        Assert.Equal(expectedCodingAgent, detector.GetCodingAgent());
+    }
+
+    [Fact]
+    public void CodingAgentDetector_ReadsCurrentEnvironmentValues()
+    {
+        var environmentVariables = new Dictionary<string, string?>();
+        var detector = new CodingAgentDetector(new TestEnvironment(environmentVariables));
+
+        Assert.Null(detector.GetCodingAgent());
+
+        environmentVariables["AI_AGENT"] = "github_copilot_app_agent";
+        Assert.Equal("copilot-app", detector.GetCodingAgent());
+
+        environmentVariables["AI_AGENT"] = "github_copilot_vscode_agent";
+        Assert.Equal("copilot-vscode", detector.GetCodingAgent());
+
+        environmentVariables.Clear();
+        Assert.Null(detector.GetCodingAgent());
     }
 
     [Fact]
@@ -840,6 +894,10 @@ public class AspireCliTelemetryTests
     public static TheoryData<(string, string?)[], string?> CodingAgentTelemetryTestCases => new()
     {
         { [("CLAUDECODE", "1")], "claude" },
+        { [("CLAUDECODE", null)], null },
+        { [("CLAUDECODE", "")], null },
+        { [("CLAUDECODE", " ")], "claude" },
+        { [("CLAUDECODE", "1"), ("CLAUDE_CODE", "1")], "claude" },
         { [("CLAUDE_CODE", "1")], "claude" },
         { [("CLAUDE_CODE_ENTRYPOINT", "some_value")], "claude" },
         { [("CLAUDE_CODE_IS_COWORK", "1")], "cowork" },
@@ -856,6 +914,11 @@ public class AspireCliTelemetryTests
         { [("COPILOT_ALLOW_ALL", "1")], "copilot-cli" },
         { [("COPILOT_GITHUB_TOKEN", "token")], "copilot-cli" },
         { [("AI_AGENT", "github_copilot_app_agent")], "copilot-app" },
+        { [("AI_AGENT", "GITHUB_COPILOT_APP_AGENT")], "copilot-app" },
+        { [("AI_AGENT", " github_copilot_app_agent ")], null },
+        { [("AI_AGENT", "unknown_agent")], null },
+        { [("AI_AGENT", "")], null },
+        { [("AI_AGENT", null)], null },
         { [("AI_AGENT", "github_copilot_vscode_agent")], "copilot-vscode" },
         { [("COPILOT_AGENT", "1")], "copilot-vscode" },
         { [("AI_AGENT", "github_copilot_vscode_agent"), ("COPILOT_AGENT", "1")], "copilot-vscode" },
@@ -865,6 +928,7 @@ public class AspireCliTelemetryTests
         { [("CODEX_THREAD_ID", "thread1")], "codex" },
         { [("OR_APP_NAME", "Aider")], "aider" },
         { [("OR_APP_NAME", "aider")], "aider" },
+        { [("OR_APP_NAME", " Aider ")], null },
         { [("OR_APP_NAME", "plandex")], "plandex" },
         { [("OR_APP_NAME", "Plandex")], "plandex" },
         { [("AMP_HOME", "/path/to/amp")], "amp" },
@@ -900,6 +964,6 @@ public class AspireCliTelemetryTests
         { [("KIMI_CLI", "false")], "kimi" },
         { [("CLAUDE_CODE_IS_COWORK", "1"), ("CLAUDE_CODE", "1")], "cowork, claude" },
         { [("OR_APP_NAME", "SomeOtherApp")], null },
-        { [("", "")], null }
+        { [], null }
     };
 }


### PR DESCRIPTION
## Description

Coding-agent telemetry should describe the process environment, not user configuration. The CLI currently reads agent markers from merged `IConfiguration`, allowing global or local settings to invent, suppress, or override an agent identity. This can produce false positives, false negatives, or incorrect attribution in `process.coding_agent`.

Read markers through the existing `IEnvironment` abstraction instead, matching the `dotnet` CLI's direct process-environment lookup. Preserve all recognized markers, presence-based and case-insensitive exact-value matching, output ordering, and deduplication. Variable-name casing now follows the native environment lookup, and each detector call reads current values.

Reuse the shared `TestEnvironment` fake so tests do not modify ambient process environment variables. No new production dependencies, public APIs, command options, console-output changes, or CI-detection changes.

Fixes #20053

### Stabilize Vite E2E scaffolding

The existing polyglot E2E test failed independently of the telemetry change: `create-vite@latest` generated a `vite: ^8.3.0` dependency immediately after Vite 8.3.0 was published, and Deno's 24-hour minimum dependency age prevented installation.

- Pin `create-vite` to `9.2.0` in `tests/Aspire.Cli.EndToEnd.Tests/package.json`. Its vanilla TypeScript template allows the already-eligible Vite 8.2.2 release.
- Read the pin through `ViteTestHelpers.GetCreateCommand` at all six TypeScript/Java Vite scaffolding call sites. Embed the manifest in the test assembly so CI archives and local runs use the same source of truth.
- Configure weekly Dependabot updates for the test manifest with a seven-day cooldown. No local npm install is required for this manifest, and Deno's dependency-age protection remains enabled.

### Verification

- Confirmed all six configuration regression cases fail against the original implementation: configuration-only markers, null/empty values masking real markers, and configuration changing the reported identity.
- All 161 targeted telemetry, telemetry-configuration, and CLI-bootstrap tests pass with the detector fix.
- Added coverage for case-sensitive and case-insensitive variable-name lookup, live environment changes, null/empty/whitespace values, exact-value matching, and duplicate markers.
- All six selected E2E helper tests pass, covering the embedded npm manifest, exact version pinning, generated commands, and shell quoting.
- In an isolated Linux container using Node 22 and Deno 2.9.0, the manifest-pinned generator successfully scaffolded the fixture, `deno install` selected Vite 8.2.2, and `deno task build` succeeded. The full Aspire E2E scenario is left to CI; this local scenario exercises the previously failing dependency-install step and the generated Vite build.
- Reviewed production DI wiring, the unchanged agent rule table, all six scaffolding call sites, and CI input routing. The embedded manifest is an MSBuild-owned input, so no manual test-trigger-map entry is needed.

```powershell
dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-restore --no-launch-profile -- --filter-class "*.AspireCliTelemetryTests" --filter-class "*.TelemetryConfigurationTests" --filter-class "*.CliBootstrapTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

dotnet test --project tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj --no-restore --no-launch-profile -- --filter-class "*.ViteTestHelpersTests" --filter-class "*.TypeScriptAppHostToolchainTestHelpersTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No