### PR TITLE
Match grid column popups to dashboard styling

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/controls.css
+++ b/src/Aspire.Dashboard/wwwroot/css/controls.css
@@ -623,11 +623,11 @@ body {
     overflow: hidden;
 }
 
-.aspire-menu-container {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) {
     --colorNeutralBackground1Hover: var(--aspire-menu-item-hover-background);
 }
 
-.aspire-menu-container fluent-menu-list {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-list {
     gap: 0;
     padding: 3px 0;
     border-radius: var(--aspire-popup-radius);
@@ -635,11 +635,11 @@ body {
     box-shadow: var(--aspire-popup-shadow);
 }
 
-.aspire-menu-container fluent-menu-list:has(> fluent-menu-item:state(submenu)) {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-list:has(> fluent-menu-item:state(submenu)) {
     min-width: 180px;
 }
 
-.aspire-menu-container fluent-menu-item {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item {
     gap: 0;
     grid-template-columns: minmax(32px, auto) 0 minmax(0, 1fr) minmax(32px, auto);
     height: 28px;
@@ -655,35 +655,48 @@ body {
     line-height: var(--lineHeightBase300);
 }
 
-.aspire-menu-container fluent-menu-item:state(submenu) {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:state(submenu) {
     grid-template-columns: minmax(32px, auto) 0 minmax(0, 1fr) minmax(32px, auto) 24px;
     height: 32px;
     min-height: 32px;
     padding-inline-end: 8px;
 }
 
-.aspire-menu-container fluent-menu-item > [slot="start"],
-.aspire-menu-container fluent-menu-item > [slot="indicator"] {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item > [slot="start"],
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item > [slot="indicator"] {
     grid-column: 1;
     grid-row: 1;
     position: relative;
     inset-inline-start: 8px;
 }
 
-.aspire-menu-container fluent-menu-item:hover,
-.aspire-menu-container fluent-menu-item:state(active),
-.aspire-menu-container fluent-menu-item:focus-visible {
+[cell-type="columnheader"] > fluent-menu fluent-menu-item {
+    text-align: left;
+}
+
+[cell-type="columnheader"] > fluent-menu fluent-menu-item > [slot="start"] {
+    color: var(--colorBrandForeground1);
+    width: 16px !important;
+}
+
+[cell-type="columnheader"] > [col-header-ui] {
+    background: var(--aspire-popup-background);
+}
+
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:hover,
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:state(active),
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:focus-visible {
     background-color: var(--aspire-menu-item-hover-background);
 }
 
-.aspire-menu-container fluent-divider {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-divider {
     margin-block: 4px;
 }
 
 /* Fluent v5 separates the indicator and start slots. Collapse the unused indicator track so the
    icon and content align with v4's 32px start track while retaining the end slot for secondary actions. */
 
-.aspire-menu-container fluent-menu-item:not(:state(submenu))::part(content) {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:not(:state(submenu))::part(content) {
     grid-column: 2 / span 2;
     grid-row: 1;
     min-width: 0;
@@ -692,7 +705,7 @@ body {
     text-overflow: ellipsis;
 }
 
-.aspire-menu-container fluent-menu-item:state(submenu)::part(content) {
+:is(.aspire-menu-container, [cell-type="columnheader"] > fluent-menu) fluent-menu-item:state(submenu)::part(content) {
     grid-column: 3;
     grid-row: 1;
     padding-inline: 0;
@@ -992,7 +1005,7 @@ table.aspire-scroll-border-grid:not(:has(tr[row-state="empty-content"], tr[row-s
 }
 
 .fluent-data-grid > thead > tr > th,
-.fluent-data-grid > thead > tr > th fluent-button,
+.fluent-data-grid > thead > tr > th > fluent-button,
 .fluent-data-grid > thead > tr > th [col-title-text] {
     color: var(--colorNeutralForeground3);
     font-weight: 400 !important;
@@ -1005,7 +1018,7 @@ table.aspire-scroll-border-grid:not(:has(tr[row-state="empty-content"], tr[row-s
     white-space: nowrap;
 }
 
-.fluent-data-grid > thead > tr > th fluent-button::part(content) {
+.fluent-data-grid > thead > tr > th > fluent-button::part(content) {
     min-width: 0;
     overflow: hidden;
 }
@@ -1020,7 +1033,7 @@ table.aspire-scroll-border-grid:not(:has(tr[row-state="empty-content"], tr[row-s
     --aspire-data-grid-cell-border-color: var(--datagrid-border-color);
 }
 
-.property-grid-container .fluent-data-grid > thead > tr > th fluent-button {
+.property-grid-container .fluent-data-grid > thead > tr > th > fluent-button {
     --colorSubtleBackground: var(--property-grid-background-color);
 }
 
@@ -1108,7 +1121,7 @@ fluent-badge.property-details-accordion-badge {
     padding: 4px 1px 4px 8px;
 }
 
-.fluent-data-grid > thead > tr > th fluent-button {
+.fluent-data-grid > thead > tr > th > fluent-button {
     --aspire-button-foreground: var(--colorNeutralForeground3);
     --aspire-button-border-color: transparent;
     --colorSubtleBackground: var(--aspire-page-background);

--- a/src/Aspire.Dashboard/wwwroot/css/layout.css
+++ b/src/Aspire.Dashboard/wwwroot/css/layout.css
@@ -636,8 +636,9 @@ fluent-dialog-body::part(content) {
     width: 67px;
 }
 
-/* v4 used Stealth colors for inactive toolbar buttons while retaining accent icons. */
-.toolbar-button:not([appearance]) {
+/* v4 used Stealth colors for inactive toolbar buttons while retaining accent icons.
+    Column-resize actions reuse the same recipe. */
+:is(.toolbar-button:not([appearance]), [resize-options] > fluent-button:not([appearance])) {
     --colorNeutralBackground1: var(--colorNeutralBackground2);
     --colorNeutralBackground1Hover: var(--colorNeutralBackground3);
     --colorNeutralBackground1Pressed: var(--aspire-link-button-pressed-background);


### PR DESCRIPTION
## Description

Fluent UI v5 grid column popups did not match the dashboard's established popup styling. Column menu labels were centered with neutral icons, and the column-width controls inherited styling intended for the header trigger instead of matching toolbar filter controls.

This change reuses the dashboard menu recipe for generated grid header menus, left-aligns menu labels, uses the accent color for menu icons, and applies the shared popup background. The column-width actions now reuse the toolbar button color recipe, while direct-child selectors keep header-trigger styles from leaking into nested controls.

Validation:

- `dotnet build src/Aspire.Dashboard/Aspire.Dashboard.csproj --no-restore`
- Browser verification in TestShop at a 1200 x 800 viewport
- Computed-style comparison between resource-filter and column-width controls

### Screenshots / Recordings

#### Column menu

| Before | After |
| --- | --- |
| ![Column menu before](https://github.com/user-attachments/assets/e4d26248-0ded-47a9-8d6c-238d6671f299) | ![Column menu after](https://github.com/user-attachments/assets/f45e801f-7abd-422b-b5e9-136b9aabf39c) |

#### Column width controls

| Before | After |
| --- | --- |
| ![Column width controls before](https://github.com/user-attachments/assets/80af6321-5a6d-419f-8453-e1018b0da876) | ![Column width controls after](https://github.com/user-attachments/assets/f85f2d7b-ae57-47ef-ae37-9ea14a419bdf) |

Fixes #

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
