### PR TITLE
Fix MAUI build queue timeout test flakiness

### DIFF
--- a/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
+++ b/src/Aspire.Hosting.Maui/Lifecycle/MauiBuildQueueEventSubscriber.cs
@@ -52,6 +52,11 @@ internal class MauiBuildQueueEventSubscriber(
     /// </summary>
     internal TimeSpan LaunchHandoffTimeout { get; set; } = TimeSpan.FromMinutes(10);
 
+    /// <summary>
+    /// Provides time for the launch handoff timeout.
+    /// </summary>
+    internal TimeProvider LaunchHandoffTimeProvider { get; set; } = TimeProvider.System;
+
     /// <inheritdoc/>
     public Task SubscribeAsync(IDistributedApplicationEventing eventing, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
@@ -322,8 +327,8 @@ internal class MauiBuildQueueEventSubscriber(
 
         try
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(LaunchHandoffTimeout);
+            using var timeoutCts = new CancellationTokenSource(LaunchHandoffTimeout, LaunchHandoffTimeProvider);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
             await notificationService.WaitForResourceAsync(
                 resource.Name,
                 e => ShouldReleaseBuildLockForLaunchState(e.Snapshot.State?.Text, stateAtCallTime, releaseOnRunning),

--- a/tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj
+++ b/tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj
+++ b/tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Maui.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Hosting.Maui.Tests;
 
@@ -772,18 +773,19 @@ public class MauiBuildQueueTests
         var subscriber = new MauiBuildQueueEventSubscriber(
             env.NotificationService,
             env.Services.GetRequiredService<ResourceLoggerService>(),
-            env.Services.GetRequiredService<ResourceCommandService>())
-        {
-            LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50)
-        };
+            env.Services.GetRequiredService<ResourceCommandService>());
+        var timeProvider = ConfigureLaunchHandoffTimeout(subscriber);
 
-        await subscriber.ReleaseSemaphoreAfterLaunchAsync(
+        var releaseTask = subscriber.ReleaseSemaphoreAfterLaunchAsync(
             env.MacCatalyst,
             annotation.BuildSemaphore,
             stateAtCallTime: "Building",
             releaseOnRunning: true,
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.MacCatalyst),
-            CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+            CancellationToken.None);
+
+        timeProvider.Advance(subscriber.LaunchHandoffTimeout);
+        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -807,10 +809,8 @@ public class MauiBuildQueueTests
         var subscriber = new MauiBuildQueueEventSubscriber(
             env.NotificationService,
             env.Services.GetRequiredService<ResourceLoggerService>(),
-            env.Services.GetRequiredService<ResourceCommandService>())
-        {
-            LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50)
-        };
+            env.Services.GetRequiredService<ResourceCommandService>());
+        var timeProvider = ConfigureLaunchHandoffTimeout(subscriber);
 
         var releaseTask = subscriber.ReleaseSemaphoreAfterLaunchAsync(
             env.Android,
@@ -820,6 +820,7 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             CancellationToken.None);
 
+        timeProvider.Advance(subscriber.LaunchHandoffTimeout);
         await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
@@ -850,7 +851,7 @@ public class MauiBuildQueueTests
 
         await annotation!.BuildSemaphore.WaitAsync();
         env.Subscriber.UseRealLaunchHandoff = true;
-        env.Subscriber.LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50);
+        var timeProvider = ConfigureLaunchHandoffTimeout(env.Subscriber);
         var releaseTask = env.Subscriber.ReleaseSemaphoreAfterLaunchAsync(
             env.Android,
             annotation.BuildSemaphore,
@@ -859,6 +860,7 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             CancellationToken.None);
 
+        timeProvider.Advance(env.Subscriber.LaunchHandoffTimeout);
         await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         var nextStartTask = Task.Run(() => env.Eventing.PublishAsync(
@@ -893,10 +895,8 @@ public class MauiBuildQueueTests
         var subscriber = new MauiBuildQueueEventSubscriber(
             env.NotificationService,
             env.Services.GetRequiredService<ResourceLoggerService>(),
-            env.Services.GetRequiredService<ResourceCommandService>())
-        {
-            LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50)
-        };
+            env.Services.GetRequiredService<ResourceCommandService>());
+        var timeProvider = ConfigureLaunchHandoffTimeout(subscriber);
 
         var releaseTask = subscriber.ReleaseSemaphoreAfterLaunchAsync(
             env.Android,
@@ -906,6 +906,7 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             CancellationToken.None);
 
+        timeProvider.Advance(subscriber.LaunchHandoffTimeout);
         await stopAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
@@ -938,7 +939,7 @@ public class MauiBuildQueueTests
 
         await annotation!.BuildSemaphore.WaitAsync();
         env.Subscriber.UseRealLaunchHandoff = true;
-        env.Subscriber.LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50);
+        var timeProvider = ConfigureLaunchHandoffTimeout(env.Subscriber);
         var releaseTask = env.Subscriber.ReleaseSemaphoreAfterLaunchAsync(
             env.Android,
             annotation.BuildSemaphore,
@@ -947,6 +948,7 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             CancellationToken.None);
 
+        timeProvider.Advance(env.Subscriber.LaunchHandoffTimeout);
         await stopAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
@@ -984,10 +986,8 @@ public class MauiBuildQueueTests
         var subscriber = new MauiBuildQueueEventSubscriber(
             env.NotificationService,
             env.Services.GetRequiredService<ResourceLoggerService>(),
-            env.Services.GetRequiredService<ResourceCommandService>())
-        {
-            LaunchHandoffTimeout = TimeSpan.FromMilliseconds(50)
-        };
+            env.Services.GetRequiredService<ResourceCommandService>());
+        var timeProvider = ConfigureLaunchHandoffTimeout(subscriber);
         using var cts = new CancellationTokenSource();
 
         var releaseTask = subscriber.ReleaseSemaphoreAfterLaunchAsync(
@@ -998,6 +998,7 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             cts.Token);
 
+        timeProvider.Advance(subscriber.LaunchHandoffTimeout);
         await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
 
@@ -1165,6 +1166,13 @@ public class MauiBuildQueueTests
                 return;
             }
         }
+    }
+
+    private static FakeTimeProvider ConfigureLaunchHandoffTimeout(MauiBuildQueueEventSubscriber subscriber)
+    {
+        var timeProvider = new FakeTimeProvider();
+        subscriber.LaunchHandoffTimeProvider = timeProvider;
+        return timeProvider;
     }
 
     // ───────────────────────────────────────────────────────────────────

--- a/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiBuildQueueTests.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Lifecycle;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -63,7 +64,7 @@ public class MauiBuildQueueTests
         Assert.Equal(0, annotation!.BuildSemaphore.CurrentCount);
 
         env.Subscriber.CompleteBuild(env.Android);
-        await eventTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await eventTask.DefaultTimeout();
     }
 
     [Fact]
@@ -75,7 +76,7 @@ public class MauiBuildQueueTests
 
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         Assert.True(env.Parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
         Assert.Equal(1, annotation!.BuildSemaphore.CurrentCount);
@@ -102,11 +103,11 @@ public class MauiBuildQueueTests
 
         // Complete first build — second should start.
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
 
         // Complete second build.
         env.Subscriber.CompleteBuild(env.MacCatalyst);
-        await task2.WaitAsync(TimeSpan.FromSeconds(5));
+        await task2.DefaultTimeout();
     }
 
     [Fact]
@@ -139,14 +140,14 @@ public class MauiBuildQueueTests
             new BeforeResourceStartedEvent(env.MacCatalyst, env.Services),
             CancellationToken.None));
 
-        var result = await queuedSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var result = await queuedSeen.Task.DefaultTimeout();
         Assert.True(result);
 
         // Clean up: complete both builds and await their tasks.
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
         env.Subscriber.CompleteBuild(env.MacCatalyst);
-        await task2.WaitAsync(TimeSpan.FromSeconds(5));
+        await task2.DefaultTimeout();
     }
 
     [Fact]
@@ -173,11 +174,11 @@ public class MauiBuildQueueTests
             new BeforeResourceStartedEvent(env.Android, env.Services),
             CancellationToken.None));
 
-        var result = await buildingSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var result = await buildingSeen.Task.DefaultTimeout();
         Assert.True(result);
 
         env.Subscriber.CompleteBuild(env.Android);
-        await eventTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await eventTask.DefaultTimeout();
     }
 
     [Fact]
@@ -206,7 +207,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuild(env.Android);
         env.Subscriber.CompleteBuild(env.Android2!);
 
-        await Task.WhenAll(task1, task2).WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.WhenAll(task1, task2).DefaultTimeout();
     }
 
     [Fact]
@@ -219,7 +220,7 @@ public class MauiBuildQueueTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => env.Eventing.PublishAsync(
                 new BeforeResourceStartedEvent(env.Android, env.Services),
-                CancellationToken.None));
+                CancellationToken.None).DefaultTimeout());
 
         // Semaphore should be released even after failure.
         Assert.True(env.Parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
@@ -247,17 +248,17 @@ public class MauiBuildQueueTests
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => task2.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => task2.DefaultTimeout());
 
         // Complete first build — semaphore should still work for a third resource.
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
 
         env.Subscriber.CompleteBuildImmediately(env.IOSSimulator);
         var task3 = env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.IOSSimulator, env.Services),
             CancellationToken.None);
-        await task3.WaitAsync(TimeSpan.FromSeconds(5));
+        await task3.DefaultTimeout();
     }
 
     [Fact]
@@ -303,7 +304,7 @@ public class MauiBuildQueueTests
 
         // Complete Android — one of the queued resources will acquire the semaphore next.
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
         Assert.Single(completionOrder);
         Assert.Equal("android", completionOrder[0]);
 
@@ -319,20 +320,20 @@ public class MauiBuildQueueTests
         if (secondStarted == macTask)
         {
             env.Subscriber.CompleteBuild(env.MacCatalyst);
-            await task2.WaitAsync(TimeSpan.FromSeconds(5));
+            await task2.DefaultTimeout();
 
             await iosTask;
             env.Subscriber.CompleteBuild(env.IOSSimulator);
-            await task3.WaitAsync(TimeSpan.FromSeconds(5));
+            await task3.DefaultTimeout();
         }
         else
         {
             env.Subscriber.CompleteBuild(env.IOSSimulator);
-            await task3.WaitAsync(TimeSpan.FromSeconds(5));
+            await task3.DefaultTimeout();
 
             await macTask;
             env.Subscriber.CompleteBuild(env.MacCatalyst);
-            await task2.WaitAsync(TimeSpan.FromSeconds(5));
+            await task2.DefaultTimeout();
         }
 
         // All three completed in sequence (android first, then the other two in either order).
@@ -358,10 +359,10 @@ public class MauiBuildQueueTests
             new BeforeResourceStartedEvent(env.Parent, env.Services),
             CancellationToken.None);
 
-        await parentTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await parentTask.DefaultTimeout(TimeSpan.FromSeconds(2));
 
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
     }
 
     [Fact]
@@ -373,7 +374,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuildImmediately(env.Android);
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         // Semaphore released after first build
         Assert.True(env.Parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
@@ -383,7 +384,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuildImmediately(env.Android);
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -409,14 +410,14 @@ public class MauiBuildQueueTests
             notificationService,
             loggerService,
             app.Services.GetRequiredService<ResourceCommandService>());
-        await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None);
+        await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None).DefaultTimeout();
 
         // Should return immediately — no annotation means no queue
         await eventing.PublishAsync(
             new BeforeResourceStartedEvent(android, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
-        await app.DisposeAsync();
+        await app.DisposeAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -445,14 +446,14 @@ public class MauiBuildQueueTests
             notificationService,
             loggerService,
             app.Services.GetRequiredService<ResourceCommandService>());
-        await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None);
+        await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None).DefaultTimeout();
 
         // Should throw InvalidOperationException — missing annotation means semaphore
         // would be held indefinitely without this guard.
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await eventing.PublishAsync(
                 new BeforeResourceStartedEvent(android, app.Services),
-                CancellationToken.None));
+                CancellationToken.None).DefaultTimeout());
 
         Assert.Contains("MauiBuildInfoAnnotation", ex.Message);
 
@@ -460,7 +461,7 @@ public class MauiBuildQueueTests
         Assert.True(parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
         Assert.Equal(1, annotation!.BuildSemaphore.CurrentCount);
 
-        await app.DisposeAsync();
+        await app.DisposeAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -473,7 +474,7 @@ public class MauiBuildQueueTests
         await Assert.ThrowsAsync<ArgumentException>(
             () => env.Eventing.PublishAsync(
                 new BeforeResourceStartedEvent(env.Android, env.Services),
-                CancellationToken.None));
+                CancellationToken.None).DefaultTimeout());
 
         // Semaphore should be released even for unexpected exception types.
         Assert.True(env.Parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
@@ -538,7 +539,7 @@ public class MauiBuildQueueTests
 
         // The handler re-throws the OCE to prevent DCP from starting the resource.
         var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => task2.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => task2.DefaultTimeout());
         Assert.IsType<OperationCanceledException>(ex);
 
         // Semaphore should still be held (count 0) — cancellation of queued resource
@@ -548,7 +549,7 @@ public class MauiBuildQueueTests
 
         // Clean up: complete Android build.
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
     }
 
     [Fact]
@@ -569,19 +570,19 @@ public class MauiBuildQueueTests
 
         Assert.Equal(ResourceCommandState.Enabled, stopCommand.UpdateState(CreateUpdateStateContext(env, "Building")));
 
-        var result = await stopCommand.ExecuteCommand(CreateExecuteCommandContext(env));
+        var result = await stopCommand.ExecuteCommand(CreateExecuteCommandContext(env)).DefaultTimeout();
 
         Assert.True(result.Success);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => eventTask.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => eventTask.DefaultTimeout());
 
         var exitedSeen = WaitForStateAsync(env, env.Android, KnownResourceStates.Exited);
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, KnownResourceStateStyles.Error)
-        });
+        }).DefaultTimeout();
 
-        await exitedSeen.WaitAsync(TimeSpan.FromSeconds(5));
+        await exitedSeen.DefaultTimeout();
     }
 
     [Fact]
@@ -594,7 +595,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuildImmediately(env.Android);
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         var stopCommand = env.Android.Annotations
             .OfType<ResourceCommandAnnotation>()
@@ -602,7 +603,7 @@ public class MauiBuildQueueTests
 
         Assert.Equal(ResourceCommandState.Enabled, stopCommand.UpdateState(CreateUpdateStateContext(env, KnownResourceStates.Running)));
 
-        var result = await stopCommand.ExecuteCommand(CreateExecuteCommandContext(env));
+        var result = await stopCommand.ExecuteCommand(CreateExecuteCommandContext(env)).DefaultTimeout();
 
         Assert.True(result.Success);
         Assert.True(originalStopInvoked);
@@ -630,7 +631,7 @@ public class MauiBuildQueueTests
         // The handler re-throws the OCE to prevent DCP from starting the resource.
         // TaskCanceledException is a subclass of OperationCanceledException, thrown by TCS.
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => task1.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => task1.DefaultTimeout());
 
         // Semaphore should be released after the building resource is cancelled.
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
@@ -646,7 +647,7 @@ public class MauiBuildQueueTests
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot("Building", KnownResourceStateStyles.Info)
-        });
+        }).DefaultTimeout();
 
         var logger = env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android);
         var subscriber = new MauiBuildQueueEventSubscriber(
@@ -667,9 +668,9 @@ public class MauiBuildQueueTests
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(30));
+        await releaseTask.DefaultTimeout(TimeSpan.FromSeconds(30));
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
 
@@ -693,10 +694,10 @@ public class MauiBuildQueueTests
 
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            startCts.Token);
+            startCts.Token).DefaultTimeout();
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.MacCatalyst, env.Services),
-            startCts.Token);
+            startCts.Token).DefaultTimeout();
 
         Assert.False(env.Subscriber.GetReleaseOnRunning(env.Android));
         Assert.True(env.Subscriber.GetReleaseOnRunning(env.MacCatalyst));
@@ -716,7 +717,7 @@ public class MauiBuildQueueTests
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot("Building", KnownResourceStateStyles.Info)
-        });
+        }).DefaultTimeout();
 
         var logger = env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android);
         var subscriber = new MauiBuildQueueEventSubscriber(
@@ -734,7 +735,7 @@ public class MauiBuildQueueTests
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
         await Assert.ThrowsAsync<TimeoutException>(() => releaseTask.WaitAsync(TimeSpan.FromMilliseconds(100)));
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
@@ -742,9 +743,9 @@ public class MauiBuildQueueTests
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot("Terminated", KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
 
@@ -785,7 +786,7 @@ public class MauiBuildQueueTests
             CancellationToken.None);
 
         timeProvider.Advance(subscriber.LaunchHandoffTimeout);
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -821,12 +822,12 @@ public class MauiBuildQueueTests
             CancellationToken.None);
 
         timeProvider.Advance(subscriber.LaunchHandoffTimeout);
-        await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopStarted.Task.DefaultTimeout();
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
 
         stopCompletion.SetResult();
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -847,7 +848,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuildImmediately(env.Android);
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         await annotation!.BuildSemaphore.WaitAsync();
         env.Subscriber.UseRealLaunchHandoff = true;
@@ -861,19 +862,19 @@ public class MauiBuildQueueTests
             CancellationToken.None);
 
         timeProvider.Advance(env.Subscriber.LaunchHandoffTimeout);
-        await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopStarted.Task.DefaultTimeout();
 
         var nextStartTask = Task.Run(() => env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
             CancellationToken.None));
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
         await env.Subscriber.WaitForBuildStartedAsync(env.Android);
         Assert.False(nextStartTask.IsCompleted);
 
         env.Subscriber.UseRealLaunchHandoff = false;
         env.Subscriber.CompleteBuild(env.Android);
-        await nextStartTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await nextStartTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -907,16 +908,16 @@ public class MauiBuildQueueTests
             CancellationToken.None);
 
         timeProvider.Advance(subscriber.LaunchHandoffTimeout);
-        await stopAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopAttempted.Task.DefaultTimeout();
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
 
         await env.NotificationService.PublishUpdateAsync(env.Android, s => s with
         {
             State = new ResourceStateSnapshot("Terminated", KnownResourceStateStyles.Success)
-        });
+        }).DefaultTimeout();
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
 
@@ -935,7 +936,7 @@ public class MauiBuildQueueTests
         env.Subscriber.CompleteBuildImmediately(env.Android);
         await env.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(env.Android, env.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         await annotation!.BuildSemaphore.WaitAsync();
         env.Subscriber.UseRealLaunchHandoff = true;
@@ -949,7 +950,7 @@ public class MauiBuildQueueTests
             CancellationToken.None);
 
         timeProvider.Advance(env.Subscriber.LaunchHandoffTimeout);
-        await stopAttempted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopAttempted.Task.DefaultTimeout();
         Assert.False(releaseTask.IsCompleted);
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
 
@@ -957,13 +958,13 @@ public class MauiBuildQueueTests
             new BeforeResourceStartedEvent(env.Android, env.Services),
             CancellationToken.None));
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.DefaultTimeout();
         await env.Subscriber.WaitForBuildStartedAsync(env.Android);
         Assert.False(nextStartTask.IsCompleted);
 
         env.Subscriber.UseRealLaunchHandoff = false;
         env.Subscriber.CompleteBuild(env.Android);
-        await nextStartTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await nextStartTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -999,11 +1000,11 @@ public class MauiBuildQueueTests
             cts.Token);
 
         timeProvider.Advance(subscriber.LaunchHandoffTimeout);
-        await stopStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopStarted.Task.DefaultTimeout();
         Assert.Equal(0, annotation.BuildSemaphore.CurrentCount);
 
-        await cts.CancelAsync();
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await cts.CancelAsync().DefaultTimeout();
+        await releaseTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -1028,8 +1029,8 @@ public class MauiBuildQueueTests
             env.Services.GetRequiredService<ResourceLoggerService>().GetLogger(env.Android),
             cts.Token);
 
-        await cts.CancelAsync();
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await cts.CancelAsync().DefaultTimeout();
+        await releaseTask.DefaultTimeout();
 
         Assert.Equal(1, annotation.BuildSemaphore.CurrentCount);
     }
@@ -1064,18 +1065,18 @@ public class MauiBuildQueueTests
         env.CancelResource(env.MacCatalyst.Name);
         // The handler re-throws the OCE to prevent DCP from starting the resource.
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => task2.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => task2.DefaultTimeout());
 
         // Complete Android — iOS should proceed (MacCatalyst was cancelled without acquiring semaphore).
         env.Subscriber.CompleteBuild(env.Android);
-        await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await task1.DefaultTimeout();
 
         // iOS should now be building.
         await env.Subscriber.WaitForBuildStartedAsync(env.IOSSimulator);
         Assert.False(task3.IsCompleted, "iOS should be building now.");
 
         env.Subscriber.CompleteBuild(env.IOSSimulator);
-        await task3.WaitAsync(TimeSpan.FromSeconds(5));
+        await task3.DefaultTimeout();
     }
 
     [Fact]
@@ -1099,7 +1100,7 @@ public class MauiBuildQueueTests
         await Assert.ThrowsAnyAsync<Exception>(
             () => env.Eventing.PublishAsync(
                 new BeforeResourceStartedEvent(env.Android, env.Services),
-                CancellationToken.None));
+            CancellationToken.None)).DefaultTimeout();
 
         // Semaphore should be released regardless.
         Assert.True(env.Parent.TryGetLastAnnotation<MauiBuildQueueAnnotation>(out var annotation));
@@ -1205,7 +1206,7 @@ public class MauiBuildQueueTests
         /// <summary>Waits until <see cref="RunBuildAsync"/> is entered for the given resource.</summary>
         public Task WaitForBuildStartedAsync(IResource resource, TimeSpan? timeout = null)
         {
-            return GetOrCreateStarted(resource.Name).Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(30));
+            return GetOrCreateStarted(resource.Name).Task.DefaultTimeout(timeout ?? TimeSpan.FromSeconds(30));
         }
 
         /// <summary>Completes the build for the given resource, unblocking the event handler.</summary>
@@ -1424,13 +1425,13 @@ public class MauiBuildQueueTests
 
             var resourceCommandService = app.Services.GetRequiredService<ResourceCommandService>();
             var subscriber = new TestableBuildQueueSubscriber(notificationService, loggerService, resourceCommandService);
-            await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None);
+            await subscriber.SubscribeAsync(eventing, execContext, CancellationToken.None).DefaultTimeout();
             return subscriber;
         }
 
         public async ValueTask DisposeAsync()
         {
-            await App.DisposeAsync();
+            await App.DisposeAsync().DefaultTimeout();
         }
     }
 }

--- a/tests/Aspire.Hosting.Maui.Tests/MauiOtlpTemplateTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiOtlpTemplateTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Maui;
 using Aspire.Hosting.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests;
 
@@ -32,7 +33,7 @@ public class MauiOtlpTemplateTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             platformResource.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.True(envVars.ContainsKey("OTEL_SERVICE_NAME"),
             "Expected OTEL_SERVICE_NAME to be set on MAUI platform resource");
@@ -59,7 +60,7 @@ public class MauiOtlpTemplateTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             platformResource.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.True(envVars.ContainsKey("OTEL_RESOURCE_ATTRIBUTES"),
             "Expected OTEL_RESOURCE_ATTRIBUTES to be set on MAUI platform resource");
@@ -82,7 +83,7 @@ public class MauiOtlpTemplateTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             androidDevice.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         // OTEL_EXPORTER_OTLP_ENDPOINT should be present (set by WithOtlpExporter)
         Assert.True(envVars.ContainsKey("OTEL_EXPORTER_OTLP_ENDPOINT"),

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -13,6 +13,7 @@ using Aspire.Hosting.Maui.Annotations;
 using Aspire.Hosting.Maui.Utilities;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Sockets;
@@ -293,7 +294,8 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
             await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-                .PublishAsync(new BeforeResourceStartedEvent(platform.Resource, app.Services), CancellationToken.None);
+                .PublishAsync(new BeforeResourceStartedEvent(platform.Resource, app.Services), CancellationToken.None)
+                .DefaultTimeout();
         });
 
         Assert.Contains($"Unable to detect {config.DisplayName}", exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -319,7 +321,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             androidEmulator.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Contains(envVars, kvp => kvp.Key == "DEBUG_MODE" && kvp.Value == "true");
         Assert.Contains(envVars, kvp => kvp.Key == "API_TIMEOUT" && kvp.Value == "30");
@@ -466,7 +468,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var argsContext = new CommandLineArgsCallbackContext(args, simulator.Resource);
         foreach (var argsAnnotation in simulator.Resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>())
         {
-            await argsAnnotation.Callback(argsContext);
+            await argsAnnotation.Callback(argsContext).DefaultTimeout();
         }
 
         Assert.Collection(args,
@@ -548,7 +550,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Contains(envVars, kvp => kvp.Key == "DEBUG_MODE" && kvp.Value == "true");
         Assert.Contains(envVars, kvp => kvp.Key == "API_TIMEOUT" && kvp.Value == "30");
@@ -589,8 +591,8 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                 app.Services.GetRequiredService<ResourceLoggerService>(),
                 app.Services.GetRequiredService<ResourceNotificationService>(),
                 app.Services.GetRequiredService<IFileSystemService>());
-        await environmentSubscriber.SubscribeAsync(eventing, executionContext, CancellationToken.None);
-        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource, app.Services), CancellationToken.None);
+        await environmentSubscriber.SubscribeAsync(eventing, executionContext, CancellationToken.None).DefaultTimeout();
+        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource, app.Services), CancellationToken.None).DefaultTimeout();
 
         var targetsFileCallback = Assert.Single(
             resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>(),
@@ -611,7 +613,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         static async Task<string> EvaluateTargetsFileAsync(CommandLineArgsCallbackAnnotation callback, IResource resource)
         {
             var args = new List<object>();
-            await callback.Callback(new CommandLineArgsCallbackContext(args, resource, CancellationToken.None));
+            await callback.Callback(new CommandLineArgsCallbackContext(args, resource, CancellationToken.None)).DefaultTimeout();
             var property = Assert.Single(
                 args.OfType<string>(),
                 argument => argument.StartsWith("-p:CustomAfterMicrosoftCommonTargets=", StringComparison.Ordinal));
@@ -724,7 +726,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             platform.Resource,
             DistributedApplicationOperation.Run,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         // Assert - OTEL_EXPORTER_OTLP_ENDPOINT should be set directly from the tunnel endpoint
         Assert.True(envVars.TryGetValue("OTEL_EXPORTER_OTLP_ENDPOINT", out var endpointValue));
@@ -771,7 +773,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == KnownEndpointNames.OtlpGrpcEndpointName);
         dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
-        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None).DefaultTimeout();
 
         Assert.Equal("http", stubEndpoint.UriScheme);
         Assert.Equal(55075, stubEndpoint.Port);
@@ -785,7 +787,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Run,
-            app.Services);
+            app.Services).DefaultTimeout();
 
         Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
         Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
@@ -829,7 +831,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         await appBuilder.Eventing.PublishAsync(
             new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
         Assert.Equal(55077, stubEndpoint.Port);
@@ -841,7 +843,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 55088, targetPortExpression: "55089");
         await appBuilder.Eventing.PublishAsync(
             new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
         Assert.Equal(55077, stubEndpoint.Port);
 
         var tunnelEndpoint = tunnelConfig.DevTunnel.GetEndpoint(tunnelConfig.OtlpStub, "otlp");
@@ -851,7 +853,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Run,
-            app.Services);
+            app.Services).DefaultTimeout();
 
         Assert.Equal("http/protobuf", environmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol]);
     }
@@ -889,7 +891,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             targetPortExpression: "55077");
         await appBuilder.Eventing.PublishAsync(
             new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(55076, tunnelConfig.OtlpStub.OtlpEndpoint.Port);
         Assert.Equal("http://localhost:55076", tunnelConfig.OtlpStub.OtlpEndpoint.AllocatedEndpoint?.UriString);
@@ -928,7 +930,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                         "http://localhost:55077",
                         IsFromSpec: false)
                 ]
-            });
+            }).DefaultTimeout();
 
         var dashboardEndpoint = dashboard.Resource.Annotations.OfType<EndpointAnnotation>().Single();
         dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(
@@ -939,7 +941,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         await appBuilder.Eventing.PublishAsync(
             new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         var stubEndpoint = tunnelConfig.OtlpStub.OtlpEndpoint;
         Assert.Equal(55077, stubEndpoint.Port);
@@ -991,11 +993,11 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
 
         await using var app = appBuilder.Build();
 
-        await appBuilder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), CancellationToken.None);
+        await appBuilder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), CancellationToken.None).DefaultTimeout();
         Assert.True(stubEndpointEventPublished);
 
         dashboardEndpoint.AllocatedEndpoint = new AllocatedEndpoint(dashboardEndpoint, "localhost", 55075);
-        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None);
+        await appBuilder.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(dashboard.Resource, app.Services), CancellationToken.None).DefaultTimeout();
 
         Assert.Equal("http", stubEndpoint.UriScheme);
         Assert.Equal(18889, stubEndpoint.Port);
@@ -1008,7 +1010,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             androidEmulator.Resource,
             DistributedApplicationOperation.Run,
-            app.Services);
+            app.Services).DefaultTimeout();
 
         Assert.Equal("https://mobile-otlp.devtunnels.ms:443", envVars[KnownOtelConfigNames.ExporterOtlpEndpoint]);
         Assert.Equal("grpc", envVars[KnownOtelConfigNames.ExporterOtlpProtocol]);
@@ -1044,7 +1046,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Run,
-            app.Services);
+            app.Services).DefaultTimeout();
 
         Assert.Equal("http/protobuf", environmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol]);
     }
@@ -1084,7 +1086,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var environmentVariables = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Publish,
-            TestServiceProvider.Instance);
+            TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.DoesNotContain(KnownOtelConfigNames.ExporterOtlpEndpoint, environmentVariables.Keys);
         Assert.DoesNotContain(KnownOtelConfigNames.ExporterOtlpProtocol, environmentVariables.Keys);
@@ -1115,7 +1117,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         Assert.False(environmentTask.IsCompleted);
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None).DefaultTimeout());
 
         Assert.Contains("requires the Aspire dashboard", exception.Message);
         await AssertEnvironmentResolutionFailsAsync(environmentTask, exception);
@@ -1141,7 +1143,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         await using var app = appBuilder.Build();
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
-            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None));
+            appBuilder.Eventing.PublishAsync(new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services), CancellationToken.None).DefaultTimeout());
 
         Assert.Contains("does not have a concrete OTLP endpoint", exception.Message);
         Assert.Contains(KnownEndpointNames.OtlpGrpcEndpointName, exception.Message);
@@ -1172,7 +1174,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
             appBuilder.Eventing.PublishAsync(
                 new BeforeResourceStartedEvent(tunnelConfig.DevTunnel.Resource, app.Services),
-                CancellationToken.None));
+                CancellationToken.None).DefaultTimeout());
 
         Assert.Contains("does not have a concrete OTLP endpoint", exception.Message);
         Assert.False(tunnelConfig.IsOtlpEndpointResolved);
@@ -1218,12 +1220,12 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             .PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
             {
                 State = KnownResourceStates.Running
-            });
+            }).DefaultTimeout();
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
             appBuilder.Eventing.PublishAsync(
                 new BeforeResourceStartedEvent(resolutionEventResource, app.Services),
-                CancellationToken.None));
+                CancellationToken.None).DefaultTimeout());
 
         Assert.Contains("did not publish a concrete OTLP listener", exception.Message);
 
@@ -1244,10 +1246,10 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
                         "http://localhost:55077",
                         IsFromSpec: false)
                 ]
-            });
+            }).DefaultTimeout();
         await appBuilder.Eventing.PublishAsync(
             new BeforeResourceStartedEvent(resolutionEventResource, app.Services),
-            CancellationToken.None);
+            CancellationToken.None).DefaultTimeout();
 
         tunnelConfig.TunnelEndpoint.EndpointAnnotation.AllocatedEndpoint =
             new AllocatedEndpoint(tunnelConfig.TunnelEndpoint.EndpointAnnotation, "mobile-otlp.devtunnels.ms", 443);
@@ -1255,7 +1257,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         var recoveredEnvironment = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
             DistributedApplicationOperation.Run,
-            app.Services);
+            app.Services).DefaultTimeout();
         Assert.Equal("https://mobile-otlp.devtunnels.ms:443", recoveredEnvironment[KnownOtelConfigNames.ExporterOtlpEndpoint]);
         Assert.Equal("http/protobuf", recoveredEnvironment[KnownOtelConfigNames.ExporterOtlpProtocol]);
     }
@@ -1286,7 +1288,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
                 iosSimulator.Resource,
                 DistributedApplicationOperation.Run,
-                app.Services));
+                app.Services).DefaultTimeout());
 
         Assert.Equal(2, exception.InnerExceptions.Count);
         Assert.All(exception.InnerExceptions, innerException => Assert.IsType<DistributedApplicationException>(innerException));
@@ -1329,7 +1331,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         await notificationService.PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
         {
             State = KnownResourceStates.Running
-        });
+        }).DefaultTimeout();
 
         var environmentTask = EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             iosSimulator.Resource,
@@ -1345,10 +1347,10 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         await notificationService.PublishUpdateAsync(dashboard.Resource, snapshot => snapshot with
         {
             State = dashboardState
-        });
+        }).DefaultTimeout();
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
-            () => beforeStartTask.WaitAsync(TimeSpan.FromSeconds(10)));
+            () => beforeStartTask.DefaultTimeout(TimeSpan.FromSeconds(10)));
         Assert.Contains("terminated", exception.Message);
 
         await AssertEnvironmentResolutionFailsAsync(environmentTask, exception);
@@ -1385,7 +1387,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
         DistributedApplicationException expectedException)
     {
         var environmentException = await Assert.ThrowsAsync<AggregateException>(
-            () => environmentTask.WaitAsync(TimeSpan.FromSeconds(10)));
+            () => environmentTask.DefaultTimeout(TimeSpan.FromSeconds(10)));
         Assert.All(
             environmentException.InnerExceptions,
             innerException => Assert.Same(expectedException, innerException));
@@ -1428,7 +1430,7 @@ public class MauiPlatformExtensionsTests(ITestOutputHelper outputHelper)
             resource,
             ExecutableLaunchMode.Debug);
         var json = JsonSerializer.Serialize(
-            await LaunchConfigurationTestHelpers.InvokeLaunchConfigurationProducerAsync(resource, callbackContext));
+            await LaunchConfigurationTestHelpers.InvokeLaunchConfigurationProducerAsync(resource, callbackContext).DefaultTimeout());
         var launchConfiguration = JsonSerializer.Deserialize<SerializedMauiLaunchConfiguration>(json);
         Assert.NotNull(launchConfiguration);
 

--- a/tests/Aspire.Hosting.Maui.Tests/MauiWithArgsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiWithArgsTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests;
 
@@ -24,7 +25,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var windows = maui.AddWindowsDevice();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(windows.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(windows.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -42,7 +43,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var macCatalyst = maui.AddMacCatalystDevice();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(macCatalyst.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(macCatalyst.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -61,7 +62,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var androidDevice = maui.AddAndroidDevice();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(androidDevice.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(androidDevice.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -81,7 +82,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var androidDevice = maui.AddAndroidDevice("my-device", "abc12345");
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(androidDevice.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(androidDevice.Resource).DefaultTimeout();
 
         Assert.Contains("-p:AdbTarget=-s abc12345", args);
         Assert.DoesNotContain("-p:AdbTarget=-d", args);
@@ -98,7 +99,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var emulator = maui.AddAndroidEmulator();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(emulator.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(emulator.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -118,7 +119,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var emulator = maui.AddAndroidEmulator("my-emulator", "emulator-5554");
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(emulator.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(emulator.Resource).DefaultTimeout();
 
         Assert.Contains("-p:AdbTarget=-s emulator-5554", args);
         Assert.DoesNotContain("-p:AdbTarget=-e", args);
@@ -135,7 +136,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var device = maui.AddiOSDevice();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(device.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(device.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -154,7 +155,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var device = maui.AddiOSDevice("my-device", "00008030-001234567890123A");
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(device.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(device.Resource).DefaultTimeout();
 
         Assert.Contains("-p:RuntimeIdentifier=ios-arm64", args);
         Assert.Contains("-p:_DeviceName=00008030-001234567890123A", args);
@@ -171,7 +172,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var simulator = maui.AddiOSSimulator();
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(simulator.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(simulator.Resource).DefaultTimeout();
 
         Assert.Contains("run", args);
         Assert.Contains("-f", args);
@@ -191,7 +192,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
         var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
         var simulator = maui.AddiOSSimulator("my-simulator", "E25BBE37-69BA-4720-B6FD-D54C97791E79");
 
-        var args = await ArgumentEvaluator.GetArgumentListAsync(simulator.Resource);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(simulator.Resource).DefaultTimeout();
 
         Assert.Contains("-p:_DeviceName=:v2:udid=E25BBE37-69BA-4720-B6FD-D54C97791E79", args);
         // Simulator should NOT have RuntimeIdentifier=ios-arm64 (that's for devices only)
@@ -230,7 +231,7 @@ public class MauiWithArgsTests(ITestOutputHelper outputHelper)
 
         foreach (var (builder, expectedTfm) in platforms)
         {
-            var args = await ArgumentEvaluator.GetArgumentListAsync(builder.Resource);
+            var args = await ArgumentEvaluator.GetArgumentListAsync(builder.Resource).DefaultTimeout();
             Assert.True(args.Count > 0, $"Expected args for {builder.Resource.Name}");
             Assert.Equal("run", args[0]);
             AssertTfm(args, expectedTfm);

--- a/tests/Aspire.Hosting.Maui.Tests/MauiiOSValidationTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiiOSValidationTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Tests;
@@ -32,7 +33,8 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
             await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-                .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None);
+                .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None)
+                .DefaultTimeout();
         });
 
         Assert.Contains("appears to be an iOS Simulator UDID", exception.Message);
@@ -57,7 +59,8 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
             await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-                .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None);
+                .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None)
+                .DefaultTimeout();
         });
 
         Assert.Contains("does not appear to be an iOS Simulator UDID", exception.Message);
@@ -81,7 +84,8 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
 
         // Should not throw — this is a valid device UDID format
         await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-            .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None);
+            .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None)
+            .DefaultTimeout();
     }
 
     [Fact]
@@ -101,7 +105,8 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
 
         // Should not throw — this is a valid simulator UDID format
         await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-            .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None);
+            .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None)
+            .DefaultTimeout();
     }
 
     [Fact]
@@ -119,7 +124,8 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
 
         // No device ID validation when no ID is provided
         await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-            .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None);
+            .PublishAsync(new BeforeResourceStartedEvent(device.Resource, app.Services), CancellationToken.None)
+            .DefaultTimeout();
     }
 
     [Fact]
@@ -137,6 +143,7 @@ public class MauiiOSValidationTests(ITestOutputHelper outputHelper)
 
         // No simulator ID validation when no ID is provided
         await app.Services.GetRequiredService<IDistributedApplicationEventing>()
-            .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None);
+            .PublishAsync(new BeforeResourceStartedEvent(simulator.Resource, app.Services), CancellationToken.None)
+            .DefaultTimeout();
     }
 }


### PR DESCRIPTION
## Description

The MAUI build queue launch-handoff tests used short wall-clock delays to exercise timeout behavior. Under heavy Windows CI contention, those timers could be delayed long enough for tests to exceed their outer timeout and fail intermittently.

This change makes the launch-handoff timeout use an injectable `TimeProvider` while preserving `TimeProvider.System` in production. The timeout tests now advance a `FakeTimeProvider` deterministically instead of depending on real 50 ms timers.

The MAUI test project also uses the shared `DefaultTimeout` helper for async operations that are expected to complete, preventing failures from hanging indefinitely and providing CI-aware timeout diagnostics. Intentional semaphore waits, cancellation waits, and timeout assertions retain their original semantics.

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Maui.Tests/Aspire.Hosting.Maui.Tests.csproj --no-restore --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 204, Failed: 0, Skipped: 0
```

Fixes #18592

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
