### PR TITLE
Allow newly released dependencies in Deno E2E fixtures

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/TypeScriptAppHostToolchainTestHelpers.cs
@@ -68,7 +68,13 @@ internal static class TypeScriptAppHostToolchainTestHelpers
     /// Gets the restore/install command for a toolchain.
     /// </summary>
     internal static string GetInstallCommand(string toolchain) =>
-        $"{GetCommandName(toolchain)} install";
+        NormalizeToolchain(toolchain) switch
+        {
+            // create-vite@latest can require packages published within Deno's minimum dependency age.
+            // Allow those releases in the test fixture: https://docs.deno.com/runtime/reference/cli/install/#options
+            "deno" => "deno install --minimum-dependency-age=0",
+            _ => $"{GetCommandName(toolchain)} install"
+        };
 
     /// <summary>
     /// Gets the no-emit type-check command for a toolchain.

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptAppHostToolchainTestHelpersTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptAppHostToolchainTestHelpersTests.cs
@@ -8,6 +8,20 @@ namespace Aspire.Cli.EndToEnd.Tests;
 
 public sealed class TypeScriptAppHostToolchainTestHelpersTests
 {
+    [Theory]
+    [InlineData("npm", "npm install")]
+    [InlineData("bun", "bun install")]
+    [InlineData("yarn", "yarn install")]
+    [InlineData("pnpm", "pnpm install")]
+    [InlineData("deno", "deno install --minimum-dependency-age=0")]
+    [InlineData("DENO", "deno install --minimum-dependency-age=0")]
+    public void GetInstallCommand_ReturnsToolchainCommand(string toolchain, string expectedCommand)
+    {
+        var installCommand = TypeScriptAppHostToolchainTestHelpers.GetInstallCommand(toolchain);
+
+        Assert.Equal(expectedCommand, installCommand);
+    }
+
     [Fact]
     public void GetTypeCheckCommand_WhenToolchainIsDeno_EnablesSloppyImports()
     {


### PR DESCRIPTION
## Description

The Deno Vite E2E fixture can fail when `create-vite@latest` requires a dependency that is newer than Deno's minimum dependency-age cutoff. In the [reported CI failure](https://github.com/microsoft/aspire/actions/runs/34496889721/job/102967619685?pr=19565), `deno install` rejected `vite@^8.3.0` because it was published after the cutoff.

Use `deno install --minimum-dependency-age=0` for the E2E fixture's Deno toolchain, leaving the other package-manager commands unchanged. Add helper coverage for all supported toolchains and case-insensitive Deno selection. The option is documented in the [Deno install reference](https://docs.deno.com/runtime/reference/cli/install/#options).

This branch contains only the Deno fixture fix from #19565, cherry-picked onto latest `main` (`9c2af96f91`). It contains no Dashboard or AOT changes.

### Validation

- All 8 `TypeScriptAppHostToolchainTestHelpersTests` cases passed on the latest-main branch (`net10.0`, Windows), excluding quarantined and outerloop tests.
- Earlier direct validation with Deno 2.9.0 reproduced the rejection using the captured cutoff, then successfully installed the fixture with `--minimum-dependency-age=0`; a subsequent ordinary install accepted the generated lockfile.
- The full Linux terminal E2E scenario was not rerun locally.
- `git diff --check` passed.

### Security considerations

This intentionally disables Deno's dependency-age protection for generated E2E fixtures so they can consume the fresh dependency versions selected by `create-vite@latest`. It does not change the CLI product, user projects, or other toolchains' install commands. The reduced dependency-age protection is limited to test fixture installation and has not had a separate security review.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
