### PR TITLE
Fix Azure Functions E2E HTTPS endpoint readiness race

### DIFF
--- a/extension/src/test-e2e/azureFunctions.e2e.test.ts
+++ b/extension/src/test-e2e/azureFunctions.e2e.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { findResource, getCommandInvocationCount, getTaskProcessEventCount, waitForCommandOutcome, waitForHttpText, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForResourceState, waitForTaskProcessEvent, waitForWorkspaceAppHost } from './helpers/assertions';
+import { findResource, getCommandInvocationCount, getTaskProcessEventCount, waitForCommandOutcome, waitForHttpText, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForResourceState, waitForRunningResourceWithUrl, waitForTaskProcessEvent, waitForWorkspaceAppHost } from './helpers/assertions';
 import { executeE2eControlCommand, reloadWorkspaceForE2E, runE2eTeardown, stopPrimaryAppHostIfRunning } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { openAspireView } from './helpers/vscode';
@@ -40,7 +40,9 @@ suite('Aspire Azure Functions E2E', function () {
         await executeE2eControlCommand({ name: 'runAppHost', appHostPath }, { waitFor: 'started' });
         await waitForCommandOutcome('aspire-vscode.runAppHost', 'success', 60000, runInvocationBefore);
 
-        const runningState = await waitForResourceState('e2e-functions', ['Running'], 300000);
+        // Running and endpoint activation are separate updates; the backchannel omits inactive URLs.
+        // Wait for both in the same snapshot before probing HTTPS (https://github.com/microsoft/aspire/issues/19639).
+        const runningState = await waitForRunningResourceWithUrl('e2e-functions', 'https:', 300000);
         const functionsResource = findResource(runningState.state, 'e2e-functions');
         assert.ok(functionsResource, 'Expected the HTTPS Azure Functions resource in extension state.');
         const httpsUrl = functionsResource.urls?.find(url => new URL(url.url).protocol === 'https:')?.url;

--- a/extension/src/test-e2e/helpers/assertions.ts
+++ b/extension/src/test-e2e/helpers/assertions.ts
@@ -78,6 +78,14 @@ export async function waitForResourceState(resourceName: string, states: readonl
     return await waitForExtensionState(file => getResources(file.state).some(resource => isResourceMatch(resource, resourceName) && resource.state !== null && states.includes(resource.state)), `resource '${resourceName}' state ${states.join(' or ')}`, timeoutMs);
 }
 
+export async function waitForRunningResourceWithUrl(resourceName: string, protocol: string, timeoutMs = 120000): Promise<ExtensionE2EStateFile> {
+    return await waitForExtensionState(file => {
+        const resource = findResource(file.state, resourceName);
+        return resource?.state === 'Running'
+            && resource.urls?.some(url => new URL(url.url).protocol === protocol) === true;
+    }, `resource '${resourceName}' to be Running with a '${protocol}' URL`, timeoutMs);
+}
+
 export async function waitForDashboardUrl(timeoutMs = 120000): Promise<ExtensionE2EStateFile> {
     return await waitForExtensionState(file => typeof file.dashboardUrl === 'string' && file.dashboardUrl.length > 0, 'dashboard URL', timeoutMs);
 }

--- a/extension/src/test/e2eResourceReadiness.test.ts
+++ b/extension/src/test/e2eResourceReadiness.test.ts
@@ -1,0 +1,146 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findResource, waitForRunningResourceWithUrl } from '../test-e2e/helpers/assertions';
+import type { AspireExtensionE2EStateFile, AspireResourceState, AspireResourceUrlState } from '../types/extensionApi';
+
+suite('E2E resource URL readiness', () => {
+    const environmentNames = [
+        'ASPIRE_EXTENSION_E2E_STATE_FILE',
+        'ASPIRE_EXTENSION_E2E_PRIMARY_APPHOST',
+        'ASPIRE_EXTENSION_E2E_RUN_ID',
+    ] as const;
+    const httpsUrl: AspireResourceUrlState = {
+        name: 'https',
+        displayName: null,
+        url: 'https://localhost:12345',
+        isInternal: false,
+    };
+    const runningResource: AspireResourceState = {
+        name: 'e2e-functions-instance',
+        displayName: 'e2e-functions',
+        resourceType: 'Project',
+        state: 'Running',
+        projectPath: null,
+        dashboardUrl: null,
+        urls: [httpsUrl],
+        commands: null,
+    };
+    let directory: string;
+    let statePath: string;
+    let previousEnvironment: Record<string, string | undefined>;
+    let snapshot: AspireExtensionE2EStateFile;
+
+    setup(() => {
+        previousEnvironment = Object.fromEntries(environmentNames.map(name => [name, process.env[name]]));
+        directory = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'aspire-e2e-readiness-'));
+        statePath = path.join(directory, 'state.json');
+        const appHostPath = path.join(directory, 'AppHost.csproj');
+        process.env.ASPIRE_EXTENSION_E2E_STATE_FILE = statePath;
+        process.env.ASPIRE_EXTENSION_E2E_PRIMARY_APPHOST = appHostPath;
+        process.env.ASPIRE_EXTENSION_E2E_RUN_ID = 'resource-readiness';
+        snapshot = {
+            extensionHostSessionId: 'resource-readiness',
+            updatedAt: '2026-01-01T00:00:00Z',
+            runId: 'resource-readiness',
+            state: {
+                viewMode: 'workspace',
+                isRepositoryLoading: false,
+                isWorkspaceAppHostDiscoveryComplete: true,
+                hasError: false,
+                errorMessage: undefined,
+                workspaceAppHost: undefined,
+                workspaceAppHostName: 'AppHost',
+                workspaceAppHostPath: appHostPath,
+                workspaceAppHostCandidatePaths: [appHostPath],
+                workspaceAppHostDescription: undefined,
+                workspaceResources: [],
+                appHosts: [],
+                launchingPaths: [],
+                stoppingPaths: [],
+                debugSessions: [],
+            },
+            commandInvocations: [],
+            terminalCommands: [],
+            debugLaunches: [],
+            debugConsoleOutputs: [],
+            stoppingPathEvents: [],
+            taskProcessEvents: [],
+            browserDebugSessions: [],
+        };
+    });
+
+    teardown(() => {
+        for (const name of environmentNames) {
+            const previousValue = previousEnvironment[name];
+            if (previousValue === undefined) {
+                delete process.env[name];
+            }
+            else {
+                process.env[name] = previousValue;
+            }
+        }
+        fs.rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    });
+
+    const notReadyCases: { name: string; resources: AspireResourceState[] }[] = [
+        { name: 'resource missing', resources: [] },
+        { name: 'starting with HTTPS', resources: [{ ...runningResource, state: 'Starting' }] },
+        { name: 'running with null URLs', resources: [{ ...runningResource, urls: null }] },
+        { name: 'running with empty URLs', resources: [{ ...runningResource, urls: [] }] },
+        {
+            name: 'running with only HTTP',
+            resources: [{ ...runningResource, urls: [{ ...httpsUrl, name: 'http', url: 'http://localhost:12345' }] }],
+        },
+        { name: 'stopped with HTTPS', resources: [{ ...runningResource, state: 'Exited' }] },
+        {
+            name: 'a different resource with HTTPS',
+            resources: [
+                { ...runningResource, urls: [] },
+                { ...runningResource, name: 'other-resource', displayName: 'other-resource' },
+            ],
+        },
+    ];
+
+    for (const { name, resources } of notReadyCases) {
+        test(`waits for a later ready snapshot when ${name}`, async () => {
+            writeResources(resources);
+
+            // The waiter reads its first snapshot synchronously before yielding to its polling delay.
+            // Publishing next makes the ordering deterministic without racing a timer.
+            const pending = waitForRunningResourceWithUrl('e2e-functions', 'https:', 5000);
+            writeResources([runningResource]);
+
+            const ready = await pending;
+            assert.deepStrictEqual(findResource(ready.state, 'e2e-functions'), runningResource);
+        });
+    }
+
+    test('accepts an already-ready resource by its instance name', async () => {
+        writeResources([runningResource]);
+
+        const ready = await waitForRunningResourceWithUrl(runningResource.name, 'https:', 5000);
+
+        assert.deepStrictEqual(findResource(ready.state, runningResource.name), runningResource);
+    });
+
+    test('reports the requested endpoint and last state when HTTPS never appears', async () => {
+        const resource = { ...runningResource, urls: [] };
+        writeResources([resource]);
+
+        await assert.rejects(
+            waitForRunningResourceWithUrl('e2e-functions', 'https:', 1000),
+            (error: Error) => {
+                assert.ok(error.message.includes("resource 'e2e-functions' to be Running with a 'https:' URL"));
+                const lastState = JSON.parse(error.message.split('\nLast state: ')[1]) as AspireExtensionE2EStateFile;
+                assert.deepStrictEqual(findResource(lastState.state, 'e2e-functions'), resource);
+                return true;
+            });
+    });
+
+    function writeResources(resources: readonly AspireResourceState[]): void {
+        snapshot.state.workspaceResources = resources;
+        fs.writeFileSync(statePath, JSON.stringify(snapshot));
+    }
+});


### PR DESCRIPTION
## Description

The Azure Functions VS Code E2E scenario can observe a resource as `Running` before its HTTPS endpoint is published, causing an immediate URL assertion failure even though the endpoint becomes available shortly afterward.

Wait for `Running` and an HTTPS URL in the same resource snapshot before probing the endpoint. Add nine focused regression tests covering delayed URL publication, resource identity, non-ready states, and timeout diagnostics. The existing HTTP proof, stop, and task-end assertions remain intact.

This is a test-readiness correction only: no product code, workflow changes, or temporary reproduction infrastructure is included. The existing advisory remains unchanged because an independent startup failure was observed during verification.

### Validation

- [Baseline Linux x64 reproduction](https://github.com/microsoft/aspire/actions/runs/34613922437): six passing iterations, then the exact missing-HTTPS assertion on iteration seven. The resource was `Running` with `urls=[]`, with HTTPS published 173 ms later.
- [Fixed Linux x64 verification](https://github.com/microsoft/aspire/actions/runs/34617640634): 10/10 fresh iterations passed with the advisory disabled, using the same product/VSIX artifacts as the baseline. Iteration four observed the empty-URL window and passed the full HTTP and lifecycle assertions.
- Compilation (`compile-e2e` and `compile-tests`), targeted ESLint, and all nine regression tests passed in the prior native ARM Linux validation. Restoring the original readiness behavior caused five of the nine regression tests to fail.
- An [earlier fixed-source run](https://github.com/microsoft/aspire/actions/runs/34616706657) encountered a separate MSBuild server fallback warning surfaced as IDE500 and Functions `FailedToStart`; this was not the endpoint-publication race.

Fixes #19639

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No