### PR TITLE
Document PR image uploads

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -66,7 +66,23 @@ If non-trivial UI changes are detected, add a prominent `### Screenshots / Recor
 
 For non-trivial UI changes, upload screenshots or recordings as GitHub user attachments. Do not commit them to the source branch unless explicitly requested.
 
-Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Prepare one flag per file and append the flags to the final `gh pr create` command in step 6 or `gh pr edit` command in step 7. For images, text after `#` is the alt text. Videos do not support alt text and must omit the `#` suffix:
+Before uploading, inspect every artifact for secrets, credentials, tokens, customer or confidential data, private URLs, and unintended personal information. Redact or regenerate any artifact that contains sensitive data, and do not upload it until the inspection passes. Treat uploads as permanent public data because this public repository exposes attachments to everyone and the attachment API has no deletion endpoint.
+
+Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Before invoking `gh`, replace the `<!-- Add screenshots/recordings here -->` placeholder in `pr-body.md` with local Markdown references at the intended location. Use a table for before/after images when appropriate:
+
+```markdown
+| Before | After |
+| --- | --- |
+| ![Before](./before.png) | ![After](./after.png) |
+```
+
+Place an image-style reference to a video on its own line in its own paragraph so GitHub CLI rewrites it to a bare asset URL that renders as a player:
+
+```markdown
+![Screen recording](./demo.mp4)
+```
+
+Prepare one flag per referenced file and append the flags to the final `gh pr create` command in step 6 or `gh pr edit` command in step 7. GitHub CLI rewrites the local references to uploaded URLs; without references, it appends the attachments to the end of the body. For images, text after `#` is the alt text when the body does not already provide it. Videos do not support alt text and must omit the `#` suffix:
 
 ```shell
 --attach './before.png#Before' --attach './after.png#After' --attach './demo.mp4'
@@ -77,7 +93,7 @@ For older GitHub CLI versions, upload each image with the authenticated attachme
 ```text
 POST https://uploads.github.com/user-attachments/assets?name=<encoded-name>&content_type=<encoded-MIME-type>&repository_id=<id>
 Authorization: Bearer <gh-token>
-Content-Type: <MIME-type>
+Content-Type: application/octet-stream
 ```
 
 Example for a PNG in PowerShell:
@@ -89,7 +105,7 @@ $repoId = gh api "repos/$repo" --jq .id
 $token = gh auth token
 $name = [Uri]::EscapeDataString((Split-Path -Leaf $file))
 $uri = "https://uploads.github.com/user-attachments/assets?name=$name&content_type=image%2Fpng&repository_id=$repoId"
-(Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "image/png" -InFile $file).url
+(Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "application/octet-stream" -InFile $file).url
 ```
 
 The response is HTTP `201` with a `url` value. Keep the token in memory and never print it. This endpoint is undocumented, so prefer `gh --attach` when available.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -68,7 +68,7 @@ For non-trivial UI changes, upload screenshots or recordings as GitHub user atta
 
 Before uploading, inspect every artifact for secrets, credentials, tokens, customer or confidential data, private URLs, and unintended personal information. Redact or regenerate any artifact that contains sensitive data, and do not upload it until the inspection passes. Treat uploads as permanent public data because this public repository exposes attachments to everyone and the attachment API has no deletion endpoint.
 
-Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Before invoking `gh`, replace the `<!-- Add screenshots/recordings here -->` placeholder in `pr-body.md` with local Markdown references at the intended location. Use a table for before/after images when appropriate:
+Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Prepare local Markdown references for step 5 to insert at the intended location in `pr-body.md`. Use a table for before/after images when appropriate:
 
 ```markdown
 | Before | After |
@@ -88,7 +88,7 @@ Prepare one flag per referenced file and append the flags to the final `gh pr cr
 --attach './before.png#Before' --attach './after.png#After' --attach './demo.mp4'
 ```
 
-For older GitHub CLI versions, upload each image with the authenticated attachment API. Resolve `repository_id` with `gh api repos/<owner>/<repo> --jq .id`, then send the raw file bytes:
+For older GitHub CLI versions, upload each supported image or video with the authenticated attachment API. Resolve `repository_id` with `gh api repos/<owner>/<repo> --jq .id`, determine the artifact's MIME type, and send the raw file bytes:
 
 ```text
 POST https://uploads.github.com/user-attachments/assets?name=<encoded-name>&content_type=<encoded-MIME-type>&repository_id=<id>
@@ -96,26 +96,39 @@ Authorization: Bearer <gh-token>
 Content-Type: application/octet-stream
 ```
 
-Example for a PNG in PowerShell:
+Example for a supported image or video in PowerShell:
 
 ```powershell
 $repo = "<owner>/<repo>"
-$file = "<absolute-path-to-image>"
+$file = "<absolute-path-to-image-or-video>"
 $repoId = gh api "repos/$repo" --jq .id
 $token = gh auth token
 $name = [Uri]::EscapeDataString((Split-Path -Leaf $file))
-$uri = "https://uploads.github.com/user-attachments/assets?name=$name&content_type=image%2Fpng&repository_id=$repoId"
-(Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "application/octet-stream" -InFile $file).url
+$contentType = switch ([IO.Path]::GetExtension($file).ToLowerInvariant()) {
+  ".png"  { "image/png" }
+  ".jpg"  { "image/jpeg" }
+  ".jpeg" { "image/jpeg" }
+  ".gif"  { "image/gif" }
+  ".webp" { "image/webp" }
+  ".mp4"  { "video/mp4" }
+  ".mov"  { "video/quicktime" }
+  ".webm" { "video/webm" }
+  default { throw "Unsupported attachment type: $([IO.Path]::GetExtension($file))" }
+}
+$encodedContentType = [Uri]::EscapeDataString($contentType)
+$uri = "https://uploads.github.com/user-attachments/assets?name=$name&content_type=$encodedContentType&repository_id=$repoId"
+$assetUrl = (Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "application/octet-stream" -InFile $file).url
 ```
 
 The response is HTTP `201` with a `url` value. Keep the token in memory and never print it. This endpoint is undocumented, so prefer `gh --attach` when available.
 
-Embed the returned `user-attachments` URLs with useful alt text, using a Markdown table for before/after comparisons. Verify each URL returns HTTP `200` and renders in the final PR body.
+Embed returned image URLs with useful alt text, using a Markdown table for before/after comparisons. Place a returned video URL bare on its own line in its own paragraph so GitHub renders it as a player. Verify each URL returns HTTP `200` and renders in the final PR body.
 
 ### 5. Build PR body from template
 
 - Read `.github/pull_request_template.md`.
 - Use the template structure as the PR body.
+- If step 4 prepared visual artifacts, replace the `<!-- Add screenshots/recordings here -->` placeholder with the prepared Markdown references before running the create or edit command. Use local paths for `gh --attach` or the returned `user-attachments` URLs for the API fallback. Do not leave the placeholder in the final body.
 - Fill known details in `## Description` with reviewer- and user-facing context:
   - Lead with **why** the change matters: the user problem, scenario, or workflow it improves.
   - Summarize the user-visible behavior before implementation details: what users can now do, see, configure, or call.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -68,7 +68,7 @@ For non-trivial UI changes, upload screenshots or recordings as GitHub user atta
 
 Before uploading, inspect every artifact for secrets, credentials, tokens, customer or confidential data, private URLs, and unintended personal information. Redact or regenerate any artifact that contains sensitive data, and do not upload it until the inspection passes. Treat uploads as permanent public data because this public repository exposes attachments to everyone and the attachment API has no deletion endpoint.
 
-Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Prepare local Markdown references for step 5 to insert at the intended location in `pr-body.md`. Use a table for before/after images when appropriate:
+Check attachment support for the command that will write the PR: `gh pr create --help` for a new PR or `gh pr edit --help` for an existing PR. Use `--attach` only when that command advertises it. Prepare local Markdown references for step 5 to insert at the intended location in `pr-body.md`. Use a table for before/after images when appropriate:
 
 ```markdown
 | Before | After |
@@ -88,47 +88,15 @@ Prepare one flag per referenced file and append the flags to the final `gh pr cr
 --attach './before.png#Before' --attach './after.png#After' --attach './demo.mp4'
 ```
 
-For older GitHub CLI versions, upload each supported image or video with the authenticated attachment API. Resolve `repository_id` with `gh api repos/<owner>/<repo> --jq .id`, determine the artifact's MIME type, and send the raw file bytes:
+If the relevant command does not advertise `--attach`, do not upload the artifacts or call GitHub's undocumented attachment endpoint. Tell the user that their installed GitHub CLI version does not support attachment uploads for that command and ask them to upgrade it. Include the detected version from `gh --version` and link to the official upgrade instructions at https://github.com/cli/cli#installation.
 
-```text
-POST https://uploads.github.com/user-attachments/assets?name=<encoded-name>&content_type=<encoded-MIME-type>&repository_id=<id>
-Authorization: Bearer <gh-token>
-Content-Type: application/octet-stream
-```
-
-Example for a supported image or video in PowerShell:
-
-```powershell
-$repo = "<owner>/<repo>"
-$file = "<absolute-path-to-image-or-video>"
-$repoId = gh api "repos/$repo" --jq .id
-$token = gh auth token
-$name = [Uri]::EscapeDataString((Split-Path -Leaf $file))
-$contentType = switch ([IO.Path]::GetExtension($file).ToLowerInvariant()) {
-  ".png"  { "image/png" }
-  ".jpg"  { "image/jpeg" }
-  ".jpeg" { "image/jpeg" }
-  ".gif"  { "image/gif" }
-  ".webp" { "image/webp" }
-  ".mp4"  { "video/mp4" }
-  ".mov"  { "video/quicktime" }
-  ".webm" { "video/webm" }
-  default { throw "Unsupported attachment type: $([IO.Path]::GetExtension($file))" }
-}
-$encodedContentType = [Uri]::EscapeDataString($contentType)
-$uri = "https://uploads.github.com/user-attachments/assets?name=$name&content_type=$encodedContentType&repository_id=$repoId"
-$assetUrl = (Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "application/octet-stream" -InFile $file).url
-```
-
-The response is HTTP `201` with a `url` value. Keep the token in memory and never print it. This endpoint is undocumented, so prefer `gh --attach` when available.
-
-Embed returned image URLs with useful alt text, using a Markdown table for before/after comparisons. Place a returned video URL bare on its own line in its own paragraph so GitHub renders it as a player. Verify each URL returns HTTP `200` and renders in the final PR body.
+After the upgrade, run `gh --version` and check the relevant command help again. Retry the upload only when `--attach` is advertised. If the user does not upgrade, continue without uploading and retain the TODO in the Screenshots / Recordings section so the missing visual evidence is explicit.
 
 ### 5. Build PR body from template
 
 - Read `.github/pull_request_template.md`.
 - Use the template structure as the PR body.
-- If step 4 prepared visual artifacts, replace the `<!-- Add screenshots/recordings here -->` placeholder with the prepared Markdown references before running the create or edit command. Use local paths for `gh --attach` or the returned `user-attachments` URLs for the API fallback. Do not leave the placeholder in the final body.
+- If step 4 prepared visual artifacts and `gh --attach` is available, replace the `<!-- Add screenshots/recordings here -->` placeholder with the prepared local Markdown references before running the create or edit command. Do not leave the placeholder in the final body after a successful upload.
 - Fill known details in `## Description` with reviewer- and user-facing context:
   - Lead with **why** the change matters: the user problem, scenario, or workflow it improves.
   - Summarize the user-visible behavior before implementation details: what users can now do, see, configure, or call.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -62,7 +62,42 @@ If non-trivial UI changes are detected, add a prominent `### Screenshots / Recor
 <!-- Add screenshots/recordings here -->
 ```
 
-### 4. Build PR body from template
+### 4. Upload visual artifacts
+
+For non-trivial UI changes, upload screenshots or recordings as GitHub user attachments. Do not commit them to the source branch unless explicitly requested.
+
+Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Repeat the flag for multiple files; text after `#` is the alt text:
+
+```shell
+gh pr create <other arguments> --attach './before.png#Before' --attach './after.png#After'
+gh pr edit <pr> --attach './before.png#Before' --attach './after.png#After'
+```
+
+For older GitHub CLI versions, upload each image with the authenticated attachment API. Resolve `repository_id` with `gh api repos/<owner>/<repo> --jq .id`, then send the raw file bytes:
+
+```text
+POST https://uploads.github.com/user-attachments/assets?name=<encoded-name>&content_type=<encoded-MIME-type>&repository_id=<id>
+Authorization: Bearer <gh-token>
+Content-Type: <MIME-type>
+```
+
+Example for a PNG in PowerShell:
+
+```powershell
+$repo = "<owner>/<repo>"
+$file = "<absolute-path-to-image>"
+$repoId = gh api "repos/$repo" --jq .id
+$token = gh auth token
+$name = [Uri]::EscapeDataString((Split-Path -Leaf $file))
+$uri = "https://uploads.github.com/user-attachments/assets?name=$name&content_type=image%2Fpng&repository_id=$repoId"
+(Invoke-RestMethod -Method Post -Uri $uri -Headers @{ Authorization = "Bearer $token"; Accept = "application/json" } -ContentType "image/png" -InFile $file).url
+```
+
+The response is HTTP `201` with a `url` value. Keep the token in memory and never print it. This endpoint is undocumented, so prefer `gh --attach` when available.
+
+Embed the returned `user-attachments` URLs with useful alt text, using a Markdown table for before/after comparisons. Verify each URL returns HTTP `200` and renders in the final PR body.
+
+### 5. Build PR body from template
 
 - Read `.github/pull_request_template.md`.
 - Use the template structure as the PR body.
@@ -161,7 +196,7 @@ If non-trivial UI changes are detected, add a prominent `### Screenshots / Recor
 - Keep `Fixes # (issue)` unless a concrete issue number is provided.
 - Write the body to a temporary file named `pr-body.md` in the repo root.
 
-### 5. Create the PR
+### 6. Create the PR
 
 Set `GH_PAGER` to `cat` to prevent interactive paging, then create the PR. The syntax differs by shell:
 
@@ -190,7 +225,7 @@ gh pr create `
 
 > **Shell differences:** `VAR=val command` is bash syntax for setting an env var for a single command. PowerShell requires a separate `$env:VAR = "val"` statement (persists for the session, which is harmless here).
 
-### 6. Handle existing PRs
+### 7. Handle existing PRs
 
 If a PR already exists for the branch:
 - Do not create another.
@@ -204,9 +239,9 @@ If a PR already exists for the branch:
 
 - Return the existing PR URL.
 
-### 7. Clean up
+### 8. Clean up
 
-After you are completely finished creating or updating the PR (after step 5 and, if needed, step 6), delete the temporary body file:
+After you are completely finished creating or updating the PR (after step 6 and, if needed, step 7), delete the temporary body file:
 - **bash:** `rm pr-body.md`
 - **PowerShell:** `Remove-Item pr-body.md`
 
@@ -225,4 +260,4 @@ After you are completely finished creating or updating the PR (after step 5 and,
 - Keep the body aligned with `.github/pull_request_template.md`.
 - If the user asks to preview before creating, show the prepared PR body first, then create after confirmation.
 - For checklist sections with Yes/No alternatives, prefer selecting exactly one option per question when information is known.
-- **After creating the PR**, if non-trivial UI changes were detected in step 3, alert the user with a message like: "This PR includes non-trivial UI changes to [Dashboard/CLI/Extension]. Please add screenshots or screen recordings to the PR description so reviewers can evaluate the visual changes without running locally." Include the PR URL so the user can edit it directly.
+- **After creating the PR**, if non-trivial UI changes were detected in step 3, verify that the screenshots or recordings from step 4 are present and rendered in the PR description. If capture or upload was not possible, alert the user with a message like: "This PR includes non-trivial UI changes to [Dashboard/CLI/Extension], but screenshots or recordings could not be added. Please add them so reviewers can evaluate the visual changes without running locally." Include the PR URL so the user can edit it directly.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -66,11 +66,10 @@ If non-trivial UI changes are detected, add a prominent `### Screenshots / Recor
 
 For non-trivial UI changes, upload screenshots or recordings as GitHub user attachments. Do not commit them to the source branch unless explicitly requested.
 
-Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Repeat the flag for multiple files; text after `#` is the alt text:
+Prefer `gh --attach` when advertised by `gh pr create --help` or `gh pr edit --help`. Prepare one flag per file and append the flags to the final `gh pr create` command in step 6 or `gh pr edit` command in step 7. For images, text after `#` is the alt text. Videos do not support alt text and must omit the `#` suffix:
 
 ```shell
-gh pr create <other arguments> --attach './before.png#Before' --attach './after.png#After'
-gh pr edit <pr> --attach './before.png#Before' --attach './after.png#After'
+--attach './before.png#Before' --attach './after.png#After' --attach './demo.mp4'
 ```
 
 For older GitHub CLI versions, upload each image with the authenticated attachment API. Resolve `repository_id` with `gh api repos/<owner>/<repo> --jq .id`, then send the raw file bytes:
@@ -208,7 +207,9 @@ GH_PAGER=cat gh pr create \
   --base <base-branch> \
   --head <head-branch> \
   --title "<pr-title>" \
-  --body-file pr-body.md
+  --body-file pr-body.md \
+  --attach './before.png#Before' \
+  --attach './after.png#After'
 ```
 
 **PowerShell/Windows:**
@@ -218,8 +219,12 @@ gh pr create `
   --base <base-branch> `
   --head <head-branch> `
   --title "<pr-title>" `
-  --body-file pr-body.md
+  --body-file pr-body.md `
+  --attach './before.png#Before' `
+  --attach './after.png#After'
 ```
+
+Omit the `--attach` lines when step 4 did not prepare visual artifacts. Attach videos without a `#` suffix.
 
 > **Why `GH_PAGER=cat`?** The `gh` CLI pipes long output through a pager (like `less`) by default, which blocks in non-interactive terminals. Setting it to `cat` disables paging so output prints directly.
 
@@ -231,9 +236,11 @@ If a PR already exists for the branch:
 - Do not create another.
 - If requested (or if the body is still mostly unfilled template text), update it:
 
-  **bash:** `GH_PAGER=cat gh pr edit <pr-number-or-url> --body-file pr-body.md`
+  **bash:** `GH_PAGER=cat gh pr edit <pr-number-or-url> --body-file pr-body.md --attach './before.png#Before' --attach './demo.mp4'`
 
-  **PowerShell:** `$env:GH_PAGER = "cat"; gh pr edit <pr-number-or-url> --body-file pr-body.md`
+  **PowerShell:** `$env:GH_PAGER = "cat"; gh pr edit <pr-number-or-url> --body-file pr-body.md --attach './before.png#Before' --attach './demo.mp4'`
+
+- Omit the `--attach` flags when step 4 did not prepare visual artifacts. Attach videos without a `#` suffix.
 
 - If a label needs to be applied to an existing PR, use `gh pr edit <pr-number-or-url> --add-label <label-name>`.
 
@@ -252,7 +259,7 @@ After you are completely finished creating or updating the PR (after step 6 and,
 | `gh: command not found` | Tell the user to install `gh` from https://cli.github.com/ |
 | `gh auth` not logged in | Tell the user to run `gh auth login` |
 | `git push` rejected | Inform the user; do not force-push without explicit permission |
-| PR already exists | Follow step 6 (Handle existing PRs) above |
+| PR already exists | Follow step 7 (Handle existing PRs) above |
 
 ## Notes
 


### PR DESCRIPTION
## Description

Updates the `create-pr` skill so agents can add visual evidence directly to pull requests.

- Use the GitHub CLI `--attach` option for image and video uploads.
- Require agents with older GitHub CLI versions to upgrade instead of calling an undocumented attachment endpoint.
- Require inspection of artifacts before upload and verification that attachments render in the final PR body.

### Security considerations

This change documents permanent uploads to public GitHub user-attachment storage through the authenticated GitHub CLI. The guidance requires agents to inspect and redact artifacts before upload, avoids direct token handling and undocumented upload APIs, and verifies the resulting public attachments. Security review has not yet been completed and is needed to validate these controls.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No