### PR TITLE
Fix CLI transitive MessagePack dependency without changing the NativeAOT RPC preview

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,6 +121,10 @@
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
+    <!-- Pin StreamJsonRpc's transitive dependency without replacing the CLI's NativeAOT preview.
+         2.5.302 combines the security fixes in 2.5.205 and 2.5.301:
+         https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases/tag/v2.5.302 -->
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />


### PR DESCRIPTION
## Description

Remove the vulnerable MessagePack dependency from the CLI dependency graph while retaining its NativeAOT-specific StreamJsonRpc preview. This addresses [CVE-2026-48109 / GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) and [CVE-2026-48506 / GHSA-vh6j-jc39-fggf](https://github.com/advisories/GHSA-vh6j-jc39-fggf) without changing commands, RPC contracts, serializers, or AOT/trimming settings.

Add a central transitive pin for `MessagePack` **2.5.302**, using the existing `CentralPackageTransitivePinningEnabled` setting. The CLI's `StreamJsonRpcPackageVersionForCli` and all its `VersionOverride` consumers remain unchanged.

### Dependency chain and compatibility

Before (confirmed by restoring the unchanged CLI):

```text
StreamJsonRpc 2.23.32-alpha -> MessagePack 2.5.198 -> MessagePack.Annotations 2.5.198
```

After (verified in every target of each project.assets.json below):

```text
StreamJsonRpc 2.23.32-alpha -> MessagePack 2.5.302 -> MessagePack.Annotations 2.5.302
```

| Verified project | Restored targets |
| --- | --- |
| `src/Aspire.Cli/Aspire.Cli.csproj` | net10.0 and all seven declared RIDs |
| `src/Aspire.Cli/Aspire.Cli.Tool.csproj` | net10.0 and win-x64; imports Aspire.Cli.csproj |
| `tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` | net10.0 |
| `benchmarks/Aspire.Cli.Benchmarks/Aspire.Cli.Benchmarks.csproj` | net10.0 |

StreamJsonRpc 2.23.32-alpha declares MessagePack >= 2.5.198, so this stays within its dependency range and the MessagePack v2 release line. Its [NativeAOT preview changes](https://github.com/microsoft/vs-streamjsonrpc/releases/tag/v2.23.32-alpha) remain intact. The CLI continues to use its source-generated System.Text.Json RPC formatter.

Both advisories identify 2.5.301 as patched, but upstream explicitly recommends [2.5.302](https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases/tag/v2.5.302): it combines the security fixes from 2.5.205 and 2.5.301, whereas 2.5.301 omitted the earlier fix. The MessagePack package itself lifts MessagePack.Annotations to the coordinated 2.5.302 version. The repository's stable StreamJsonRpc 2.25.29 already depends on MessagePack 2.5.302, so its graph is not lifted further by this pin.

### Validation

- Bootstrapped with `restore.cmd -projects src\Aspire.Cli\Aspire.Cli.csproj -verbosity quiet` and confirmed the baseline 2.5.198 selection.
- Built the CLI test project and ran existing backchannel/serialization/RPC contract coverage: **119 passed, 6 platform-specific skips, 0 failed**. No runtime code changes or new tests.
  ```powershell
  dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class 'Aspire.Cli.Tests.Backchannel.*' --filter-class '*.AppHostCodeGenerationDiagnosticWireContractTests' --filter-not-trait 'quarantined=true' --filter-not-trait 'outerloop=true'
  ```
- Restored the CLI tool project and built the CLI benchmark project successfully; benchmark build reported zero warnings/errors.
- Checked all four resolved graphs: MessagePack and MessagePack.Annotations are 2.5.302, StreamJsonRpc is 2.23.32-alpha, and no MessagePack 2.5.198 remains.
- Managed Release/win-x64 CLI smoke test (`aspire.dll --version`) returned `13.6.0-dev`.
- Verified both patched package downloads are available from the configured approved mirror. No package source changes or alternate-feed fallback.
- **NativeAOT validation is blocked locally:** `dotnet publish src\Aspire.Cli\Aspire.Cli.csproj -c Release -r win-x64 --verbosity quiet` stops with `Platform linker not found` because the Windows C++ toolchain is not installed. This is a tooling prerequisite failure, not a passing NativeAOT build. Keep this draft pending successful NativeAOT publication and native smoke coverage in a provisioned environment.

### Security considerations

This is a dependency remediation, not a change to RPC trust boundaries. The advisories cover unsafe LZ4 decompression and recursive skipping of MessagePack structures. The CLI's JSON transport and source-generated formatter are unchanged; this PR removes the affected package version from its resolved graph rather than claiming that those particular exploit paths are reachable through the CLI.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No