### PR TITLE
Use AWS-LC for Rust playground OTLP TLS

### DIFF
--- a/playground/rust/app/Cargo.lock
+++ b/playground/rust/app/Cargo.lock
@@ -51,6 +51,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +156,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -141,6 +166,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -168,6 +202,12 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -201,6 +241,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -293,8 +339,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -560,6 +617,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +926,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -951,9 +1030,9 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -987,6 +1066,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/playground/rust/app/Cargo.toml
+++ b/playground/rust/app/Cargo.toml
@@ -12,5 +12,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["registry", "env-filter"] }
 tracing-opentelemetry = "0.33.0"
 opentelemetry-appender-tracing = "0.32.0"
-opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "tls-roots", "tls-ring", "internal-logs", "metrics", "logs", "trace"] }
-tonic = { version = "0.14.6", default-features = false, features = ["transport", "tls-native-roots", "tls-ring"] }
+# Select the same provider on both paths: Cargo features are additive, so leaving
+# either on tls-ring would compile both providers rather than replace ring.
+opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "tls-roots", "tls-aws-lc", "internal-logs", "metrics", "logs", "trace"] }
+tonic = { version = "0.14.6", default-features = false, features = ["transport", "tls-native-roots", "tls-aws-lc"] }

--- a/playground/rust/app/README.md
+++ b/playground/rust/app/README.md
@@ -1,0 +1,51 @@
+# Rust sample application
+
+This application serves `/`, `/health`, `/ping`, and `/error`, and exports traces,
+metrics, and logs over OTLP/gRPC. Run it through the AppHost in the parent
+directory, or use `cargo run --locked` here with an OTLP collector configured via
+the standard `OTEL_EXPORTER_OTLP_*` environment variables.
+
+## TLS provider
+
+Both `opentelemetry-otlp` and `tonic` select `tls-aws-lc`, so rustls uses AWS-LC
+instead of ring. Keep those feature selections consistent: Cargo features are
+additive, and enabling `tls-ring` on either dependency would bring ring back.
+There is only one enabled built-in provider, allowing rustls to select it without
+a process-global provider override. This is the ordinary, non-FIPS AWS-LC backend;
+it does not enable or claim FIPS mode.
+
+The exporters still use `ClientTlsConfig::new().with_native_roots()`. HTTPS
+collectors must present a valid certificate for their hostname, trusted by the
+native certificate store. HTTP collectors remain supported. This change does not
+disable certificate verification or change telemetry signals, endpoints, or
+request handling.
+
+Building AWS-LC requires native build tools. See the upstream requirements for
+[Linux](https://aws.github.io/aws-lc-rs/requirements/linux.html),
+[macOS](https://aws.github.io/aws-lc-rs/requirements/apple.html), and
+[Windows](https://aws.github.io/aws-lc-rs/requirements/windows.html).
+The selected features enable upstream prebuilt NASM objects for supported Windows
+x86-64 targets when NASM is unavailable; Windows still needs a C/C++ toolchain.
+Other targets can have additional requirements.
+
+## Checking the dependency graph
+
+From this directory:
+
+```shell
+cargo check --locked --all-targets
+cargo build --locked
+cargo test --locked
+cargo tree --locked --target all --all-features -e features -i aws-lc-rs
+cargo tree --locked --target all --all-features -e features -i ring
+```
+
+The AWS-LC tree should lead through rustls and tonic to the exporters. The ring
+tree should have nothing to print. However, **ring still appears in `Cargo.lock`**
+because rustls-webpki 0.103 uses the weak optional feature reference `ring?/alloc`.
+This is tracked in [rust-lang/cargo#10801](https://github.com/rust-lang/cargo/issues/10801)
+and [rustls/rustls#3093](https://github.com/rustls/rustls/issues/3093).
+It is not enabled or compiled by this sample, but lockfile-based scanners can
+still report it. Do not remove the entry by hand: Cargo regenerates it.
+Removing that entry requires a supported upstream dependency chain or Cargo fix;
+switching the active TLS provider alone does not resolve a lockfile-based finding.


### PR DESCRIPTION
## Description

The Rust playground uses `ring`, which was flagged by dependency scanning. This switches its OTLP TLS backend to AWS-LC and updates the lockfile, preserving telemetry and native-root certificate validation.

**Remaining blocker:** `ring` is no longer compiled, but Cargo still lists it as an inactive optional dependency in the lockfile due to [rust-lang/cargo#10801](https://github.com/rust-lang/cargo/issues/10801). This is not yet a complete fix for lockfile-based scanning.

Linux build and smoke checks passed, including telemetry delivery and rejection of untrusted certificates and hostname mismatches. Windows/macOS and full AppHost startup were not tested. Platform requirements and dependency details are in the sample README.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No