### PR TITLE
Filter blank values from dashboard filter dialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -225,6 +225,7 @@ public partial class FilterDialog : IAsyncDisposable
                 }
 
                 _allValues = fieldValues
+                    .Where(kvp => !string.IsNullOrEmpty(kvp.Key))
                     .Select(kvp => new FieldValue { Value = kvp.Key, Count = kvp.Value })
                     .OrderByDescending(v => v.Count)
                     .ThenBy(v => v.Value, StringComparers.OtlpFieldValue)

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
@@ -101,6 +101,34 @@ public class FilterDialogTests : DashboardTestContext
     }
 
     [Fact]
+    public void Render_StringFilter_EmptyFieldValueIsNotDisplayed()
+    {
+        SetupFilterDialogServices();
+        var content = new FilterDialogViewModel
+        {
+            Filter = new FieldTelemetryFilter
+            {
+                Field = KnownTraceFields.TraceIdField,
+                Condition = FilterCondition.Contains,
+                Value = ""
+            },
+            KnownKeys = [KnownTraceFields.TraceIdField],
+            GetPropertyKeysAsync = static _ => Task.FromResult<List<string>>([]),
+            GetFieldValuesAsync = static (_, _) => Task.FromResult(new Dictionary<string, int>
+            {
+                [""] = 3,
+                ["trace-id"] = 2
+            })
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+
+        var option = Assert.Single(cut.Find("fluent-dropdown[type='combobox']").QuerySelectorAll("fluent-option:not([freeform])"));
+        Assert.Equal("trace-id", option.GetAttribute("text"));
+        Assert.Single(option.QuerySelectorAll("[data-filtercount='2']"));
+    }
+
+    [Fact]
     public async Task Render_PropertyKeysLoading_DisablesParameterSelectAndDisplaysProgressRing()
     {
         SetupFilterDialogServices();


### PR DESCRIPTION
## Description

Filter value comboboxes no longer display blank options with a count, such as an empty trace ID. Empty values are removed when the dialog builds its suggestions, while non-empty values retain their aggregated counts.

### User-facing usage

When selecting a field in the dashboard filter dialog, the value suggestions now contain only selectable, non-empty values.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

## Validation

`dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-method "*.Render_StringFilter_EmptyFieldValueIsNotDisplayed" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
