### PR TITLE
Require patched Snappier for MongoDB v2 integration

### DIFF
--- a/src/Components/Aspire.MongoDB.Driver.v2/Aspire.MongoDB.Driver.v2.csproj
+++ b/src/Components/Aspire.MongoDB.Driver.v2/Aspire.MongoDB.Driver.v2.csproj
@@ -35,6 +35,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" VersionOverride="[1.5.0,2.0.0)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <!-- MongoDB.Driver.Core 2.30.0 permits Snappier >= 1.0.0. Require the patched version
+         for consumers of this v2 package without changing the central MongoDB v3 graph.
+         https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
+    <PackageReference Include="Snappier" VersionOverride="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.MongoDB.Driver.v2.Tests/SnappyCompressionTests.cs
+++ b/tests/Aspire.MongoDB.Driver.v2.Tests/SnappyCompressionTests.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using MongoDB.Driver.Core.Compression;
+using Snappier;
+using Xunit;
+
+namespace Aspire.MongoDB.Driver.Tests;
+
+public class SnappyCompressionTests
+{
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(1024, false)]
+    [InlineData(131072, false)]
+    [InlineData(131072, true)]
+    public void DriverCompressorRoundTrips(int length, bool randomize)
+    {
+        var data = new byte[length];
+        if (randomize)
+        {
+            new Random(42).NextBytes(data);
+        }
+        else
+        {
+            Array.Fill(data, (byte)'a');
+        }
+
+        var compressor = CreateDriverCompressor();
+        using var input = new MemoryStream(data);
+        using var compressed = new MemoryStream();
+        compressor.Compress(input, compressed);
+
+        compressed.Position = 0;
+        using var decompressed = new MemoryStream();
+        compressor.Decompress(compressed, decompressed);
+
+        Assert.Equal(data, decompressed.ToArray());
+    }
+
+    [Fact]
+    public void DriverCompressorReadsRawSnappyBlock()
+    {
+        // Raw Snappy: uncompressed length 5, literal tag (5 - 1) << 2, then "hello".
+        // MongoDB uses raw blocks, not the framed SnappyStream format.
+        // https://github.com/google/snappy/blob/main/format_description.txt
+        byte[] data = [0x05, 0x10, (byte)'h', (byte)'e', (byte)'l', (byte)'l', (byte)'o'];
+        using var input = new MemoryStream(data);
+        using var output = new MemoryStream();
+
+        CreateDriverCompressor().Decompress(input, output);
+
+        Assert.Equal("hello"u8.ToArray(), output.ToArray());
+    }
+
+    [Fact]
+    public void FramedStreamRoundTrips()
+    {
+        var data = new byte[131072];
+        new Random(42).NextBytes(data);
+        using var compressed = new MemoryStream();
+        using (var compressor = new SnappyStream(compressed, CompressionMode.Compress, leaveOpen: true))
+        {
+            compressor.Write(data);
+        }
+
+        compressed.Position = 0;
+        using var decompressor = new SnappyStream(compressed, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        decompressor.CopyTo(output);
+
+        Assert.Equal(data, output.ToArray());
+    }
+
+    [Fact]
+    public async Task MalformedFramedStreamThrows()
+    {
+        // The advisory's 15-byte frame has a compressed chunk containing only a checksum.
+        // Keep the test's wait bounded if the vulnerable non-terminating decoder is restored.
+        // https://github.com/advisories/GHSA-pggp-6c3x-2xmx
+        await Task.Run(() =>
+        {
+            byte[] data = [0x00, 0x04, 0x00, 0x00, 0x64, 0x4e, 0x6c, 0x71, 0x79, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64];
+            using var input = new MemoryStream(data);
+            using var decompressor = new SnappyStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+
+            Assert.Throws<InvalidDataException>(() => decompressor.CopyTo(output));
+        }).WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+    }
+
+    private static ICompressor CreateDriverCompressor()
+    {
+        // The v2 implementation is internal. Exercise the shipped driver binary, rather than
+        // duplicating its Snappier calls, to catch binary incompatibility with the dependency.
+        var type = typeof(ICompressor).Assembly.GetType("MongoDB.Driver.Core.Compression.SnappyCompressor", throwOnError: true)!;
+
+        return Assert.IsAssignableFrom<ICompressor>(Activator.CreateInstance(type));
+    }
+}


### PR DESCRIPTION
## Description

Require patched Snappier for consumers of `Aspire.MongoDB.Driver.v2` without migrating them to MongoDB.Driver 3.x.

[CVE-2026-44302 / GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx) affects Snappier <= 1.3.0; **1.3.1 is the first patched version**, not just an assumed safe upgrade. The [upstream fix](https://github.com/brantburnett/Snappier/pull/147) rejects undersized compressed chunks instead of looping indefinitely.

Add a direct `Snappier` package reference with `VersionOverride="1.3.1"` only to the shipping v2 project. This establishes a minimum version in the published package; the v2 tests inherit it through their project reference rather than masking the shipping graph with a test-only override.

| Dependency | Before | After |
| --- | --- | --- |
| v2 shipping/test graph | MongoDB.Driver 2.30.0 -> MongoDB.Driver.Core 2.30.0 -> Snappier 1.0.0 | Same Driver/Core versions; Snappier resolves to 1.3.1 |
| Shipping package requirement | Snappier only inherited through Driver.Core | Direct Snappier >= 1.3.1 in net8.0, net9.0 and net10.0 dependency groups |
| Driver / DiagnosticSources constraints | `[2.30.0,3.0.0)` / `[1.5.0,2.0.0)` | Unchanged; resolve to 2.30.0 / 1.5.0 |

### Compatibility and scope

MongoDB.Driver.Core 2.30.0's [published dependency metadata](https://www.nuget.org/packages/MongoDB.Driver.Core/2.30.0#dependencies-body-tab) permits Snappier >= 1.0.0 without an upper bound. Snappier 1.3.1 provides a dependency-free net8.0 asset, selected for all three supported Aspire target frameworks. Tests execute the actual Driver.Core 2.30.0 compressor binary against the replacement assembly, rather than reimplementing its calls.

The driver version, v2 APIs, connection settings and target frameworks remain unchanged. There is no intentional change to supported MongoDB server versions, but live-server compatibility was not exercised locally because Docker was unavailable. MongoDB describes 2.30.0 as its [last scheduled 2.x release](https://github.com/mongodb/mongo-csharp-driver/releases/tag/v2.30.0); this is a dependency correction, not a claim of renewed upstream v2 support.

No central versions, feeds or SDK settings change. The modern Driver/EF changes remain in #20041; this does not duplicate those changes or the central dependency refresh in #20046.

### User-facing usage

Existing v2 consumers keep their registration unchanged:

```csharp
builder.AddMongoDBClient("mongodb");
```

Updating the Aspire v2 package brings the patched dependency without requiring migration to Driver 3.x.

### Validation

- Targeted repository restore and build succeeded with unchanged approved feeds.
- Inspected actual `project.assets.json` files for **both** v2 shipping and test projects on **net8.0, net9.0 and net10.0**: Driver/Core 2.30.0, DiagnosticSources 1.5.0, Snappier 1.3.1 using `lib/net8.0/Snappier.dll`.
- `dotnet pack src\Components\Aspire.MongoDB.Driver.v2\Aspire.MongoDB.Driver.v2.csproj --no-restore --configuration Debug --output artifacts\snappier-validation --verbosity minimal` succeeded. Inspected the resulting nuspec and confirmed Snappier >= 1.3.1 in all three dependency groups, with the existing Driver/DiagnosticSources ranges preserved. Pack emitted a missing-readme notice.
- New `SnappyCompressionTests`: **24/24 passed** across the three frameworks. Coverage includes the real driver compressor with empty, small, compressible and incompressible payloads; an independently encoded raw Snappy block; framed-stream round-trip; and the advisory's malformed frame throwing `InvalidDataException`.
- Container-free existing/new suite: **141 passed, 6 skipped** across the three frameworks (the skipped cases report unsupported metrics). For this run only, Docker/Podman executable directories were removed from the child process PATH so the repository feature gate could exclude unavailable container tests using `--filter-not-trait "category=failing"`. Quarantined and outerloop tests were also excluded.
- The initial unrestricted run built successfully but failed fixture initialization because the Docker engine was unavailable at `npipe://./pipe/docker_engine`. Live MongoDB tests remain for CI; no clean vulnerability scan is claimed.

The test invocation used an absolute `--project` path because the installed SDK runner duplicated a relative project path:

```powershell
dotnet test --project "$PWD\tests\Aspire.MongoDB.Driver.v2.Tests\Aspire.MongoDB.Driver.v2.Tests.csproj" --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true" --filter-not-trait "category=failing"
```

### Security considerations

The advisory concerns **framed `SnappyStream` decompression**. MongoDB.Driver.Core 2.30.0's [SnappyCompressor](https://github.com/mongodb/mongo-csharp-driver/blob/v2.30.0/src/MongoDB.Driver.Core/Core/Compression/SnappyCompressor.cs) calls the raw `Snappy` APIs, not `SnappyStream`. This removes the affected dependency version; it does **not** establish that the advisory is reachable through MongoDB's network compression path, nor claim to remediate unrelated dependency advisories. Formal security review and live-server CI validation remain pending.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No