### PR TITLE
Use repository NuGet configuration for SDK dump restores

### DIFF
--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Utils;
 using Aspire.Shared.Json;
@@ -165,14 +164,7 @@ internal sealed class SdkDumpCommand : BaseCommand
     private Task<IAppHostServerProject> CreateCapabilityScannerProjectAsync(string tempDir, CancellationToken cancellationToken)
     {
         var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(tempDir);
-        if (repoRoot is not null && NuGetConfigMerger.TryFindNuGetConfigInDirectory(new DirectoryInfo(repoRoot), out var nugetConfig))
-        {
-            // The scanner's temporary app directory is outside the checkout. Preserve the
-            // repository's source names and mappings so its project references can restore.
-            nugetConfig.CopyTo(Path.Combine(tempDir, "nuget.config"));
-        }
-
-        return _appHostServerProjectFactory.CreateAsync(tempDir, cancellationToken);
+        return _appHostServerProjectFactory.CreateAsync(tempDir, restoreRootConfigDirectory: repoRoot, cancellationToken);
     }
 
     private async Task<int> DumpCapabilitiesAsync(

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -9,7 +9,9 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 using Aspire.Shared.Json;
 using Microsoft.Extensions.Logging;
 using Semver;
@@ -160,6 +162,19 @@ internal sealed class SdkDumpCommand : BaseCommand
             emoji: KnownEmojis.MagnifyingGlassTiltedLeft));
     }
 
+    private Task<IAppHostServerProject> CreateCapabilityScannerProjectAsync(string tempDir, CancellationToken cancellationToken)
+    {
+        var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(tempDir);
+        if (repoRoot is not null && NuGetConfigMerger.TryFindNuGetConfigInDirectory(new DirectoryInfo(repoRoot), out var nugetConfig))
+        {
+            // The scanner's temporary app directory is outside the checkout. Preserve the
+            // repository's source names and mappings so its project references can restore.
+            nugetConfig.CopyTo(Path.Combine(tempDir, "nuget.config"));
+        }
+
+        return _appHostServerProjectFactory.CreateAsync(tempDir, cancellationToken);
+    }
+
     private async Task<int> DumpCapabilitiesAsync(
         List<IntegrationReference> integrations,
         FileInfo? outputFile,
@@ -171,7 +186,7 @@ internal sealed class SdkDumpCommand : BaseCommand
 
         try
         {
-            var appHostServerProject = await _appHostServerProjectFactory.CreateAsync(tempDir, cancellationToken);
+            var appHostServerProject = await CreateCapabilityScannerProjectAsync(tempDir, cancellationToken);
 
             _logger.LogDebug("Building AppHost server for capability scanning with {Count} integrations", integrations.Count);
 
@@ -270,7 +285,7 @@ internal sealed class SdkDumpCommand : BaseCommand
 
         try
         {
-            var appHostServerProject = await _appHostServerProjectFactory.CreateAsync(tempDir, cancellationToken);
+            var appHostServerProject = await CreateCapabilityScannerProjectAsync(tempDir, cancellationToken);
 
             _logger.LogDebug("Building AppHost server for batched capability scanning with {Count} integrations", integrations.Count);
 

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -17,6 +17,7 @@ namespace Aspire.Cli.Projects;
 internal interface IAppHostServerProjectFactory
 {
     Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default);
+    Task<IAppHostServerProject> CreateAsync(string appPath, string? restoreRootConfigDirectory, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -34,7 +35,10 @@ internal sealed class AppHostServerProjectFactory(
     IProcessExecutionFactory processExecutionFactory,
     ILoggerFactory loggerFactory) : IAppHostServerProjectFactory
 {
-    public async Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
+    public Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
+        => CreateAsync(appPath, restoreRootConfigDirectory: null, cancellationToken);
+
+    public async Task<IAppHostServerProject> CreateAsync(string appPath, string? restoreRootConfigDirectory, CancellationToken cancellationToken)
     {
         var socketPath = CliPathHelper.CreateGuestAppHostSocketPath("apphost.sock");
 
@@ -51,7 +55,8 @@ internal sealed class AppHostServerProjectFactory(
                 processExecutionFactory,
                 environment,
                 loggerFactory.CreateLogger<DotNetBasedAppHostServerProject>(),
-                logFilePath: executionContext.LogFilePath);
+                logFilePath: executionContext.LogFilePath,
+                restoreRootConfigDirectory: restoreRootConfigDirectory);
         }
 
         // Priority 2: Ensure bundle is extracted and check for layout

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -49,6 +49,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
     private readonly IEnvironment _environment;
     private readonly ILogger _logger;
     private readonly string? _logFilePath;
+    private readonly string? _restoreRootConfigDirectory;
 
     public DotNetBasedAppHostServerProject(
         string appPath,
@@ -60,7 +61,8 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         IEnvironment environment,
         ILogger<DotNetBasedAppHostServerProject> logger,
         string? projectModelPath = null,
-        string? logFilePath = null)
+        string? logFilePath = null,
+        string? restoreRootConfigDirectory = null)
     {
         _appPath = Path.GetFullPath(appPath);
         _appPath = new Uri(_appPath).LocalPath;
@@ -73,6 +75,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         _environment = environment;
         _logger = logger;
         _logFilePath = logFilePath;
+        _restoreRootConfigDirectory = restoreRootConfigDirectory is not null ? Path.GetFullPath(restoreRootConfigDirectory) : null;
 
         var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(_appPath));
 
@@ -317,7 +320,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         // Handle NuGet config and channel resolution
         string? channelName = null;
 
-        var userNugetConfig = FindNuGetConfig(_appPath);
+        var userNugetConfig = _restoreRootConfigDirectory is null ? FindNuGetConfig(_appPath) : null;
         var nugetConfigContent = userNugetConfig is not null
             ? File.ReadAllText(userNugetConfig)
             : null;
@@ -365,6 +368,14 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
 
         // Create the project file
         var doc = CreateProjectFile(integrations);
+
+        if (_restoreRootConfigDirectory is not null)
+        {
+            // Read configs in their original hierarchy so relative feeds and inherited settings
+            // retain their meaning even though the scanner project is generated elsewhere.
+            doc.Root!.Descendants("PropertyGroup").First()
+                .Add(new XElement("RestoreRootConfigDirectory", _restoreRootConfigDirectory));
+        }
 
         // Add channel sources to the project
         if (channelSources.Count > 0)

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Commands.Sdk;
-using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -252,30 +251,21 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task SdkDump_PreparesRepositoryNuGetConfigBeforeCreatingScanner(bool outputDirectory)
+    public async Task SdkDump_PassesRepositoryRootAsScannerRestoreConfigDirectory(bool outputDirectory)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(workspace.Path);
-        if (repoRoot is null)
-        {
-            Assert.Skip("This test requires repository-development mode.");
-            return;
-        }
-
-        Assert.True(NuGetConfigMerger.TryFindNuGetConfigInDirectory(new DirectoryInfo(repoRoot), out var repoConfig));
-        var expectedConfig = await File.ReadAllTextAsync(repoConfig.FullName);
         string? scannerPath = null;
-        string? scannerConfig = null;
+        string[]? scannerFiles = null;
         var factory = new TestAppHostServerProjectFactory
         {
-            CreateAsyncCallback = async (appPath, cancellationToken) =>
+            CreateAsyncCallback = (appPath, cancellationToken) =>
             {
                 scannerPath = appPath;
-                var configPath = Path.Combine(appPath, "nuget.config");
-                scannerConfig = File.Exists(configPath)
-                    ? await File.ReadAllTextAsync(configPath, cancellationToken)
-                    : null;
-                return new FakeFailingAppHostServerProject(appPath);
+                scannerFiles = Directory.GetFiles(appPath);
+                // Fail preparation after capturing the factory arguments to avoid a real build or RPC session.
+                // The command is therefore expected to return FailedToBuildArtifacts.
+                return Task.FromResult<IAppHostServerProject>(new FakeFailingAppHostServerProject(appPath));
             }
         };
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
@@ -290,7 +280,9 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
         Assert.NotNull(scannerPath);
-        Assert.Equal(expectedConfig, scannerConfig);
+        Assert.Equal(repoRoot, factory.RestoreRootConfigDirectory);
+        Assert.NotNull(scannerFiles);
+        Assert.Empty(scannerFiles);
         Assert.False(Directory.Exists(scannerPath));
     }
 
@@ -323,10 +315,31 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
                 Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
 
-                // ExtraLongTimeout because this spawns a real dotnet build of Aspire.Hosting.csproj
-                // in a child process, which can exceed the default timeout under concurrent test load.
-                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-                Assert.Equal((int)CliExitCodes.Success, exitCode);
+                using var standardOutput = new StringWriter();
+                using var standardError = new StringWriter();
+                var originalOutput = Console.Out;
+                var originalError = Console.Error;
+                int exitCode;
+                Console.SetOut(standardOutput);
+                Console.SetError(standardError);
+                try
+                {
+                    // ExtraLongTimeout because this spawns a real dotnet build of Aspire.Hosting.csproj
+                    // in a child process, which can exceed the default timeout under concurrent test load.
+                    exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+                }
+                finally
+                {
+                    Console.SetOut(originalOutput);
+                    Console.SetError(originalError);
+                    // Forward both streams to the parent test even when the command throws or times out.
+                    Console.WriteLine($"SDK dump stdout:{Environment.NewLine}{standardOutput}");
+                    Console.WriteLine($"SDK dump stderr:{Environment.NewLine}{standardError}");
+                }
+
+                Assert.True(exitCode == CliExitCodes.Success,
+                    $"aspire sdk dump --format ci failed for '{projectPath}'. Expected exit code {CliExitCodes.Success}, actual {exitCode}.{Environment.NewLine}" +
+                    $"stdout:{Environment.NewLine}{standardOutput}{Environment.NewLine}stderr:{Environment.NewLine}{standardError}");
 
                 var output = await File.ReadAllTextAsync(outputPath);
                 Assert.NotEmpty(output);

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -3,7 +3,11 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Commands.Sdk;
+using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.DotNet.RemoteExecutor;
@@ -243,6 +247,51 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         // "Aspire.Hosting.Redis@" is not a valid semver, so it should fail version validation
         Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SdkDump_PreparesRepositoryNuGetConfigBeforeCreatingScanner(bool outputDirectory)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(workspace.Path);
+        if (repoRoot is null)
+        {
+            Assert.Skip("This test requires repository-development mode.");
+            return;
+        }
+
+        Assert.True(NuGetConfigMerger.TryFindNuGetConfigInDirectory(new DirectoryInfo(repoRoot), out var repoConfig));
+        var expectedConfig = await File.ReadAllTextAsync(repoConfig.FullName);
+        string? scannerPath = null;
+        string? scannerConfig = null;
+        var factory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = async (appPath, cancellationToken) =>
+            {
+                scannerPath = appPath;
+                var configPath = Path.Combine(appPath, "nuget.config");
+                scannerConfig = File.Exists(configPath)
+                    ? await File.ReadAllTextAsync(configPath, cancellationToken)
+                    : null;
+                return new FakeFailingAppHostServerProject(appPath);
+            }
+        };
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        services.AddSingleton<IAppHostServerProjectFactory>(factory);
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var outputOption = outputDirectory ? "--output-directory" : "--output";
+        var result = command.Parse(["sdk", "dump", "--format", "ci", outputOption,
+            Path.Combine(workspace.Path, "output"), "Aspire.Hosting.Redis@13.2.0"]);
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.FailedToBuildArtifacts, exitCode);
+        Assert.NotNull(scannerPath);
+        Assert.Equal(expectedConfig, scannerConfig);
+        Assert.False(Directory.Exists(scannerPath));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Packaging;
@@ -43,8 +45,114 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         return new DotNetBasedAppHostServerProject(appPath, socketPath, repoRoot, runner, packagingService, new TestProcessExecutionFactory(), new TestEnvironment(), logger);
     }
 
-    [Fact]
-    public async Task CreateProjectFiles_AppSettingsJson_MatchesSnapshot()
+        [Fact]
+        public async Task CreateProjectFiles_RestoreRootConfigDirectory_PreservesRelativeSources()
+        {
+                var repoRoot = _workspace.CreateDirectory("repo");
+                var appPath = _workspace.CreateDirectory("app");
+                var projectModelPath = _workspace.CreateDirectory("model");
+                var parentFeed = _workspace.CreateDirectory("parent-feed");
+                var parentConfigPath = Path.Combine(_workspace.Path, "NuGet.Config");
+                await File.WriteAllTextAsync(parentConfigPath, """
+                        <configuration>
+                            <packageSources>
+                                <clear />
+                                <add key="parent-feed" value="./parent-feed" />
+                            </packageSources>
+                            <packageSourceMapping>
+                                <clear />
+                                <packageSource key="parent-feed">
+                                    <package pattern="*" />
+                                </packageSource>
+                            </packageSourceMapping>
+                        </configuration>
+                        """);
+                var feed = repoRoot.CreateSubdirectory("feed");
+                var repoConfigPath = Path.Combine(repoRoot.FullName, "NuGet.Config");
+                await File.WriteAllTextAsync(repoConfigPath, """
+                        <configuration>
+                            <packageSources>
+                                <add key="repo-feed" value="./feed" />
+                            </packageSources>
+                            <packageSourceMapping>
+                                <packageSource key="repo-feed">
+                                    <package pattern="*" />
+                                </packageSource>
+                            </packageSourceMapping>
+                        </configuration>
+                        """);
+                await File.WriteAllTextAsync(Path.Combine(repoRoot.FullName, "Directory.Packages.props"), "<Project />");
+                await File.WriteAllTextAsync(Path.Combine(appPath.FullName, "NuGet.Config"), """
+                        <configuration>
+                            <packageSources>
+                                <clear />
+                                <add key="app-feed" value="./other-feed" />
+                            </packageSources>
+                        </configuration>
+                        """);
+                var packagingService = new TestPackagingService
+                {
+                        GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([])
+                };
+                var project = new DotNetBasedAppHostServerProject(
+                        appPath.FullName, "test.sock", repoRoot.FullName,
+                        new TestDotNetCliRunner(), packagingService,
+                        new TestProcessExecutionFactory(), new TestEnvironment(),
+                        NullLogger<DotNetBasedAppHostServerProject>.Instance,
+                        projectModelPath: projectModelPath.FullName,
+                        restoreRootConfigDirectory: repoRoot.FullName);
+
+                var (projectFilePath, _) = await project.CreateProjectFilesAsync([]).DefaultTimeout();
+
+                Assert.Equal(repoRoot.FullName, XDocument.Load(projectFilePath).Descendants("RestoreRootConfigDirectory").Single().Value);
+                Assert.False(NuGetConfigMerger.TryFindNuGetConfigInDirectory(projectModelPath, out _));
+
+                // Evaluate NuGet's actual settings without restoring packages. A relative source such as
+                // <add key="repo-feed" value="./feed" /> must resolve beside the original config file.
+                var startInfo = new ProcessStartInfo("dotnet")
+                {
+                        WorkingDirectory = projectModelPath.FullName,
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true,
+                        ArgumentList =
+                        {
+                                "msbuild", projectFilePath, "-nologo", "-target:_GetRestoreSettings",
+                                "-property:RestoreProjectStyle=PackageReference",
+                                "-getProperty:_OutputSources,_OutputConfigFilePaths"
+                        }
+                };
+                using var process = Process.Start(startInfo);
+                Assert.NotNull(process);
+                try
+                {
+                        var outputTask = process.StandardOutput.ReadToEndAsync();
+                        var errorTask = process.StandardError.ReadToEndAsync();
+                        await process.WaitForExitAsync().DefaultTimeout();
+                        var output = await outputTask.DefaultTimeout();
+                        var error = await errorTask.DefaultTimeout();
+                        Assert.True(process.ExitCode == 0, $"{output}{Environment.NewLine}{error}");
+
+                        using var document = JsonDocument.Parse(output);
+                        var properties = document.RootElement.GetProperty("Properties");
+                        var sources = properties.GetProperty("_OutputSources").GetString()!.Split(';');
+                        Assert.Equal(new[] { parentFeed.FullName, feed.FullName }.Order(StringComparer.Ordinal), sources.Order(StringComparer.Ordinal));
+                        var configPaths = properties.GetProperty("_OutputConfigFilePaths").GetString()!.Split(';');
+                        Assert.Contains(repoConfigPath, configPaths);
+                        Assert.Contains(parentConfigPath, configPaths);
+                }
+                finally
+                {
+                        if (!process.HasExited)
+                        {
+                                process.Kill(entireProcessTree: true);
+                        }
+                }
+        }
+
+        [Fact]
+        public async Task CreateProjectFiles_AppSettingsJson_MatchesSnapshot()
     {
         // Arrange
         var project = CreateProject();

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -719,7 +719,7 @@ public class GuestAppHostProjectTests : IDisposable
     /// <remarks>
     /// The test drives <see cref="GuestAppHostProject.UpdatePackagesAsync"/> through the
     /// code path that detects updates, then expects the call to throw from
-    /// <c>BuildAndGenerateSdkAsync</c> because <see cref="TestAppHostServerProjectFactory.CreateAsync"/>
+    /// <c>BuildAndGenerateSdkAsync</c> because <see cref="TestAppHostServerProjectFactory.CreateAsync(string, CancellationToken)"/>
     /// throws. The on-disk config should still contain the original versions.
     /// </remarks>
     [Fact]

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerProjectFactory.cs
@@ -9,8 +9,14 @@ internal sealed class TestAppHostServerProjectFactory : IAppHostServerProjectFac
 {
     public Func<string, CancellationToken, Task<IAppHostServerProject>>? CreateAsyncCallback { get; set; }
 
+    public string? RestoreRootConfigDirectory { get; private set; }
+
     public Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
+        => CreateAsync(appPath, restoreRootConfigDirectory: null, cancellationToken);
+
+    public Task<IAppHostServerProject> CreateAsync(string appPath, string? restoreRootConfigDirectory, CancellationToken cancellationToken)
     {
+        RestoreRootConfigDirectory = restoreRootConfigDirectory;
         if (CreateAsyncCallback is { } callback)
         {
             return callback(appPath, cancellationToken);


### PR DESCRIPTION
## Description

Running `aspire sdk dump` against the local Aspire checkout can fail before scanning capabilities because the scanner's temporary app directory is outside the repository's NuGet configuration hierarchy. The failures linked from #20029 report `NU1100` errors resolving Dashboard's Fluent UI packages, not warnings in the exported capabilities.

In repository-development mode, SDK dump now starts NuGet configuration discovery from the repository root. Configuration files remain in their original locations, preserving package-source names and mappings, relative feed paths, and settings inherited from parent directories.

- Both `--output` and `--output-directory` pass the detected repository root through the AppHost server project factory.
- The generated scanner project sets `RestoreRootConfigDirectory` and skips copying the app's NuGet configuration when this override is supplied. Other callers retain their existing configuration behavior.
- The real SDK dump integration test now includes the command, project path, expected and actual exit codes, stdout, and stderr in failure diagnostics. Captured streams are also forwarded to test output if the command throws or times out.

Fixes #20029

### Example

The existing checkout-development command uses the repository's NuGet configuration automatically, without new command-line options:

```shell
aspire sdk dump --format ci --output capabilities.txt ./src/Aspire.Hosting/Aspire.Hosting.csproj
```

### Validation

- Added coverage for both output modes to verify the scanner's restore configuration root, absence of copied files in its temporary directory, and temporary-directory cleanup. The test deliberately stops preparation before a real build or RPC session.
- Added a regression that evaluates NuGet's actual `_GetRestoreSettings` target without restoring packages. It verifies that relative feeds resolve beside the original repository and parent configuration files, inherited settings remain available, and a conflicting app-local configuration is not used.
- All 101 tests across `SdkDumpCommandTests`, `AppHostServerProjectTests`, and `GuestAppHostProjectTests` passed locally on Windows, with quarantined and outerloop tests excluded.
- Verified the integration test's failure diagnostics using a temporary missing-project probe, then removed the probe and reran `SdkDumpCi_ForHostingProject_DoesNotEmitWarnings` successfully.
- `git diff --check` passed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No