### PR TITLE
Fix dashboard overflow behavior

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor
@@ -20,9 +20,10 @@
 @* Each item is approximately 36px tall, plus 48px for the header and container padding. Include the always-rendered "All" checkbox row. The popover body has a CSS max-height of 300px. *@
 <FluentPopover AnchorId="@id" @bind-Opened="Filter.PopupVisible" Class="content-list-popover chart-filter-popover">
     <strong>@Filter.Name</strong>
-    <div>
+    <div class="dimension-popup-container">
         <FluentStack Orientation="Orientation.Vertical" Class="content-list-popover-items dimension-popup">
             <FluentCheckbox Label="@Loc[nameof(ControlsStrings.LabelAll)]"
+                            Class="aspire-checkbox"
                             ThreeState="true"
                             ShowIndeterminate="false"
                             ThreeStateOrderUncheckToIntermediate="true"
@@ -33,6 +34,7 @@
             {
                 var isChecked = Filter.SelectedValues.Contains(tag);
                 <FluentCheckbox Label="@tag.Text"
+                                Class="aspire-checkbox"
                                 title="@tag.Text"
                                 @key=tag
                                 @bind-Value:get="isChecked"

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterPopover.razor.css
@@ -23,8 +23,30 @@
 
 .chart-filter-button-container + ::deep .chart-filter-popover::part(dialog) {
     transform: translateX(calc(-100% + 32px));
+    box-sizing: border-box;
+    max-width: 400px;
+    width: max-content;
 }
 
-::deep .chart-filter-popover .dimension-popup > fluent-field {
+.dimension-popup-container {
+    min-width: 0;
+}
+
+.dimension-popup-container ::deep .dimension-popup {
+    min-width: 0;
+    row-gap: 4px;
+    width: 100%;
+}
+
+.dimension-popup-container ::deep .dimension-popup > fluent-field {
     cursor: pointer;
+    grid-template-columns: auto minmax(0, 1fr);
+    min-width: 0;
+    width: 100%;
+}
+
+.dimension-popup-container ::deep .dimension-popup > fluent-field > label[slot="label"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -14,8 +14,8 @@
         {
             var isIncludedInFilters = Filter.SelectedValues.Contains(item);
             var isIncludedInFiltersClass = isIncludedInFilters ? "included-in-filters" : "";
-            // Always display the first item by setting a fixed value.
-            <div behavior="@(i == 0 ? "fixed" : null)">
+            // Keep the first value visible until the overflow container is too narrow to display it in full.
+            <div class="@(i == 0 ? "dimension-overflow-ellipsis" : null)" behavior="@(i == 0 ? "ellipsis" : null)">
                 <button type="button"
                         class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
                         aria-pressed="@isIncludedInFilters"
@@ -28,7 +28,7 @@
     </ChildContent>
     <MoreTemplate Context="overflow">
         @{
-            // The first item is fixed, so managed overflow item indexes start at the second value.
+            // The first item has ellipsis behavior, so managed overflow item indexes start at the second value.
             var firstOverflowItem = overflow.ItemsOverflow.FirstOrDefault();
             var hasSelectedInOverflow = firstOverflowItem is not null && orderedValues.Skip(firstOverflowItem.Index + 1).Any(Filter.SelectedValues.Contains);
             var isIncludedInFiltersClass = hasSelectedInOverflow ? "included-in-filters" : "";

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
@@ -14,6 +14,22 @@
     overflow-y: hidden;
 }
 
+.dimension-overflow-ellipsis {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: fit-content;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dimension-overflow-ellipsis > .dimension-tag {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .filter-value-tag {
     cursor: pointer;
     user-select: none;

--- a/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor
@@ -24,6 +24,7 @@
         var label = string.IsNullOrEmpty(key.ToString()) ? Loc[nameof(Resources.ResourceFilterOptionEmpty)] : key.ToString();
 
         <FluentCheckbox Label="@label"
+                        title="@label"
                         Class="aspire-checkbox"
                         @bind-Value:get="@isChecked"
                         @bind-Value:set="@(c => OnValueVisibilityChangedInternalAsync(key, c))" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -67,15 +67,17 @@
         </ToolbarSection>
 
         <MainSection>
-            <FluentPopover AnchorId="resourceFilterButton"
-                           @bind-Opened="_isFilterPopupVisible"
-                           Class="resources-filter-popup">
-                <ResourceFilters ResourceStates="@PageViewModel.ResourceStatesToVisibility"
-                                 ResourceTypes="@PageViewModel.ResourceTypesToVisibility"
-                                 ResourceHealthStates="@PageViewModel.ResourceHealthStatusesToVisibility"
-                                 OnAllFilterVisibilityCheckedChangedAsync="@OnAllFilterVisibilityCheckedChangedAsync"
-                                 OnResourceFilterVisibilityChangedAsync="@OnResourceFilterVisibilityChangedAsync" />
-            </FluentPopover>
+            <div class="resources-filter-popup-container">
+                <FluentPopover AnchorId="resourceFilterButton"
+                               @bind-Opened="_isFilterPopupVisible"
+                               Class="resources-filter-popup">
+                    <ResourceFilters ResourceStates="@PageViewModel.ResourceStatesToVisibility"
+                                     ResourceTypes="@PageViewModel.ResourceTypesToVisibility"
+                                     ResourceHealthStates="@PageViewModel.ResourceHealthStatusesToVisibility"
+                                     OnAllFilterVisibilityCheckedChangedAsync="@OnAllFilterVisibilityCheckedChangedAsync"
+                                     OnResourceFilterVisibilityChangedAsync="@OnResourceFilterVisibilityChangedAsync" />
+                </FluentPopover>
+            </div>
 
             <SummaryDetailsView DetailsTitle="@(PageViewModel.SelectedResource != null ? $"{PageViewModel.SelectedResource.ResourceType}: {GetResourceName(PageViewModel.SelectedResource)}" : null)"
                                 ShowDetails="@showDetailsView"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -122,11 +122,18 @@
     justify-content: flex-end;
 }
 
-::deep .resources-filter-popup::part(dialog) {
+.resources-filter-popup-container {
+    display: contents;
+}
+
+.resources-filter-popup-container ::deep .resources-filter-popup::part(dialog) {
     transform: translateX(calc(-100% + 32px));
     box-sizing: border-box;
-    max-height: 400px;
+    width: max-content;
+    max-width: 400px;
+    max-height: 500px;
     padding: 0;
+    overflow-x: hidden;
     overflow-y: auto;
     border: 0;
     border-radius: 0;
@@ -134,24 +141,41 @@
     box-shadow: var(--aspire-popup-shadow);
 }
 
-::deep .resources-filter-popup > .fluent-stack-vertical {
+.resources-filter-popup-container ::deep .resources-filter-popup > .fluent-stack-vertical {
+    box-sizing: border-box;
+    max-width: 100%;
     padding: 14px;
 }
 
-::deep .resources-filter-popup .filter-group > legend {
+.resources-filter-popup-container ::deep .resources-filter-popup .filter-group {
+    min-width: 0;
+}
+
+.resources-filter-popup-container ::deep .resources-filter-popup .filter-group > legend {
     font-family: var(--aspire-font-display);
     font-size: 16px;
     font-weight: 500;
     line-height: 27px;
 }
 
-::deep .resources-filter-popup .filter-group > .fluent-stack-vertical {
-    row-gap: 10px;
+.resources-filter-popup-container ::deep .resources-filter-popup .filter-group > .fluent-stack-vertical {
+    min-width: 0;
+    row-gap: 4px;
+    width: 100%;
 }
 
-::deep .resources-filter-popup .filter-group fluent-field {
+.resources-filter-popup-container ::deep .resources-filter-popup .filter-group fluent-field {
+    grid-template-columns: auto minmax(0, 1fr);
     height: 20px;
     margin: 0;
+    min-width: 0;
+    width: 100%;
+}
+
+.resources-filter-popup-container ::deep .resources-filter-popup .filter-group fluent-field > label[slot="label"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 @container (max-width: 500px) {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -36,7 +36,7 @@ else if (DisplayedUrls.Count > 1)
             </MoreTemplate>
             <OverflowTemplate Context="overflow">
                 @{
-                    // The first URL is fixed, so managed overflow item indexes start at the second URL.
+                    // The first URL uses ellipsis behavior, so managed overflow item indexes start at the second URL.
                     var firstOverflowItem = overflow.ItemsOverflow.FirstOrDefault();
                     var items = firstOverflowItem is null ? [] : DisplayedUrls.Skip(firstOverflowItem.Index + 1);
                 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -14,15 +14,15 @@ else if (DisplayedUrls.Count == 1)
 else if (DisplayedUrls.Count > 1)
 {
     <div class="url-container" @onclick:stopPropagation="true" @onkeydown:stopPropagation="true">
-        <FluentOverflow Class="url-overflow" MaxRenderedItems="@MaxRenderedOverflowItems">
+        <FluentOverflow Class="url-overflow" MaxRenderedItems="@MaxRenderedOverflowItems" Threshold="0">
             <ChildContent>
                 @* TODO: Filter the URLs before rendering if resource URL cardinality becomes large enough to cause performance problems. *@
                 @for (var i = 0; i < DisplayedUrls.Count; i++)
                 {
                     var displayedUrl = DisplayedUrls[i];
 
-                    // Always display the first item by setting a fixed value.
-                    <div behavior="@(i == 0 ? "fixed" : null)">
+                    // Keep the first URL visible until the overflow container is too narrow to display it in full.
+                    <div behavior="@(i == 0 ? "ellipsis" : null)">
                         @WriteUrl(displayedUrl)
                     </div>
                 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.css
@@ -8,7 +8,7 @@
     overflow-y: visible !important;
 }
 
-::deep .url-overflow > [behavior="fixed"]:not(.fluent-overflow-more) {
+::deep .url-overflow > [behavior="ellipsis"] {
     flex: 0 1 auto;
     min-width: 0;
     max-width: fit-content;

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -90,6 +90,13 @@ public class ChartFiltersTests : DashboardTestContext
         Assert.DoesNotContain("(None)", cut.Markup);
         Assert.Single(cut.FindAll(".chart-filter-button-container"));
         Assert.Contains("aria-label=\"All tags\"", cut.Markup);
+        Assert.NotNull(cut.Find(".dimension-popup-container"));
+        Assert.All(cut.FindAll(".dimension-popup fluent-field"), field => Assert.Contains("aspire-checkbox", field.ClassList));
+        var overflowItems = cut.FindAll(".dimension-overflow > div:not(.fluent-overflow-more)");
+        Assert.Equal("ellipsis", overflowItems[0].GetAttribute("behavior"));
+        Assert.Contains("dimension-overflow-ellipsis", overflowItems[0].ClassList);
+        Assert.All(overflowItems.Skip(1), item => Assert.Null(item.GetAttribute("behavior")));
+        Assert.All(overflowItems.Skip(1), item => Assert.DoesNotContain("dimension-overflow-ellipsis", item.ClassList));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/UrlsColumnDisplayTests.cs
@@ -33,10 +33,13 @@ public class UrlsColumnDisplayTests : DashboardTestContext
         });
 
         // Assert
-    var overflow = cut.Find("fluent-overflow");
+        var overflow = cut.Find("fluent-overflow");
         var overflowItems = cut.FindAll("fluent-overflow > div:not(.fluent-overflow-more)");
-    Assert.Equal("20", overflow.GetAttribute("max-rendered-items"));
-    Assert.Equal(totalUrls, overflowItems.Count);
+        Assert.Equal("20", overflow.GetAttribute("max-rendered-items"));
+        Assert.Equal("0", overflow.GetAttribute("threshold"));
+        Assert.Equal("ellipsis", overflowItems[0].GetAttribute("behavior"));
+        Assert.All(overflowItems.Skip(1), item => Assert.Null(item.GetAttribute("behavior")));
+        Assert.Equal(totalUrls, overflowItems.Count);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -51,6 +51,8 @@ public partial class ResourcesTests : DashboardTestContext
         var allCheckbox = cut.FindComponents<FluentCheckbox>()[0].Instance;
         Assert.True(allCheckbox.Value);
         Assert.True(allCheckbox.CheckState);
+        Assert.NotNull(cut.Find("fluent-checkbox[title='Container']"));
+        Assert.NotNull(cut.Find("fluent-checkbox[title='Project']"));
 
         values["Container"] = false;
         cut.SetParametersAndRender(builder => builder.Add(component => component.Values, values));

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -310,6 +310,8 @@ public partial class ResourcesTests : DashboardTestContext
             builder.AddCascadingValue(viewport);
         });
 
+        Assert.NotNull(cut.Find(".resources-filter-popup-container"));
+
         // Open the resource filter
         cut.Find("#resourceFilterButton").Click();
 


### PR DESCRIPTION
## Description

Dashboard overflow could hide or shrink the primary resource URL and metric dimension value before secondary values, while long filter labels could expand beyond their intended popup bounds. This change gives the first URL and dimension tag ellipsis priority, and constrains filter popup content so long values remain usable without horizontal overflow.

Resource URL overflow now starts at the container boundary and preserves the first URL until it must be truncated. Metric dimension tags use the same priority behavior. The Metrics and Resources filter popups cap their rendered width at 400px, trim long checkbox labels with an ellipsis, use pointer cursors for enabled labels, and space checkbox rows by 4px.

### User-facing usage

On the Resources and Metrics pages, users can resize the dashboard without secondary values displacing the first URL or dimension value. Long filter values remain available through their existing tooltip while the visible label is trimmed within the popup.

### Screenshots / Recordings

#### Resource URL priority at 700px

| Current | This PR |
| --- | --- |
| ![Current resource URL overflow](https://github.com/user-attachments/assets/c33da2ed-3bca-419b-a134-c4d5b06ccc2b) | ![Updated resource URL overflow](https://github.com/user-attachments/assets/f4dbf9e8-1f36-4516-b3e7-39b711a0e2a3) |

The catalog replicas now keep the primary `Catalog API` URL visible and move `Swagger UI` into the `+1` overflow menu.

#### Resources filter popup

![Resources filter popup with compact checkbox spacing](https://github.com/user-attachments/assets/cfa7f561-8550-4d34-afe5-435968bf4072)

#### Npgsql `pool.name` dimension filter

![Npgsql pool.name popup capped at 400px with an ellipsized value](https://github.com/user-attachments/assets/dedef560-88e6-4eea-83e7-ddd86c895638)

### Validation

- `ChartFiltersTests`, `UrlsColumnDisplayTests`, and `ResourcesTests`: 48 tests passed
- Playwright width checks for resource URLs and metric dimension tags
- Playwright checks confirmed 400px popup caps, label ellipsis, 4px row gaps, pointer labels, and no horizontal overflow

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
